### PR TITLE
feat: application-key-first credential model, master key optional

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,30 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.5.0] - 2026-06-09
+
+### Changed
+- **Credential model: application key first, master key optional.** The
+  application key (`B2_APPLICATION_KEY_ID`/`KEY`, `X-B2-Key-*`) is now the single
+  workhorse for the B2 native API, S3, **and** key management — a non-master key
+  covers everything except the Partner API and `bz_*` Computer Backup. Those two
+  families use an optional, separately-labeled master key
+  (`B2_MASTER_KEY_ID`/`KEY`, `X-B2-Master-Key-*`), routed to them internally and
+  falling back to the application key when unset. So the common case is one key
+  with no S3 second-key dance, and the powerful master key is loaded only by the
+  handful of admin tools.
+- Corrected the docs: key management (`b2_create_key`/`list_keys`/`delete_key`)
+  needs the `writeKeys`/`listKeys`/`deleteKeys` capabilities, **not** a master
+  key (verified live — a non-master key created and deleted a key). The README
+  and CLAUDE.md previously overstated this.
+
+### Deprecated
+- `B2_APP_KEY_ID`/`B2_APP_KEY` and `X-B2-App-Key-*` — the legacy non-master S3
+  override that existed only because the primary slot could hold a master key.
+  The model is now reversed; these still work for one release (with a
+  deprecation warning). Use a non-master application key as the primary and
+  `B2_MASTER_KEY_*` for Partner/`bz_*`.
+
 ## [1.4.5] - 2026-06-09
 
 ### Fixed

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -24,15 +24,15 @@ Run a single test by name:
 npx jest --testNamePattern="should cache the token"
 ```
 
-Integration tests require env vars. A single application key works for both B2 native and S3 tools. A master key is only needed if you also want to exercise Partner API, `bz_*`, or account-level key-management tests — in that case set `B2_APP_KEY_ID` / `B2_APP_KEY` to a non-master key for S3 (master keys are rejected by the S3 endpoint):
+Integration tests require env vars. A single non-master application key works for B2 native, S3, **and** key management (`b2_create_key`/`list_keys`/`delete_key` only need `writeKeys`/`listKeys`/`deleteKeys`). A master key is only needed to exercise the Partner API or `bz_*` tests — set `B2_MASTER_KEY_ID` / `B2_MASTER_KEY` for those (the master key is used only by those tools; the application key drives everything else):
 
 ```bash
-# Most users — one application key:
+# Most users — one (non-master) application key covers native + S3 + key mgmt:
 B2_APPLICATION_KEY_ID=xxx B2_APPLICATION_KEY=yyy npm run test:integration
 
