### PR TITLE
test: harden coverage — 401 re-auth, large-file concurrency, fs-guard/injection guards

### DIFF
--- a/tests/integration/contract.test.ts
+++ b/tests/integration/contract.test.ts
@@ -285,3 +285,64 @@ describe("Contract: b2_update_bucket Object Lock retrofit", () => {
     90_000,
   );
 });
+
+// ── b2_hide_file write shape ──────────────────────────────────────────────────
+describe("Contract: b2_hide_file", () => {
+  liveIt(
+    "hides a file: { bucketId, fileName } is accepted, the name reads as gone, a hide marker appears",
+    async () => {
+      if (!writableBucketId) {
+        console.log("  No writable bucket; skipping.");
+        return;
+      }
+      const fileName = "__contract/hide-me.txt";
+      let uploadId = "";
+      let hideId = "";
+      try {
+        const up = parseResult(
+          await callTool(server, "b2_upload_file", {
+            bucketId: writableBucketId,
+            fileName,
+            content: Buffer.from("hide-test").toString("base64"),
+            contentType: "text/plain",
+          }),
+        );
+        expect(isError(up)).toBe(false);
+        uploadId = up.fileId;
+
+        const hidden = await callTool(server, "b2_hide_file", {
+          bucketId: writableBucketId,
+          fileName,
+        });
+        expect(isError(hidden)).toBe(false);
+        const hideMarker = parseResult(hidden);
+        expect(hideMarker.action).toBe("hide");
+        hideId = hideMarker.fileId;
+
+        // The visible listing no longer shows the name...
+        const names = parseResult(
+          await callTool(server, "b2_list_file_names", {
+            bucketId: writableBucketId,
+            prefix: fileName,
+          }),
+        );
+        expect((names.files ?? []).some((f: any) => f.fileName === fileName)).toBe(false);
+
+        // ...but a hide marker exists in the version history.
+        const versions = parseResult(
+          await callTool(server, "b2_list_file_versions", {
+            bucketId: writableBucketId,
+            startFileName: fileName,
+            maxFileCount: 5,
+          }),
+        );
+        expect((versions.files ?? []).some((f: any) => f.action === "hide")).toBe(true);
+      } finally {
+        if (hideId) await callTool(server, "b2_delete_file_version", { fileName, fileId: hideId });
+        if (uploadId)
+          await callTool(server, "b2_delete_file_version", { fileName, fileId: uploadId });
+      }
+    },
+    60_000,
+  );
+});

--- a/tests/unit/b2-tools.test.ts
+++ b/tests/unit/b2-tools.test.ts
@@ -111,6 +111,33 @@ describe("b2_authorize_account", () => {
   });
 });
 
