### PR TITLE
chore: docs/polish — drop phantom README tool, fix rate-limiter comment, unify optional-param idiom

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,22 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.5.2] - 2026-06-09
+
+### Fixed
+- README listed a `s3_get_presigned_post` tool that does not exist — B2 does not
+  support presigned POST (the `POST Object` form-policy returns
+  `501 NotImplemented`), so the tool was intentionally never implemented. Removed
+  the stale row.
+- The rate-limiter doc comment described the rate key as the "X-B2-Key-Id prefix";
+  it is actually a SHA-256 hash of the full key id (`deriveRateKey`). Comment
+  corrected to match the code.
+
+### Changed
+- Internal: unified the "forward optional parameters into the request payload"
+  pattern across B2-native handlers behind a small `assignDefined` helper (one
+  obvious way instead of three).
+
 ## [1.5.1] - 2026-06-09
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -189,7 +189,6 @@ This server does **not** phone home — there is no analytics endpoint and nothi
 | `s3_list_multipart_uploads`    | List in-progress uploads  |
 | `s3_list_parts`                | List uploaded parts       |
 | `s3_get_presigned_url`         | Generate presigned URL    |
-| `s3_get_presigned_post`        | Generate presigned POST   |
 
 ## Example Usage with Claude
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backblaze/b2-mcp-server",
-  "version": "1.5.1",
+  "version": "1.5.2",
   "description": "MCP server for Backblaze B2 — full B2 native API + S3-compatible API coverage",
   "main": "dist/index.js",
   "bin": {

--- a/src/b2/buckets.ts
+++ b/src/b2/buckets.ts
@@ -3,6 +3,7 @@ import { z } from "zod";
 import { B2Client } from "./client.js";
 import { B2AuthManager } from "../auth.js";
 import { toolJson, toolError } from "../utils/errors.js";
+import { assignDefined } from "../utils/payload.js";
 
 export function registerBucketTools(
   server: McpServer,
@@ -233,7 +234,7 @@ export function registerBucketTools(
           accountId: authData.accountId,
           bucketId: args.bucketId,
         };
-        const optional = [
+        assignDefined(payload, args, [
           "bucketType",
           "bucketInfo",
           "corsRules",
@@ -243,10 +244,7 @@ export function registerBucketTools(
           "fileLockEnabled",
           "defaultRetention",
           "ifRevisionIs",
-        ] as const;
-        for (const key of optional) {
-          if (args[key] !== undefined) payload[key] = args[key];
-        }
+        ]);
         const result = await client.call("b2_update_bucket", payload);
         return toolJson(result);
       } catch (err) {

--- a/src/b2/download-urls.ts
+++ b/src/b2/download-urls.ts
@@ -3,6 +3,7 @@ import { z } from "zod";
 import { B2Client } from "./client.js";
 import { B2AuthManager } from "../auth.js";
 import { toolJson, toolError } from "../utils/errors.js";
+import { assignDefined } from "../utils/payload.js";
 
 export function registerDownloadUrlTools(
   server: McpServer,
@@ -45,17 +46,14 @@ export function registerDownloadUrlTools(
           fileNamePrefix: args.fileNamePrefix,
           validDurationInSeconds: args.validDurationInSeconds,
         };
-        const optional = [
+        assignDefined(payload, args, [
           "b2ContentDisposition",
           "b2ContentLanguage",
           "b2Expires",
           "b2CacheControl",
           "b2ContentEncoding",
           "b2ContentType",
-        ] as const;
-        for (const key of optional) {
-          if (args[key] !== undefined) payload[key] = args[key];
-        }
+        ]);
 
         const result = await client.call("b2_get_download_authorization", payload);
         return toolJson(result);

--- a/src/b2/files.ts
+++ b/src/b2/files.ts
@@ -8,6 +8,7 @@ import { B2Client } from "./client.js";
 import { B2AuthManager } from "../auth.js";
 import { B2Config } from "../utils/types.js";
 import { toolJson, toolError, toolSuccess } from "../utils/errors.js";
+import { assignDefined } from "../utils/payload.js";
 import { resolveLocalPath } from "../utils/fs-guard.js";
 import { uploadLargeFile } from "./large-files.js";
 
@@ -572,17 +573,14 @@ export function registerFileTools(
           fileName: args.fileName,
           metadataDirective: args.metadataDirective ?? "COPY",
         };
-        const optional = [
+        assignDefined(payload, args, [
           "destinationBucketId",
           "range",
           "contentType",
           "fileInfo",
           "destinationServerSideEncryption",
           "sourceServerSideEncryption",
-        ] as const;
-        for (const key of optional) {
-          if (args[key] !== undefined) payload[key] = args[key];
-        }
+        ]);
 
         const result = await client.call("b2_copy_file", payload);
         return toolJson(result);

--- a/src/utils/payload.ts
+++ b/src/utils/payload.ts
@@ -1,0 +1,18 @@
+/**
+ * Copy each listed key from `args` into `target` when its value is defined.
+ *
+ * Unifies the "forward optional parameters into the request payload" pattern
+ * used across the B2-native tool handlers — the one obvious way to do it,
+ * instead of hand-rolling an `if (args.x !== undefined) payload.x = args.x`
+ * chain (or an inline loop) in each handler.
+ */
+export function assignDefined<T extends Record<string, unknown>>(
+  target: Record<string, unknown>,
+  args: T,
+  keys: readonly (keyof T)[],
+): Record<string, unknown> {
+  for (const key of keys) {
+    if (args[key] !== undefined) target[key as string] = args[key];
+  }
+  return target;
+}

--- a/src/utils/rate-limiter.ts
+++ b/src/utils/rate-limiter.ts
@@ -3,8 +3,9 @@
  *
  * Nginx already rate-limits by IP. This is the second tier: a misbehaving
  * key (runaway client loop) gets throttled even when its IP is fine. The
- * key is the X-B2-Key-Id prefix that was used to establish the session;
- * we look it up from the session record.
+ * rate key is a SHA-256 hash of the full X-B2-Key-Id (see deriveRateKey in
+ * http-server.ts) — not a prefix, so distinct tenants can't collide. We look
+ * it up from the session record.
  *
  * Defaults: 60 requests/sec sustained, burst capacity 120. Override via
  * B2_MCP_RATE_LIMIT_RPS and B2_MCP_RATE_LIMIT_BURST env vars.

--- a/tests/unit/payload.test.ts
+++ b/tests/unit/payload.test.ts
@@ -1,0 +1,24 @@
+import { assignDefined } from "../../src/utils/payload";
+
+describe("assignDefined", () => {
+  it("copies only defined keys into the target", () => {
+    const target: Record<string, unknown> = { a: 1 };
+    const args = { b: 2, c: undefined, d: "x" };
+    assignDefined(target, args, ["b", "c", "d"]);
+    expect(target).toEqual({ a: 1, b: 2, d: "x" }); // c (undefined) skipped
+  });
+
+  it("copies falsy-but-defined values (0, '', false, null)", () => {
+    const target: Record<string, unknown> = {};
+    const args = { zero: 0, empty: "", flag: false, nul: null };
+    assignDefined(target, args, ["zero", "empty", "flag", "nul"]);
+    expect(target).toEqual({ zero: 0, empty: "", flag: false, nul: null });
+  });
+
+  it("returns the same target reference and ignores unlisted keys", () => {
+    const target: Record<string, unknown> = {};
+    const args = { keep: 1, ignore: 2 };
+    expect(assignDefined(target, args, ["keep"])).toBe(target);
+    expect(target).toEqual({ keep: 1 });
+  });
+});


### PR DESCRIPTION
PR D of the audit remediation — **docs accuracy + readability polish**.

- **README**: removed the `s3_get_presigned_post` row. B2 doesn't support presigned POST (`POST Object` → `501 NotImplemented`, verified live), so the tool was intentionally never implemented — the README contradicted the code.
- **`rate-limiter.ts`**: the header comment said the rate key is a "prefix"; it's actually a SHA-256 hash of the full key id (`deriveRateKey`). Corrected to match.
- **`assignDefined` helper**: unified the array-driven optional-param passthrough (`b2_copy_file`, `b2_update_bucket`, `b2_get_download_authorization`) behind one small helper instead of an inline loop in each. Behavior-preserving; direct unit test added.

### Deliberately not changed here
The SSE-C upload-header difference between the small-file and large-file paths (they use different customer-key header names) is a **potential correctness issue**, not just style — fixing it needs a verified customer-key test, not a blind "make them match" in a polish PR. Flagged as follow-up.

514 unit tests pass; lint + format clean.

> Note: the object-lock skill's "only at creation" wording was also corrected (the native `b2_update_bucket` retrofits Object Lock on existing buckets) — that file lives in the skills pack outside this repo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)