### PR TITLE
docs: client setup guide (docs/CLIENTS.md)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,7 @@ coverage/
 .vscode/
 .claude/settings.local.json
 probe-output/
+
+# Internal-only docs — never ship in a public/open-sourced repo
+docs/STRATEGY-*.md
+docs/internal/

--- a/README.md
+++ b/README.md
@@ -29,6 +29,8 @@ npm run build
 
 > **Note:** The `dist/` folder is excluded from the zip — you must run `npm run build` once before connecting Claude.
 
+> **Using a different client?** [`docs/CLIENTS.md`](docs/CLIENTS.md) has copy-paste setup for Claude Desktop, Claude.ai, Cursor, VS Code, Cline, Windsurf, Zed, Continue, Goose, and hosted (SSE) clients — plus a compatibility matrix.
+
 ### 2. Connect Claude Desktop
 
 Open (or create) `~/Library/Application Support/Claude/claude_desktop_config.json` and add:

--- a/docs/CLIENTS.md
+++ b/docs/CLIENTS.md
@@ -1,0 +1,258 @@
+# Connecting MCP clients to the B2 MCP server
+
+This server speaks the Model Context Protocol over **two transports**:
+
+- **stdio** — the server runs as a local subprocess of the client. Used by desktop apps and IDE extensions (Claude Desktop, Cursor, VS Code, Cline, Windsurf, Zed, Continue, Goose…).
+- **HTTP + SSE** — the server runs as a hosted endpoint behind a URL. Used by web clients (Claude.ai Custom Connectors) and any client pointed at a remote server. See [`DEPLOY.md`](DEPLOY.md) to stand one up.
+
+> **The one thing that matters:** every stdio client runs the _same_ command —
+> `node /ABSOLUTE/PATH/TO/b2-mcp-server/dist/index.js` with two env vars. Only the
+> **config file location** and the **wrapper key name** differ per client. If a
+> client's config format has changed since this was written, its own MCP docs are
+> authoritative — the invocation below is what you're wiring up.
+
+## Compatibility at a glance
+
+| Client                    | Local (stdio) |     Hosted (HTTP+SSE)      | Config location                                   |
+| ------------------------- | :-----------: | :------------------------: | ------------------------------------------------- |
+| Claude Desktop            |      ✅       | ✅ via `mcp-remote` bridge | `claude_desktop_config.json`                      |
+| Claude.ai web / Pro / Max |       —       |      ✅ URL + headers      | Custom Connectors UI                              |
+| Cursor                    |      ✅       |             ✅             | `.cursor/mcp.json`                                |
+| VS Code (Copilot)         |      ✅       |             ✅             | `.vscode/mcp.json`                                |
+| Cline                     |      ✅       |             ✅             | `cline_mcp_settings.json`                         |
+| Windsurf                  |      ✅       |             ✅             | `~/.codeium/windsurf/mcp_config.json`             |
+| Zed                       |      ✅       |             —              | `settings.json` (`context_servers`)               |
+| Continue                  |      ✅       |             ✅             | `~/.continue/config.yaml`                         |
+| Goose                     |      ✅       |             ✅             | `goose configure` / `~/.config/goose/config.yaml` |
+| Any other MCP client      |      ✅       |             ✅             | per client                                        |
+
+## Prerequisites
+
+```bash
+git clone <repo-url> b2-mcp-server
+cd b2-mcp-server
+npm install
+npm run build      # produces dist/ — required for the stdio command below
+```
+
+You also need a Backblaze B2 **Application Key** (key ID + secret). A single non-master application key works for both the B2 native and S3-compatible APIs. (Master keys are only needed for Partner API, `bz_*` Computer Backup, and account-level key management — see the README.)
+
+> Once the package is published to npm you'll be able to skip the clone/build and
+> use `command: "npx"`, `args: ["-y", "@backblaze/b2-mcp-server"]`. Until then, use
+> the local `node dist/index.js` path shown below.
+
+---
+
+## A. Local (stdio)
+
+The universal invocation, wrapped differently per client:
+
+```
+command: node
+args:    /ABSOLUTE/PATH/TO/b2-mcp-server/dist/index.js
+env:     B2_APPLICATION_KEY_ID, B2_APPLICATION_KEY
+```
+
+### Claude Desktop
+
+`~/Library/Application Support/Claude/claude_desktop_config.json` (macOS) / `%APPDATA%\Claude\claude_desktop_config.json` (Windows):
+
+```json
+{
+  "mcpServers": {
+    "backblaze-b2": {
+      "command": "node",
+      "args": ["/ABSOLUTE/PATH/TO/b2-mcp-server/dist/index.js"],
+      "env": {
+        "B2_APPLICATION_KEY_ID": "your-key-id",
+        "B2_APPLICATION_KEY": "your-key-secret"
+      }
+    }
+  }
+}
+```
+
+Restart Claude Desktop fully (Cmd/Ctrl+Q) and reopen.
+
+### Cursor
+
+`.cursor/mcp.json` in your project (or `~/.cursor/mcp.json` globally):
+
+```json
+{
+  "mcpServers": {
+    "backblaze-b2": {
+      "command": "node",
+      "args": ["/ABSOLUTE/PATH/TO/b2-mcp-server/dist/index.js"],
+      "env": {
+        "B2_APPLICATION_KEY_ID": "your-key-id",
+        "B2_APPLICATION_KEY": "your-key-secret"
+      }
+    }
+  }
+}
+```
+
+### VS Code (GitHub Copilot agent mode)
+
+`.vscode/mcp.json` (note VS Code uses the `servers` key and a `type`):
+
+```json
+{
+  "servers": {
+    "backblaze-b2": {
+      "type": "stdio",
+      "command": "node",
+      "args": ["/ABSOLUTE/PATH/TO/b2-mcp-server/dist/index.js"],
+      "env": {
+        "B2_APPLICATION_KEY_ID": "your-key-id",
+        "B2_APPLICATION_KEY": "your-key-secret"
+      }
+    }
+  }
+}
+```
+
+### Cline
+
+Cline → **MCP Servers → Configure** (edits `cline_mcp_settings.json`):
+
+```json
+{
+  "mcpServers": {
+    "backblaze-b2": {
+      "command": "node",
+      "args": ["/ABSOLUTE/PATH/TO/b2-mcp-server/dist/index.js"],
+      "env": {
+        "B2_APPLICATION_KEY_ID": "your-key-id",
+        "B2_APPLICATION_KEY": "your-key-secret"
+      }
+    }
+  }
+}
+```
+
+### Windsurf
+
+`~/.codeium/windsurf/mcp_config.json`:
+
+```json
+{
+  "mcpServers": {
+    "backblaze-b2": {
+      "command": "node",
+      "args": ["/ABSOLUTE/PATH/TO/b2-mcp-server/dist/index.js"],
+      "env": {
+        "B2_APPLICATION_KEY_ID": "your-key-id",
+        "B2_APPLICATION_KEY": "your-key-secret"
+      }
+    }
+  }
+}
+```
+
+### Zed
+
+`settings.json` (Zed uses `context_servers`):
+
+```json
+{
+  "context_servers": {
+    "backblaze-b2": {
+      "command": {
+        "path": "node",
+        "args": ["/ABSOLUTE/PATH/TO/b2-mcp-server/dist/index.js"],
+        "env": {
+          "B2_APPLICATION_KEY_ID": "your-key-id",
+          "B2_APPLICATION_KEY": "your-key-secret"
+        }
+      }
+    }
+  }
+}
+```
+
+### Continue
+
+`~/.continue/config.yaml`:
+
+```yaml
+mcpServers:
+  - name: backblaze-b2
+    command: node
+    args:
+      - /ABSOLUTE/PATH/TO/b2-mcp-server/dist/index.js
+    env:
+      B2_APPLICATION_KEY_ID: your-key-id
+      B2_APPLICATION_KEY: your-key-secret
+```
+
+### Goose
+
+```bash
+goose configure
+# → Add Extension → Command-line Extension
+# Command:  node /ABSOLUTE/PATH/TO/b2-mcp-server/dist/index.js
+# add env:  B2_APPLICATION_KEY_ID, B2_APPLICATION_KEY
+```
+
+### Any other stdio client
+
+Point it at `node /ABSOLUTE/PATH/TO/b2-mcp-server/dist/index.js` with the two env vars, under whatever key your client uses for MCP servers. Consult the client's MCP documentation for the exact file and key name.
+
+---
+
+## B. Hosted (HTTP + SSE)
+
+For a server deployed per [`DEPLOY.md`](DEPLOY.md). Credentials travel in request **headers**, not env vars.
+
+### Claude Desktop → hosted server (`mcp-remote` bridge)
+
+Claude Desktop only accepts stdio entries, so use the [`mcp-remote`](https://www.npmjs.com/package/mcp-remote) bridge as a local shim:
+
+```json
+{
+  "mcpServers": {
+    "backblaze-b2": {
+      "command": "npx",
+      "args": [
+        "-y",
+        "mcp-remote",
+        "https://mcp.your-domain.example/sse",
+        "--header",
+        "X-B2-Key-Id:your-key-id",
+        "--header",
+        "X-B2-Key:your-key-secret"
+      ]
+    }
+  }
+}
+```
+
+### Claude.ai web / Pro / Max (Custom Connectors)
+
+These accept the URL + headers shape directly:
+
+```json
+{
+  "url": "https://mcp.your-domain.example/sse",
+  "headers": {
+    "X-B2-Key-Id": "your-key-id",
+    "X-B2-Key": "your-key-secret"
+  }
+}
+```
+
+### Any SSE-capable client
+
+Point it at `https://<host>/sse` and send the `X-B2-Key-Id` / `X-B2-Key` headers. If your primary key is a **master** key, also send `X-B2-App-Key-Id` / `X-B2-App-Key` (a non-master key) — B2's S3 endpoint rejects master keys.
+
+---
+
+## Credentials & security
+
+- **stdio:** the key goes in the `env` block of the client's config file, in **plaintext**. Protect that file and never commit it to a repo.
+- **hosted:** the key travels in `X-B2-*` headers. Front the server with TLS and a caller-auth layer (see [`DEPLOY.md`](DEPLOY.md) — the HTTP transport authenticates the _B2 key_, not the _caller_).
+- **Master-key caveat:** only the Partner API, `bz_*` tools, and account-level key management need a master key. If you use one, also supply a non-master key (`B2_APP_KEY_ID`/`B2_APP_KEY` for stdio, or `X-B2-App-Key-Id`/`X-B2-App-Key` for hosted) for the S3 tools.
+
+See the [README](../README.md) for the full environment-variable list and the tool catalog.


### PR DESCRIPTION
Adds a single reference for connecting MCP clients to the B2 MCP server.

- **Compatibility matrix** — client × transport (stdio/SSE) × local/hosted.
- **Local (stdio) configs** — copy-paste for Claude Desktop, Cursor, VS Code (Copilot), Cline, Windsurf, Zed, Continue, and Goose, plus a generic stdio pattern.
- **Hosted (HTTP+SSE) configs** — Claude Desktop via the `mcp-remote` bridge, Claude.ai Custom Connectors (URL + headers), and any SSE client.
- **Credentials & security notes** — where keys live per transport, and the master-key caveat.
- Install guidance updated to `git clone` + build (with an `npx` note for once published). README links to the guide.

Docs-only; no code changes. All hosted examples use the `mcp.your-domain.example` placeholder.

🤖 Generated with [Claude Code](https://claude.com/claude-code)