-# Master-key flows (Partner API, bz_*, key management) + S3:
-B2_APPLICATION_KEY_ID=master_id B2_APPLICATION_KEY=master_secret \
-B2_APP_KEY_ID=appkey_id B2_APP_KEY=appkey_secret \
+# Add a master key ONLY for Partner API / bz_* flows:
+B2_APPLICATION_KEY_ID=appkey_id B2_APPLICATION_KEY=appkey_secret \
+B2_MASTER_KEY_ID=master_id B2_MASTER_KEY=master_secret \
 npm run test:integration
 ```
 
@@ -56,7 +56,9 @@ Each register function receives the server + client(s) and calls `server.tool(na
 
 **B2 native API** (`src/b2/`): Uses `B2Client` which wraps axios. All calls go through `B2Client.call()`, which injects the auth token and retries on 401 by calling `auth.invalidate()` then re-authorizing. The `apiPath` option switches between `b2api/v2` (default), `b2api/v3` (Partner API), and `api/backup/v1` (Backup/Computer API).
 
-**S3-compatible API** (`src/s3/`): Uses AWS SDK v3 `S3Client` configured to point at B2's S3 endpoint. B2 rejects **master** keys on the S3 endpoint, but ordinary application keys are accepted. By default the S3 client uses `B2_APPLICATION_KEY_ID` / `B2_APPLICATION_KEY` — which works as long as that's a non-master key. If the primary credential is a master key, set `B2_APP_KEY_ID` / `B2_APP_KEY` to a non-master application key so the S3 client can authenticate.
+**S3-compatible API** (`src/s3/`): Uses AWS SDK v3 `S3Client` configured to point at B2's S3 endpoint. B2 rejects **master** keys on the S3 endpoint, but ordinary application keys are accepted — which is why the application key (`B2_APPLICATION_KEY_ID` / `B2_APPLICATION_KEY`) is the primary credential and signs S3 requests. (The deprecated `B2_APP_KEY_ID` / `B2_APP_KEY` override remains only for legacy setups whose application key is a master key.)
+
+**Credential routing** (`createServer` in `server.ts`): the application key drives the B2 native API, S3, and key management. Only the Partner API and `bz_*` tools use the master key — `createServer` builds a second `B2Client` from `B2_MASTER_KEY_*` and wires it into `registerPartnerTools`, falling back to the application-key client when no distinct master key is set.
 
 ### Auth token lifecycle (`src/auth.ts`)
 
@@ -94,11 +96,11 @@ Integration tests (`tests/integration/live.test.ts`) use these skip guards:
 - `partnerIt` — skips unless `B2_PARTNER_LIVE=1` **and** the primary key is a master key on a Partner-API-entitled account. Runs the read-only Groups flow (`b2_list_groups → b2_list_group_members`); bails gracefully if the account isn't entitled.
 - The mutating Groups test (`create_group_member → eject`) is additionally gated on `B2_PARTNER_MUTATE=1` + `B2_PARTNER_TEST_EMAIL`, and skipped by default — `b2_create_group_member` creates a **real, non-deletable** Backblaze account that eject does not remove, so it must never run in CI.
 
-To run the Partner Groups test, the primary key must be a **master** key (Partner endpoints reject non-master keys); set `B2_APP_KEY_ID`/`B2_APP_KEY` to a non-master key so S3 tests still work in the same run:
+To run the Partner Groups test, supply a **master** key via `B2_MASTER_KEY_*` (Partner endpoints reject non-master keys); the application key stays non-master so native + S3 tests still work in the same run:
 
 ```bash
-B2_APPLICATION_KEY_ID=master_id B2_APPLICATION_KEY=master_secret \
-B2_APP_KEY_ID=appkey_id B2_APP_KEY=appkey_secret \
+B2_APPLICATION_KEY_ID=appkey_id B2_APPLICATION_KEY=appkey_secret \
+B2_MASTER_KEY_ID=master_id B2_MASTER_KEY=master_secret \
 B2_PARTNER_LIVE=1 npm run test:integration
 ```
 
@@ -118,7 +120,7 @@ Client config notes:
 - **Claude Desktop** (`claude_desktop_config.json`) only accepts stdio entries. To connect to a hosted SSE server, use the `mcp-remote` bridge as a local stdio shim (`command: "npx"`, `args: ["-y", "mcp-remote", "<url>", "--header", "X-B2-Key-Id:…", "--header", "X-B2-Key:…"]`). The URL + headers shape is rejected by Claude Desktop with "not a valid MCP server configuration."
 - **Claude.ai web / Pro / Max Custom Connectors** accept the URL + headers shape directly: `{ url, headers: { "X-B2-Key-Id": "…", "X-B2-Key": "…" } }`.
 
-`X-B2-Key-Id` / `X-B2-Key` are required (any application key — used for B2 native API calls, and also the S3 client unless overridden). `X-B2-App-Key-Id` / `X-B2-App-Key` are optional non-master application key credentials for the S3-compatible API; they only need to be set when `X-B2-Key-Id` is a **master** key, because B2 rejects master keys on the S3 endpoint. Master keys are only required for Partner API, `bz_*` Computer Backup tools, and account-level key management.
+`X-B2-Key-Id` / `X-B2-Key` are required — the application key, used for B2 native, S3, and key management. `X-B2-Master-Key-Id` / `X-B2-Master-Key` are optional and used **only** by the Partner API and `bz_*` tools (they fall back to the application key when absent). `X-B2-App-Key-Id` / `X-B2-App-Key` are the deprecated legacy non-master S3 override, kept only for setups whose `X-B2-Key-Id` is a master key.
 
 ## Deployment target
 

--- a/README.md
+++ b/README.md
@@ -54,9 +54,11 @@ Replace `/ABSOLUTE/PATH/TO/b2-mcp-server` with the actual path where you cloned 
 
 Restart Claude Desktop — you should see the B2 tools available in Claude.
 
-> **A single application key is enough for most users.** Create one in the B2 Console under **Application Keys** and use it for `B2_APPLICATION_KEY_ID` / `B2_APPLICATION_KEY`. It will work for both the B2 native API and the S3-compatible API.
+> **A single application key is enough for almost everything.** Create one in the B2 Console under **Application Keys** and use it for `B2_APPLICATION_KEY_ID` / `B2_APPLICATION_KEY`. A non-master key works for the B2 native API, the S3-compatible API, **and** key management (`b2_create_key` / `b2_list_keys` / `b2_delete_key`, which just need the `writeKeys` / `listKeys` / `deleteKeys` capabilities — not a master key).
 >
-> **When you need a master key:** only the [Partner API](#partner-api-requires-master-key), the Backblaze Computer Backup tools (`bz_*`), and account-level key management (`b2_create_key`, `b2_list_keys`, `b2_delete_key`) require the master application key. If you use those, set `B2_APPLICATION_KEY_ID` / `B2_APPLICATION_KEY` to the master key, then **also** set `B2_APP_KEY_ID` / `B2_APP_KEY` to a non-master application key — B2's S3 endpoint rejects master keys, so S3 tools need a separate key in that setup.
+> **When you need a master key (optional):** only the [Partner API](#partner-api-requires-master-key) and the Backblaze Computer Backup tools (`bz_*`) require a master application key. Set `B2_MASTER_KEY_ID` / `B2_MASTER_KEY` for those — the master key is used **only** by those tools, while everything else keeps using your application key. (B2's S3 endpoint rejects master keys, which is exactly why the application key, not the master key, is the primary credential.)
+>
+> _Deprecated:_ `B2_APP_KEY_ID` / `B2_APP_KEY` was the old way to supply a separate non-master S3 key when the primary key was a master key. The model is now reversed — make the application key your non-master workhorse and use `B2_MASTER_KEY_*` only for Partner/`bz_*`. The old variables still work for one release.
 
 ### Cursor / VS Code
 
@@ -80,16 +82,18 @@ Add to `.cursor/mcp.json` in your project root:
 
 ## Environment Variables
 
-| Variable                  | Required | Default                 | Description                                                                                                     |
-| ------------------------- | -------- | ----------------------- | --------------------------------------------------------------------------------------------------------------- |
-| `B2_APPLICATION_KEY_ID`   | ✅       | —                       | Application key ID (master or non-master). Used for B2 native + S3 API                                          |
-| `B2_APPLICATION_KEY`      | ✅       | —                       | Application key secret                                                                                          |
-| `B2_APP_KEY_ID`           | —        | falls back to the above | Non-master application key ID — only set when the primary key is a master key (S3 endpoint rejects master keys) |
-| `B2_APP_KEY`              | —        | falls back to the above | Non-master application key secret                                                                               |
-| `B2_REGION`               | —        | `us-west-004`           | B2 region for S3-compatible endpoint                                                                            |
-| `B2_LARGE_FILE_THRESHOLD` | —        | `104857600` (100MB)     | File size above which multipart upload is used                                                                  |
-| `B2_PART_SIZE`            | —        | `104857600` (100MB)     | Size of each multipart upload part                                                                              |
-| `B2_MCP_UA_SUFFIX`        | —        | —                       | Optional token appended to the outbound User-Agent (e.g. to tag a deployment)                                   |
+| Variable                  | Required | Default               | Description                                                                                                 |
+| ------------------------- | -------- | --------------------- | ----------------------------------------------------------------------------------------------------------- |
+| `B2_APPLICATION_KEY_ID`   | ✅       | —                     | Application key ID (non-master). The workhorse: B2 native + S3 + key management                             |
+| `B2_APPLICATION_KEY`      | ✅       | —                     | Application key secret                                                                                      |
+| `B2_MASTER_KEY_ID`        | —        | falls back to app key | Master key ID — used **only** by the Partner API and `bz_*` Computer Backup tools                           |
+| `B2_MASTER_KEY`           | —        | falls back to app key | Master key secret                                                                                           |
+| `B2_APP_KEY_ID`           | —        | _deprecated_          | Legacy non-master S3 override (only for setups whose primary key is a master key). Prefer `B2_MASTER_KEY_*` |
+| `B2_APP_KEY`              | —        | _deprecated_          | Legacy non-master S3 override secret                                                                        |
+| `B2_REGION`               | —        | `us-west-004`         | B2 region for S3-compatible endpoint                                                                        |
+| `B2_LARGE_FILE_THRESHOLD` | —        | `104857600` (100MB)   | File size above which multipart upload is used                                                              |
+| `B2_PART_SIZE`            | —        | `104857600` (100MB)   | Size of each multipart upload part                                                                          |
+| `B2_MCP_UA_SUFFIX`        | —        | —                     | Optional token appended to the outbound User-Agent (e.g. to tag a deployment)                               |
 
 > Security/hardening vars (`B2_FILE_ROOT`, `B2_ALLOW_LOCAL_FILES`, `B2_MAX_SESSIONS`, `B2_ALLOWED_HOSTS`/`B2_ALLOWED_ORIGINS`) are documented in [`docs/DEPLOY.md`](docs/DEPLOY.md).
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backblaze/b2-mcp-server",
-  "version": "1.4.5",
+  "version": "1.5.0",
   "description": "MCP server for Backblaze B2 — full B2 native API + S3-compatible API coverage",
   "main": "dist/index.js",
   "bin": {

--- a/src/b2/partner.ts
+++ b/src/b2/partner.ts
@@ -7,7 +7,12 @@ import { toolJson, toolError } from "../utils/errors.js";
 /**
  * Partner API tools — Group management, trial account provisioning, and
  * computer backup management. These endpoints require the admin account to
- * be authorized for the Partner API.
+ * be authorized for the Partner API and a MASTER application key.
+ *
+ * `client` here is the master-key B2Client wired up in createServer (it falls
+ * back to the application-key client when no distinct master key is set). These
+ * are the only tools that use the master key; everything else uses the
+ * application key.
  *
  * Group endpoints use /b2api/v3/
  * Backup (bz_*) endpoints use /api/backup/v1/

--- a/src/http-server.ts
+++ b/src/http-server.ts
@@ -3,10 +3,12 @@
  * Backblaze B2 MCP Server — HTTP + SSE transport entry point.
  *
  * Credentials are read per-connection from request headers:
- *   X-B2-Key-Id       — B2 key ID (master or application key)
- *   X-B2-Key          — B2 key secret
- *   X-B2-App-Key-Id   — non-master application key ID for S3-compatible API (optional)
- *   X-B2-App-Key      — non-master application key secret for S3-compatible API (optional)
+ *   X-B2-Key-Id          — application key ID (the workhorse: native + S3 + key mgmt)
+ *   X-B2-Key             — application key secret
+ *   X-B2-Master-Key-Id   — master key ID, ONLY for Partner API + bz_* tools (optional)
+ *   X-B2-Master-Key      — master key secret (optional)
+ *   X-B2-App-Key-Id      — DEPRECATED non-master S3 override for legacy master-primary setups
+ *   X-B2-App-Key         — DEPRECATED (see above)
  *
  * The server listens on:
  *   GET  /sse      — SSE event stream for server-to-client messages
@@ -79,11 +81,19 @@ export function configFromHeaders(req: { headers: http.IncomingHttpHeaders }): B
   const appKey = req.headers["x-b2-app-key"];
   const resolvedAppKeyId = !Array.isArray(appKeyId) && appKeyId ? appKeyId : keyId;
   const resolvedAppKey = !Array.isArray(appKey) && appKey ? appKey : key;
+  // Optional master key — used only by the Partner API and bz_* tools. Falls
+  // back to the application key, so a single key remains a complete config.
+  const masterKeyId = req.headers["x-b2-master-key-id"];
+  const masterKey = req.headers["x-b2-master-key"];
+  const resolvedMasterKeyId = !Array.isArray(masterKeyId) && masterKeyId ? masterKeyId : keyId;
+  const resolvedMasterKey = !Array.isArray(masterKey) && masterKey ? masterKey : key;
   return {
     applicationKeyId: keyId,
     applicationKey: key,
     appKeyId: resolvedAppKeyId,
     appKey: resolvedAppKey,
+    masterKeyId: resolvedMasterKeyId,
+    masterKey: resolvedMasterKey,
     region: process.env.B2_REGION ?? DEFAULT_REGION,
     largeFileThreshold: parseIntEnv(process.env.B2_LARGE_FILE_THRESHOLD, DEFAULT_PART_SIZE),
     partSize: parseIntEnv(process.env.B2_PART_SIZE, DEFAULT_PART_SIZE),

--- a/src/server.ts
+++ b/src/server.ts
@@ -36,16 +36,35 @@ export function loadConfig(): B2Config {
     process.exit(1);
   }
 
+  // Optional master key — only the Partner API and bz_* tools need it. Falls
+  // back to the application key so a single non-master key is a complete config
+  // for everything else. Require both halves or neither.
+  const masterId = process.env.B2_MASTER_KEY_ID;
+  const masterKey = process.env.B2_MASTER_KEY;
+  if (!!masterId !== !!masterKey) {
+    logger.warn(
+      "config: B2_MASTER_KEY_ID and B2_MASTER_KEY must both be set; ignoring the partial master key and using the application key for Partner/bz_* tools",
+    );
+  }
+  // B2_APP_KEY was the old way to supply a non-master S3 key when the primary
+  // was a master key. The current model is the reverse — make the application
+  // key the (non-master) workhorse and set B2_MASTER_KEY only for Partner/bz_*.
+  if (process.env.B2_APP_KEY_ID) {
+    logger.warn(
+      "config: B2_APP_KEY_ID/B2_APP_KEY is deprecated. Set B2_APPLICATION_KEY_ID to a non-master application key (it handles the S3 API too) and use B2_MASTER_KEY_ID/B2_MASTER_KEY only for Partner/bz_* tools.",
+    );
+  }
+
   return {
     applicationKeyId: keyId,
     applicationKey: key,
-    // S3-compatible API: B2 rejects master keys on the S3 endpoint but
-    // accepts ordinary application keys. By default we reuse the primary
-    // credential — that's fine when it's a non-master key. Set B2_APP_KEY_ID
-    // / B2_APP_KEY to override with a non-master key when the primary is a
-    // master key (needed for Partner API + S3 in the same process).
+    // S3-compatible API: B2 rejects master keys on the S3 endpoint but accepts
+    // ordinary application keys, so this should be the application key. The
+    // deprecated B2_APP_KEY override remains only for legacy master-primary setups.
     appKeyId: process.env.B2_APP_KEY_ID ?? keyId,
     appKey: process.env.B2_APP_KEY ?? key,
+    masterKeyId: (masterId && masterKey ? masterId : undefined) ?? keyId,
+    masterKey: (masterId && masterKey ? masterKey : undefined) ?? key,
     region: process.env.B2_REGION ?? "us-west-004",
     largeFileThreshold: parseIntEnv(process.env.B2_LARGE_FILE_THRESHOLD, 100 * 1024 * 1024),
     partSize: parseIntEnv(process.env.B2_PART_SIZE, 100 * 1024 * 1024),
@@ -69,10 +88,13 @@ export function loadConfig(): B2Config {
  * and logged at startup ("server.ready") rather than tracked here, so this
  * comment can't drift out of date.
  *
- * Note: B2's S3 endpoint rejects master keys. If B2_APPLICATION_KEY_ID is
- * a master key (only needed for Partner API, bz_*, and key-management tools),
- * also set B2_APP_KEY_ID / B2_APP_KEY to a non-master application key for S3.
- * For typical users, a single non-master application key works for everything.
+ * Credential model: B2_APPLICATION_KEY_ID/KEY is the application key — the
+ * workhorse for the B2 native API, S3, and key management. A single non-master
+ * key works for everything except the Partner API and bz_* Computer Backup,
+ * which need a master key — set B2_MASTER_KEY_ID/KEY for those (optional). The
+ * master key is used only by those tools; everything else uses the application
+ * key. (B2's S3 endpoint rejects master keys, which is exactly why the
+ * application key, not the master key, is the primary credential.)
  */
 export function createServer(config: B2Config): McpServer {
   const server = new McpServer(
@@ -105,10 +127,25 @@ export function createServer(config: B2Config): McpServer {
     },
   );
 
-  // Initialize clients
+  // Initialize clients. The application (workhorse) key drives the B2 native
+  // API, S3, and key management. The Partner API and bz_* tools use the master
+  // key; when no distinct master key is configured they fall back to the same
+  // application-key client, so a single non-master key needs no extra wiring.
   const auth = new B2AuthManager(config);
   const b2Client = new B2Client(auth, buildUserAgent(config));
   const s3Client = createS3Client(config);
+
+  const masterIsDistinct = config.masterKeyId !== config.applicationKeyId;
+  const masterAuth = masterIsDistinct
+    ? new B2AuthManager({
+        ...config,
+        applicationKeyId: config.masterKeyId,
+        applicationKey: config.masterKey,
+      })
+    : auth;
+  const masterClient = masterIsDistinct
+    ? new B2Client(masterAuth, buildUserAgent(config))
+    : b2Client;
 
   // ── B2 Native API tools ─────────────────────────────────────────────────
   registerBucketTools(server, b2Client, auth);
@@ -118,8 +155,8 @@ export function createServer(config: B2Config): McpServer {
   registerKeyTools(server, b2Client, auth);
   registerObjectLockTools(server, b2Client);
 
-  // ── Partner API tools ───────────────────────────────────────────────────
-  registerPartnerTools(server, b2Client, auth);
+  // ── Partner API tools (master key) ──────────────────────────────────────
+  registerPartnerTools(server, masterClient, masterAuth);
 
   // ── S3-Compatible API tools ─────────────────────────────────────────────
   registerS3BucketTools(server, s3Client);

--- a/src/utils/types.ts
+++ b/src/utils/types.ts
@@ -1,13 +1,22 @@
 // ── Shared Types ─────────────────────────────────────────────────────────────
 
 export interface B2Config {
+  /** The application key — the workhorse credential. Used for the B2 native API,
+   *  the S3-compatible API, and key management. A non-master key is all most
+   *  users need; it works for everything except the Partner API and `bz_*`. */
   applicationKeyId: string;
   applicationKey: string;
-  /** Application key ID for S3-compatible API calls. Defaults to applicationKeyId.
-   *  Set B2_APP_KEY_ID to a non-master application key to enable S3 tools. */
+  /** Credential the S3-compatible client signs with. Defaults to the application
+   *  key (which is what should be used). The deprecated B2_APP_KEY_ID override
+   *  remains only for legacy setups whose application key is a master key (B2's
+   *  S3 endpoint rejects master keys). */
   appKeyId: string;
-  /** Application key secret for S3-compatible API calls. Defaults to applicationKey. */
   appKey: string;
+  /** Optional master application key, used ONLY by the Partner API and `bz_*`
+   *  Computer Backup tools. Falls back to the application key when unset, so a
+   *  single non-master key remains a complete config for everything else. */
+  masterKeyId: string;
+  masterKey: string;
   region: string;
   largeFileThreshold: number; // bytes
   partSize: number; // bytes

--- a/tests/integration/live.test.ts
+++ b/tests/integration/live.test.ts
@@ -84,6 +84,8 @@ beforeAll(async () => {
         applicationKey: "test",
         appKeyId: "test",
         appKey: "test",
+        masterKeyId: "test",
+        masterKey: "test",
         region: "us-west-004",
         largeFileThreshold: 1e8,
         partSize: 1e8,

--- a/tests/unit/auth.test.ts
+++ b/tests/unit/auth.test.ts
@@ -13,6 +13,8 @@ const mockConfig: B2Config = {
   applicationKey: "test-key-secret",
   appKeyId: "test-app-key-id",
   appKey: "test-app-key-secret",
+  masterKeyId: "test-app-key-secret",
+  masterKey: "test-app-key-secret",
   region: "us-west-004",
   largeFileThreshold: 100 * 1024 * 1024,
   partSize: 100 * 1024 * 1024,

--- a/tests/unit/b2-error-paths.test.ts
+++ b/tests/unit/b2-error-paths.test.ts
@@ -33,6 +33,8 @@ const config: B2Config = {
   applicationKey: "s",
   appKeyId: "k",
   appKey: "s",
+  masterKeyId: "s",
+  masterKey: "s",
   region: "us-west-004",
   largeFileThreshold: 1e8,
   partSize: 1e8,

--- a/tests/unit/b2-tools.test.ts
+++ b/tests/unit/b2-tools.test.ts
@@ -46,6 +46,8 @@ const testConfig = {
   applicationKey: "test-key-secret",
   appKeyId: "test-app-key-id",
   appKey: "test-app-key-secret",
+  masterKeyId: "test-app-key-secret",
+  masterKey: "test-app-key-secret",
   region: "us-west-004",
   largeFileThreshold: 100 * 1024 * 1024,
   partSize: 100 * 1024 * 1024,

--- a/tests/unit/download-stream.test.ts
+++ b/tests/unit/download-stream.test.ts
@@ -37,6 +37,8 @@ const config: B2Config = {
   applicationKey: "s",
   appKeyId: "k",
   appKey: "s",
+  masterKeyId: "s",
+  masterKey: "s",
   region: "us-west-004",
   largeFileThreshold: 1e8,
   partSize: 1e8,

--- a/tests/unit/fs-guard.test.ts
+++ b/tests/unit/fs-guard.test.ts
@@ -15,6 +15,8 @@ const baseConfig: B2Config = {
   applicationKey: "s",
   appKeyId: "k",
   appKey: "s",
+  masterKeyId: "s",
+  masterKey: "s",
   region: "us-west-004",
   largeFileThreshold: 1e8,
   partSize: 1e8,

--- a/tests/unit/http-handler.test.ts
+++ b/tests/unit/http-handler.test.ts
@@ -198,6 +198,45 @@ describe("configFromHeaders — filesystem policy", () => {
   });
 });
 
+describe("configFromHeaders — credential model", () => {
+  it("application key drives native+S3; master falls back to it when unset", () => {
+    const cfg = configFromHeaders({
+      headers: { "x-b2-key-id": "app-id", "x-b2-key": "app-secret" },
+    });
+    expect(cfg?.applicationKeyId).toBe("app-id");
+    expect(cfg?.appKeyId).toBe("app-id"); // S3 uses the application key
+    expect(cfg?.masterKeyId).toBe("app-id"); // master falls back to the application key
+    expect(cfg?.masterKey).toBe("app-secret");
+  });
+
+  it("uses X-B2-Master-Key-* for the master credential when provided", () => {
+    const cfg = configFromHeaders({
+      headers: {
+        "x-b2-key-id": "app-id",
+        "x-b2-key": "app-secret",
+        "x-b2-master-key-id": "master-id",
+        "x-b2-master-key": "master-secret",
+      },
+    });
+    expect(cfg?.applicationKeyId).toBe("app-id"); // workhorse stays the app key
+    expect(cfg?.masterKeyId).toBe("master-id"); // Partner/bz_* use the master key
+    expect(cfg?.masterKey).toBe("master-secret");
+  });
+
+  it("still honors the deprecated X-B2-App-Key-* S3 override", () => {
+    const cfg = configFromHeaders({
+      headers: {
+        "x-b2-key-id": "master-id",
+        "x-b2-key": "master-secret",
+        "x-b2-app-key-id": "s3-id",
+        "x-b2-app-key": "s3-secret",
+      },
+    });
+    expect(cfg?.appKeyId).toBe("s3-id"); // legacy: S3 signs with the non-master override
+    expect(cfg?.applicationKeyId).toBe("master-id");
+  });
+});
+
 describe("deriveRateKey", () => {
   it("is deterministic and distinct per key id", () => {
     expect(deriveRateKey("abc")).toBe(deriveRateKey("abc"));

--- a/tests/unit/large-file-abort.test.ts
+++ b/tests/unit/large-file-abort.test.ts
@@ -35,6 +35,8 @@ function makeConfig(over: Partial<B2Config>): B2Config {
     applicationKey: "test-key-secret",
     appKeyId: "test-app-key-id",
     appKey: "test-app-key-secret",
+    masterKeyId: "test-app-key-secret",
+    masterKey: "test-app-key-secret",
     region: "us-west-004",
     largeFileThreshold: 100 * 1024 * 1024,
     partSize: 100 * 1024 * 1024,

--- a/tests/unit/large-files-coverage.test.ts
+++ b/tests/unit/large-files-coverage.test.ts
@@ -38,6 +38,8 @@ function makeConfig(over: Partial<B2Config> = {}): B2Config {
     applicationKey: "s",
     appKeyId: "k",
     appKey: "s",
+    masterKeyId: "s",
+    masterKey: "s",
     region: "us-west-004",
     largeFileThreshold: 100 * 1024 * 1024,
     partSize: 100 * 1024 * 1024,

--- a/tests/unit/s3-coverage.test.ts
+++ b/tests/unit/s3-coverage.test.ts
@@ -18,6 +18,8 @@ const testConfig: B2Config = {
   applicationKey: "s",
   appKeyId: "k",
   appKey: "s",
+  masterKeyId: "s",
+  masterKey: "s",
   region: "us-west-004",
   largeFileThreshold: 100 * 1024 * 1024,
   partSize: 100 * 1024 * 1024,

--- a/tests/unit/s3-tools.test.ts
+++ b/tests/unit/s3-tools.test.ts
@@ -33,6 +33,8 @@ const testConfig = {
   applicationKey: "test-key-secret",
   appKeyId: "test-app-key-id",
   appKey: "test-app-key-secret",
+  masterKeyId: "test-app-key-secret",
+  masterKey: "test-app-key-secret",
   region: "us-west-004",
   largeFileThreshold: 100 * 1024 * 1024,
   partSize: 100 * 1024 * 1024,

--- a/tests/unit/server-config.test.ts
+++ b/tests/unit/server-config.test.ts
@@ -127,4 +127,37 @@ describe("loadConfig — valid env vars", () => {
     expect(config.applicationKeyId).toBe("key-id-123");
     expect(config.applicationKey).toBe("key-secret-abc");
   });
+
+  describe("master key resolution", () => {
+    afterEach(() => {
+      delete process.env.B2_MASTER_KEY_ID;
+      delete process.env.B2_MASTER_KEY;
+    });
+
+    it("defaults masterKeyId to the application key when B2_MASTER_KEY is unset", async () => {
+      delete process.env.B2_MASTER_KEY_ID;
+      delete process.env.B2_MASTER_KEY;
+      const config = await loadConfig();
+      expect(config.masterKeyId).toBe("key-id-123");
+      expect(config.masterKey).toBe("key-secret-abc");
+    });
+
+    it("uses B2_MASTER_KEY_ID/B2_MASTER_KEY when both are set (Partner/bz_* only)", async () => {
+      process.env.B2_MASTER_KEY_ID = "master-id";
+      process.env.B2_MASTER_KEY = "master-secret";
+      const config = await loadConfig();
+      expect(config.masterKeyId).toBe("master-id");
+      expect(config.masterKey).toBe("master-secret");
+      // The application key stays the workhorse for everything else.
+      expect(config.applicationKeyId).toBe("key-id-123");
+    });
+
+    it("ignores a partial master key (only one half set) and falls back to the application key", async () => {
+      process.env.B2_MASTER_KEY_ID = "master-id";
+      delete process.env.B2_MASTER_KEY;
+      const config = await loadConfig();
+      expect(config.masterKeyId).toBe("key-id-123");
+      expect(config.masterKey).toBe("key-secret-abc");
+    });
+  });
 });

--- a/tests/unit/tools-schema.test.ts
+++ b/tests/unit/tools-schema.test.ts
@@ -50,6 +50,8 @@ beforeAll(() => {
     applicationKey: "test",
     appKeyId: "test",
     appKey: "test",
+    masterKeyId: "test",
+    masterKey: "test",
     region: "us-west-004",
     largeFileThreshold: 1e8,
     partSize: 1e8,

--- a/tests/unit/upload-headers.test.ts
+++ b/tests/unit/upload-headers.test.ts
@@ -25,6 +25,8 @@ const testConfig: B2Config = {
   applicationKey: "test-key-secret",
   appKeyId: "test-app-key-id",
   appKey: "test-app-key-secret",
+  masterKeyId: "test-app-key-secret",
+  masterKey: "test-app-key-secret",
   region: "us-west-004",
   largeFileThreshold: 100 * 1024 * 1024,
   partSize: 100 * 1024 * 1024,


### PR DESCRIPTION
Makes the **application key** the single workhorse and the **master key** a clearly optional, separately-labeled add-on — so the common case is one key, easy to configure.

## Why
We verified against backblaze.com **and live**: a non-master application key (with `writeKeys`/`listKeys`/`deleteKeys`) can create/list/delete keys. So **key management does NOT require a master key** — the docs (and the old model) overstated it. The only things that genuinely need master are the **Partner API** and **`bz_*`** Computer Backup.

The old model put the master key in the *primary* slot when you needed Partner tools, which then broke S3 and forced a confusing second `B2_APP_KEY`. This reverses it.

## Model
- **`B2_APPLICATION_KEY_ID`/`KEY`** (`X-B2-Key-*`) — the workhorse: B2 native + S3 + key management. A non-master key is a complete config for almost everything.
- **`B2_MASTER_KEY_ID`/`KEY`** (`X-B2-Master-Key-*`) — **optional**, used *only* by Partner/`bz_*`. `createServer` builds a second `B2Client` from it and wires it into `registerPartnerTools`, falling back to the application-key client when unset (single-key setups need no extra wiring). Bonus: the powerful master key is loaded only by the handful of admin tools.
- **Deprecated** `B2_APP_KEY_ID`/`KEY` + `X-B2-App-Key-*` — kept working for one release with a warning.

## Verification
- 504 unit tests pass (new `loadConfig` + `configFromHeaders` resolution cases); lint + format clean.
- **Live**: a single non-master App Key did `b2_list_buckets` (native), `s3_list_buckets` (S3), and `b2_create_key`→`b2_delete_key` (key mgmt); Partner `b2_list_groups` reached B2 and returned the expected entitlement 401 (routing unchanged). Fully back-compatible with single-key, new-master, and legacy master+app-key setups.

Docs updated: README (incl. env-var table), CLAUDE.md, and the HTTP header block.

🤖 Generated with [Claude Code](https://claude.com/claude-code)