### PR TITLE
fix: make B2 Object Lock work — retention/legal-hold request shapes + fileLockEnabled

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,27 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.4.3] - 2026-06-09
+
+### Fixed
+- **Object Lock was completely non-functional.** Two write tools modeled the
+  *response* shape as the *request* body, so B2 rejected every call:
+  - `b2_update_file_retention` sent `fileRetention: { isClientAuthorizedToRead,
+    value: { mode, retainUntilTimestamp } }` → `400 unknown field … isClientAuthorizedToRead`.
+    The request schema is now the flat `fileRetention: { mode, retainUntilTimestamp }`
+    that B2's write API expects.
+  - `b2_update_file_legal_hold` sent `legalHold: { isClientAuthorizedToRead, value }`
+    → now the bare `"on"`/`"off"` string B2 expects.
+  Both caught by live testing; the mocked unit tests had asserted the broken shape.
+
+### Added
+- **`fileLockEnabled` on `b2_create_bucket`.** Object Lock can only be enabled at
+  bucket creation — B2 rejects enabling it on an existing bucket
+  (`put_object_lock_configuration` → `400 cannot be enabled on existing buckets`).
+  Without this parameter there was no way to create a lock-enabled bucket through
+  the server, so the retention/legal-hold tools (even once fixed) had no usable
+  target. Object Lock immutability now works end-to-end.
+
 ## [1.4.2] - 2026-06-08
 
 ### Fixed

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backblaze/b2-mcp-server",
-  "version": "1.4.2",
+  "version": "1.4.3",
   "description": "MCP server for Backblaze B2 — full B2 native API + S3-compatible API coverage",
   "main": "dist/index.js",
   "bin": {

--- a/src/b2/buckets.ts
+++ b/src/b2/buckets.ts
@@ -80,6 +80,14 @@ export function registerBucketTools(
         })
         .optional()
         .describe("Default server-side encryption for new files in this bucket."),
