### PR TITLE
Local telemetry foundation + traffic-attribution User-Agent (1.4.0)

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -18,6 +18,10 @@ labels: bug
 
 **Actual behavior**
 
+<!-- If a tool returned an error, paste the full error line. It looks like:
+     B2 Error [NoSuchKey] (HTTP 404): ... (requestId: abc123)
+     The code/status and especially the requestId let us (and Backblaze) trace it. -->
+
 **Environment**
 
 - Server version (`/health` endpoint or `package.json`):

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -12,6 +12,13 @@ labels: enhancement
 
 <!-- What you'd like to see. If this corresponds to a specific B2 API or S3 API operation, name it. -->
 
+**Which API surface?** <!-- B2 native / S3-compatible / Partner-Groups-Backup / not sure -->
+
+**Did an existing tool fall short?**
+
+<!-- If a tool errored or couldn't do what you needed, paste the error line —
+     it carries a requestId we can trace: B2 Error [code] (HTTP nnn): ... (requestId: ...) -->
+
 **Alternatives considered**
 
 **Additional context**

--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,7 @@ coverage/
 .vscode/
 .claude/settings.local.json
 probe-output/
+
+# Internal-only docs — never ship in a public/open-sourced repo
+docs/STRATEGY-*.md
+docs/internal/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,22 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.4.0] - 2026-06-07
+
+### Added
+- **Local telemetry foundation (no phone-home).** Each tool call's audit event
+  now carries the classified error `code`/`status`/`requestId` (argument *names*
+  and duration only — never values, credentials, bucket/file names, or PII), so
+  operators can mine failing/slow tools from their own logs.
+- **Outbound User-Agent for traffic attribution.** B2-native requests send
+  `backblaze-b2-mcp/<version> (<transport>) axios/<v> Node.js/<v>` (the original
+  axios/Node stack is preserved, not clobbered); S3 requests append the product
+  token to the AWS SDK User-Agent. No credentials or per-user identifiers.
+  Optional `B2_MCP_UA_SUFFIX` to tag a deployment.
+- README "Logging & telemetry" section stating explicitly that nothing phones
+  home and documenting exactly what is logged/sent. Enhanced issue templates to
+  capture the affected API surface and the error `requestId`.
+
 ## [1.3.0] - 2026-06-05
 
 ### Security

--- a/README.md
+++ b/README.md
@@ -87,6 +87,16 @@ Add to `.cursor/mcp.json` in your project root:
 | `B2_REGION`               | —        | `us-west-004`           | B2 region for S3-compatible endpoint                                                                            |
 | `B2_LARGE_FILE_THRESHOLD` | —        | `104857600` (100MB)     | File size above which multipart upload is used                                                                  |
 | `B2_PART_SIZE`            | —        | `104857600` (100MB)     | Size of each multipart upload part                                                                              |
