### PR TITLE
fix: add ca-east to Partner API region enum

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.4.1] - 2026-06-09
+
+### Fixed
+- Partner API region enum was missing `ca-east` (Canada East / Toronto). A real
+  MCP client provisioning a tenant in `ca-east` via `b2_create_group_member` or
+  `b2_reserve_trial_create_account` was rejected at schema validation before the
+  request reached B2. The complete region set is now
+  `us-east`, `us-west`, `eu-central`, `ca-east`. Verified against Backblaze's
+  data-regions documentation.
+
 ## [1.4.0] - 2026-06-07
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backblaze/b2-mcp-server",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "description": "MCP server for Backblaze B2 — full B2 native API + S3-compatible API coverage",
   "main": "dist/index.js",
   "bin": {

--- a/src/b2/partner.ts
+++ b/src/b2/partner.ts
@@ -84,7 +84,7 @@ export function registerPartnerTools(
           "Email address for the new Group member. Must not already be a Backblaze account.",
         ),
       region: z
-        .enum(["us-east", "us-west", "eu-central"])
+        .enum(["us-east", "us-west", "eu-central", "ca-east"])
         .optional()
         .describe(
           "Region for the new account's data. Defaults to the current default region if omitted.",
@@ -217,7 +217,7 @@ export function registerPartnerTools(
         .max(50)
         .describe("Storage capacity for the trial in TB (1-50 inclusive)."),
       region: z
-        .enum(["us-east", "us-west", "eu-central"])
+        .enum(["us-east", "us-west", "eu-central", "ca-east"])
         .optional()
         .describe("Region for the new account's data. Backblaze picks a region if not specified."),
     },


### PR DESCRIPTION
The Partner API `region` enum on `b2_create_group_member` and `b2_reserve_trial_create_account` was `["us-east","us-west","eu-central"]` — **missing `ca-east`** (Canada East / Toronto).

Because it's a Zod enum, a real MCP client trying to provision a tenant in **`ca-east` was rejected at schema validation** before the request ever reached B2 — a functional bug.

**Fix:** both enums are now `["us-east","us-west","eu-central","ca-east"]` — the complete B2 region set, verified against [Backblaze's data-regions docs](https://www.backblaze.com/docs/cloud-storage-data-regions).

Found while cross-referencing the b2-mcp-server against the `Neocloud` SE knowledge base (whose docs correctly listed `ca-east`). Patch bump 1.4.0 → 1.4.1. Build/lint/format clean; 490 unit tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)