+      fileLockEnabled: z
+        .boolean()
+        .optional()
+        .describe(
+          "Enable Object Lock (file lock) on the bucket. Can only be set at creation — B2 " +
+            "rejects enabling Object Lock on an existing bucket. Must be true before any " +
+            "retention or legal hold can be applied to files in this bucket.",
+        ),
     },
     async (args) => {
       try {
@@ -94,6 +102,7 @@ export function registerBucketTools(
         if (args.lifecycleRules) payload.lifecycleRules = args.lifecycleRules;
         if (args.defaultServerSideEncryption)
           payload.defaultServerSideEncryption = args.defaultServerSideEncryption;
+        if (args.fileLockEnabled !== undefined) payload.fileLockEnabled = args.fileLockEnabled;
 
         const result = await client.call("b2_create_bucket", payload);
         return toolJson(result);

--- a/src/b2/object-lock.ts
+++ b/src/b2/object-lock.ts
@@ -19,13 +19,11 @@ export function registerObjectLockTools(server: McpServer, client: B2Client): vo
         .string()
         .describe("The name of the file (required by the B2 API alongside fileId)."),
       legalHold: z
-        .object({
-          isClientAuthorizedToRead: z
-            .boolean()
-            .describe("Whether the current key can read the legal hold status."),
-          value: z.enum(["on", "off"]).describe("'on' to apply a legal hold; 'off' to remove it."),
-        })
-        .describe("The legal hold configuration to apply."),
+        .enum(["on", "off"])
+        .describe(
+          "'on' to apply a legal hold; 'off' to remove it. B2's write API expects this bare " +
+            "string — not the isClientAuthorizedToRead/value object that b2_get_file_info returns.",
+        ),
     },
     async (args) => {
       try {
@@ -52,29 +50,24 @@ export function registerObjectLockTools(server: McpServer, client: B2Client): vo
         .describe("The name of the file (required by the B2 API alongside fileId)."),
       fileRetention: z
         .object({
-          isClientAuthorizedToRead: z
-            .boolean()
-            .describe("Whether the current key can read the retention status."),
-          value: z
-            .object({
-              mode: z
-                .enum(["governance", "compliance"])
-                .nullable()
-                .describe(
-                  "Retention mode. null clears the retention policy (governance mode only with bypassGovernance).",
-                ),
-              retainUntilTimestamp: z
-                .number()
-                .nullable()
-                .describe(
-                  "Unix timestamp (ms) until which the file is retained. null when mode is null.",
-                ),
-            })
+          mode: z
+            .enum(["governance", "compliance"])
+            .nullable()
             .describe(
-              "Retention policy to apply, or {mode: null, retainUntilTimestamp: null} to clear.",
+              "Retention mode. null clears the retention policy (governance mode only, with bypassGovernance).",
+            ),
+          retainUntilTimestamp: z
+            .number()
+            .nullable()
+            .describe(
+              "Unix timestamp (ms) until which the file is retained. null when mode is null.",
             ),
         })
-        .describe("The file retention configuration."),
+        .describe(
+          "Retention policy to apply, or { mode: null, retainUntilTimestamp: null } to clear. " +
+            "This is the flat shape B2's write API expects — do NOT include the read-only " +
+            "isClientAuthorizedToRead/value wrapper that b2_get_file_info returns.",
+        ),
       bypassGovernance: z
         .boolean()
         .optional()

--- a/tests/unit/b2-tools.test.ts
+++ b/tests/unit/b2-tools.test.ts
@@ -173,6 +173,29 @@ describe("b2_create_bucket", () => {
       }),
     );
   });
+
+  it("forwards fileLockEnabled when set (Object Lock can only be enabled at creation)", async () => {
+    await callTool(server, "b2_create_bucket", {
+      bucketName: "locked-bucket",
+      bucketType: "allPrivate",
+      fileLockEnabled: true,
+    });
+    expect(mockedAxios).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({ fileLockEnabled: true }),
+      }),
+    );
+  });
+
+  it("omits fileLockEnabled when not provided", async () => {
+    await callTool(server, "b2_create_bucket", {
+      bucketName: "plain-bucket",
+      bucketType: "allPrivate",
+    });
+    const data = (mockedAxios.mock.calls[0][0] as unknown as { data: Record<string, unknown> })
+      .data;
+    expect(data).not.toHaveProperty("fileLockEnabled");
+  });
 });
 
 // ── b2_delete_bucket ──────────────────────────────────────────────────────────
@@ -994,7 +1017,7 @@ describe("b2_update_file_legal_hold", () => {
     setupMocks({
       fileId: "file-001",
       fileName: "doc.pdf",
-      legalHold: { isClientAuthorizedToRead: true, value: "on" },
+      legalHold: "on",
     }),
   );
 
@@ -1003,23 +1026,21 @@ describe("b2_update_file_legal_hold", () => {
       await callTool(server, "b2_update_file_legal_hold", {
         fileId: "file-001",
         fileName: "doc.pdf",
-        legalHold: { isClientAuthorizedToRead: true, value: "on" },
+        legalHold: "on",
       }),
     );
-    expect(result.legalHold.value).toBe("on");
+    expect(result.legalHold).toBe("on");
   });
 
