### PR TITLE
fix: copy_file destination SSE, upload_part_copy versionId, update_bucket Object Lock retrofit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,26 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.4.5] - 2026-06-09
+
+### Fixed
+- `b2_copy_file` sent the destination encryption settings under the wrong field
+  name `serverSideEncryption`, which B2 rejects outright
+  (`400 unknown field … B2CopyFileRequest: serverSideEncryption`) — so an
+  encrypted copy failed entirely. Renamed to the documented
+  `destinationServerSideEncryption`. Verified live.
+- `s3_upload_part_copy` declared a `copySourceVersionId` argument but never
+  applied it, silently copying the *current* version. It is now folded into
+  `CopySource` as `?versionId=…` (matching `s3_copy_object`).
+
+### Added
+- `b2_update_bucket` now supports `fileLockEnabled` and `defaultRetention`.
+  B2's **native** API allows enabling Object Lock on an **existing** bucket
+  (unlike the S3 `PutObjectLockConfiguration` path, which only enables it at
+  creation) — verified live, including reading the default retention back. The
+  `b2_create_bucket` description that wrongly claimed Object Lock could *only*
+  be enabled at creation has been corrected.
+
 ## [1.4.4] - 2026-06-09
 
 ### Changed

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backblaze/b2-mcp-server",
-  "version": "1.4.4",
+  "version": "1.4.5",
   "description": "MCP server for Backblaze B2 — full B2 native API + S3-compatible API coverage",
   "main": "dist/index.js",
   "bin": {

--- a/src/b2/buckets.ts
+++ b/src/b2/buckets.ts
@@ -84,8 +84,8 @@ export function registerBucketTools(
         .boolean()
         .optional()
         .describe(
-          "Enable Object Lock (file lock) on the bucket. Can only be set at creation — B2 " +
-            "rejects enabling Object Lock on an existing bucket. Must be true before any " +
+          "Enable Object Lock (file lock) on the bucket at creation. (Object Lock can also be " +
+            "enabled later on an existing bucket via b2_update_bucket.) Must be true before any " +
             "retention or legal hold can be applied to files in this bucket.",
         ),
     },
@@ -192,6 +192,35 @@ export function registerBucketTools(
             .optional(),
         })
         .optional(),
+      fileLockEnabled: z
+        .boolean()
+        .optional()
+        .describe(
+          "Enable Object Lock on the bucket. Unlike S3's PutObjectLockConfiguration (which only " +
+            "enables lock at bucket creation), the B2 native API allows enabling Object Lock on an " +
+            "existing bucket here. Requires the writeBucketRetentions capability.",
+        ),
+      defaultRetention: z
+        .object({
+          mode: z
+            .enum(["governance", "compliance"])
+            .nullable()
+            .describe("Retention mode applied to new objects. null clears the default."),
+          period: z
+            .object({
+              duration: z.number().int().positive(),
+              unit: z.enum(["days", "years"]),
+            })
+            .nullable()
+            .describe(
+              "Retention period, e.g. { duration: 7, unit: 'days' }. null clears the default.",
+            ),
+        })
+        .optional()
+        .describe(
+          "Default Object Lock retention for newly uploaded objects. Requires Object Lock enabled " +
+            "on the bucket. Send { mode: null, period: null } to clear.",
+        ),
       ifRevisionIs: z
         .number()
         .optional()
