### PR TITLE
test: live request-shape contract tests + Contract CI workflow

### DIFF
--- a/.github/workflows/contract.yml
+++ b/.github/workflows/contract.yml
@@ -1,0 +1,47 @@
+name: Contract
+
+# Live request-shape contract tests (tests/integration/contract.test.ts).
+#
+# Mocked unit tests cannot catch a tool that sends the wrong payload SHAPE to B2 —
+# two real bugs shipped that way (notification objectNamePrefix; Object Lock
+# retention/legal-hold response-shaped requests) and were only caught by hand.
+# These drive the real B2 write API so a shape regression fails CI instead.
+#
+# Triggers:
+#   - workflow_dispatch:  manual trigger from the Actions tab
+#   - release.published:  before a tagged release goes out
+#   - schedule:           every 6 hours as a heartbeat
+# Deliberately NOT on every PR: each run creates + deletes a real Object-Lock
+# bucket, and per-PR churn against the demo account isn't worth it.
+#
+# Gated to the canonical org repo so personal mirrors don't fire failing runs
+# (they don't have the credentials set as secrets).
+
+on:
+  workflow_dispatch:
+  release:
+    types: [published]
+  schedule:
+    - cron: "30 */6 * * *"
+
+jobs:
+  contract:
+    if: github.repository == 'backblaze-b2-samples/b2-mcp-server'
+    runs-on: ubuntu-latest
+    timeout-minutes: 6
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/setup-node@v6
+        with:
+          node-version: 22
+          cache: npm
+      - run: npm ci
+      - run: npm run build
+      - run: npm run test:contract
+        env:
+          # The contract tests read B2_APPLICATION_KEY_ID / B2_APPLICATION_KEY;
+          # map the repo's existing smoke-test secrets onto them.
+          B2_APPLICATION_KEY_ID: ${{ secrets.B2_KEY_ID }}
+          B2_APPLICATION_KEY: ${{ secrets.B2_KEY }}
+          B2_APP_KEY_ID: ${{ secrets.B2_APP_KEY_ID }}
+          B2_APP_KEY: ${{ secrets.B2_APP_KEY }}

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "dev": "ts-node src/index.ts",
     "test": "NODE_ENV=test jest --testPathPattern=tests/unit",
     "test:integration": "NODE_ENV=test jest --testPathPattern=tests/integration",
+    "test:contract": "NODE_ENV=test jest --testPathPattern=tests/integration/contract",
     "smoke": "node scripts/smoke-test.mjs",
     "probe:500": "npm run build && node scripts/probe-b2-500s.mjs",
     "lint": "eslint src tests",