+// ── B2Client 401 re-auth (core resilience path) ───────────────────────────────
+
+describe("B2Client 401 re-auth-and-retry", () => {
+  it("re-authorizes and retries exactly once on a 401, then succeeds", async () => {
+    // Authorize succeeds every time; the first API call 401s (token expired
+    // between our 23h cache and B2's 24h lifetime), the retry succeeds.
+    mockedAxios.get = jest.fn().mockResolvedValue({ data: mockAuthData });
+    mockedAxios
+      .mockRejectedValueOnce({ response: { status: 401 }, isAxiosError: true })
+      .mockResolvedValueOnce({ data: { buckets: [] } });
+
+    const result = parseResult(await callTool(server, "b2_list_buckets", {}));
+    expect(result.buckets).toEqual([]); // recovered silently
+    expect(mockedAxios).toHaveBeenCalledTimes(2); // original + one retry
+    expect(mockedAxios.get).toHaveBeenCalledTimes(2); // re-authorized after invalidate
+  });
+
+  it("does not retry more than once — a second 401 surfaces the error", async () => {
+    mockedAxios.get = jest.fn().mockResolvedValue({ data: mockAuthData });
+    mockedAxios.mockRejectedValue({ response: { status: 401 }, isAxiosError: true });
+
+    const result = await callTool(server, "b2_list_buckets", {});
+    expect(result.isError).toBe(true);
+    expect(mockedAxios).toHaveBeenCalledTimes(2); // original + exactly one retry, then throws
+  });
+});
+
 // ── b2_list_buckets ───────────────────────────────────────────────────────────
 
 describe("b2_list_buckets", () => {
@@ -293,7 +320,7 @@ describe("b2_hide_file", () => {
     }),
   );
 
-  it("returns the hide marker file info", async () => {
+  it("returns the hide marker and sends { bucketId, fileName } to the API", async () => {
     const result = parseResult(
       await callTool(server, "b2_hide_file", {
         bucketId: "bucket-001",
@@ -302,6 +329,11 @@ describe("b2_hide_file", () => {
     );
     expect(result.action).toBe("hide");
     expect(result.fileName).toBe("photo.jpg");
+    expect(mockedAxios).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({ bucketId: "bucket-001", fileName: "photo.jpg" }),
+      }),
+    );
   });
 });
 
@@ -378,15 +410,30 @@ describe("b2_create_key", () => {
     }),
   );
 
-  it("returns the new key info including keyId", async () => {
+  it("returns the new key info and forwards accountId + scope to the API", async () => {
     const result = parseResult(
       await callTool(server, "b2_create_key", {
         keyName: "test-key",
         capabilities: ["readFiles", "writeFiles"],
+        bucketId: "bucket-001",
+        namePrefix: "incoming/",
+        validDurationInSeconds: 3600,
       }),
     );
     expect(result.keyName).toBe("test-key");
     expect(result.applicationKeyId).toBe("key-123");
+    expect(mockedAxios).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({
+          accountId: "test-account-123",
+          keyName: "test-key",
+          capabilities: ["readFiles", "writeFiles"],
+          bucketId: "bucket-001",
+          namePrefix: "incoming/",
+          validDurationInSeconds: 3600,
+        }),
+      }),
+    );
   });
 });
 
@@ -504,11 +551,14 @@ describe("b2_list_unfinished_large_files", () => {
 describe("b2_delete_key", () => {
   beforeEach(() => setupMocks({ applicationKeyId: "key-ro", keyName: "readonly" }));
 
-  it("returns deleted key info", async () => {
+  it("returns deleted key info and sends applicationKeyId to the API", async () => {
     const result = parseResult(
       await callTool(server, "b2_delete_key", { applicationKeyId: "key-ro" }),
     );
     expect(result.applicationKeyId).toBe("key-ro");
+    expect(mockedAxios).toHaveBeenCalledWith(
+      expect.objectContaining({ data: expect.objectContaining({ applicationKeyId: "key-ro" }) }),
+    );
   });
 });
 
@@ -760,6 +810,19 @@ describe("b2_upload_file", () => {
     });
     expect(result.isError).toBe(true);
     expect(result.content[0].text).toContain("filePath or content");
+  });
+
+  it("rejects a fileInfo key with header-injection characters", async () => {
+    const result = await callTool(server, "b2_upload_file", {
+      bucketId: "bucket-001",
+      fileName: "hello.txt",
+      content: Buffer.from("x").toString("base64"),
+      // X-Bz-Info-* header name — must be [A-Za-z0-9-]; a space/newline could
+      // smuggle a second header. The guard must reject it.
+      fileInfo: { "bad key\r\nX-Evil": "1" },
+    });
+    expect(result.isError).toBe(true);
+    expect(result.content[0].text).toMatch(/fileInfo|invalid|header/i);
   });
 });
 

--- a/tests/unit/large-files-coverage.test.ts
+++ b/tests/unit/large-files-coverage.test.ts
@@ -8,6 +8,7 @@ import axios from "axios";
 import * as fs from "fs";
 import * as os from "os";
 import * as path from "path";
