### PR TITLE
fix: b2_upload_file server-side-encryption headers (SSE-B2 and SSE-C were broken)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,19 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.5.3] - 2026-06-09
+
+### Fixed
+- `b2_upload_file` with `serverSideEncryption` was broken for small (non-large)
+  files in **both** modes — it sent the wrong B2 headers, so SSE-B2 uploads
+  failed and SSE-C uploads were rejected with `400 INVALID_ARGUMENT`. Corrected
+  to B2's documented header scheme (verified against backblaze.com b2-upload-file
+  and live): **SSE-B2** sends `X-Bz-Server-Side-Encryption: AES256` (not the
+  literal `"SSE-B2"`); **SSE-C** sends `X-Bz-Server-Side-Encryption-Customer-Algorithm:
+  AES256` + the customer key + key-MD5, and omits the plain mode header (B2
+  forbids both being present). The large-file (`b2_start_large_file` body +
+  per-part `…-Customer-Algorithm`) and copy paths already used the correct form.
+
 ## [1.5.2] - 2026-06-09
 
 ### Fixed

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backblaze/b2-mcp-server",
-  "version": "1.5.2",
+  "version": "1.5.3",
   "description": "MCP server for Backblaze B2 — full B2 native API + S3-compatible API coverage",
   "main": "dist/index.js",
   "bin": {

--- a/src/b2/files.ts
+++ b/src/b2/files.ts
@@ -69,11 +69,20 @@ function buildUploadHeaders(opts: UploadHeaderOptions): Record<string, string> {
   }
   if (opts.serverSideEncryption) {
     const sse = opts.serverSideEncryption;
-    headers["X-Bz-Server-Side-Encryption"] = sse.mode;
-    if (sse.algorithm) headers["X-Bz-Server-Side-Encryption-Algorithm"] = sse.algorithm;
-    if (sse.customerKey) headers["X-Bz-Server-Side-Encryption-Customer-Key"] = sse.customerKey;
-    if (sse.customerKeyMd5)
-      headers["X-Bz-Server-Side-Encryption-Customer-Key-Md5"] = sse.customerKeyMd5;
+    if (sse.mode === "SSE-C") {
+      // SSE-C (customer-managed): the three customer headers, and the plain
+      // X-Bz-Server-Side-Encryption header must NOT be present. B2 names the
+      // algorithm header "...-Customer-Algorithm" (value AES256), distinct from
+      // the SSE-B2 header. Verified against backblaze.com b2-upload-file + live.
+      headers["X-Bz-Server-Side-Encryption-Customer-Algorithm"] = sse.algorithm ?? "AES256";
+      if (sse.customerKey) headers["X-Bz-Server-Side-Encryption-Customer-Key"] = sse.customerKey;
+      if (sse.customerKeyMd5)
+        headers["X-Bz-Server-Side-Encryption-Customer-Key-Md5"] = sse.customerKeyMd5;
+    } else {
+      // SSE-B2 (Backblaze-managed): the only valid value is the algorithm
+      // AES256 — NOT the literal "SSE-B2".
+      headers["X-Bz-Server-Side-Encryption"] = sse.algorithm ?? "AES256";
+    }
   }
   return headers;
 }

--- a/tests/integration/contract.test.ts
+++ b/tests/integration/contract.test.ts
@@ -346,3 +346,52 @@ describe("Contract: b2_hide_file", () => {
     60_000,
   );
 });
+
+// ── b2_upload_file server-side encryption headers ─────────────────────────────
+describe("Contract: b2_upload_file SSE headers", () => {
+  liveIt(
+    "uploads with SSE-B2 and SSE-C (the correct B2 header scheme, not mode-as-value)",
+    async () => {
+      if (!writableBucketId) {
+        console.log("  No writable bucket; skipping.");
+        return;
+      }
+      const ids: Array<[string, string]> = [];
+      try {
+        // SSE-B2: header value must be AES256, not "SSE-B2".
+        const b2 = await callTool(server, "b2_upload_file", {
+          bucketId: writableBucketId,
+          fileName: "__contract/sse-b2.txt",
+          content: Buffer.from("sse-b2").toString("base64"),
+          serverSideEncryption: { mode: "SSE-B2" },
+        });
+        expect(isError(b2)).toBe(false);
+        const b2j = parseResult(b2);
+        expect(b2j.serverSideEncryption?.mode).toBe("SSE-B2");
+        ids.push([b2j.fileName, b2j.fileId]);
+
+        // SSE-C: customer headers, no plain mode header (B2 rejects both together).
+        const crypto = await import("crypto");
+        const key = crypto.randomBytes(32);
+        const c = await callTool(server, "b2_upload_file", {
+          bucketId: writableBucketId,
+          fileName: "__contract/sse-c.txt",
+          content: Buffer.from("sse-c").toString("base64"),
+          serverSideEncryption: {
+            mode: "SSE-C",
+            customerKey: key.toString("base64"),
+            customerKeyMd5: crypto.createHash("md5").update(key).digest("base64"),
+          },
+        });
+        expect(isError(c)).toBe(false);
+        const cj = parseResult(c);
+        expect(cj.serverSideEncryption?.mode).toBe("SSE-C");
+        ids.push([cj.fileName, cj.fileId]);
+      } finally {
+        for (const [fileName, fileId] of ids)
+          await callTool(server, "b2_delete_file_version", { fileName, fileId });
+      }
+    },
+    60_000,
+  );
+});