@@ -211,6 +240,8 @@ export function registerBucketTools(
           "lifecycleRules",
           "defaultServerSideEncryption",
           "replicationConfiguration",
+          "fileLockEnabled",
+          "defaultRetention",
           "ifRevisionIs",
         ] as const;
         for (const key of optional) {

--- a/src/b2/files.ts
+++ b/src/b2/files.ts
@@ -543,14 +543,18 @@ export function registerFileTools(
         .record(z.string(), z.string())
         .optional()
         .describe("New file info (only used when metadataDirective is REPLACE)."),
-      serverSideEncryption: z
+      destinationServerSideEncryption: z
         .object({
           mode: z.enum(["SSE-B2", "SSE-C"]),
           algorithm: z.string().optional(),
           customerKey: z.string().optional(),
           customerKeyMd5: z.string().optional(),
         })
-        .optional(),
+        .optional()
+        .describe(
+          "Server-side encryption for the destination copy. B2's b2_copy_file request names " +
+            "this field 'destinationServerSideEncryption' (not 'serverSideEncryption').",
+        ),
       sourceServerSideEncryption: z
         .object({
           mode: z.enum(["SSE-C"]),
@@ -573,7 +577,7 @@ export function registerFileTools(
           "range",
           "contentType",
           "fileInfo",
-          "serverSideEncryption",
+          "destinationServerSideEncryption",
           "sourceServerSideEncryption",
         ] as const;
         for (const key of optional) {

--- a/src/s3/extras.ts
+++ b/src/s3/extras.ts
@@ -246,13 +246,18 @@ export function registerS3ExtraTools(server: McpServer, s3: S3Client): void {
     },
     async (args) => {
       try {
+        // Fold the source version into CopySource (same form as s3_copy_object); without
+        // this the declared copySourceVersionId was silently dropped and the live version copied.
+        const copySource = args.copySourceVersionId
+          ? `${args.copySource}?versionId=${args.copySourceVersionId}`
+          : args.copySource;
         const result = await s3.send(
           new UploadPartCopyCommand({
             Bucket: args.bucket,
             Key: args.key,
             UploadId: args.uploadId,
             PartNumber: args.partNumber,
-            CopySource: args.copySource,
+            CopySource: copySource,
             CopySourceRange: args.copySourceRange,
           }),
         );

--- a/tests/integration/contract.test.ts
+++ b/tests/integration/contract.test.ts
@@ -188,3 +188,100 @@ describe("Contract: notification rules objectNamePrefix", () => {
     30_000,
   );
 });
+
+// ── b2_copy_file destination encryption field name ────────────────────────────
+describe("Contract: b2_copy_file destination SSE", () => {
+  liveIt(
+    "copies with destinationServerSideEncryption (B2 rejects the old 'serverSideEncryption' name)",
+    async () => {
+      if (!writableBucketId) {
+        console.log("  No writable bucket; skipping.");
+        return;
+      }
+      let origId = "";
+      let copyId = "";
+      try {
+        const up = parseResult(
+          await callTool(server, "b2_upload_file", {
+            bucketId: writableBucketId,
+            fileName: "__contract/copy-src.txt",
+            content: Buffer.from("copy-sse").toString("base64"),
+            contentType: "text/plain",
+          }),
+        );
+        expect(isError(up)).toBe(false);
+        origId = up.fileId;
+
+        const copy = await callTool(server, "b2_copy_file", {
+          sourceFileId: origId,
+          fileName: "__contract/copy-dst.txt",
+          destinationServerSideEncryption: { mode: "SSE-B2", algorithm: "AES256" },
+        });
+        // Regression guard: the old 'serverSideEncryption' name returns
+        // 400 "unknown field ... B2CopyFileRequest: serverSideEncryption".
+        expect(isError(copy)).toBe(false);
+        const copied = parseResult(copy);
+        copyId = copied.fileId;
+        expect(
+          copied.serverSideEncryption?.mode ?? copied.serverSideEncryption?.algorithm,
+        ).toBeTruthy();
+      } finally {
+        if (copyId)
+          await callTool(server, "b2_delete_file_version", {
+            fileName: "__contract/copy-dst.txt",
+            fileId: copyId,
+          });
+        if (origId)
+          await callTool(server, "b2_delete_file_version", {
+            fileName: "__contract/copy-src.txt",
+            fileId: origId,
+          });
+      }
+    },
+    60_000,
+  );
+});
+
+// ── b2_update_bucket Object Lock retrofit + defaultRetention ───────────────────
+describe("Contract: b2_update_bucket Object Lock retrofit", () => {
+  liveIt(
+    "enables Object Lock on an existing bucket and sets defaultRetention via b2_update_bucket",
+    async () => {
+      const bucketName = `mcp-contract-retrofit-${Date.now().toString(36)}`;
+      let bucketId = "";
+      try {
+        const created = parseResult(
+          await callTool(server, "b2_create_bucket", { bucketName, bucketType: "allPrivate" }),
+        );
+        if (isError(created)) {
+          console.log("  Could not create bucket; skipping:", errText(created));
+          return;
+        }
+        bucketId = created.bucketId;
+        expect(created.fileLockConfiguration?.value?.isFileLockEnabled).toBe(false);
+
+        // Retrofit: enable Object Lock on the EXISTING bucket (native API allows this).
+        const enabled = await callTool(server, "b2_update_bucket", {
+          bucketId,
+          fileLockEnabled: true,
+        });
+        expect(isError(enabled)).toBe(false);
+        expect(parseResult(enabled).fileLockConfiguration?.value?.isFileLockEnabled).toBe(true);
+
+        // Set the bucket default retention and confirm it took.
+        const retained = await callTool(server, "b2_update_bucket", {
+          bucketId,
+          defaultRetention: { mode: "governance", period: { duration: 7, unit: "days" } },
+        });
+        expect(isError(retained)).toBe(false);
+        const back = parseResult(await callTool(server, "b2_list_buckets", { bucketId })).buckets[0]
+          .fileLockConfiguration?.value?.defaultRetention;
+        expect(back?.mode).toBe("governance");
+        expect(back?.period).toEqual({ duration: 7, unit: "days" });
+      } finally {
+        if (bucketId) await callTool(server, "b2_delete_bucket", { bucketId });
+      }
+    },
+    90_000,
+  );
+});

--- a/tests/unit/b2-tools.test.ts
+++ b/tests/unit/b2-tools.test.ts
@@ -174,7 +174,7 @@ describe("b2_create_bucket", () => {
     );
   });
 
-  it("forwards fileLockEnabled when set (Object Lock can only be enabled at creation)", async () => {
+  it("forwards fileLockEnabled when set (Object Lock enabled at creation)", async () => {
     await callTool(server, "b2_create_bucket", {
       bucketName: "locked-bucket",
       bucketType: "allPrivate",
@@ -324,6 +324,19 @@ describe("b2_copy_file", () => {
     );
     expect(result.fileId).toBe("copy-001");
     expect(result.fileName).toBe("photo-copy.jpg");
+  });
+
+  it("forwards destination SSE under B2's field name 'destinationServerSideEncryption'", async () => {
+    await callTool(server, "b2_copy_file", {
+      sourceFileId: "file-001",
+      fileName: "photo-copy.jpg",
+      destinationServerSideEncryption: { mode: "SSE-B2" },
+    });
+    const data = (mockedAxios.mock.calls[0][0] as unknown as { data: Record<string, unknown> })
+      .data;
+    // B2 rejects 'serverSideEncryption' on b2_copy_file with 400 unknown field.
+    expect(data).toHaveProperty("destinationServerSideEncryption", { mode: "SSE-B2" });
+    expect(data).not.toHaveProperty("serverSideEncryption");
   });
 });
 
@@ -598,6 +611,21 @@ describe("b2_update_bucket", () => {
     });
     expect(mockedAxios).toHaveBeenCalledWith(
       expect.objectContaining({ data: expect.objectContaining({ bucketType: "allPrivate" }) }),
+    );
+  });
+
+  it("enables Object Lock on an existing bucket (B2 native allows the retrofit)", async () => {
+    await callTool(server, "b2_update_bucket", { bucketId: "bucket-001", fileLockEnabled: true });
+    expect(mockedAxios).toHaveBeenCalledWith(
+      expect.objectContaining({ data: expect.objectContaining({ fileLockEnabled: true }) }),
+    );
+  });
+
+  it("forwards defaultRetention with the flat { mode, period } shape", async () => {
+    const defaultRetention = { mode: "governance", period: { duration: 7, unit: "days" } };
+    await callTool(server, "b2_update_bucket", { bucketId: "bucket-001", defaultRetention });
+    expect(mockedAxios).toHaveBeenCalledWith(
+      expect.objectContaining({ data: expect.objectContaining({ defaultRetention }) }),
     );
   });
 });

--- a/tests/unit/s3-tools.test.ts
+++ b/tests/unit/s3-tools.test.ts
@@ -890,6 +890,19 @@ describe("s3_upload_part_copy", () => {
     expect(cmd.input.UploadId).toBe("upload-xyz");
     expect(cmd.input.CopySource).toBe("src-bucket/chunk.bin");
   });
+
+  it("folds copySourceVersionId into CopySource (was previously dropped)", async () => {
+    await callTool(server, "s3_upload_part_copy", {
+      bucket: "dst-bucket",
+      key: "assembled.bin",
+      uploadId: "upload-xyz",
+      partNumber: 1,
+      copySource: "src-bucket/chunk.bin",
+      copySourceVersionId: "ver-42",
+    });
+    const cmd = sendSpy.mock.calls[0][0];
+    expect(cmd.input.CopySource).toBe("src-bucket/chunk.bin?versionId=ver-42");
+  });
 });
 
 // ── s3_put_bucket_acl ─────────────────────────────────────────────────────────


### PR DESCRIPTION
First of four audit-remediation PRs (PR A — the confirmed correctness bugs). Every fix was verified against the live B2 API.

## Bugs fixed

1. **`b2_copy_file` destination encryption was broken.** It sent `serverSideEncryption`; B2 rejects that with `400 unknown field … B2CopyFileRequest: serverSideEncryption` — so any encrypted copy failed outright. Renamed to the documented **`destinationServerSideEncryption`**. (Same wrong-shape family as the notification `objectNamePrefix` and retention/legal-hold fixes.) *Live-verified: old name → 400; new name accepted.*

2. **`s3_upload_part_copy` silently dropped `copySourceVersionId`.** The schema declared it; the handler never used it → it copied the *current* version. Now folded into `CopySource` as `?versionId=…`, matching `s3_copy_object`.

3. **`b2_update_bucket` couldn't enable Object Lock or set default retention.** B2's **native** API *does* allow enabling Object Lock on an **existing** bucket (the S3 `PutObjectLockConfiguration` path rejects it — which is what misled an earlier conclusion). Added `fileLockEnabled` + `defaultRetention`. *Live-verified: retrofit enables lock on an existing bucket, and `defaultRetention { mode, period:{duration,unit} }` round-trips via `b2_list_buckets`.* Also corrected the `b2_create_bucket` description that wrongly said lock could only be enabled at creation.

## Tests
- Unit: outgoing-payload assertions for all three (copy_file `destinationServerSideEncryption`, upload_part_copy `?versionId=`, update_bucket `fileLockEnabled`/`defaultRetention`).
- `contract.test.ts` extended with **live** round-trips for copy_file destination SSE and the update_bucket Object-Lock retrofit + defaultRetention — both pass against a real account.
- 498 unit tests pass; lint + format clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)