--- a/tests/integration/contract.test.ts
+++ b/tests/integration/contract.test.ts
@@ -1,0 +1,190 @@
+/**
+ * Live request-shape contract tests.
+ *
+ * These exist because mocked unit tests cannot catch a tool that sends the wrong
+ * PAYLOAD SHAPE to B2 — the mock happily accepts whatever the code sends. Two real
+ * bugs shipped that way and were only caught by hand:
+ *   - b2_set_bucket_notification_rules omitted the required objectNamePrefix.
+ *   - b2_update_file_retention / b2_update_file_legal_hold sent the response shape
+ *     (isClientAuthorizedToRead/value wrapper) as the request body.
+ *
+ * Each test below drives the real B2 write API and asserts the contract holds, so a
+ * future shape regression fails here instead of in production.
+ *
+ * Credentials (same as the integration suite): B2_APPLICATION_KEY_ID / B2_APPLICATION_KEY.
+ * Skipped automatically when absent, so this file is safe to run anywhere.
+ */
+
+import { loadConfig, createServer } from "../../src/server";
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+
+const HAS_CREDS = !!(process.env.B2_APPLICATION_KEY_ID && process.env.B2_APPLICATION_KEY);
+const liveIt = HAS_CREDS ? test : test.skip;
+
+async function callTool(server: McpServer, toolName: string, args: Record<string, unknown>) {
+  const tool = (server as any)._registeredTools?.[toolName];
+  if (!tool) throw new Error(`Tool not found: ${toolName}`);
+  const handler = tool.handler ?? tool.callback ?? tool.execute;
+  return handler(args, {} as any);
+}
+function parseResult(result: any): any {
+  const text = result?.content?.[0]?.text;
+  if (!text) return result;
+  try {
+    return JSON.parse(text);
+  } catch {
+    return text;
+  }
+}
+const isError = (r: any): boolean => r?.isError === true;
+const errText = (r: any): string => r?.content?.[0]?.text ?? "";
+const isUserWritableBucket = (n: string) =>
+  !n.toLowerCase().includes("snapshot") && !n.toLowerCase().startsWith("b2-");
+
+let server: McpServer;
+let writableBucketId = "";
+
+beforeAll(async () => {
+  if (!HAS_CREDS) return;
+  server = createServer(loadConfig());
+  const buckets = parseResult(await callTool(server, "b2_list_buckets", {}));
+  const w = (buckets?.buckets ?? []).find((b: any) => isUserWritableBucket(b.bucketName));
+  if (w) writableBucketId = w.bucketId;
+});
+
+// ── Object Lock write-shape contract ──────────────────────────────────────────
+describe("Contract: Object Lock write shapes", () => {
+  liveIt(
+    "create fileLockEnabled bucket → governance retention → legal hold → immutability, all with B2's request shapes",
+    async () => {
+      const bucketName = `mcp-contract-lock-${Date.now().toString(36)}`;
+      let bucketId = "";
+      let fileId = "";
+      try {
+        // create with fileLockEnabled — the only way to a lock-enabled bucket
+        const created = parseResult(
+          await callTool(server, "b2_create_bucket", {
+            bucketName,
+            bucketType: "allPrivate",
+            fileLockEnabled: true,
+          }),
+        );
+        if (isError(created)) {
+          // Account may not be entitled for Object Lock — skip rather than fail.
+          console.log("  Object Lock not available on this account; skipping:", errText(created));
+          return;
+        }
+        bucketId = created.bucketId;
+        expect(created.fileLockConfiguration?.value?.isFileLockEnabled).toBe(true);
+
+        const up = parseResult(
+          await callTool(server, "b2_upload_file", {
+            bucketId,
+            fileName: "locked.txt",
+            content: Buffer.from("immutable").toString("base64"),
+            contentType: "text/plain",
+          }),
+        );
+        expect(isError(up)).toBe(false);
+        fileId = up.fileId;
+
+        // CONTRACT: flat fileRetention { mode, retainUntilTimestamp }, no read-only wrapper.
+        const setR = await callTool(server, "b2_update_file_retention", {
+          fileId,
+          fileName: "locked.txt",
+          fileRetention: { mode: "governance", retainUntilTimestamp: Date.now() + 120_000 },
+        });
+        expect(isError(setR)).toBe(false); // would fail with "unknown field isClientAuthorizedToRead" on regression
+
+        const info = parseResult(await callTool(server, "b2_get_file_info", { fileId }));
+        expect(info.fileRetention?.value?.mode).toBe("governance");
+
+        // Immutability: delete without bypass must be rejected.
+        const delNo = await callTool(server, "b2_delete_file_version", {
+          fileName: "locked.txt",
+          fileId,
+        });
+        expect(isError(delNo)).toBe(true);
+
+        // CONTRACT: legalHold is the bare "on"/"off" string.
+        const lhOn = await callTool(server, "b2_update_file_legal_hold", {
+          fileId,
+          fileName: "locked.txt",
+          legalHold: "on",
+        });
+        expect(isError(lhOn)).toBe(false);
+        const info2 = parseResult(await callTool(server, "b2_get_file_info", { fileId }));
+        expect(info2.legalHold?.value).toBe("on");
+        await callTool(server, "b2_update_file_legal_hold", {
+          fileId,
+          fileName: "locked.txt",
+          legalHold: "off",
+        });
+      } finally {
+        // Self-clean: clear governance retention (with bypass), delete the version, delete the bucket.
+        if (fileId) {
+          await callTool(server, "b2_update_file_retention", {
+            fileId,
+            fileName: "locked.txt",
+            bypassGovernance: true,
+            fileRetention: { mode: null, retainUntilTimestamp: null },
+          });
+          await callTool(server, "b2_delete_file_version", {
+            fileName: "locked.txt",
+            fileId,
+            bypassGovernance: true,
+          });
+        }
+        if (bucketId) await callTool(server, "b2_delete_bucket", { bucketId });
+      }
+    },
+    90_000,
+  );
+});
+
+// ── Notification rules write-shape contract ───────────────────────────────────
+describe("Contract: notification rules objectNamePrefix", () => {
+  liveIt(
+    "b2_set_bucket_notification_rules never fails for a missing objectNamePrefix",
+    async () => {
+      if (!writableBucketId) {
+        console.log("  No writable bucket; skipping.");
+        return;
+      }
+      // Capture existing rules to restore.
+      const before = parseResult(
+        await callTool(server, "b2_get_bucket_notification_rules", { bucketId: writableBucketId }),
+      );
+      const original = before?.eventNotificationRules ?? [];
+      try {
+        const res = await callTool(server, "b2_set_bucket_notification_rules", {
+          bucketId: writableBucketId,
+          eventNotificationRules: [
+            {
+              name: "mcp-contract-rule",
+              // objectNamePrefix deliberately omitted — the tool must inject "".
+              eventTypes: ["b2:ObjectCreated:*"],
+              isEnabled: false,
+              targetConfiguration: {
+                targetType: "webhook",
+                url: "https://example.com/contract",
+              },
+            },
+          ],
+        });
+        // The account may have Event Notifications disabled ("API not enabled") — that is fine.
+        // The CONTRACT is only that we never see the objectNamePrefix-missing rejection again.
+        if (isError(res)) {
+          expect(errText(res).toLowerCase()).not.toContain("objectnameprefix");
+        }
+      } finally {
+        // Restore whatever was there before (best-effort).
+        await callTool(server, "b2_set_bucket_notification_rules", {
+          bucketId: writableBucketId,
+          eventNotificationRules: original,
+        });
+      }
+    },
+    30_000,
+  );
+});