-  it("passes legalHold payload to the API", async () => {
+  it("forwards legalHold to the API as a bare string (B2 write-API shape)", async () => {
     await callTool(server, "b2_update_file_legal_hold", {
       fileId: "file-001",
       fileName: "doc.pdf",
-      legalHold: { isClientAuthorizedToRead: true, value: "off" },
+      legalHold: "off",
     });
     expect(mockedAxios).toHaveBeenCalledWith(
       expect.objectContaining({
-        data: expect.objectContaining({
-          legalHold: expect.objectContaining({ value: "off" }),
-        }),
+        data: expect.objectContaining({ legalHold: "off" }),
       }),
     );
   });
@@ -1428,39 +1449,53 @@ describe("b2_update_file_retention", () => {
     setupMocks({
       fileId: "file-001",
       fileName: "audit.log",
-      fileRetention: {
-        isClientAuthorizedToRead: true,
-        value: { mode: "compliance", retainUntilTimestamp: retentionTimestamp },
-      },
+      fileRetention: { mode: "compliance", retainUntilTimestamp: retentionTimestamp },
     }),
   );
 
-  it("returns the updated file retention info", async () => {
+  it("forwards a flat fileRetention to the API (B2 write-API shape, no read-only wrapper)", async () => {
     const result = parseResult(
       await callTool(server, "b2_update_file_retention", {
         fileId: "file-001",
         fileName: "audit.log",
-        fileRetention: {
-          isClientAuthorizedToRead: true,
-          value: { mode: "compliance", retainUntilTimestamp: retentionTimestamp },
-        },
+        fileRetention: { mode: "compliance", retainUntilTimestamp: retentionTimestamp },
       }),
     );
-    expect(result.fileRetention.value.mode).toBe("compliance");
+    expect(result.fileRetention.mode).toBe("compliance");
+    expect(mockedAxios).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({
+          fileRetention: { mode: "compliance", retainUntilTimestamp: retentionTimestamp },
+        }),
+      }),
+    );
   });
 
   it("passes bypassGovernance when set to true", async () => {
     await callTool(server, "b2_update_file_retention", {
       fileId: "file-001",
       fileName: "doc.pdf",
-      fileRetention: {
-        isClientAuthorizedToRead: true,
-        value: { mode: "governance", retainUntilTimestamp: retentionTimestamp },
-      },
+      fileRetention: { mode: "governance", retainUntilTimestamp: retentionTimestamp },
       bypassGovernance: true,
     });
     expect(mockedAxios).toHaveBeenCalledWith(
       expect.objectContaining({ data: expect.objectContaining({ bypassGovernance: true }) }),
+    );
+  });
+
+  it("clears retention with mode: null", async () => {
+    await callTool(server, "b2_update_file_retention", {
+      fileId: "file-001",
+      fileName: "doc.pdf",
+      fileRetention: { mode: null, retainUntilTimestamp: null },
+      bypassGovernance: true,
+    });
+    expect(mockedAxios).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({
+          fileRetention: { mode: null, retainUntilTimestamp: null },
+        }),
+      }),
     );
   });
 });


### PR DESCRIPTION
## Problem

Object Lock — B2's headline immutability / ransomware-protection feature — was **completely non-functional** through the server. Found by live testing against a real account (the mocked unit tests passed because they asserted the broken payloads).

Two write tools modeled the **response** shape (what `b2_get_file_info` returns) as the **request** body:

- `b2_update_file_retention` sent `fileRetention: { isClientAuthorizedToRead, value: { mode, retainUntilTimestamp } }` → B2 rejects with `400 unknown field … isClientAuthorizedToRead`.
- `b2_update_file_legal_hold` sent `legalHold: { isClientAuthorizedToRead, value }` instead of the bare `"on"`/`"off"` string.

And there was **no way to create a lock-enabled bucket**: B2 only enables Object Lock at bucket creation (`put_object_lock_configuration` → `400 cannot be enabled on existing buckets`), but `b2_create_bucket` had no `fileLockEnabled` parameter — so even once the write tools were fixed they had no usable target.

## Fix

- `b2_update_file_retention` — flat `fileRetention: { mode, retainUntilTimestamp }`.
- `b2_update_file_legal_hold` — bare `legalHold: "on" | "off"`.
- `b2_create_bucket` — add optional `fileLockEnabled`.
- Unit tests rewritten to the corrected shapes (+ create-bucket lock cases).

## Verification

- `npm run build` / `npm test` (494 pass) / `npm run lint` / `npm run format:check` — all clean.
- **Live, end-to-end** on a real account: create `fileLockEnabled` bucket → set GOVERNANCE retention → confirm via `get_file_info` → **delete without bypass is rejected (immutability holds)** → legal hold on/off → clear + delete with `bypassGovernance` → bucket removed. Self-cleaning, no residue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)