### PR TITLE
fix: add required objectNamePrefix to b2_set_bucket_notification_rules

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,17 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.4.2] - 2026-06-08
+
+### Fixed
+- `b2_set_bucket_notification_rules` omitted the required `objectNamePrefix`
+  field on each rule, so **every** call was rejected by B2 with
+  `400 required field objectNamePrefix is missing` — the tool could not set a
+  single notification rule. The rule schema now includes `objectNamePrefix`
+  (defaults to `""`, which matches all objects) and the handler always forwards
+  it to B2. Caught by live testing; the mocked unit tests did not exercise the
+  real B2 payload contract.
+
 ## [1.4.1] - 2026-06-09
 
 ### Fixed

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backblaze/b2-mcp-server",
-  "version": "1.4.1",
+  "version": "1.4.2",
   "description": "MCP server for Backblaze B2 — full B2 native API + S3-compatible API coverage",
   "main": "dist/index.js",
   "bin": {

--- a/src/b2/buckets.ts
+++ b/src/b2/buckets.ts
@@ -243,6 +243,13 @@ export function registerBucketTools(
       eventNotificationRules: z.array(
         z.object({
           name: z.string().describe("A name for this notification rule."),
+          objectNamePrefix: z
+            .string()
+            .optional()
+            .default("")
+            .describe(
+              "Only objects whose names start with this prefix trigger the rule. Empty string ('') matches all objects. Required by B2 on every rule.",
+            ),
           eventTypes: z
             .array(z.string())
             .describe(
@@ -265,7 +272,12 @@ export function registerBucketTools(
       try {
         const result = await client.call("b2_set_bucket_notification_rules", {
           bucketId: args.bucketId,
-          eventNotificationRules: args.eventNotificationRules,
+          // B2 requires objectNamePrefix on every rule; default to "" (matches
+          // all objects) when a caller omits it, regardless of Zod default.
+          eventNotificationRules: args.eventNotificationRules.map((rule) => ({
+            ...rule,
+            objectNamePrefix: rule.objectNamePrefix ?? "",
+          })),
         });
         return toolJson(result);
       } catch (err) {

--- a/tests/unit/b2-tools.test.ts
+++ b/tests/unit/b2-tools.test.ts
@@ -617,10 +617,11 @@ describe("b2_set_bucket_notification_rules", () => {
     }),
   );
 
-  it("sends rules and returns the updated configuration", async () => {
+  it("forwards an explicit objectNamePrefix and returns the updated configuration", async () => {
     const rules = [
       {
         name: "on-delete",
+        objectNamePrefix: "incoming/",
         eventTypes: ["b2:ObjectDeleted:*"],
         isEnabled: true,
         targetConfiguration: { targetType: "webhook", url: "https://example.com/hook" },
@@ -636,6 +637,28 @@ describe("b2_set_bucket_notification_rules", () => {
     expect(mockedAxios).toHaveBeenCalledWith(
       expect.objectContaining({
         data: expect.objectContaining({ bucketId: "bucket-001", eventNotificationRules: rules }),
+      }),
+    );
+  });
+
+  it("injects objectNamePrefix='' when a rule omits it (B2 requires the field)", async () => {
+    const rules = [
+      {
+        name: "on-create",
+        eventTypes: ["b2:ObjectCreated:*"],
+        isEnabled: true,
+        targetConfiguration: { targetType: "webhook", url: "https://example.com/hook" },
+      },
+    ];
+    await callTool(server, "b2_set_bucket_notification_rules", {
+      bucketId: "bucket-001",
+      eventNotificationRules: rules,
+    });
+    expect(mockedAxios).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({
+          eventNotificationRules: [expect.objectContaining({ objectNamePrefix: "" })],
+        }),
       }),
     );
   });


### PR DESCRIPTION
## Problem

`b2_set_bucket_notification_rules` was unusable: B2 rejected **every** call with `400 required field objectNamePrefix is missing`. The `eventNotificationRules` rule schema omitted the mandatory per-rule `objectNamePrefix` field, so no notification rule could be set at all. Found by live testing against a real bucket — the mocked unit tests passed because they never exercised B2's real payload contract.

## Fix

- Add `objectNamePrefix` to the `eventNotificationRules` rule schema, defaulting to `""` (matches all objects).
- Handler always forwards `objectNamePrefix` to B2 (`?? ""`), so a caller that omits it still produces a valid payload.
- Regression tests: an explicit prefix is forwarded verbatim; an omitted prefix is injected as `""`.
- Bump `1.4.1` → `1.4.2`; CHANGELOG entry.

## Verification

- `npm run build` — clean
- `npm test` — 491 passed
- `npm run lint` / `npm run format:check` — clean
- Re-tested live after merge (read → set test rule with `objectNamePrefix:""` → verify → restore original).

🤖 Generated with [Claude Code](https://claude.com/claude-code)