### PR TITLE
chore: authorize via b2api/v4 (current, Apr 2025) instead of v3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,17 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.4.4] - 2026-06-09
+
+### Changed
+- `b2_authorize_account` now calls Backblaze's current **v4** endpoint
+  (`/b2api/v4/b2_authorize_account`, April 2025) instead of v3. Verified live
+  that a v4 token is accepted at the `b2api/v2` and `b2api/v3` endpoint paths,
+  so the B2 native API plus the Partner (Groups) and Backup APIs all continue
+  to work. v4 restructured the `allowed` field for Multi-Bucket Application
+  Keys (`allowed.buckets[]`); we only consume `apiInfo.storageApi`, which is
+  unchanged from v3, so the bump is transparent to every tool.
+
 ## [1.4.3] - 2026-06-09
 
 ### Fixed

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backblaze/b2-mcp-server",
-  "version": "1.4.3",
+  "version": "1.4.4",
   "description": "MCP server for Backblaze B2 — full B2 native API + S3-compatible API coverage",
   "main": "dist/index.js",
   "bin": {

--- a/src/auth.ts
+++ b/src/auth.ts
@@ -6,10 +6,16 @@ import { buildUserAgent } from "./utils/user-agent.js";
 /** Timeout for the authorize_account request. */
 const AUTH_TIMEOUT_MS = 30_000;
 
-// v3 is required: Partner API (Groups) and Backup API endpoints reject v2 tokens.
-const AUTH_URL = "https://api.backblazeb2.com/b2api/v3/b2_authorize_account";
+// v4 is Backblaze's current authorize_account (April 2025). A v4 token is accepted
+// at the v2 and v3 endpoint paths the tools use (verified live: a v4 token succeeds
+// on b2api/v2 and b2api/v3 calls), so this covers the B2 native API plus the Partner
+// (Groups) and Backup APIs. v2 must NOT be used — Partner/Backup endpoints reject v2
+// tokens. v4 also restructured the `allowed` field for Multi-Bucket Application Keys
+// (`allowed.buckets[]` instead of a single bucketId/bucketName); we only consume
+// `apiInfo.storageApi`, which is unchanged from v3, so that restructure is transparent.
+const AUTH_URL = "https://api.backblazeb2.com/b2api/v4/b2_authorize_account";
 
-interface B2V3AuthResponse {
+interface B2AuthorizeResponse {
   accountId: string;
   authorizationToken: string;
   apiInfo: {
@@ -89,7 +95,7 @@ export class B2AuthManager {
     ).toString("base64");
 
     const response = await withRetry(() =>
-      axios.get<B2V3AuthResponse>(AUTH_URL, {
+      axios.get<B2AuthorizeResponse>(AUTH_URL, {
         headers: {
           Authorization: `Basic ${credentials}`,
           "User-Agent": buildUserAgent(this.config),
@@ -98,15 +104,15 @@ export class B2AuthManager {
       }),
     );
 
-    const v3 = response.data;
+    const data = response.data;
     this.cachedAuth = {
-      accountId: v3.accountId,
-      authorizationToken: v3.authorizationToken,
-      apiUrl: v3.apiInfo.storageApi.apiUrl,
-      downloadUrl: v3.apiInfo.storageApi.downloadUrl,
-      s3ApiUrl: v3.apiInfo.storageApi.s3ApiUrl,
-      recommendedPartSize: v3.apiInfo.storageApi.recommendedPartSize,
-      absoluteMinimumPartSize: v3.apiInfo.storageApi.absoluteMinimumPartSize,
+      accountId: data.accountId,
+      authorizationToken: data.authorizationToken,
+      apiUrl: data.apiInfo.storageApi.apiUrl,
+      downloadUrl: data.apiInfo.storageApi.downloadUrl,
+      s3ApiUrl: data.apiInfo.storageApi.s3ApiUrl,
+      recommendedPartSize: data.apiInfo.storageApi.recommendedPartSize,
+      absoluteMinimumPartSize: data.apiInfo.storageApi.absoluteMinimumPartSize,
     };
     this.authTime = Date.now();
     return this.cachedAuth;

--- a/tests/unit/auth.test.ts
+++ b/tests/unit/auth.test.ts
@@ -20,7 +20,7 @@ const mockConfig: B2Config = {
   fileRoot: null,
 };
 
-// v3 b2_authorize_account response shape — auth manager flattens this internally
+// v4 b2_authorize_account response shape (apiInfo.storageApi) — auth manager flattens this internally
 const mockAuthResponse = {
   accountId: "test-account-id",
   authorizationToken: "test-auth-token",


### PR DESCRIPTION
## What

`b2_authorize_account` now calls Backblaze's **current v4** endpoint (`/b2api/v4/b2_authorize_account`, April 2025) instead of v3 — a one-line change to `AUTH_URL`, plus a version-agnostic rename of the response interface.

## Why it's safe (verified live)

- A **v4 token is accepted at the `b2api/v2` and `b2api/v3` endpoint paths** the tools use — confirmed live: a v4 token succeeded on `b2api/v2/b2_list_buckets` and `b2api/v3/b2_list_buckets`.
- The Partner `b2_list_groups` 401 is an **account-entitlement** gate, **identical with v3 and v4 tokens** — not a token-version issue. So Partner/Backup tools are unaffected.
- v4 restructured the `allowed` field for **Multi-Bucket Application Keys** (`allowed.buckets[]` vs single `bucketId`/`bucketName`), but the code only consumes `apiInfo.storageApi`, which is **unchanged from v3** — so the bump is transparent to every tool.
- Verified against backblaze.com (v4 dated April 24, 2025) and against a live account (built server authorizes via v4 → lists buckets).

## Verification

`npm test` (494 pass), lint + format clean; built server authorizes via v4 and lists buckets live. Bump 1.4.3 → 1.4.4.

🤖 Generated with [Claude Code](https://claude.com/claude-code)