+| `B2_MCP_UA_SUFFIX`        | —        | —                       | Optional token appended to the outbound User-Agent (e.g. to tag a deployment)                                   |
+
+> Security/hardening vars (`B2_FILE_ROOT`, `B2_ALLOW_LOCAL_FILES`, `B2_MAX_SESSIONS`, `B2_ALLOWED_HOSTS`/`B2_ALLOWED_ORIGINS`) are documented in [`docs/DEPLOY.md`](docs/DEPLOY.md).
+
+## Logging & telemetry
+
+This server does **not** phone home — there is no analytics endpoint and nothing is sent to Backblaze or any third party beyond your own B2 API calls. Specifically:
+
+- **Local audit log.** Each tool call emits a structured line to **stderr** (captured by journald/your log pipeline): tool name, a truncated key prefix, the argument **key names only** (never values), duration, and — on error — the classified `code`/`status`/`requestId`. It never logs credentials, argument values, bucket names, or file contents. Mine these locally to spot failing/slow tools.
+- **Outbound User-Agent.** B2 API requests carry a `User-Agent` like `backblaze-b2-mcp/<version> (<transport>) axios/<v> Node.js/<v>` (S3 requests append the same product token to the AWS SDK's User-Agent). This lets B2 attribute traffic to the MCP server. It contains **no credentials or per-user identifiers** — only product, version, and transport. Append your own token with `B2_MCP_UA_SUFFIX`.
 
 ## Available Tools
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backblaze/b2-mcp-server",
-  "version": "1.3.0",
+  "version": "1.4.0",
   "description": "MCP server for Backblaze B2 — full B2 native API + S3-compatible API coverage",
   "main": "dist/index.js",
   "bin": {

--- a/src/auth.ts
+++ b/src/auth.ts
@@ -1,6 +1,7 @@
 import axios from "axios";
 import { B2AuthResponse, B2Config } from "./utils/types.js";
 import { withRetry } from "./utils/retry.js";
+import { buildUserAgent } from "./utils/user-agent.js";
 
 /** Timeout for the authorize_account request. */
 const AUTH_TIMEOUT_MS = 30_000;
@@ -89,7 +90,10 @@ export class B2AuthManager {
 
     const response = await withRetry(() =>
       axios.get<B2V3AuthResponse>(AUTH_URL, {
-        headers: { Authorization: `Basic ${credentials}` },
+        headers: {
+          Authorization: `Basic ${credentials}`,
+          "User-Agent": buildUserAgent(this.config),
+        },
         timeout: AUTH_TIMEOUT_MS,
       }),
     );

--- a/src/b2/client.ts
+++ b/src/b2/client.ts
@@ -21,9 +21,11 @@ const MAX_BUFFER_DOWNLOAD_BYTES = 100 * 1024 * 1024; // 100 MB
  */
 export class B2Client {
   private auth: B2AuthManager;
+  private userAgent: string;
 
-  constructor(auth: B2AuthManager) {
+  constructor(auth: B2AuthManager, userAgent = "backblaze-b2-mcp") {
     this.auth = auth;
+    this.userAgent = userAgent;
   }
 
   /**
@@ -59,7 +61,10 @@ export class B2Client {
             const config: AxiosRequestConfig = {
               method: options.method ?? (data !== undefined ? "POST" : "GET"),
               url,
-              headers: { Authorization: authData.authorizationToken },
+              headers: {
+                Authorization: authData.authorizationToken,
+                "User-Agent": this.userAgent,
+              },
               timeout: API_TIMEOUT_MS,
               ...(data !== undefined && { data }),
               ...(options.params !== undefined && { params: options.params }),
@@ -95,6 +100,7 @@ export class B2Client {
         const response = await axios.post<T>(uploadUrl, body, {
           headers: {
             Authorization: uploadAuthToken,
+            "User-Agent": this.userAgent,
             ...headers,
           },
           maxBodyLength: Infinity,
@@ -122,6 +128,7 @@ export class B2Client {
         const authData = await this.auth.getAuth();
         const headers: Record<string, string> = {
           Authorization: authToken ?? authData.authorizationToken,
+          "User-Agent": this.userAgent,
         };
         if (range) headers["Range"] = range;
 
@@ -163,6 +170,7 @@ export class B2Client {
         const authData = await this.auth.getAuth();
         const headers: Record<string, string> = {
           Authorization: authToken ?? authData.authorizationToken,
+          "User-Agent": this.userAgent,
         };
         if (range) headers["Range"] = range;
 

--- a/src/http-server.ts
+++ b/src/http-server.ts
@@ -93,6 +93,7 @@ export function configFromHeaders(req: { headers: http.IncomingHttpHeaders }): B
     // unrestricted over HTTP).
     allowLocalFiles: process.env.B2_ALLOW_LOCAL_FILES === "true" && !!process.env.B2_FILE_ROOT,
     fileRoot: process.env.B2_FILE_ROOT ?? null,
+    transport: "http",
   };
 }
 

--- a/src/s3/client.ts
+++ b/src/s3/client.ts
@@ -1,5 +1,6 @@
 import { S3Client, S3ClientConfig } from "@aws-sdk/client-s3";
 import { B2Config } from "../utils/types.js";
+import { VERSION } from "../version.js";
 
 /**
  * Create an AWS SDK S3Client configured to point at the B2 S3-compatible endpoint.
@@ -15,6 +16,13 @@ export function createS3Client(config: B2Config): S3Client {
       secretAccessKey: config.appKey,
     },
     forcePathStyle: true, // Required for B2 S3-compatible API
+    // Attribute S3 traffic to the MCP in B2's server-side logs (appended to the
+    // SDK User-Agent). The SDK signs requests, so this is the safe way to tag
+    // them — never inject raw headers. No credentials/PII, only product+transport.
+    customUserAgent: [
+      ["backblaze-b2-mcp", VERSION],
+      ["transport", config.transport ?? "stdio"],
+    ],
   };
 
   return new S3Client(s3Config);

--- a/src/server.ts
+++ b/src/server.ts
@@ -1,6 +1,8 @@
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { B2Config } from "./utils/types.js";
 import { parseIntEnv } from "./utils/config.js";
+import { buildUserAgent } from "./utils/user-agent.js";
+import { parseErrorText } from "./utils/errors.js";
 import { VERSION } from "./version.js";
 import { logger } from "./utils/logger.js";
 import { B2AuthManager } from "./auth.js";
@@ -52,6 +54,7 @@ export function loadConfig(): B2Config {
     // confine all file paths to one directory.
     allowLocalFiles: process.env.B2_ALLOW_LOCAL_FILES !== "false",
     fileRoot: process.env.B2_FILE_ROOT ?? null,
+    transport: "stdio",
   };
 }
 
@@ -104,7 +107,7 @@ export function createServer(config: B2Config): McpServer {
 
   // Initialize clients
   const auth = new B2AuthManager(config);
-  const b2Client = new B2Client(auth);
+  const b2Client = new B2Client(auth, buildUserAgent(config));
   const s3Client = createS3Client(config);
 
   // ── B2 Native API tools ─────────────────────────────────────────────────
@@ -197,8 +200,23 @@ export function wrapToolsWithAudit(server: McpServer, config: B2Config): number 
         const result = await original.call(this, args, extra);
         const durationMs = Date.now() - start;
         const isError = result?.isError === true;
+        // When the tool returned a structured error, surface the classified
+        // code/status/requestId in the audit event — this is the local metrics
+        // stream operators mine for failing/slow tools (no values, no PII).
+        const errInfo = isError ? parseErrorText(result?.content?.[0]?.text) : null;
         logger.info(
-          { tool: name, key: keyPrefix, argKeys, durationMs, error: isError },
+          {
+            tool: name,
+            key: keyPrefix,
+            argKeys,
+            durationMs,
+            error: isError,
+            ...(errInfo && {
+              code: errInfo.code,
+              status: errInfo.status,
+              ...(errInfo.requestId && { requestId: errInfo.requestId }),
+            }),
+          },
           "tool.call",
         );
         return result;

--- a/src/utils/errors.ts
+++ b/src/utils/errors.ts
@@ -72,6 +72,21 @@ export function parseB2Error(err: unknown): B2ApiError {
 }
 
 /**
+ * Parse a formatB2Error() string back into its parts. Used by the audit layer
+ * to record error code/status/requestId from a tool's error response (the tool
+ * surface only carries the formatted text). Returns null if the text isn't a
+ * formatted B2 error.
+ */
+export function parseErrorText(
+  text: string | undefined,
+): { code: string; status: number; requestId?: string } | null {
+  if (!text) return null;
+  const m = text.match(/^B2 Error \[(.+?)\] \(HTTP (\d+)\): [\s\S]*?(?: \(requestId: (.+?)\))?$/);
+  if (!m) return null;
+  return { code: m[1], status: Number(m[2]), requestId: m[3] };
+}
+
+/**
  * Format a B2 error into a human-readable string for MCP tool responses.
  * Includes the provider requestId when available — the field a Backblaze
  * support ticket needs to trace a server-side failure.

--- a/src/utils/types.ts
+++ b/src/utils/types.ts
@@ -24,6 +24,8 @@ export interface B2Config {
    * single-user stdio process. Set via B2_FILE_ROOT.
    */
   fileRoot: string | null;
+  /** Which transport launched this server — surfaced in the outbound User-Agent. */
+  transport?: "stdio" | "http";
 }
 
 export interface B2AuthResponse {

--- a/src/utils/user-agent.ts
+++ b/src/utils/user-agent.ts
@@ -1,0 +1,26 @@
+import axios from "axios";
+import { VERSION } from "../version.js";
+import { B2Config } from "./types.js";
+
+/**
+ * Build the outbound User-Agent for B2 *native* (axios) API calls so server-side
+ * logs can attribute traffic to the MCP server (product, version, transport).
+ *
+ * Setting a User-Agent on an axios request replaces axios's default, so we
+ * explicitly append the original stack (axios + Node version) to preserve it —
+ * the B2 backend still sees the underlying client, plus our product tag.
+ * Carries NO credentials, bucket/file names, or per-user identifiers. Operators
+ * can append a token via B2_MCP_UA_SUFFIX.
+ *
+ * Example: "backblaze-b2-mcp/1.3.0 (http) axios/1.16.1 Node.js/22.16.0"
+ *
+ * (The S3 client preserves its original User-Agent automatically — the AWS SDK
+ * *appends* our token via customUserAgent, so no manual stacking is needed there.)
+ */
+export function buildUserAgent(config: B2Config): string {
+  const transport = config.transport ?? "stdio";
+  const product = `backblaze-b2-mcp/${VERSION} (${transport})`;
+  const stack = `axios/${axios.VERSION ?? "unknown"} Node.js/${process.versions.node}`;
+  const suffix = process.env.B2_MCP_UA_SUFFIX?.trim();
+  return [product, stack, suffix].filter(Boolean).join(" ");
+}

--- a/tests/unit/audit-wrapper.test.ts
+++ b/tests/unit/audit-wrapper.test.ts
@@ -73,6 +73,30 @@ describe("wrapToolsWithAudit", () => {
     );
   });
 
+  it("enriches the tool.call event with code/status/requestId on a structured error", async () => {
+    const original = jest.fn().mockResolvedValue({
+      isError: true,
+      content: [
+        { type: "text", text: "B2 Error [NoSuchKey] (HTTP 404): missing (requestId: req-7)" },
+      ],
+    });
+    const tool: Record<string, unknown> = { callback: original };
+    const server = { _registeredTools: { s3_get_object: tool } } as unknown as McpServer;
+    wrapToolsWithAudit(server, cfg);
+
+    await (tool.callback as (...a: unknown[]) => Promise<unknown>)({ bucket: "b", key: "k" }, {});
+    expect(infoSpy).toHaveBeenCalledWith(
+      expect.objectContaining({
+        tool: "s3_get_object",
+        error: true,
+        code: "NoSuchKey",
+        status: 404,
+        requestId: "req-7",
+      }),
+      "tool.call",
+    );
+  });
+
   it("logs tool.error and rethrows when the handler throws", async () => {
     const original = jest.fn().mockRejectedValue(new Error("boom"));
     const tool: Record<string, unknown> = { callback: original };

--- a/tests/unit/errors.test.ts
+++ b/tests/unit/errors.test.ts
@@ -1,6 +1,7 @@
 import {
   parseB2Error,
   formatB2Error,
+  parseErrorText,
   toolError,
   toolSuccess,
   toolJson,
@@ -109,6 +110,31 @@ describe("formatB2Error", () => {
       $metadata: { httpStatusCode: 500, requestId: "req-500-1" },
     };
     expect(formatB2Error(err)).toContain("requestId: req-500-1");
+  });
+});
+
+describe("parseErrorText (round-trips formatB2Error for the audit layer)", () => {
+  it("extracts code, status, and requestId", () => {
+    const text = formatB2Error({
+      name: "NoSuchKey",
+      message: "missing",
+      $metadata: { httpStatusCode: 404, requestId: "req-9" },
+    });
+    expect(parseErrorText(text)).toEqual({ code: "NoSuchKey", status: 404, requestId: "req-9" });
+  });
+
+  it("works without a requestId", () => {
+    const text = "B2 Error [bad_request] (HTTP 400): nope";
+    expect(parseErrorText(text)).toEqual({
+      code: "bad_request",
+      status: 400,
+      requestId: undefined,
+    });
+  });
+
+  it("returns null for non-error / undefined text", () => {
+    expect(parseErrorText(undefined)).toBeNull();
+    expect(parseErrorText("some success text")).toBeNull();
   });
 });
 

--- a/tests/unit/user-agent.test.ts
+++ b/tests/unit/user-agent.test.ts
@@ -1,0 +1,35 @@
+import { buildUserAgent } from "../../src/utils/user-agent";
+import { B2Config } from "../../src/utils/types";
+
+function cfg(over: Partial<B2Config> = {}): B2Config {
+  return { transport: "stdio", ...over } as B2Config;
+}
+
+describe("buildUserAgent", () => {
+  afterEach(() => delete process.env.B2_MCP_UA_SUFFIX);
+
+  it("includes product, version, and transport", () => {
+    const ua = buildUserAgent(cfg({ transport: "http" }));
+    expect(ua).toMatch(/^backblaze-b2-mcp\/\d+\.\d+\.\d+ \(http\)/);
+  });
+
+  it("preserves the underlying stack (axios + Node)", () => {
+    const ua = buildUserAgent(cfg());
+    expect(ua).toContain("axios/");
+    expect(ua).toContain(`Node.js/${process.versions.node}`);
+  });
+
+  it("defaults transport to stdio when unset", () => {
+    expect(buildUserAgent(cfg({ transport: undefined }))).toContain("(stdio)");
+  });
+
+  it("appends an operator suffix when set", () => {
+    process.env.B2_MCP_UA_SUFFIX = "deploy/prod-1";
+    expect(buildUserAgent(cfg())).toContain("deploy/prod-1");
+  });
+
+  it("carries no obvious secrets", () => {
+    const ua = buildUserAgent(cfg());
+    expect(ua).not.toMatch(/key|secret|authorization/i);
+  });
+});


### PR DESCRIPTION
A **no-phone-home** observability layer so the repo can be tracked and improved over time — identify failing/slow tools, attribute API traffic, and see what agents tried — without sending anything to Backblaze beyond the user's own B2 API calls.

## What's in it

**Enriched local metrics.** Each `tool.call` audit event now carries the classified error `code`/`status`/`requestId` in addition to tool name, truncated key, duration, and arg **key names**. Never values, credentials, bucket/file names, or PII. Operators mine these from their own logs (journald/CloudWatch/etc.) to spot failing and slow tools.

**Outbound User-Agent for traffic attribution** (works on every deployment, self-hosted included — no infra):
- B2-native: `backblaze-b2-mcp/<version> (<transport>) axios/<v> Node.js/<v>` — the original axios/Node UA is **preserved**, not clobbered.
- S3: the product token is **appended** to the AWS SDK User-Agent (the SDK signs requests, so this is the safe path — no raw header injection).
- `(stdio)` vs `(http)` transport tag distinguishes self-hosted-local from gateway traffic. Optional `B2_MCP_UA_SUFFIX` to tag a deployment. No credentials or per-user identifiers.

**Transparency + the improvement loop.** New README "Logging & telemetry" section states explicitly that nothing phones home and documents exactly what's logged/sent. Issue templates now capture the affected API surface and the error `requestId` so tool gaps and bugs land as actionable issues.

## Deliberately deferred (not requested)
- Opt-in self-hosted telemetry **phone-home** — kept out by design; would be a separate trust decision.
- Forwarding the **inbound MCP client's** User-Agent through the HTTP gateway (so B2 sees which client drove a call) — small follow-up if wanted.

## Privacy stance
No credentials, no argument values, no bucket/file names, no per-user identifiers — anywhere in logs or the User-Agent. Consistent with the self-host trust posture.

## Tests
- **391 → 400 unit tests** (User-Agent assembly incl. preserved stack + suffix; `parseErrorText`; enriched audit event with code/status/requestId).
- `npm run build` / `npm test` / `npm run lint` / `format:check` all clean.
- Version `1.3.0 → 1.4.0` (the UA embeds the version).

🤖 Generated with [Claude Code](https://claude.com/claude-code)