--- a/tests/unit/upload-headers.test.ts
+++ b/tests/unit/upload-headers.test.ts
@@ -138,8 +138,25 @@ describe("b2_upload_file header parity", () => {
     expect(h["Content-Length"]).toBe(String(bytes.length));
     expect(h["X-Bz-File-Name"]).toBe(encodeURIComponent("name with spaces.txt"));
     expect(h["X-Bz-Info-foo"]).toBe(encodeURIComponent("bar baz"));
-    expect(h["X-Bz-Server-Side-Encryption"]).toBe("SSE-C");
+    // SSE-C: the customer headers, and NO plain X-Bz-Server-Side-Encryption
+    // header (B2 rejects the request if both are present).
+    expect(h["X-Bz-Server-Side-Encryption-Customer-Algorithm"]).toBe("AES256");
     expect(h["X-Bz-Server-Side-Encryption-Customer-Key"]).toBe(sse.customerKey);
+    expect(h["X-Bz-Server-Side-Encryption-Customer-Key-Md5"]).toBe(sse.customerKeyMd5);
+    expect(h["X-Bz-Server-Side-Encryption"]).toBeUndefined();
+  });
+
+  it("SSE-B2 sets X-Bz-Server-Side-Encryption to AES256 (not the literal 'SSE-B2')", async () => {
+    await callTool(server, "b2_upload_file", {
+      bucketId: "b",
+      fileName: "f.txt",
+      content: bytes.toString("base64"),
+      contentType: "text/plain",
+      serverSideEncryption: { mode: "SSE-B2" },
+    });
+    const h = lastPostHeaders();
+    expect(h["X-Bz-Server-Side-Encryption"]).toBe("AES256");
+    expect(h["X-Bz-Server-Side-Encryption-Customer-Algorithm"]).toBeUndefined();
   });
 
   it("rejects a fileInfo key that could inject a header", async () => {


### PR DESCRIPTION
The SSE-C follow-up flagged in PR D — and it turned out to be a real bug, not just an inconsistency.

## Problem
`b2_upload_file` with `serverSideEncryption` sent the wrong B2 headers for **small** files (both modes): it set `X-Bz-Server-Side-Encryption` to the literal mode (`"SSE-B2"`/`"SSE-C"`) and used `X-Bz-Server-Side-Encryption-Algorithm`.

Verified live (and against [backblaze.com b2-upload-file](https://www.backblaze.com/apidocs/b2-upload-file)):
```
MCP SSE-B2 upload:  failed
MCP SSE-C upload:   400 INVALID_ARGUMENT
```
B2 actually wants:
- **SSE-B2**: `X-Bz-Server-Side-Encryption: AES256` (only `AES256` is valid — not `"SSE-B2"`)
- **SSE-C**: `X-Bz-Server-Side-Encryption-Customer-Algorithm: AES256` + `…-Customer-Key` + `…-Customer-Key-Md5`, and **no** plain mode header (B2 rejects the request if both are present)

## Fix
Corrected `buildUploadHeaders` to B2's scheme. The large-file path (SSE in the `b2_start_large_file` body + per-part `…-Customer-Algorithm` headers) and the copy path already used the correct form, so only the small-file header builder changed.

## Verification
Live through the MCP: SSE-B2 and SSE-C uploads now succeed and encrypt (response shows `mode: SSE-B2` / `SSE-C`), where both were B2-rejected before. Unit test corrected to the right headers + an SSE-B2 case; live contract test added (passes). 515 unit tests pass; lint + format clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)