+import * as crypto from "crypto";
 import { createServer } from "../../src/server";
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { B2Config } from "../../src/utils/types";
@@ -160,5 +161,64 @@ describe("standalone large-file tools", () => {
   it("b2_list_parts forwards startPartNumber", async () => {
     const result = await callTool(server, "b2_list_parts", { fileId: "lf1", startPartNumber: 5 });
     expect(result.isError).toBeFalsy();
+  });
+});
+
+describe("large-file concurrency (out-of-order completion)", () => {
+  it("assembles partSha1Array in part order even when parts finish out of order", async () => {
+    // 4 distinct 50-byte parts (each filled with its index), partSize 50,
+    // concurrency 4. Make low part numbers finish LAST so the workers complete
+    // in reverse — the SHA1 array must still come out in ascending part order.
+    const buf = Buffer.alloc(200);
+    for (let i = 0; i < 4; i++) buf.fill(i, i * 50, (i + 1) * 50);
+    const expectedSha1 = [0, 1, 2, 3].map((i) =>
+      crypto
+        .createHash("sha1")
+        .update(buf.subarray(i * 50, (i + 1) * 50))
+        .digest("hex"),
+    );
+
+    mockedAxios.post = jest.fn().mockImplementation((_url: string, _data: unknown, cfg: any) => {
+      const partNumber = Number(cfg?.headers?.["X-Bz-Part-Number"] ?? 1);
+      // part 1 waits longest, part 4 returns first → reverse completion order
+      return new Promise((resolve) =>
+        setTimeout(() => resolve({ data: { partNumber } }), (5 - partNumber) * 15),
+      );
+    });
+
+    const server = createServer(makeConfig({ largeFileThreshold: 10, partSize: 50 }));
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), "b2-conc-"));
+    const file = path.join(dir, "multi.bin");
+    fs.writeFileSync(file, buf);
+    try {
+      const result = parse(
+        await callTool(server, "b2_upload_file", {
+          bucketId: "b",
+          fileName: "multi.bin",
+          filePath: file,
+          concurrency: 4,
+        }),
+      );
+      expect(result.fileId).toBe("lf1");
+      const finish = mockedAxios.mock.calls
+        .map((c) => c[0] as { url?: string; data?: { partSha1Array?: string[] } })
+        .find((c) => (c.url ?? "").includes("b2_finish_large_file"));
+      expect(finish?.data?.partSha1Array).toEqual(expectedSha1); // correct order despite reverse completion
+    } finally {
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  });
+});
+
+describe("filesystem policy through a tool", () => {
+  it("b2_upload_file rejects a filePath when local file access is disabled", async () => {
+    const server = createServer(makeConfig({ allowLocalFiles: false }));
+    const result = await callTool(server, "b2_upload_file", {
+      bucketId: "b",
+      fileName: "x.txt",
+      filePath: "/etc/passwd",
+    });
+    expect(result.isError).toBe(true);
+    expect(result.content[0].text).toMatch(/file access|not allowed|disabled|sandbox/i);
   });
 });


### PR DESCRIPTION
PR C of the audit remediation — **test hardening**. Closes the highest-risk coverage gaps the audit flagged (paths where a real bug would ship undetected).

## New / strengthened tests
- **`B2Client.call` 401 re-auth** (core resilience loop, was untested): recovers silently on one 401 (re-authorizes + retries *exactly once*), and a second 401 surfaces the error (no infinite retry).
- **Large-file concurrency ordering**: 4 distinct parts driven to complete in *reverse* order (part 1 finishes last); asserts `partSha1Array` still comes out in ascending part order — exercises the out-of-order indexing in the worker pool (the trickiest code in the repo).
- **Filesystem policy through a tool**: `b2_upload_file` with a `filePath` is rejected when `allowLocalFiles` is false — the HTTP-hardening promise, previously only tested at the `fs-guard` unit level.
- **Header-injection guard**: a `fileInfo` key with CR/LF is rejected before it can smuggle an `X-Bz-Info-*` header.
- **Strengthened self-confirming tests** (`b2_hide_file`, `b2_create_key`, `b2_delete_key`) to assert the **outgoing payload**, not just the echoed mock — the exact weakness that let the earlier shape bugs pass.
- **`contract.test.ts`**: live `b2_hide_file` round-trip (upload → hide → name gone + hide marker in versions). *Verified live.*

511 unit tests pass; lint + format clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)