### PR TITLE
Bound large-bucket tool walks + master-key S3 guidance (2.3.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,33 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.3.0] - 2026-06-29
+
+### Added
+- **Scan bounds on the live insight tools.** `b2_largest_files` gains `max_scan`
+  (default 50,000, max 500,000) and `b2_unfinished_uploads` gains `max_uploads`
+  (default 1,000, max 10,000), each paired with an internal wall-clock budget.
+  Sorting a bucket by object size — or summing every abandoned upload's parts —
+  requires a full listing, which on a bucket with millions of files (or a bloated
+  upload backlog) is an unbounded, rate-limited fan-out that hangs and times out.
+  The tools now stop at the cap or budget and return `truncated: true` (and, for
+  unfinished uploads, `wasted_is_lower_bound`) so the result is honest, fast, and
+  never a hang. The oldest upload is still reported accurately when truncated.
+- **`limit` on `b2_list_buckets`** (default 100, max 1,000). The B2 API returns
+  every bucket in one response; the tool now caps how many are surfaced and adds
+  `total_bucket_count` plus a `truncated` flag/note when more exist, keeping the
+  payload and token cost bounded for accounts with many buckets.
+
+### Changed
+- The bounded insight tools always emit a `truncated` boolean for a uniform
+  response shape.
+
+### Fixed
+- **Actionable master-key error on the S3 surface.** When the S3-compatible API
+  rejects an account master key (`InvalidAccessKeyId` / "Malformed Access Key
+  Id"), the formatted error now explains that the `s3_*` and insight tools need a
+  regular (non-master) application key — turning a cryptic 403 into a clear fix.
+
 ## [2.2.0] - 2026-06-28
 
 ### Added

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@backblaze/b2-mcp-server",
-  "version": "2.0.0",
+  "version": "2.3.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@backblaze/b2-mcp-server",
-      "version": "2.0.0",
+      "version": "2.3.0",
       "license": "MIT",
       "dependencies": {
         "@aws-sdk/client-s3": "^3.1048.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backblaze/b2-mcp-server",
-  "version": "2.2.0",
+  "version": "2.3.0",
   "description": "MCP server for Backblaze B2 — full B2 native API + a minimal S3-compatible set (only operations with no native equivalent)",
   "main": "dist/index.js",
   "bin": {

--- a/scripts/seed-trunc-bucket.mjs
+++ b/scripts/seed-trunc-bucket.mjs
@@ -1,0 +1,84 @@
+// Preseed a bucket with 5,000 small objects so the live truncation test has a
+// bucket big enough to trip max_scan. Idempotent: creates the bucket if missing
+// and only uploads objects that aren't already there. Uses a regular (S3-capable)
+// application key — the master key is rejected by the S3 endpoint.
+import {
+  S3Client,
+  CreateBucketCommand,
+  HeadBucketCommand,
+  ListObjectsV2Command,
+  PutObjectCommand,
+} from "@aws-sdk/client-s3";
+
+const region = process.env.B2_REGION ?? "us-west-004";
+const bucket = process.env.B2_TRUNCATION_BUCKET ?? "mcp-trunc-5k";
+const COUNT = Number(process.env.SEED_COUNT ?? 5000);
+const PREFIX = "f/";
+const CONCURRENCY = 64;
+
+const keyId = process.env.B2_APPLICATION_KEY_ID;
+const key = process.env.B2_APPLICATION_KEY;
+if (!keyId || !key) {
+  console.error("missing B2_APPLICATION_KEY_ID / B2_APPLICATION_KEY (source .env.local)");
+  process.exit(2);
+}
+
+const s3 = new S3Client({
+  region,
+  endpoint: `https://s3.${region}.backblazeb2.com`,
+  credentials: { accessKeyId: keyId, secretAccessKey: key },
+});
+
+const pad = (n) => String(n).padStart(5, "0");
+
+async function ensureBucket() {
+  try {
+    await s3.send(new HeadBucketCommand({ Bucket: bucket }));
+    console.log(`bucket "${bucket}" exists — reusing`);
+  } catch {
+    await s3.send(new CreateBucketCommand({ Bucket: bucket }));
+    console.log(`created bucket "${bucket}"`);
+  }
+}
+
+async function existingCount() {
+  let token, n = 0;
+  do {
+    const page = await s3.send(new ListObjectsV2Command({ Bucket: bucket, Prefix: PREFIX, ContinuationToken: token }));
+    n += page.Contents?.length ?? 0;
+    token = page.IsTruncated ? page.NextContinuationToken : undefined;
+  } while (token);
+  return n;
+}
+
+async function seed() {
+  await ensureBucket();
+  const have = await existingCount();
+  if (have >= COUNT) {
+    console.log(`already has ${have} objects under ${PREFIX} — nothing to upload`);
+    return;
+  }
+  console.log(`uploading ${COUNT - have} objects (have ${have}, target ${COUNT})…`);
+
+  let next = have; // resume-ish: skip indices already covered by count
+  let done = have;
+  const worker = async () => {
+    while (next < COUNT) {
+      const i = next++;
+      // Vary size 10–59 bytes so "largest" is meaningful; one clear max at i=0.
+      const size = i === 0 ? 200 : 10 + (i % 50);
+      await s3.send(new PutObjectCommand({
+        Bucket: bucket,
+        Key: `${PREFIX}${pad(i)}.txt`,
+        Body: "x".repeat(size),
+        ContentType: "text/plain",
+      }));
+      if (++done % 500 === 0) console.log(`  ${done}/${COUNT}`);
+    }
+  };
+  await Promise.all(Array.from({ length: CONCURRENCY }, worker));
+  console.log(`upload complete: ${done} objects under ${PREFIX} in "${bucket}"`);
+}
+
+await seed();
+console.log(`\nDONE. Truncation-test bucket: ${bucket}`);

--- a/src/b2/buckets.ts
+++ b/src/b2/buckets.ts
@@ -105,7 +105,7 @@ export function registerBucketTools(
   // ── b2_list_buckets ───────────────────────────────────────────────────────
   server.tool(
     "b2_list_buckets",
-    "List all B2 buckets for the authorized account. Optionally filter by bucket ID, name, or type. Returns bucket ID, name, type, CORS rules, and lifecycle rules for each bucket.",
+    "List B2 buckets for the authorized account. Optionally filter by bucket ID, name, or type. Returns bucket ID, name, type, CORS rules, and lifecycle rules for each bucket. Capped to `limit` buckets (default 100, max 1000) to keep the response small for accounts with many buckets; if more exist the result is truncated with total_bucket_count and a note — raise limit or filter to target specific buckets.",
     {
       bucketId: z.string().optional().describe("Filter to a specific bucket by its ID"),
       bucketName: z.string().optional().describe("Filter to a specific bucket by its name"),
@@ -113,6 +113,16 @@ export function registerBucketTools(
         .array(z.enum(["allPublic", "allPrivate", "snapshot", "all"]))
         .optional()
         .describe("Filter by bucket types. Defaults to all types."),
+      limit: z
+        .number()
+        .int()
+        .min(1)
+        .max(1000)
+        .optional()
+        .default(100)
+        .describe(
+          "Maximum number of buckets to return (default 100, max 1000). The B2 API returns every bucket in one response; this caps how many are surfaced to keep the payload and token cost bounded. If the account has more buckets than the limit, the result is truncated with total_bucket_count and a note — raise limit (up to 1000) or filter by bucketName / bucketId / bucketTypes.",
+        ),
     },
     async (args) => {
       try {
@@ -122,8 +132,29 @@ export function registerBucketTools(
         if (args.bucketName) payload.bucketName = args.bucketName;
         if (args.bucketTypes) payload.bucketTypes = args.bucketTypes;
 
-        const result = await client.call("b2_list_buckets", payload);
-        return toolJson(result);
+        // B2's b2_list_buckets has no count/pagination param — it returns every
+        // bucket in one response. For accounts with thousands of buckets that is
+        // a large, token-heavy payload, so cap how many we surface to the model.
+        const result = (await client.call("b2_list_buckets", payload)) as {
+          buckets?: unknown[];
+          [k: string]: unknown;
+        };
+        const all = Array.isArray(result.buckets) ? result.buckets : [];
+        const truncated = all.length > args.limit;
+        const buckets = truncated ? all.slice(0, args.limit) : all;
+
+        return toolJson({
+          ...result,
+          buckets,
+          bucket_count: buckets.length,
+          total_bucket_count: all.length,
+          ...(truncated
+            ? {
+                truncated: true,
+                note: `Showing the first ${args.limit} of ${all.length} buckets. Raise limit (up to 1000), or filter by bucketName, bucketId, or bucketTypes to target specific buckets.`,
+              }
+            : {}),
+        });
       } catch (err) {
         return toolError(err);
       }

--- a/src/b2/insights.ts
+++ b/src/b2/insights.ts
@@ -415,7 +415,7 @@ export function registerInsightTools(
   // ── b2_largest_files ──────────────────────────────────────────────────────
   server.tool(
     "b2_largest_files",
-    "List a bucket's largest objects by size via a live listing. For 'largest files', 'what's taking up space in <bucket>'. Give the bucket by name or bucketId; optional path prefix. Returns name, size, and upload time — never contents.",
+    "List a bucket's largest objects by size via a live listing. For 'largest files', 'what's taking up space in <bucket>'. Give the bucket by name or bucketId; optional path prefix. Sorting by size requires a full listing, so on very large buckets the scan is bounded by max_scan and a time budget — it then returns the largest among the objects scanned with truncated=true; pass a prefix to focus on a subtree for a complete ranking. Returns name, size, and upload time — never contents.",
     {
       bucket: z.string().describe("Bucket name or bucketId to inspect."),
       limit: z
@@ -427,6 +427,16 @@ export function registerInsightTools(
         .default(10)
         .describe("How many of the largest files to return (default 10, max 100)."),
       prefix: z.string().optional().describe('Optional path prefix, e.g. "checkpoints/".'),
+      max_scan: z
+        .number()
+        .int()
+        .min(1000)
+        .max(500_000)
+        .optional()
+        .default(50_000)
+        .describe(
+          "Safety cap on objects scanned (default 50,000, max 500,000). Buckets with millions of files cannot be fully sorted by size in one live call; the scan stops at this cap (or a time budget) and returns truncated=true. Narrow with prefix for an exhaustive ranking of a subtree.",
+        ),
     },
     async (args) => {
       try {
@@ -440,11 +450,21 @@ export function registerInsightTools(
               : `No bucket matches '${args.bucket}'.`,
           });
 
-        // Bounded top-N by size — never accumulate every object.
+        // Bounded top-N by size — never accumulate every object. Sorting by size
+        // also requires a full listing, so bound the WORK too: stop at max_scan
+        // objects or a wall-clock budget, whichever comes first. Without this a
+        // bucket with millions of files means thousands of sequential (billable,
+        // rate-limited) LIST calls that run for minutes and time out. On a bound
+        // hit we return what we have with truncated=true so the caller knows the
+        // ranking covers only the objects scanned.
+        const TIME_BUDGET_MS = 12_000;
+        const startedAt = Date.now();
         const top: Array<{ name: string; size: number; uploaded?: Date }> = [];
         let smallest = -Infinity;
         let token: string | undefined;
         let scanned = 0;
+        let truncated = false;
+        let stopReason: "complete" | "max_scan" | "time_budget" = "complete";
         do {
           const page = await s3.send(
             new ListObjectsV2Command({
@@ -464,12 +484,31 @@ export function registerInsightTools(
             }
           }
           token = page.IsTruncated ? page.NextContinuationToken : undefined;
+          if (token && scanned >= args.max_scan) {
+            truncated = true;
+            stopReason = "max_scan";
+            break;
+          }
+          if (token && Date.now() - startedAt > TIME_BUDGET_MS) {
+            truncated = true;
+            stopReason = "time_budget";
+            break;
+          }
         } while (token);
 
         return toolJson({
           bucket: resolved.name,
           scanned,
+          truncated,
           returned: top.length,
+          ...(truncated
+            ? {
+                note:
+                  stopReason === "max_scan"
+                    ? `Stopped at the max_scan cap of ${args.max_scan.toLocaleString()} objects — these are the largest among those scanned, not the whole bucket. Pass a narrower prefix (or raise max_scan) for a more complete ranking.`
+                    : `Stopped after a ${TIME_BUDGET_MS / 1000}s time budget (${scanned.toLocaleString()} objects scanned) — these are the largest among those scanned, not the whole bucket. Pass a narrower prefix to focus the scan.`,
+              }
+            : {}),
           files: top.map((f) => ({
             name: f.name,
             size_bytes: f.size,
@@ -486,7 +525,7 @@ export function registerInsightTools(
   // ── b2_unfinished_uploads ─────────────────────────────────────────────────
   server.tool(
     "b2_unfinished_uploads",
-    "Find abandoned multipart uploads that silently consume storage in a bucket. For 'bucket bloat', 'stuck/incomplete uploads', 'wasted storage'. Returns count, oldest upload age, and wasted bytes. Give the bucket by name or bucketId. Live listing.",
+    "Find abandoned multipart uploads that silently consume storage in a bucket. For 'bucket bloat', 'stuck/incomplete uploads', 'wasted storage'. Returns count, oldest upload age, and wasted bytes. Give the bucket by name or bucketId. Live listing, bounded by max_uploads and an internal time budget — on a very bloated bucket it returns a truncated result (and wasted_gb may be a lower bound) and recommends a lifecycle rule.",
     {
       bucket: z.string().describe("Bucket name or bucketId to inspect."),
       older_than_days: z
@@ -495,6 +534,16 @@ export function registerInsightTools(
         .min(0)
         .optional()
         .describe("Only count uploads started more than this many days ago (optional)."),
+      max_uploads: z
+        .number()
+        .int()
+        .min(1)
+        .max(10_000)
+        .optional()
+        .default(1000)
+        .describe(
+          "Safety cap on how many unfinished uploads to scan (default 1000, max 10,000). A bucket bloated with abandoned uploads would otherwise trigger an unbounded walk plus a per-upload parts fan-out that times out. If the cap or an internal time budget is hit, the result is truncated and wasted_gb may be a lower bound — add a lifecycle rule to auto-cancel unfinished large files.",
+        ),
     },
     async (args) => {
       try {
@@ -511,9 +560,21 @@ export function registerInsightTools(
         const cutoff =
           args.older_than_days != null ? Date.now() - args.older_than_days * 86400_000 : null;
 
+        // Bound the work. A bucket bloated with abandoned uploads — exactly what
+        // this tool hunts for — otherwise means an unbounded upload walk plus a
+        // per-upload ListParts fan-out (O(uploads × parts)) of sequential,
+        // rate-limited calls that hang and time out. Cap the uploads walked and
+        // put an overall wall-clock budget over the parts summation; report
+        // truncated / lower-bound results instead of failing.
+        const TIME_BUDGET_MS = 12_000;
+        const startedAt = Date.now();
+        const overBudget = () => Date.now() - startedAt > TIME_BUDGET_MS;
+
         const uploads: Array<{ key: string; uploadId: string; initiated?: Date }> = [];
         let keyMarker: string | undefined;
         let idMarker: string | undefined;
+        let truncated = false;
+        let stopReason: "complete" | "max_uploads" | "time_budget" = "complete";
         do {
           const page = await s3.send(
             new ListMultipartUploadsCommand({
@@ -534,6 +595,16 @@ export function registerInsightTools(
             keyMarker = undefined;
             idMarker = undefined;
           }
+          if ((keyMarker || idMarker) && uploads.length >= args.max_uploads) {
+            truncated = true;
+            stopReason = "max_uploads";
+            break;
+          }
+          if ((keyMarker || idMarker) && overBudget()) {
+            truncated = true;
+            stopReason = "time_budget";
+            break;
+          }
         } while (keyMarker || idMarker);
 
         if (!uploads.length)
@@ -544,11 +615,17 @@ export function registerInsightTools(
           });
 
         // Sum already-uploaded part bytes for wasted storage; find the oldest.
+        // The ListParts fan-out is the heaviest part, so stop summing once the
+        // budget is hit and report wasted_gb as a lower bound (oldest stays exact
+        // — finding it needs only the cheap upload list).
         let wasted = 0;
         let oldest = uploads[0];
+        let wastedIsLowerBound = false;
+        let sizedUploads = 0;
         for (const u of uploads) {
           if ((u.initiated?.getTime() ?? Infinity) < (oldest.initiated?.getTime() ?? Infinity))
             oldest = u;
+          if (wastedIsLowerBound) continue; // budget hit — keep scanning for oldest only
           let partMarker: number | undefined;
           do {
             const parts = await s3.send(
@@ -562,17 +639,32 @@ export function registerInsightTools(
             for (const p of parts.Parts ?? []) wasted += p.Size ?? 0;
             partMarker = parts.IsTruncated ? Number(parts.NextPartNumberMarker) : undefined;
           } while (partMarker != null);
+          sizedUploads++;
+          if (overBudget()) wastedIsLowerBound = true;
         }
+
+        const lifecycleTip =
+          "Add a lifecycle rule to auto-cancel unfinished large uploads (daysFromStartingToCancelingUnfinishedLargeFiles).";
+        const lowerBoundTip = wastedIsLowerBound
+          ? ` wasted_gb is a lower bound — stopped summing parts after a ${TIME_BUDGET_MS / 1000}s budget (sized ${sizedUploads} of ${uploads.length} uploads).`
+          : "";
+        const note = truncated
+          ? (stopReason === "max_uploads"
+              ? `Stopped at the max_uploads cap of ${args.max_uploads.toLocaleString()} — the bucket has more abandoned uploads than shown.${lowerBoundTip} ${lifecycleTip}`
+              : `Stopped after a ${TIME_BUDGET_MS / 1000}s time budget (${uploads.length.toLocaleString()} uploads found).${lowerBoundTip} ${lifecycleTip}`)
+          : wastedIsLowerBound
+            ? `${lowerBoundTip.trim()} ${lifecycleTip}`
+            : `Consider a lifecycle rule to auto-cancel unfinished large uploads (daysFromStartingToCancelingUnfinishedLargeFiles).`;
 
         return toolJson({
           bucket: resolved.name,
           unfinished_count: uploads.length,
+          truncated,
           wasted_gb: gb(wasted),
+          ...(wastedIsLowerBound ? { wasted_is_lower_bound: true, sized_uploads: sizedUploads } : {}),
           oldest_started_at: oldest.initiated,
           oldest_file: oldest.key,
-          note:
-            "Consider a lifecycle rule to auto-cancel unfinished large uploads " +
-            "(daysFromStartingToCancelingUnfinishedLargeFiles).",
+          note,
         });
       } catch (err) {
         return toolError(err);

--- a/src/utils/errors.ts
+++ b/src/utils/errors.ts
@@ -93,8 +93,28 @@ export function parseErrorText(
  */
 export function formatB2Error(err: unknown): string {
   const parsed = parseB2Error(err);
-  const base = `B2 Error [${parsed.code}] (HTTP ${parsed.status}): ${parsed.message}`;
+  const base = `B2 Error [${parsed.code}] (HTTP ${parsed.status}): ${parsed.message}${errorHint(parsed)}`;
   return parsed.requestId ? `${base} (requestId: ${parsed.requestId})` : base;
+}
+
+/**
+ * Extra guidance appended to otherwise-cryptic B2 errors.
+ *
+ * The big one: B2's S3-compatible API (every s3_* tool and the live insight
+ * tools) rejects the account MASTER key — and any malformed key id — with
+ * InvalidAccessKeyId / "Malformed Access Key Id". Connecting with a master key
+ * is a natural mistake (it's the "full access" key), so the raw error is a
+ * common dead end. Point the operator at a regular application key.
+ */
+function errorHint(parsed: B2ApiError): string {
+  if (parsed.code === "InvalidAccessKeyId" || /malformed access key id/i.test(parsed.message)) {
+    return (
+      " — B2's S3-compatible API (used by the s3_* and insight tools) only accepts a regular " +
+      "application key, not an account master key. If you're connecting with a master key, switch " +
+      "to a non-master application key (or set B2_APP_KEY_ID / B2_APP_KEY to one for the S3 surface)."
+    );
+  }
+  return "";
 }
 
 /**

--- a/tests/integration/live.test.ts
+++ b/tests/integration/live.test.ts
@@ -33,6 +33,11 @@ const liveS3It = HAS_S3_CREDS ? test : test.skip;
 // Partner-entitled account. Gated off by default so a normal live run skips it.
 const HAS_PARTNER = HAS_CREDS && process.env.B2_PARTNER_LIVE === "1";
 const partnerIt = HAS_PARTNER ? test : test.skip;
+// Large-bucket truncation: point B2_TRUNCATION_BUCKET at a bucket preseeded with
+// > max_scan objects (5k tiny files; see scripts/seed-trunc-bucket.mjs). Needs S3
+// creds. Skipped unless both are set, so a normal live run doesn't require it.
+const TRUNC_BUCKET = process.env.B2_TRUNCATION_BUCKET;
+const truncIt = HAS_S3_CREDS && TRUNC_BUCKET ? test : test.skip;
 
 // ── Helpers ───────────────────────────────────────────────────────────────────
 
@@ -432,5 +437,35 @@ describe("Error handling", () => {
       bucket: "this-bucket-does-not-exist-xyz-99999",
     });
     expect(isError(result)).toBe(true);
+  });
+});
+
+// Verifies the scan bound on a real, large bucket (preseeded with 5k objects).
+describe("Large-bucket truncation — b2_largest_files (gated: B2_TRUNCATION_BUCKET)", () => {
+  truncIt("trips max_scan on a >max_scan bucket and reports truncated", async () => {
+    const raw = await callTool(server, "b2_largest_files", {
+      bucket: TRUNC_BUCKET,
+      limit: 5,
+      max_scan: 1000,
+    });
+    expect(isError(raw)).toBe(false);
+    const result = parseResult(raw);
+    expect(result.truncated).toBe(true);
+    expect(result.scanned).toBeGreaterThanOrEqual(1000);
+    expect(result.returned).toBeLessThanOrEqual(5);
+    expect(result.note).toContain("max_scan");
+    console.log(`  truncated at scanned=${result.scanned}, largest=${result.files?.[0]?.size_bytes}B`);
+  });
+
+  truncIt("returns a complete result when max_scan exceeds the object count", async () => {
+    const result = parseResult(
+      await callTool(server, "b2_largest_files", {
+        bucket: TRUNC_BUCKET,
+        limit: 5,
+        max_scan: 50000,
+      }),
+    );
+    expect(result.truncated).toBe(false);
+    expect(result.scanned).toBeGreaterThanOrEqual(5000);
   });
 });

--- a/tests/unit/b2-tools.test.ts
+++ b/tests/unit/b2-tools.test.ts
@@ -163,6 +163,34 @@ describe("b2_list_buckets", () => {
       }),
     );
   });
+
+  const manyBuckets = (n: number) =>
+    Array.from({ length: n }, (_, i) => ({
+      bucketId: `bucket-${i}`,
+      bucketName: `bucket-${i}`,
+      bucketType: "allPrivate",
+    }));
+
+  // NOTE: this harness calls the handler directly, so the schema's .default(100)
+  // (applied by the MCP SDK's zod parse in production) is not injected here — we
+  // pass `limit` explicitly to exercise the truncation logic itself.
+  it("caps to the requested limit and reports truncation", async () => {
+    setupMocks({ buckets: manyBuckets(150) });
+    const result = parseResult(await callTool(server, "b2_list_buckets", { limit: 100 }));
+    expect(result.buckets).toHaveLength(100);
+    expect(result.bucket_count).toBe(100);
+    expect(result.total_bucket_count).toBe(150);
+    expect(result.truncated).toBe(true);
+    expect(result.note).toContain("first 100 of 150");
+  });
+
+  it("returns all buckets when limit covers the total, and omits the truncation flag", async () => {
+    setupMocks({ buckets: manyBuckets(150) });
+    const result = parseResult(await callTool(server, "b2_list_buckets", { limit: 1000 }));
+    expect(result.buckets).toHaveLength(150);
+    expect(result.total_bucket_count).toBe(150);
+    expect(result.truncated).toBeUndefined();
+  });
 });
 
 // ── b2_create_bucket ──────────────────────────────────────────────────────────

--- a/tests/unit/errors.test.ts
+++ b/tests/unit/errors.test.ts
@@ -111,6 +111,24 @@ describe("formatB2Error", () => {
     };
     expect(formatB2Error(err)).toContain("requestId: req-500-1");
   });
+
+  it("appends master-key guidance on an S3 InvalidAccessKeyId / Malformed Access Key Id", () => {
+    const err = {
+      name: "InvalidAccessKeyId",
+      message: "Malformed Access Key Id",
+      $metadata: { httpStatusCode: 403, requestId: "req-403" },
+    };
+    const formatted = formatB2Error(err);
+    expect(formatted).toContain("InvalidAccessKeyId");
+    expect(formatted).toContain("only accepts a regular");
+    expect(formatted).toContain("master key");
+    expect(formatted).toContain("requestId: req-403"); // hint sits before the requestId
+  });
+
+  it("does not append the hint to unrelated errors", () => {
+    const err = { response: { status: 404, data: { code: "file_not_present", message: "gone" } } };
+    expect(formatB2Error(err)).not.toContain("application key");
+  });
 });
 
 describe("parseErrorText (round-trips formatB2Error for the audit layer)", () => {

--- a/tests/unit/insights-bounds.test.ts
+++ b/tests/unit/insights-bounds.test.ts
@@ -1,0 +1,214 @@
+/**
+ * Unit tests for the large-bucket safety bounds on the live insight tools.
+ *
+ * b2_largest_files and b2_unfinished_uploads walk a bucket via the S3 client; on
+ * very large / bloated buckets that walk must stop at a scan cap or a wall-clock
+ * budget rather than hang. These tests drive a mocked S3 client through those
+ * bound conditions.
+ *
+ * Mocks:
+ *   - axios (module)            → auth (axios.get) + resolveBucketName's
+ *                                 b2Client.call("b2_list_buckets")
+ *   - S3Client.prototype.send   → the ListObjectsV2 / ListMultipartUploads /
+ *                                 ListParts pages the handlers paginate
+ *
+ * NOTE: callTool invokes handlers directly, so the MCP SDK's zod .default() is
+ * not applied here — we pass limit / max_scan / max_uploads explicitly.
+ */
+
+import axios from "axios";
+import {
+  S3Client,
+  ListObjectsV2Command,
+  ListMultipartUploadsCommand,
+  ListPartsCommand,
+} from "@aws-sdk/client-s3";
+import { createServer } from "../../src/server";
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+
+jest.mock("axios");
+
+const mockedAxios = axios as jest.MockedFunction<typeof axios> & {
+  get: jest.MockedFunction<typeof axios.get>;
+};
+
+const mockAuthData = {
+  accountId: "test-account-123",
+  authorizationToken: "mock-token-xyz",
+  apiInfo: {
+    storageApi: {
+      apiUrl: "https://api005.backblazeb2.com",
+      downloadUrl: "https://f005.backblazeb2.com",
+      s3ApiUrl: "https://s3.us-west-004.backblazeb2.com",
+      recommendedPartSize: 100 * 1024 * 1024,
+      absoluteMinimumPartSize: 5 * 1024 * 1024,
+    },
+  },
+};
+
+const testConfig = {
+  applicationKeyId: "test-key-id",
+  applicationKey: "test-key-secret",
+  appKeyId: "test-app-key-id",
+  appKey: "test-app-key-secret",
+  masterKeyId: "test-app-key-secret",
+  masterKey: "test-app-key-secret",
+  region: "us-west-004",
+  allowLocalFiles: true,
+  fileRoot: null,
+};
+
+async function callTool(server: McpServer, name: string, args: Record<string, unknown> = {}) {
+  const tool = (server as any)._registeredTools?.[name];
+  if (!tool) throw new Error(`Tool not found: ${name}`);
+  const handler = tool.handler ?? tool.callback ?? tool.execute;
+  return handler(args, {} as any);
+}
+
+function parseResult(result: any) {
+  const text = result?.content?.[0]?.text;
+  if (!text) return result;
+  try {
+    return JSON.parse(text);
+  } catch {
+    return text;
+  }
+}
+
+let server: McpServer;
+let sendSpy: jest.SpyInstance;
+
+beforeEach(() => {
+  server = createServer(testConfig);
+  // Auth + bucket resolution: resolveBucketName resolves "test-bucket" by name.
+  mockedAxios.get = jest.fn().mockResolvedValue({ data: mockAuthData });
+  mockedAxios.mockResolvedValue({
+    data: { buckets: [{ bucketName: "test-bucket", bucketId: "bucket-1" }] },
+  } as any);
+  sendSpy = jest.spyOn(S3Client.prototype as any, "send").mockResolvedValue({} as any);
+});
+
+afterEach(() => jest.restoreAllMocks());
+
+/** Route the mocked S3 send to queued pages by command type. */
+function queueS3(opts: {
+  objectPages?: any[];
+  uploadPages?: any[];
+  partsByKey?: Record<string, any[]>;
+}) {
+  const objQ = [...(opts.objectPages ?? [])];
+  const upQ = [...(opts.uploadPages ?? [])];
+  const parts = opts.partsByKey ?? {};
+  sendSpy.mockImplementation(async (command: any) => {
+    if (command instanceof ListObjectsV2Command) return objQ.shift() ?? { Contents: [], IsTruncated: false };
+    if (command instanceof ListMultipartUploadsCommand) return upQ.shift() ?? { Uploads: [], IsTruncated: false };
+    if (command instanceof ListPartsCommand) return { Parts: parts[command.input?.Key as string] ?? [], IsTruncated: false };
+    return {};
+  });
+}
+
+const obj = (Key: string, Size: number) => ({ Key, Size, LastModified: new Date("2021-01-01") });
+
+// ── b2_largest_files ──────────────────────────────────────────────────────────
+
+describe("b2_largest_files — scan bound", () => {
+  it("stops at max_scan, reports truncated, and ranks the largest seen", async () => {
+    queueS3({
+      objectPages: [
+        { Contents: [obj("a", 10), obj("b", 20), obj("c", 30)], IsTruncated: true, NextContinuationToken: "t1" },
+        { Contents: [obj("d", 5), obj("e", 40), obj("f", 15)], IsTruncated: true, NextContinuationToken: "t2" },
+        // further pages exist (IsTruncated stays true) but the cap fires first
+      ],
+    });
+
+    const result = parseResult(
+      await callTool(server, "b2_largest_files", { bucket: "test-bucket", limit: 3, max_scan: 5 }),
+    );
+
+    expect(result.truncated).toBe(true);
+    expect(result.scanned).toBe(6); // stopped after the 2nd page (6 ≥ 5) with a token still pending
+    expect(result.returned).toBe(3);
+    expect(result.files.map((f: any) => f.size_bytes)).toEqual([40, 30, 20]);
+    expect(result.note).toContain("max_scan");
+  });
+
+  it("returns a complete (non-truncated) result when the listing ends within the cap", async () => {
+    queueS3({
+      objectPages: [{ Contents: [obj("a", 10), obj("b", 20)], IsTruncated: false }],
+    });
+
+    const result = parseResult(
+      await callTool(server, "b2_largest_files", { bucket: "test-bucket", limit: 10, max_scan: 50000 }),
+    );
+
+    expect(result.truncated).toBe(false); // largest_files always emits the flag
+    expect(result.scanned).toBe(2);
+    expect(result.returned).toBe(2);
+    expect(result.files[0].size_bytes).toBe(20);
+  });
+});
+
+// ── b2_unfinished_uploads ───────────────────────────────────────────────────--
+
+describe("b2_unfinished_uploads — upload bound", () => {
+  const up = (Key: string, UploadId: string, isoDate: string) => ({
+    Key,
+    UploadId,
+    Initiated: new Date(isoDate),
+  });
+
+  it("stops at max_uploads, reports truncated, and still finds the oldest + wasted bytes", async () => {
+    queueS3({
+      uploadPages: [
+        {
+          Uploads: [up("u1", "1", "2020-02-01"), up("u2", "2", "2020-01-01")],
+          IsTruncated: true,
+          NextKeyMarker: "k",
+          NextUploadIdMarker: "i",
+        },
+      ],
+      partsByKey: { u1: [{ Size: 1e9 }], u2: [{ Size: 2e9 }] },
+    });
+
+    const result = parseResult(
+      await callTool(server, "b2_unfinished_uploads", { bucket: "test-bucket", max_uploads: 2 }),
+    );
+
+    expect(result.truncated).toBe(true);
+    expect(result.unfinished_count).toBe(2);
+    expect(result.oldest_file).toBe("u2");
+    expect(result.wasted_gb).toBe(3); // (1 + 2) GB
+    expect(result.note).toContain("max_uploads");
+  });
+
+  it("reports wasted_gb as a lower bound when the parts-summing budget is hit", async () => {
+    // Walk completes (no markers); the per-upload parts fan-out trips the budget.
+    queueS3({
+      uploadPages: [
+        { Uploads: [up("u1", "1", "2020-02-01"), up("u2", "2", "2020-01-01")], IsTruncated: false },
+      ],
+      partsByKey: { u1: [{ Size: 1e9 }], u2: [{ Size: 2e9 }] },
+    });
+
+    // Clock: 0 through auth/walk/u1, then jump past the 12s budget so overBudget()
+    // trips right after u1's parts are summed (u2 is then skipped for sizing).
+    let clock = 0;
+    jest.spyOn(Date, "now").mockImplementation(() => clock);
+    const realImpl = sendSpy.getMockImplementation()!;
+    sendSpy.mockImplementation(async (command: any) => {
+      const out = await realImpl(command);
+      if (command instanceof ListPartsCommand && command.input?.Key === "u1") clock = 999_999;
+      return out;
+    });
+
+    const result = parseResult(
+      await callTool(server, "b2_unfinished_uploads", { bucket: "test-bucket", max_uploads: 1000 }),
+    );
+
+    expect(result.truncated).toBe(false); // the walk itself completed
+    expect(result.wasted_is_lower_bound).toBe(true);
+    expect(result.sized_uploads).toBe(1);
+    expect(result.wasted_gb).toBe(1); // only u1 (1 GB) summed before the budget
+    expect(result.oldest_file).toBe("u2"); // oldest still found via the cheap list
+  });
+});


### PR DESCRIPTION
> **Stacked on #39** — base is `capability-aware-tool-registration`, not `main`. Review/merge after #39; GitHub will retarget to `main` once #39 lands.

## Problem
The live insight tools walked a bucket with no upper bound:
- `b2_largest_files` listed **every** object to sort by size.
- `b2_unfinished_uploads` walked **every** multipart upload, then listed **every part** of each — O(uploads × parts).

On a bucket with millions of files (or a bloated upload backlog) that's an unbounded, rate-limited fan-out that hangs and times out — worst on exactly the buckets these tools are meant to inspect.

## Changes
- **`b2_largest_files`** — `max_scan` (default 50k, max 500k) + a 12s wall-clock budget; stops at either and returns `truncated: true` with a note (narrow with a `prefix`).
- **`b2_unfinished_uploads`** — `max_uploads` (default 1k, max 10k) + the same budget over the parts fan-out; reports `wasted_is_lower_bound` when summing is cut short, while still finding the oldest upload accurately. Always emits `truncated`.
- **`b2_list_buckets`** — `limit` (default 100, max 1000); the B2 API returns every bucket in one response, so cap what's surfaced and add `total_bucket_count` + `truncated`.
- **Errors** — when the S3 endpoint rejects a master key (`InvalidAccessKeyId` / "Malformed Access Key Id"), the formatted error now explains that the `s3_*` and insight tools need a regular (non-master) application key.

## Tests & validation
- Unit coverage for every bound: new `tests/unit/insights-bounds.test.ts` (S3-mock drives the cap + time-budget paths) plus `b2-tools`/`errors` cases. **345 unit tests pass.**
- Gated live truncation test (`tests/integration/live.test.ts`, on `B2_TRUNCATION_BUCKET`) against a 5k-object bucket seeded by `scripts/seed-trunc-bucket.mjs`.
- Validated live against B2: `b2_largest_files` truncates at `scanned=1000`; the master-key hint appears on the real 403; `b2_unfinished_uploads` counts real multipart uploads.

## Notes
- Additive params + response fields (non-breaking) → minor bump to **2.3.0** with CHANGELOG entry.
- The master-key/S3 rule is already documented in the Technical Specification; this just makes the in-product error actionable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01P5rL3v9jLUQBegR3RLdjbT