### PR DESCRIPTION
## Why

Mocked unit tests can't catch a tool that sends the wrong **payload shape** to B2 — the mock accepts whatever the code sends. Two real bugs shipped exactly that way and were only caught by hand:
- `b2_set_bucket_notification_rules` omitted the required `objectNamePrefix` (fixed in #21).
- `b2_update_file_retention` / `b2_update_file_legal_hold` sent the *response* shape (`isClientAuthorizedToRead`/`value` wrapper) as the request body (fixed in #22).

## What

- **`tests/integration/contract.test.ts`** — drives the real B2 write API and asserts the contract holds:
  - Object Lock: create `fileLockEnabled` bucket → governance retention (flat shape) → legal hold (`"on"` string) → confirm delete-without-bypass is **rejected** → self-cleaning teardown.
  - Notifications: setting a rule with `objectNamePrefix` omitted must never return the `objectNamePrefix`-missing rejection (tolerates "API not enabled").
  - Gated on `B2_APPLICATION_KEY_ID`; skips cleanly without creds.
- **`npm run test:contract`**.
- **`.github/workflows/contract.yml`** — schedule (6h) + release + manual dispatch, gated to the canonical repo, mapping the existing smoke-test B2 secrets. Deliberately **not** per-PR (each run creates/deletes a real Object-Lock bucket).

## Verification

`npm test` (494 unit, pass), lint + format clean, and **both contract tests pass live** against a real account (self-cleaning, no residue).

🤖 Generated with [Claude Code](https://claude.com/claude-code)