### PR TITLE
feat: add explicit credential providers

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -29,7 +29,7 @@ B2_APPLICATION_KEY=
 # Bounded capability-discovery cache TTL and size. Cache identity is secret-bound;
 # logs use only non-secret credential fingerprints or verified principal labels.
 # B2_CAPABILITY_CACHE_TTL_MS=300000
-# B2_CAPABILITY_CACHE_MAX_ENTRIES=1000
+# B2_CAPABILITY_CACHE_MAX_ENTRIES=10000
 # Allow b2_create_key to grant key-management caps (default false).
 # B2_ALLOW_KEY_MGMT_GRANTS=false
 # Allow b2_create_key to mint unscoped write keys (default false).
@@ -47,7 +47,7 @@ B2_APPLICATION_KEY=
 # B2_HTTP_CREDENTIAL_MODE=headers
 #
 # Principal mode map and env-backed secret-broker material.
-# B2_PRINCIPAL_CREDENTIAL_MAP={"alice@example.com":"TENANT_A"}
+# B2_PRINCIPAL_CREDENTIAL_MAP={"alice":"TENANT_A"}
 # B2_CREDENTIAL_TENANT_A_APPLICATION_KEY_ID=
 # B2_CREDENTIAL_TENANT_A_APPLICATION_KEY=
 # B2_CREDENTIAL_TENANT_A_MASTER_KEY_ID=
@@ -60,6 +60,9 @@ B2_APPLICATION_KEY=
 # Per-credential request throttling.
 # B2_MCP_RATE_LIMIT_RPS=60
 # B2_MCP_RATE_LIMIT_BURST=120
+# Concurrent in-flight MCP request caps.
+# B2_MAX_SESSIONS=1000
+# B2_MAX_SESSIONS_PER_KEY=20
 # Local filesystem access for filePath/saveToPath (HTTP: off unless BOTH set).
 # B2_ALLOW_LOCAL_FILES=true
 # B2_FILE_ROOT=/sandbox/dir

--- a/.env.example
+++ b/.env.example
@@ -3,7 +3,7 @@
 # systemd environment. A single non-master application key covers the B2 native
 # API, the S3-compatible API, and key management.
 
-# ── Required ────────────────────────────────────────────────────────────────
+# ── Required for stdio and HTTP server mode ─────────────────────────────────
 B2_APPLICATION_KEY_ID=
 B2_APPLICATION_KEY=
 
@@ -22,9 +22,13 @@ B2_APPLICATION_KEY=
 # HTTP transport = block (safe-by-default). Set this to opt down/up explicitly.
 # B2_DESTRUCTIVE_POLICY=confirm
 # Capability-aware registration is ON by default: only tools the connected key
-# can use are registered (smaller surface, no dead tools). Set to true to always
-# register the full surface regardless of the key's capabilities.
+# can use are registered (smaller surface, no dead tools). Lookup failures fail
+# closed. Set to true to explicitly register the full surface regardless of the
+# key's capabilities.
 # B2_REGISTER_ALL_TOOLS=false
+# Bounded capability-discovery cache TTL. Cache keys use a non-secret credential
+# fingerprint or verified principal.
+# B2_CAPABILITY_CACHE_TTL_MS=300000
 # Allow b2_create_key to grant key-management caps (default false).
 # B2_ALLOW_KEY_MGMT_GRANTS=false
 # Allow b2_create_key to mint unscoped write keys (default false).
@@ -33,6 +37,19 @@ B2_APPLICATION_KEY=
 # B2_MAX_KEY_DURATION_SECONDS=
 
 # ── HTTP transport only ───────────────────────────────────────────────────────
+# Credential mode: server | principal | headers.
+# server: B2_APPLICATION_KEY_ID / B2_APPLICATION_KEY stay in the server process.
+# principal: verified MCP authInfo maps to an env-backed credential reference.
+# headers: compatibility only; B2 credential headers must be sent on every MCP request.
+# B2_HTTP_CREDENTIAL_MODE=server
+#
+# Principal mode map and env-backed secret-broker material.
+# B2_PRINCIPAL_CREDENTIAL_MAP={"alice@example.com":"TENANT_A"}
+# B2_CREDENTIAL_TENANT_A_APPLICATION_KEY_ID=
+# B2_CREDENTIAL_TENANT_A_APPLICATION_KEY=
+# B2_CREDENTIAL_TENANT_A_MASTER_KEY_ID=
+# B2_CREDENTIAL_TENANT_A_MASTER_KEY=
+#
 # Host/Origin allowlists (DNS-rebinding protection). With NEITHER set, the server
 # accepts ONLY localhost — set B2_ALLOWED_HOSTS for any internet-facing deployment.
 # B2_ALLOWED_HOSTS=mcp.example.com

--- a/.env.example
+++ b/.env.example
@@ -26,9 +26,10 @@ B2_APPLICATION_KEY=
 # closed. Set to true to explicitly register the full surface regardless of the
 # key's capabilities.
 # B2_REGISTER_ALL_TOOLS=false
-# Bounded capability-discovery cache TTL. Cache keys use a non-secret credential
-# fingerprint or verified principal.
+# Bounded capability-discovery cache TTL and size. Cache identity is secret-bound;
+# logs use only non-secret credential fingerprints or verified principal labels.
 # B2_CAPABILITY_CACHE_TTL_MS=300000
+# B2_CAPABILITY_CACHE_MAX_ENTRIES=1000
 # Allow b2_create_key to grant key-management caps (default false).
 # B2_ALLOW_KEY_MGMT_GRANTS=false
 # Allow b2_create_key to mint unscoped write keys (default false).
@@ -37,11 +38,13 @@ B2_APPLICATION_KEY=
 # B2_MAX_KEY_DURATION_SECONDS=
 
 # ── HTTP transport only ───────────────────────────────────────────────────────
-# Credential mode: server | principal | headers.
+# Credential mode: headers | server | principal. Unset defaults to headers for
+# compatibility with existing hosted clients; set server/principal explicitly for
+# deployments where clients send no B2 key.
 # server: B2_APPLICATION_KEY_ID / B2_APPLICATION_KEY stay in the server process.
 # principal: verified MCP authInfo maps to an env-backed credential reference.
-# headers: compatibility only; B2 credential headers must be sent on every MCP request.
-# B2_HTTP_CREDENTIAL_MODE=server
+# headers: B2 credential headers must be sent on every MCP request.
+# B2_HTTP_CREDENTIAL_MODE=headers
 #
 # Principal mode map and env-backed secret-broker material.
 # B2_PRINCIPAL_CREDENTIAL_MAP={"alice@example.com":"TENANT_A"}
@@ -54,9 +57,9 @@ B2_APPLICATION_KEY=
 # accepts ONLY localhost — set B2_ALLOWED_HOSTS for any internet-facing deployment.
 # B2_ALLOWED_HOSTS=mcp.example.com
 # B2_ALLOWED_ORIGINS=https://app.example.com
-# Concurrent-session caps.
-# B2_MAX_SESSIONS=1000
-# B2_MAX_SESSIONS_PER_KEY=20
+# Per-credential request throttling.
+# B2_MCP_RATE_LIMIT_RPS=60
+# B2_MCP_RATE_LIMIT_BURST=120
 # Local filesystem access for filePath/saveToPath (HTTP: off unless BOTH set).
 # B2_ALLOW_LOCAL_FILES=true
 # B2_FILE_ROOT=/sandbox/dir

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,14 +12,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   documentation, and public contract skeleton documents for Phase 1 ownership.
 - Added policy coverage for live workflow secret gates and the Streamable HTTP
   smoke helper contract.
+- Added explicit environment, per-request header, server-managed, and
+  verified-principal B2 credential providers.
 
 ### Changed
 - Canonicalized repository, package, workflow, security, and setup metadata for
   `backblaze-labs/b2-mcp`.
 - Aligned package metadata on the `0.1.0` Phase 1 release line.
 - Raised the enforced minimum Node runtime in `engines.node` from `>=18.0.0` to
-  `>=22.0.0`; operators on Node 18 or Node 20 must upgrade to Node 22 before
+  `>=22.3.0`; operators on Node 18 or Node 20 must upgrade to Node 22 before
   running `npm ci`, `npm run build`, or the release gate.
+- Migrated HTTP and stdio serving to the MCP TypeScript SDK v2 modern entry
+  points for MCP `2026-07-28`.
 - Made `b2-mcp` the canonical CLI binary while preserving `b2-mcp-server` as a
   transition alias.
 - Switched the smoke helper to Streamable HTTP `/mcp` and the 40-tool Phase 1

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -48,14 +48,14 @@ npm run test:integration
 ### Entry points
 
 - `src/index.ts` — stdio transport (Claude Desktop, local use)
-- `src/http-server.ts` — **Streamable HTTP** transport (MCP spec 2025-03-26; replaced the deprecated HTTP+SSE transport) for hosted deployments. Single `/mcp` endpoint (`POST` for JSON-RPC incl. `initialize`, `GET` for the server→client stream, `DELETE` to terminate); `GET /health`. Reads B2 credentials per-session from the headers on the `initialize` POST (`X-B2-Key-Id`, `X-B2-Key`, optional `X-B2-App-Key-Id`, `X-B2-App-Key`); returns 401 without them. The `initialize` response returns an `Mcp-Session-Id` header that follow-up requests must send. Each session gets its own `McpServer` + `B2Config` — no shared credential state. Sessions are tracked in `Map<Mcp-Session-Id, {transport, mcpServer, lastActivity, rateKey}>` and swept after 30 minutes of inactivity. Handles `SIGTERM`/`SIGINT` for graceful drain on deploy.
+- `src/http-server.ts` — **Streamable HTTP** transport for hosted deployments. Production serving uses the MCP SDK v2 per-request handler for MCP `2026-07-28` and a stateless 2025-era transition fallback; it does not create or depend on protocol sessions. Each `/mcp` request resolves credentials through the selected provider (`headers`, `server`, or `principal`) before the SDK handler runs. B2 credential and Authorization headers are stripped before crossing into the SDK boundary; verified caller identity travels only as `authInfo`. Handles `GET /health`, Host/Origin checks, request body caps, rate limiting, in-flight caps, graceful drain, and periodic cache sweeps.
 
 ### Tool registration flow
 
 `server.ts` exports three functions:
 
 - `loadConfig()` — reads env vars, validates required keys, returns `B2Config`
-- `fetchCapabilities(config)` — one-shot authorize that returns the key's `allowed.capabilities` (or `null` on failure / `B2_REGISTER_ALL_TOOLS=true`)
+- `fetchCapabilities(config)` — one-shot authorize that returns the key's `allowed.capabilities`; returns `null` only for `B2_REGISTER_ALL_TOOLS=true`. Lookup failures throw so HTTP fails closed.
 - `createServer(config, capabilities?)` — instantiates `B2AuthManager`, `B2Client`, and `S3Client`, then calls all `register*Tools()` functions
 
 Each register function receives the server + client(s) and calls `server.tool(name, description, zodSchema, handler)` for each tool. Adding a new tool means adding it to the appropriate register file — no changes to `server.ts` needed unless it's a new register file. **New tools should also be added to the capability map** (`src/utils/tool-capabilities.ts`).
@@ -112,14 +112,14 @@ B2_MASTER_KEY_ID=master_id B2_MASTER_KEY=master_secret \
 B2_PARTNER_LIVE=1 npm run test:integration
 ```
 
-## HTTP transport: per-session credentials & hardening
+## HTTP transport: per-request credentials & hardening
 
-The HTTP server (`src/http-server.ts`) implements the MCP **Streamable HTTP** transport (single `/mcp` endpoint; SSE was the legacy transport, deprecated in MCP 2025-03-26). It reads credentials per-session from the headers on the `initialize` POST. Each session gets its own `B2Config` + `McpServer` instance, torn down (transport **and** server) on `DELETE`, client disconnect, or idle sweep.
+The HTTP server (`src/http-server.ts`) implements a single `/mcp` endpoint with MCP `2026-07-28` as the preferred era and stateless 2025-era compatibility during migration. Credentials are resolved per request. Unset `B2_HTTP_CREDENTIAL_MODE` defaults to `headers` for one-release compatibility; hosted operators should set `server` or `principal` explicitly when clients must not send B2 keys.
 
 Because this transport is internet-facing, it is hardened by default:
 
 - **Local filesystem access is OFF.** `filePath` / `saveToPath` are rejected unless an operator sets `B2_ALLOW_LOCAL_FILES=true` **and** `B2_FILE_ROOT=/sandbox/dir` — and even then every path is confined (symlinks resolved) to that root via `src/utils/fs-guard.ts`. Remote callers can pass small (≤ 1 MiB) base64 `content` inline; for real object data they should use a presigned PutObject URL (`s3_get_presigned_url`) so bytes go client→B2 directly. On the stdio transport disk access is on by default (trusted local user); set `B2_FILE_ROOT` to sandbox it or `B2_ALLOW_LOCAL_FILES=false` to disable.
-- **Session caps:** `B2_MAX_SESSIONS` (default 1000) total and `B2_MAX_SESSIONS_PER_KEY` (default 20) per credential, returning 503 / 429 over the cap.
+- **In-flight caps:** `B2_MAX_SESSIONS` (default 1000) total and `B2_MAX_SESSIONS_PER_KEY` (default 20) per credential, returning 503 / 429 over the cap. The env names are retained for deploy-manifest compatibility.
 - **Rate limiting** keys on a SHA-256 hash of the full key id (not a prefix), so distinct tenants can't collide.
 - **DNS-rebinding protection:** set `B2_ALLOWED_HOSTS` / `B2_ALLOWED_ORIGINS` (comma-separated) to enable Host/Origin validation on the `/mcp` endpoint.
 - **Body cap:** POST bodies to `/mcp` are capped at 1 MB (413 over the cap).

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Destructive actions are gated, credentials never enter the model's context, and 
 
 ## Quick start
 
-**Prerequisites:** [Node.js 22 LTS](https://nodejs.org) and a Backblaze B2 [application key](https://www.backblaze.com/docs/cloud-storage-application-keys) (a non-master key is all you need).
+**Prerequisites:** [Node.js 22.3+](https://nodejs.org) and a Backblaze B2 [application key](https://www.backblaze.com/docs/cloud-storage-application-keys) (a non-master key is all you need).
 
 **1. Build:**
 
@@ -69,15 +69,16 @@ Replace the path with where you put the folder, then restart Claude Desktop — 
 
 **Security / policy (safe defaults; override as needed):**
 
-| Variable                                                         | Default           | Description                                                                                                               |
-| ---------------------------------------------------------------- | ----------------- | ------------------------------------------------------------------------------------------------------------------------- |
-| `B2_DESTRUCTIVE_POLICY`                                          | `confirm`         | Gate on destructive tools: `confirm` (require `confirm: true`), `block` (refuse), `allow` (off)                           |
-| `B2_ALLOW_KEY_MGMT_GRANTS`                                       | `false`           | Allow `b2_create_key` to grant key-management caps (a self-perpetuating key)                                              |
-| `B2_ALLOW_UNSCOPED_KEYS`                                         | `false`           | Allow `b2_create_key` to mint unscoped write keys                                                                         |
-| `B2_MAX_KEY_DURATION_SECONDS`                                    | _none_            | Cap minted-key validity; reject non-expiring keys                                                                         |
-| `B2_ALLOWED_HOSTS` / `B2_ALLOWED_ORIGINS`                        | _none_            | HTTP transport: Host/Origin allowlists (DNS-rebinding protection) — **set these for any internet-facing HTTP deployment** |
-| `B2_MCP_RATE_LIMIT_RPS` / `B2_MCP_RATE_LIMIT_BURST`              | `60` / `120`      | HTTP transport: per-credential request throttling                                                                         |
-| `B2_CAPABILITY_CACHE_TTL_MS` / `B2_CAPABILITY_CACHE_MAX_ENTRIES` | `300000` / `1000` | Bounded capability-discovery cache TTL and size. Cache identity is secret-bound; log labels are non-secret fingerprints   |
+| Variable                                                         | Default            | Description                                                                                                               |
+| ---------------------------------------------------------------- | ------------------ | ------------------------------------------------------------------------------------------------------------------------- |
+| `B2_DESTRUCTIVE_POLICY`                                          | `confirm`          | Gate on destructive tools: `confirm` (require `confirm: true`), `block` (refuse), `allow` (off)                           |
+| `B2_ALLOW_KEY_MGMT_GRANTS`                                       | `false`            | Allow `b2_create_key` to grant key-management caps (a self-perpetuating key)                                              |
+| `B2_ALLOW_UNSCOPED_KEYS`                                         | `false`            | Allow `b2_create_key` to mint unscoped write keys                                                                         |
+| `B2_MAX_KEY_DURATION_SECONDS`                                    | _none_             | Cap minted-key validity; reject non-expiring keys                                                                         |
+| `B2_ALLOWED_HOSTS` / `B2_ALLOWED_ORIGINS`                        | _none_             | HTTP transport: Host/Origin allowlists (DNS-rebinding protection) — **set these for any internet-facing HTTP deployment** |
+| `B2_MCP_RATE_LIMIT_RPS` / `B2_MCP_RATE_LIMIT_BURST`              | `60` / `120`       | HTTP transport: per-credential request throttling                                                                         |
+| `B2_MAX_SESSIONS` / `B2_MAX_SESSIONS_PER_KEY`                    | `1000` / `20`      | HTTP transport: global and per-credential concurrent in-flight request caps                                               |
+| `B2_CAPABILITY_CACHE_TTL_MS` / `B2_CAPABILITY_CACHE_MAX_ENTRIES` | `300000` / `10000` | Bounded capability-discovery cache TTL and size. Cache identity is secret-bound; log labels are non-secret fingerprints   |
 
 A ready-to-copy [`.env.example`](.env.example) lists these. HTTP-only file-access vars (`B2_ALLOW_LOCAL_FILES`, `B2_FILE_ROOT`) are covered in [`docs/DEPLOY.md`](docs/DEPLOY.md).
 
@@ -159,6 +160,7 @@ Running it safely:
 - **Local use → stdio** (the Quick Start above). Credentials stay in your client config / environment.
 - **Exposing HTTP → choose a credential mode.** Unset mode remains `headers` for one-release compatibility with existing header clients; B2 credential headers must be present on every MCP request. Set `B2_HTTP_CREDENTIAL_MODE=server` to keep one B2 credential in the server process/customer secret manager, or `principal` to map verified MCP `authInfo` to customer-held credentials.
 - **Caller auth stays at your edge.** For `principal` mode, terminate TLS and validate OAuth before the SDK handler receives `authInfo`; strip any trusted identity headers at the edge and only re-add them inside an allowlisted proxy boundary.
+- **MCP SDK v2 packages are pinned.** HTTP and stdio use the official `@modelcontextprotocol/server` v2 package from `github.com/modelcontextprotocol/typescript-sdk`; dependency versions are pinned in `package.json` and `package-lock.json`.
 - **Never commit credentials** — use env vars / a secrets manager. `.env*` is gitignored.
 
 Full hosted runbook (nginx, Let's Encrypt, hardened systemd, fail2ban, monitoring, and a security baseline checklist): [`docs/DEPLOY.md`](docs/DEPLOY.md).

--- a/README.md
+++ b/README.md
@@ -55,29 +55,29 @@ Replace the path with where you put the folder, then restart Claude Desktop — 
 
 ## Configuration
 
-| Variable                                                      | Required              | Default               | Description                                                                                                              |
-| ------------------------------------------------------------- | --------------------- | --------------------- | ------------------------------------------------------------------------------------------------------------------------ |
-| `B2_APPLICATION_KEY_ID`                                       | stdio / HTTP `server` | —                     | Application key ID (non-master) — the workhorse: native + S3 + key management                                            |
-| `B2_APPLICATION_KEY`                                          | stdio / HTTP `server` | —                     | Application key secret                                                                                                   |
-| `B2_MASTER_KEY_ID` / `B2_MASTER_KEY`                          | —                     | falls back to app key | Master key — used **only** by Partner API tools                                                                          |
-| `B2_REGION`                                                   | —                     | `us-west-004`         | Region for the S3-compatible endpoint                                                                                    |
-| `B2_MCP_UA_SUFFIX`                                            | —                     | —                     | Token appended to the outbound User-Agent (tag a deployment)                                                             |
-| `B2_APP_KEY_ID` / `B2_APP_KEY`                                | —                     | _deprecated_          | Legacy non-master S3 override (only if your primary key is a master key) — prefer `B2_MASTER_KEY_*`                      |
-| `B2_HTTP_CREDENTIAL_MODE`                                     | HTTP only             | `server`              | `server`, `principal`, or `headers`; headers mode is explicit compatibility and requires B2 headers on every MCP request |
-| `B2_PRINCIPAL_CREDENTIAL_MAP`                                 | HTTP `principal`      | —                     | JSON map from verified MCP principal to a customer-managed credential reference                                          |
-| `B2_CREDENTIAL_<REF>_APPLICATION_KEY_ID` / `_APPLICATION_KEY` | HTTP `principal`      | —                     | Env-backed secret-broker material for the mapped reference                                                               |
+| Variable                                                      | Required              | Default               | Description                                                                                                               |
+| ------------------------------------------------------------- | --------------------- | --------------------- | ------------------------------------------------------------------------------------------------------------------------- |
+| `B2_APPLICATION_KEY_ID`                                       | stdio / HTTP `server` | —                     | Application key ID (non-master) — the workhorse: native + S3 + key management                                             |
+| `B2_APPLICATION_KEY`                                          | stdio / HTTP `server` | —                     | Application key secret                                                                                                    |
+| `B2_MASTER_KEY_ID` / `B2_MASTER_KEY`                          | —                     | falls back to app key | Master key — used **only** by Partner API tools                                                                           |
+| `B2_REGION`                                                   | —                     | `us-west-004`         | Region for the S3-compatible endpoint                                                                                     |
+| `B2_MCP_UA_SUFFIX`                                            | —                     | —                     | Token appended to the outbound User-Agent (tag a deployment)                                                              |
+| `B2_APP_KEY_ID` / `B2_APP_KEY`                                | —                     | _deprecated_          | Legacy non-master S3 override (only if your primary key is a master key) — prefer `B2_MASTER_KEY_*`                       |
+| `B2_HTTP_CREDENTIAL_MODE`                                     | HTTP only             | `headers`             | `headers`, `server`, or `principal`; unset preserves existing header-based clients. Set explicitly for hosted deployments |
+| `B2_PRINCIPAL_CREDENTIAL_MAP`                                 | HTTP `principal`      | —                     | JSON map from verified MCP principal to a customer-managed credential reference                                           |
+| `B2_CREDENTIAL_<REF>_APPLICATION_KEY_ID` / `_APPLICATION_KEY` | HTTP `principal`      | —                     | Env-backed secret-broker material for the mapped reference                                                                |
 
 **Security / policy (safe defaults; override as needed):**
 
-| Variable                                      | Default       | Description                                                                                                               |
-| --------------------------------------------- | ------------- | ------------------------------------------------------------------------------------------------------------------------- |
-| `B2_DESTRUCTIVE_POLICY`                       | `confirm`     | Gate on destructive tools: `confirm` (require `confirm: true`), `block` (refuse), `allow` (off)                           |
-| `B2_ALLOW_KEY_MGMT_GRANTS`                    | `false`       | Allow `b2_create_key` to grant key-management caps (a self-perpetuating key)                                              |
-| `B2_ALLOW_UNSCOPED_KEYS`                      | `false`       | Allow `b2_create_key` to mint unscoped write keys                                                                         |
-| `B2_MAX_KEY_DURATION_SECONDS`                 | _none_        | Cap minted-key validity; reject non-expiring keys                                                                         |
-| `B2_ALLOWED_HOSTS` / `B2_ALLOWED_ORIGINS`     | _none_        | HTTP transport: Host/Origin allowlists (DNS-rebinding protection) — **set these for any internet-facing HTTP deployment** |
-| `B2_MAX_SESSIONS` / `B2_MAX_SESSIONS_PER_KEY` | `1000` / `20` | HTTP transport: concurrent-session caps                                                                                   |
-| `B2_CAPABILITY_CACHE_TTL_MS`                  | `300000`      | Bounded capability-discovery cache TTL; cache keys use a non-secret credential fingerprint or verified principal          |
+| Variable                                                         | Default           | Description                                                                                                               |
+| ---------------------------------------------------------------- | ----------------- | ------------------------------------------------------------------------------------------------------------------------- |
+| `B2_DESTRUCTIVE_POLICY`                                          | `confirm`         | Gate on destructive tools: `confirm` (require `confirm: true`), `block` (refuse), `allow` (off)                           |
+| `B2_ALLOW_KEY_MGMT_GRANTS`                                       | `false`           | Allow `b2_create_key` to grant key-management caps (a self-perpetuating key)                                              |
+| `B2_ALLOW_UNSCOPED_KEYS`                                         | `false`           | Allow `b2_create_key` to mint unscoped write keys                                                                         |
+| `B2_MAX_KEY_DURATION_SECONDS`                                    | _none_            | Cap minted-key validity; reject non-expiring keys                                                                         |
+| `B2_ALLOWED_HOSTS` / `B2_ALLOWED_ORIGINS`                        | _none_            | HTTP transport: Host/Origin allowlists (DNS-rebinding protection) — **set these for any internet-facing HTTP deployment** |
+| `B2_MCP_RATE_LIMIT_RPS` / `B2_MCP_RATE_LIMIT_BURST`              | `60` / `120`      | HTTP transport: per-credential request throttling                                                                         |
+| `B2_CAPABILITY_CACHE_TTL_MS` / `B2_CAPABILITY_CACHE_MAX_ENTRIES` | `300000` / `1000` | Bounded capability-discovery cache TTL and size. Cache identity is secret-bound; log labels are non-secret fingerprints   |
 
 A ready-to-copy [`.env.example`](.env.example) lists these. HTTP-only file-access vars (`B2_ALLOW_LOCAL_FILES`, `B2_FILE_ROOT`) are covered in [`docs/DEPLOY.md`](docs/DEPLOY.md).
 
@@ -157,7 +157,7 @@ Running it safely:
 
 - **Use a least-privilege key** — scope `b2_create_key` to the buckets/capabilities you need; a non-master key is correct.
 - **Local use → stdio** (the Quick Start above). Credentials stay in your client config / environment.
-- **Exposing HTTP → choose a credential mode.** `server` mode keeps B2 keys in the server process/customer secret manager. `principal` mode requires verified MCP `authInfo` from your OAuth/resource-server boundary and maps the caller to a credential reference. `headers` mode is compatibility only; B2 credential headers must be present on every MCP request and cannot switch within a session.
+- **Exposing HTTP → choose a credential mode.** Unset mode remains `headers` for one-release compatibility with existing header clients; B2 credential headers must be present on every MCP request. Set `B2_HTTP_CREDENTIAL_MODE=server` to keep one B2 credential in the server process/customer secret manager, or `principal` to map verified MCP `authInfo` to customer-held credentials.
 - **Caller auth stays at your edge.** For `principal` mode, terminate TLS and validate OAuth before the SDK handler receives `authInfo`; strip any trusted identity headers at the edge and only re-add them inside an allowlisted proxy boundary.
 - **Never commit credentials** — use env vars / a secrets manager. `.env*` is gitignored.
 
@@ -173,7 +173,7 @@ npm run typecheck          # type-check src + tests (no emit)
 npm test                   # unit tests (no credentials needed)
 npm run test:integration   # live B2 tests — needs B2_APPLICATION_KEY_ID / B2_APPLICATION_KEY
 npm start                  # stdio transport
-npm run start:http -- --port 3000   # Streamable HTTP transport
+npm run start:http -- --port 3000   # MCP 2026-07-28 HTTP transport
 npx @modelcontextprotocol/inspector node ./dist/index.js   # interactive inspector
 ```
 

--- a/README.md
+++ b/README.md
@@ -55,14 +55,17 @@ Replace the path with where you put the folder, then restart Claude Desktop — 
 
 ## Configuration
 
-| Variable                             | Required | Default               | Description                                                                                         |
-| ------------------------------------ | -------- | --------------------- | --------------------------------------------------------------------------------------------------- |
-| `B2_APPLICATION_KEY_ID`              | ✅       | —                     | Application key ID (non-master) — the workhorse: native + S3 + key management                       |
-| `B2_APPLICATION_KEY`                 | ✅       | —                     | Application key secret                                                                              |
-| `B2_MASTER_KEY_ID` / `B2_MASTER_KEY` | —        | falls back to app key | Master key — used **only** by Partner API tools                                                     |
-| `B2_REGION`                          | —        | `us-west-004`         | Region for the S3-compatible endpoint                                                               |
-| `B2_MCP_UA_SUFFIX`                   | —        | —                     | Token appended to the outbound User-Agent (tag a deployment)                                        |
-| `B2_APP_KEY_ID` / `B2_APP_KEY`       | —        | _deprecated_          | Legacy non-master S3 override (only if your primary key is a master key) — prefer `B2_MASTER_KEY_*` |
+| Variable                                                      | Required              | Default               | Description                                                                                                              |
+| ------------------------------------------------------------- | --------------------- | --------------------- | ------------------------------------------------------------------------------------------------------------------------ |
+| `B2_APPLICATION_KEY_ID`                                       | stdio / HTTP `server` | —                     | Application key ID (non-master) — the workhorse: native + S3 + key management                                            |
+| `B2_APPLICATION_KEY`                                          | stdio / HTTP `server` | —                     | Application key secret                                                                                                   |
+| `B2_MASTER_KEY_ID` / `B2_MASTER_KEY`                          | —                     | falls back to app key | Master key — used **only** by Partner API tools                                                                          |
+| `B2_REGION`                                                   | —                     | `us-west-004`         | Region for the S3-compatible endpoint                                                                                    |
+| `B2_MCP_UA_SUFFIX`                                            | —                     | —                     | Token appended to the outbound User-Agent (tag a deployment)                                                             |
+| `B2_APP_KEY_ID` / `B2_APP_KEY`                                | —                     | _deprecated_          | Legacy non-master S3 override (only if your primary key is a master key) — prefer `B2_MASTER_KEY_*`                      |
+| `B2_HTTP_CREDENTIAL_MODE`                                     | HTTP only             | `server`              | `server`, `principal`, or `headers`; headers mode is explicit compatibility and requires B2 headers on every MCP request |
+| `B2_PRINCIPAL_CREDENTIAL_MAP`                                 | HTTP `principal`      | —                     | JSON map from verified MCP principal to a customer-managed credential reference                                          |
+| `B2_CREDENTIAL_<REF>_APPLICATION_KEY_ID` / `_APPLICATION_KEY` | HTTP `principal`      | —                     | Env-backed secret-broker material for the mapped reference                                                               |
 
 **Security / policy (safe defaults; override as needed):**
 
@@ -74,6 +77,7 @@ Replace the path with where you put the folder, then restart Claude Desktop — 
 | `B2_MAX_KEY_DURATION_SECONDS`                 | _none_        | Cap minted-key validity; reject non-expiring keys                                                                         |
 | `B2_ALLOWED_HOSTS` / `B2_ALLOWED_ORIGINS`     | _none_        | HTTP transport: Host/Origin allowlists (DNS-rebinding protection) — **set these for any internet-facing HTTP deployment** |
 | `B2_MAX_SESSIONS` / `B2_MAX_SESSIONS_PER_KEY` | `1000` / `20` | HTTP transport: concurrent-session caps                                                                                   |
+| `B2_CAPABILITY_CACHE_TTL_MS`                  | `300000`      | Bounded capability-discovery cache TTL; cache keys use a non-secret credential fingerprint or verified principal          |
 
 A ready-to-copy [`.env.example`](.env.example) lists these. HTTP-only file-access vars (`B2_ALLOW_LOCAL_FILES`, `B2_FILE_ROOT`) are covered in [`docs/DEPLOY.md`](docs/DEPLOY.md).
 
@@ -147,13 +151,14 @@ Scope follows the caller's key — a partner key sees its sub-accounts; a custom
 
 ## Security & self-hosting
 
-Built-in safeguards (on by default): destructive-action gating (`B2_DESTRUCTIVE_POLICY`), a `b2_create_key` lockdown (no key-management or unscoped write keys without opt-in), per-session credentials, rate limiting, and a values-redacted audit log (key names only — never secrets, values, or file contents). The server never phones home.
+Built-in safeguards (on by default): destructive-action gating (`B2_DESTRUCTIVE_POLICY`), a `b2_create_key` lockdown (no key-management or unscoped write keys without opt-in), explicit credential-provider modes, capability-aware tool registration that fails closed, rate limiting, and a values-redacted audit log (non-secret credential fingerprints only — never secrets, values, or file contents). The server never phones home.
 
 Running it safely:
 
 - **Use a least-privilege key** — scope `b2_create_key` to the buckets/capabilities you need; a non-master key is correct.
 - **Local use → stdio** (the Quick Start above). Credentials stay in your client config / environment.
-- **Exposing HTTP → you own the front door.** The server reads B2 credentials per session but performs **no caller authentication**. Put it behind **your own reverse proxy with TLS and caller auth** (SSO/Cloudflare Access/mTLS), and **set `B2_ALLOWED_HOSTS`** for DNS-rebinding protection.
+- **Exposing HTTP → choose a credential mode.** `server` mode keeps B2 keys in the server process/customer secret manager. `principal` mode requires verified MCP `authInfo` from your OAuth/resource-server boundary and maps the caller to a credential reference. `headers` mode is compatibility only; B2 credential headers must be present on every MCP request and cannot switch within a session.
+- **Caller auth stays at your edge.** For `principal` mode, terminate TLS and validate OAuth before the SDK handler receives `authInfo`; strip any trusted identity headers at the edge and only re-add them inside an allowlisted proxy boundary.
 - **Never commit credentials** — use env vars / a secrets manager. `.env*` is gitignored.
 
 Full hosted runbook (nginx, Let's Encrypt, hardened systemd, fail2ban, monitoring, and a security baseline checklist): [`docs/DEPLOY.md`](docs/DEPLOY.md).

--- a/docs/CLIENTS.md
+++ b/docs/CLIENTS.md
@@ -3,7 +3,7 @@
 This server speaks the Model Context Protocol over **two transports**:
 
 - **stdio** — the server runs as a local subprocess of the client. Used by desktop apps and IDE extensions (Claude Desktop, Cursor, VS Code, Cline, Windsurf, Zed, Continue, Goose…).
-- **Streamable HTTP** — the server runs as a hosted endpoint behind a URL (single `/mcp` endpoint; the MCP Streamable HTTP transport, spec 2025-03-26, which replaced the deprecated HTTP+SSE transport). Used by web clients (Claude.ai Custom Connectors) and any client pointed at a remote server. See [`DEPLOY.md`](DEPLOY.md) to stand one up.
+- **HTTP** — the server runs as a hosted MCP 2026-07-28 endpoint behind a URL (single `/mcp` endpoint). Used by web clients (Claude.ai Custom Connectors) and any client pointed at a remote server. See [`DEPLOY.md`](DEPLOY.md) to stand one up.
 
 > **The one thing that matters:** every stdio client runs the _same_ command —
 > `node /ABSOLUTE/PATH/TO/b2-mcp/dist/index.js` with two env vars. Only the
@@ -202,9 +202,9 @@ Point it at `node /ABSOLUTE/PATH/TO/b2-mcp/dist/index.js` with the two env vars,
 
 ---
 
-## B. Hosted (Streamable HTTP)
+## B. Hosted HTTP
 
-For a server deployed per [`DEPLOY.md`](DEPLOY.md). The hosted endpoint is `https://<host>/mcp` (Streamable HTTP; SSE was the legacy transport, deprecated in MCP 2025-03-26). By default, hosted deployments use `B2_HTTP_CREDENTIAL_MODE=server`, so the client sends no B2 key.
+For a server deployed per [`DEPLOY.md`](DEPLOY.md). The hosted endpoint is `https://<host>/mcp`. Unset `B2_HTTP_CREDENTIAL_MODE` defaults to `headers` for compatibility with existing hosted clients; set `server` or `principal` explicitly when the client should send no B2 key.
 
 ### Claude Desktop → hosted server (`mcp-remote` bridge)
 
@@ -231,13 +231,13 @@ These accept the URL + headers shape directly:
 }
 ```
 
-### Any Streamable-HTTP-capable client
+### Any HTTP-capable MCP client
 
 Point it at `https://<host>/mcp`. In `server` mode, do not send B2 credential headers. In `principal` mode, your OAuth/resource-server layer must validate the caller and attach verified MCP `authInfo` before the handler runs.
 
 ### Header compatibility mode
 
-If the operator explicitly sets `B2_HTTP_CREDENTIAL_MODE=headers`, send B2 credentials on every MCP request. Prefer the explicit header names:
+If the operator sets `B2_HTTP_CREDENTIAL_MODE=headers` or leaves it unset, send B2 credentials on every MCP request. Prefer the explicit header names:
 
 ```json
 {

--- a/docs/CLIENTS.md
+++ b/docs/CLIENTS.md
@@ -204,7 +204,7 @@ Point it at `node /ABSOLUTE/PATH/TO/b2-mcp/dist/index.js` with the two env vars,
 
 ## B. Hosted (Streamable HTTP)
 
-For a server deployed per [`DEPLOY.md`](DEPLOY.md). The hosted endpoint is `https://<host>/mcp` (Streamable HTTP; SSE was the legacy transport, deprecated in MCP 2025-03-26). Credentials travel in request **headers** on the initialize request, not env vars.
+For a server deployed per [`DEPLOY.md`](DEPLOY.md). The hosted endpoint is `https://<host>/mcp` (Streamable HTTP; SSE was the legacy transport, deprecated in MCP 2025-03-26). By default, hosted deployments use `B2_HTTP_CREDENTIAL_MODE=server`, so the client sends no B2 key.
 
 ### Claude Desktop → hosted server (`mcp-remote` bridge)
 
@@ -215,15 +215,7 @@ Claude Desktop only accepts stdio entries, so use the [`mcp-remote`](https://www
   "mcpServers": {
     "backblaze-b2": {
       "command": "npx",
-      "args": [
-        "-y",
-        "mcp-remote",
-        "https://mcp.your-domain.example/mcp",
-        "--header",
-        "X-B2-Key-Id:your-key-id",
-        "--header",
-        "X-B2-Key:your-key-secret"
-      ]
+      "args": ["-y", "mcp-remote", "https://mcp.your-domain.example/mcp"]
     }
   }
 }
@@ -235,24 +227,37 @@ These accept the URL + headers shape directly:
 
 ```json
 {
-  "url": "https://mcp.your-domain.example/mcp",
-  "headers": {
-    "X-B2-Key-Id": "your-key-id",
-    "X-B2-Key": "your-key-secret"
-  }
+  "url": "https://mcp.your-domain.example/mcp"
 }
 ```
 
 ### Any Streamable-HTTP-capable client
 
-Point it at `https://<host>/mcp` and send the `X-B2-Key-Id` / `X-B2-Key` headers. If your primary key is a **master** key, also send `X-B2-App-Key-Id` / `X-B2-App-Key` (a non-master key) — B2's S3 endpoint rejects master keys.
+Point it at `https://<host>/mcp`. In `server` mode, do not send B2 credential headers. In `principal` mode, your OAuth/resource-server layer must validate the caller and attach verified MCP `authInfo` before the handler runs.
+
+### Header compatibility mode
+
+If the operator explicitly sets `B2_HTTP_CREDENTIAL_MODE=headers`, send B2 credentials on every MCP request. Prefer the explicit header names:
+
+```json
+{
+  "url": "https://mcp.your-domain.example/mcp",
+  "headers": {
+    "X-B2-MCP-Key-Id": "your-key-id",
+    "X-B2-MCP-Key": "your-key-secret"
+  }
+}
+```
+
+If Partner API tools require a distinct master key, also send `X-B2-MCP-Master-Key-Id` / `X-B2-MCP-Master-Key`.
 
 ---
 
 ## Credentials & security
 
 - **stdio:** the key goes in the `env` block of the client's config file, in **plaintext**. Protect that file and never commit it to a repo.
-- **hosted:** the key travels in `X-B2-*` headers. Front the server with TLS and a caller-auth layer (see [`DEPLOY.md`](DEPLOY.md) — the HTTP transport authenticates the _B2 key_, not the _caller_).
-- **Master-key caveat:** only the Partner API and account-level key management need a master key in Phase 1. If you use one, also supply a non-master key (`B2_APP_KEY_ID`/`B2_APP_KEY` for stdio, or `X-B2-App-Key-Id`/`X-B2-App-Key` for hosted) for the S3 tools.
+- **hosted server/principal modes:** the client sends no B2 key. Front the server with TLS and, for principal mode, an MCP OAuth resource-server validation layer that supplies verified `authInfo`.
+- **hosted headers mode:** the key travels in `X-B2-MCP-*` headers on every request. Treat those headers as durable secrets in the proxy, logs, APM, and test fixtures.
+- **Master-key caveat:** only the Partner API and account-level key management need a master key in Phase 1. If you use one, also supply a non-master key (`B2_APP_KEY_ID`/`B2_APP_KEY` for stdio, or `X-B2-MCP-App-Key-Id`/`X-B2-MCP-App-Key` in hosted headers mode) for the S3 tools.
 
 See the [README](../README.md) for the full environment-variable list and the tool catalog.

--- a/docs/DEPLOY.md
+++ b/docs/DEPLOY.md
@@ -26,7 +26,9 @@ api.backblazeb2.com / s3.<region>.backblazeb2.com
 ```
 
 Each `/mcp` request resolves credentials before the SDK v2 handler builds a
-fresh `McpServer` instance. Credential selection is explicit: header
+fresh `McpServer` instance. B2 authorization managers are cached by a
+secret-bound key so steady-state requests reuse valid B2 auth tokens.
+Credential selection is explicit: header
 compatibility, server-held credentials, or verified-principal mapping. The
 server does not depend on `initialize` or `Mcp-Session-Id` in production.
 
@@ -42,20 +44,21 @@ server does not depend on `initialize` or `Mcp-Session-Id` in production.
 Before exposing the server, confirm each of these. Most are on by default; the
 two **you must set for any internet-facing HTTP deployment** are marked ⚠️.
 
-| Control                   | How                                                                                                                                                                                                                                         | Default          |
-| ------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ---------------- |
-| **TLS**                   | Terminate at nginx with Let's Encrypt (Step 5). Never expose `:3000` directly.                                                                                                                                                              | —                |
-| ⚠️ **DNS-rebinding**      | `B2_ALLOWED_HOSTS=your.domain` (+ `B2_ALLOWED_ORIGINS` if browser clients). With neither set the server accepts **only localhost** — so an internet-facing deploy must set this or it will refuse its own hostname.                         | localhost-only   |
-| ⚠️ **Caller auth**        | `server` mode is single-tenant. `principal` mode requires your TLS/OAuth resource-server layer to validate each request and pass verified MCP `authInfo` to the SDK handler before credential lookup.                                       | none (your job)  |
-| **Least-privilege key**   | Use a **non-master** application key scoped to the buckets/capabilities the workload needs.                                                                                                                                                 | —                |
-| **Destructive-op gate**   | `B2_DESTRUCTIVE_POLICY` — `confirm` (interactive), `block` (unattended/read-mostly), `allow` (trusted).                                                                                                                                     | `confirm`        |
-| **`create_key` lockdown** | Rejects minting key-management or unscoped write keys. Override only if required: `B2_ALLOW_KEY_MGMT_GRANTS`, `B2_ALLOW_UNSCOPED_KEYS`, `B2_MAX_KEY_DURATION_SECONDS`.                                                                      | locked down      |
-| **Request rate caps**     | Per-credential token-bucket rate limit via `B2_MCP_RATE_LIMIT_RPS` / `B2_MCP_RATE_LIMIT_BURST`.                                                                                                                                             | on               |
-| **Local file access**     | On HTTP, `filePath`/`saveToPath` are off unless `B2_ALLOW_LOCAL_FILES=true` **and** `B2_FILE_ROOT=/sandbox` (paths confined to that root). Prefer base64 `content`.                                                                         | off              |
-| **Capability cache**      | Capability discovery is cached by a secret-bound verifier or verified principal, with non-secret labels for logs. `B2_CAPABILITY_CACHE_TTL_MS` and `B2_CAPABILITY_CACHE_MAX_ENTRIES` bound staleness and size. Lookup failures fail closed. | 5 minutes / 1000 |
-| **Webhook targets**       | `b2_set_bucket_notification_rules` enforces HTTPS and rejects internal/SSRF URLs; responses redact signing secrets.                                                                                                                         | enforced         |
-| **Audit log**             | Structured, values-redacted (key names only — never secrets/values). Ship stderr to journald/CloudWatch.                                                                                                                                    | on               |
-| **Secrets**               | Provide via the systemd unit's `Environment=` (or a secrets manager) — never commit. `.env*` is gitignored; see [`.env.example`](../.env.example).                                                                                          | —                |
+| Control                   | How                                                                                                                                                                                                                                         | Default           |
+| ------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ----------------- |
+| **TLS**                   | Terminate at nginx with Let's Encrypt (Step 5). Never expose `:3000` directly.                                                                                                                                                              | —                 |
+| ⚠️ **DNS-rebinding**      | `B2_ALLOWED_HOSTS=your.domain` (+ `B2_ALLOWED_ORIGINS` if browser clients). With neither set the server accepts **only localhost** — so an internet-facing deploy must set this or it will refuse its own hostname.                         | localhost-only    |
+| ⚠️ **Caller auth**        | `server` mode is single-tenant. `principal` mode requires your TLS/OAuth resource-server layer to validate each request and pass verified MCP `authInfo` to the SDK handler before credential lookup.                                       | none (your job)   |
+| **Least-privilege key**   | Use a **non-master** application key scoped to the buckets/capabilities the workload needs.                                                                                                                                                 | —                 |
+| **Destructive-op gate**   | `B2_DESTRUCTIVE_POLICY` — `confirm` (interactive), `block` (unattended/read-mostly), `allow` (trusted).                                                                                                                                     | `confirm`         |
+| **`create_key` lockdown** | Rejects minting key-management or unscoped write keys. Override only if required: `B2_ALLOW_KEY_MGMT_GRANTS`, `B2_ALLOW_UNSCOPED_KEYS`, `B2_MAX_KEY_DURATION_SECONDS`.                                                                      | locked down       |
+| **Request rate caps**     | Per-credential token-bucket rate limit via `B2_MCP_RATE_LIMIT_RPS` / `B2_MCP_RATE_LIMIT_BURST`.                                                                                                                                             | on                |
+| **In-flight caps**        | Concurrent `/mcp` requests are capped globally and per credential with `B2_MAX_SESSIONS` / `B2_MAX_SESSIONS_PER_KEY`; the names are retained for deploy-manifest compatibility.                                                             | 1000 / 20         |
+| **Local file access**     | On HTTP, `filePath`/`saveToPath` are off unless `B2_ALLOW_LOCAL_FILES=true` **and** `B2_FILE_ROOT=/sandbox` (paths confined to that root). Prefer base64 `content`.                                                                         | off               |
+| **Capability cache**      | Capability discovery is cached by a secret-bound verifier or verified principal, with non-secret labels for logs. `B2_CAPABILITY_CACHE_TTL_MS` and `B2_CAPABILITY_CACHE_MAX_ENTRIES` bound staleness and size. Lookup failures fail closed. | 5 minutes / 10000 |
+| **Webhook targets**       | `b2_set_bucket_notification_rules` enforces HTTPS and rejects internal/SSRF URLs; responses redact signing secrets.                                                                                                                         | enforced          |
+| **Audit log**             | Structured, values-redacted (key names only — never secrets/values). Ship stderr to journald/CloudWatch.                                                                                                                                    | on                |
+| **Secrets**               | Provide via the systemd unit's `Environment=` (or a secrets manager) — never commit. `.env*` is gitignored; see [`.env.example`](../.env.example).                                                                                          | —                 |
 
 ## Credential modes
 
@@ -73,6 +76,9 @@ header-based clients keep working when new code is deployed. To migrate to
 `B2_APPLICATION_KEY_ID` / `B2_APPLICATION_KEY` in every instance's deploy
 manifest, then roll the fleet. During a mixed fleet window, both old and new
 pods must agree on the selected mode before clients stop sending B2 headers.
+The HTTP entry also accepts the SDK v2 stateless 2025-era fallback during the
+transition window; sessionful continuity is not required, so drain or reconnect
+long-lived 2025-era clients before switching them to the 2026-07-28 path.
 
 In `server` and `principal` mode, public `X-B2-*` credential headers are
 rejected so a caller cannot select a different B2 account. In `headers` mode,
@@ -491,6 +497,14 @@ requests a short drain window before process exit.
 After every deploy, run the included end-to-end smoke test against the
 live server. It connects via HTTP, lists tools, and exercises one
 tool per credential scope.
+
+Server or principal mode, where the client sends no B2 key:
+
+```bash
+MCP_URL=https://mcp.your-domain.example/mcp npm run smoke
+```
+
+Header compatibility mode, where the client still sends B2 credential headers:
 
 ```bash
 MCP_URL=https://mcp.your-domain.example/mcp \

--- a/docs/DEPLOY.md
+++ b/docs/DEPLOY.md
@@ -1,8 +1,8 @@
 # Self-hosting the B2 MCP server
 
-This guide walks through deploying the Streamable HTTP transport behind nginx with
-Let's Encrypt TLS on AWS EC2. The same recipe works on any Linux VM — only
-the AWS-specific steps differ.
+This guide walks through deploying the MCP 2026-07-28 HTTP transport behind
+nginx with Let's Encrypt TLS on AWS EC2. The same recipe works on any Linux VM
+— only the AWS-specific steps differ.
 
 If you only need local stdio use (Claude Desktop on your laptop), follow the
 README's Quick Start instead — none of this is required.
@@ -12,24 +12,23 @@ README's Quick Start instead — none of this is required.
 ```
 Client (Claude Desktop)
     │
-    │ HTTPS  POST/GET/DELETE /mcp  (B2 keys stay server-side by default)
+    │ HTTPS  POST /mcp  (credential source selected per request)
     ▼
 nginx :443  ──TLS termination, rate limits, ACL, security headers──┐
     │                                                              │
     │  HTTP (loopback only)                                         │
     ▼                                                              │
-node :3000  ── per-session McpServer, credentials in memory only ──┘
+node :3000  ── per-request MCP handler, no protocol sessions ─────┘
     │
     │ HTTPS to B2
     ▼
 api.backblazeb2.com / s3.<region>.backblazeb2.com
 ```
 
-Each session (opened by an `initialize` POST to `/mcp`) creates its own
-`McpServer` instance with its own `B2Config`. Credential selection is explicit:
-server-held credentials, verified-principal mapping, or opt-in header
-compatibility. This is the MCP **Streamable HTTP** transport (spec 2025-03-26),
-which replaced the now-deprecated HTTP+SSE transport.
+Each `/mcp` request resolves credentials before the SDK v2 handler builds a
+fresh `McpServer` instance. Credential selection is explicit: header
+compatibility, server-held credentials, or verified-principal mapping. The
+server does not depend on `initialize` or `Mcp-Session-Id` in production.
 
 ## Prerequisites
 
@@ -43,20 +42,20 @@ which replaced the now-deprecated HTTP+SSE transport.
 Before exposing the server, confirm each of these. Most are on by default; the
 two **you must set for any internet-facing HTTP deployment** are marked ⚠️.
 
-| Control                   | How                                                                                                                                                                                                                 | Default         |
-| ------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | --------------- |
-| **TLS**                   | Terminate at nginx with Let's Encrypt (Step 5). Never expose `:3000` directly.                                                                                                                                      | —               |
-| ⚠️ **DNS-rebinding**      | `B2_ALLOWED_HOSTS=your.domain` (+ `B2_ALLOWED_ORIGINS` if browser clients). With neither set the server accepts **only localhost** — so an internet-facing deploy must set this or it will refuse its own hostname. | localhost-only  |
-| ⚠️ **Caller auth**        | `server` mode is single-tenant. `principal` mode requires your TLS/OAuth resource-server layer to validate each request and pass verified MCP `authInfo` to the SDK handler before credential lookup.               | none (your job) |
-| **Least-privilege key**   | Use a **non-master** application key scoped to the buckets/capabilities the workload needs.                                                                                                                         | —               |
-| **Destructive-op gate**   | `B2_DESTRUCTIVE_POLICY` — `confirm` (interactive), `block` (unattended/read-mostly), `allow` (trusted).                                                                                                             | `confirm`       |
-| **`create_key` lockdown** | Rejects minting key-management or unscoped write keys. Override only if required: `B2_ALLOW_KEY_MGMT_GRANTS`, `B2_ALLOW_UNSCOPED_KEYS`, `B2_MAX_KEY_DURATION_SECONDS`.                                              | locked down     |
-| **Session / rate caps**   | `B2_MAX_SESSIONS` (1000), `B2_MAX_SESSIONS_PER_KEY` (20); per-key token-bucket rate limit.                                                                                                                          | on              |
-| **Local file access**     | On HTTP, `filePath`/`saveToPath` are off unless `B2_ALLOW_LOCAL_FILES=true` **and** `B2_FILE_ROOT=/sandbox` (paths confined to that root). Prefer base64 `content`.                                                 | off             |
-| **Capability cache**      | Capability discovery is cached only by non-secret credential fingerprint or verified principal, with `B2_CAPABILITY_CACHE_TTL_MS` bounding staleness. Lookup failures fail closed.                                  | 5 minutes       |
-| **Webhook targets**       | `b2_set_bucket_notification_rules` enforces HTTPS and rejects internal/SSRF URLs; responses redact signing secrets.                                                                                                 | enforced        |
-| **Audit log**             | Structured, values-redacted (key names only — never secrets/values). Ship stderr to journald/CloudWatch.                                                                                                            | on              |
-| **Secrets**               | Provide via the systemd unit's `Environment=` (or a secrets manager) — never commit. `.env*` is gitignored; see [`.env.example`](../.env.example).                                                                  | —               |
+| Control                   | How                                                                                                                                                                                                                                         | Default          |
+| ------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ---------------- |
+| **TLS**                   | Terminate at nginx with Let's Encrypt (Step 5). Never expose `:3000` directly.                                                                                                                                                              | —                |
+| ⚠️ **DNS-rebinding**      | `B2_ALLOWED_HOSTS=your.domain` (+ `B2_ALLOWED_ORIGINS` if browser clients). With neither set the server accepts **only localhost** — so an internet-facing deploy must set this or it will refuse its own hostname.                         | localhost-only   |
+| ⚠️ **Caller auth**        | `server` mode is single-tenant. `principal` mode requires your TLS/OAuth resource-server layer to validate each request and pass verified MCP `authInfo` to the SDK handler before credential lookup.                                       | none (your job)  |
+| **Least-privilege key**   | Use a **non-master** application key scoped to the buckets/capabilities the workload needs.                                                                                                                                                 | —                |
+| **Destructive-op gate**   | `B2_DESTRUCTIVE_POLICY` — `confirm` (interactive), `block` (unattended/read-mostly), `allow` (trusted).                                                                                                                                     | `confirm`        |
+| **`create_key` lockdown** | Rejects minting key-management or unscoped write keys. Override only if required: `B2_ALLOW_KEY_MGMT_GRANTS`, `B2_ALLOW_UNSCOPED_KEYS`, `B2_MAX_KEY_DURATION_SECONDS`.                                                                      | locked down      |
+| **Request rate caps**     | Per-credential token-bucket rate limit via `B2_MCP_RATE_LIMIT_RPS` / `B2_MCP_RATE_LIMIT_BURST`.                                                                                                                                             | on               |
+| **Local file access**     | On HTTP, `filePath`/`saveToPath` are off unless `B2_ALLOW_LOCAL_FILES=true` **and** `B2_FILE_ROOT=/sandbox` (paths confined to that root). Prefer base64 `content`.                                                                         | off              |
+| **Capability cache**      | Capability discovery is cached by a secret-bound verifier or verified principal, with non-secret labels for logs. `B2_CAPABILITY_CACHE_TTL_MS` and `B2_CAPABILITY_CACHE_MAX_ENTRIES` bound staleness and size. Lookup failures fail closed. | 5 minutes / 1000 |
+| **Webhook targets**       | `b2_set_bucket_notification_rules` enforces HTTPS and rejects internal/SSRF URLs; responses redact signing secrets.                                                                                                                         | enforced         |
+| **Audit log**             | Structured, values-redacted (key names only — never secrets/values). Ship stderr to journald/CloudWatch.                                                                                                                                    | on               |
+| **Secrets**               | Provide via the systemd unit's `Environment=` (or a secrets manager) — never commit. `.env*` is gitignored; see [`.env.example`](../.env.example).                                                                                          | —                |
 
 ## Credential modes
 
@@ -64,9 +63,16 @@ Set `B2_HTTP_CREDENTIAL_MODE` explicitly for hosted deployments:
 
 | Mode        | Who holds the B2 key             | Client sends B2 key? | Notes                                                                                                                                     |
 | ----------- | -------------------------------- | -------------------- | ----------------------------------------------------------------------------------------------------------------------------------------- |
-| `server`    | Server process or secret manager | No                   | Default. Single-tenant deployment; `B2_APPLICATION_KEY_ID` and `B2_APPLICATION_KEY` are read from the server environment.                 |
+| `headers`   | MCP client or bridge             | Yes                  | Default for compatibility. B2 credential headers must be supplied on every request.                                                       |
+| `server`    | Server process or secret manager | No                   | Single-tenant deployment; `B2_APPLICATION_KEY_ID` and `B2_APPLICATION_KEY` are read from the server environment.                          |
 | `principal` | Customer-operated secret broker  | No                   | Requires verified MCP `authInfo`; `B2_PRINCIPAL_CREDENTIAL_MAP` maps a principal to `B2_CREDENTIAL_<REF>_*` env-injected secret material. |
-| `headers`   | MCP client or bridge             | Yes                  | Compatibility only. B2 credential headers must be supplied on every POST/GET/DELETE request and must not change within a session.         |
+
+Rolling deploy note: because unset mode defaults to `headers`, existing
+header-based clients keep working when new code is deployed. To migrate to
+`server` mode, first configure `B2_HTTP_CREDENTIAL_MODE=server` plus
+`B2_APPLICATION_KEY_ID` / `B2_APPLICATION_KEY` in every instance's deploy
+manifest, then roll the fleet. During a mixed fleet window, both old and new
+pods must agree on the selected mode before clients stop sending B2 headers.
 
 In `server` and `principal` mode, public `X-B2-*` credential headers are
 rejected so a caller cannot select a different B2 account. In `headers` mode,
@@ -286,15 +292,15 @@ server {
 
     access_log /var/log/nginx/access.log mcp_safe;
 
-    # Streamable HTTP: one endpoint handles POST (JSON-RPC, incl. initialize),
-    # GET (long-lived server->client stream), and DELETE (terminate session).
+    # MCP 2026-07-28 HTTP: the production path is per-request and does not
+    # depend on initialize or Mcp-Session-Id.
     location = /mcp {
         limit_req zone=mcp_msg burst=30 nodelay;
         proxy_pass http://127.0.0.1:3000;
         proxy_http_version 1.1;
         proxy_set_header Connection "";
         proxy_set_header Host $host;
-        # Default server/principal modes reject B2 credential headers. Strip
+        # Server/principal modes reject B2 credential headers. Strip
         # public copies at the edge so callers cannot try to select accounts.
         # Remove these lines only for explicit B2_HTTP_CREDENTIAL_MODE=headers.
         proxy_set_header X-B2-Key-Id "";
@@ -389,9 +395,11 @@ For a single host this is optional, but useful at scale:
 
 ## Step 9 — Connect a client
 
-In the default `B2_HTTP_CREDENTIAL_MODE=server` deployment, clients send only
-MCP traffic to `https://mcp.your-domain.example/mcp`; the B2 key is held by the
-server process or customer secret manager.
+For a server-held B2 key, set `B2_HTTP_CREDENTIAL_MODE=server` and clients send
+only MCP traffic to `https://mcp.your-domain.example/mcp`; the B2 key is held
+by the server process or customer secret manager. If `B2_HTTP_CREDENTIAL_MODE`
+is unset, header compatibility remains active and clients must continue sending
+B2 credentials on every request.
 
 ### Claude Desktop (macOS / Windows)
 
@@ -428,9 +436,9 @@ Do **not** put this shape in `claude_desktop_config.json` — Claude Desktop wil
 
 ### Header compatibility mode
 
-Use this only when `B2_HTTP_CREDENTIAL_MODE=headers` is explicitly set and your
+Use this when `B2_HTTP_CREDENTIAL_MODE=headers` is set or left unset and your
 proxy does not strip B2 credential headers. The headers must be sent on every
-MCP request, not only `initialize`; `mcp-remote --header` does that.
+MCP request; `mcp-remote --header` does that.
 
 ```json
 {
@@ -457,13 +465,13 @@ S3-compatible API.
 
 ## Capacity planning
 
-The server is stateless apart from in-memory session records. A 2 vCPU /
-4 GB host comfortably serves 10–20 concurrent sessions. Memory grows by
-~50–100 MB per active large-file upload (one `partSize` chunk per worker).
+The HTTP server is stateless at the MCP transport layer. A 2 vCPU / 4 GB host
+comfortably serves many short requests; memory grows by ~50–100 MB per active
+large-file upload (one `partSize` chunk per worker).
 
-For larger deployments, run multiple instances behind an ALB with sticky
-sessions — each session's requests must reach the same backend that created
-it (the session ID is in-memory).
+For larger deployments, run multiple instances behind an ALB. Sticky sessions
+are not required by the MCP transport, though your own auth/proxy layer may
+still choose affinity for operational reasons.
 
 ## Updates
 
@@ -475,13 +483,13 @@ npm run build
 sudo systemctl restart b2-mcp
 ```
 
-The `SIGTERM` handler drains active sessions before exiting (10 second cap),
-so an in-flight request will not be cut mid-response.
+The `SIGTERM` handler stops accepting new traffic and gives in-flight HTTP
+requests a short drain window before process exit.
 
 ## Smoke test
 
 After every deploy, run the included end-to-end smoke test against the
-live server. It connects via Streamable HTTP, lists tools, and exercises one
+live server. It connects via HTTP, lists tools, and exercises one
 tool per credential scope.
 
 ```bash

--- a/docs/DEPLOY.md
+++ b/docs/DEPLOY.md
@@ -12,7 +12,7 @@ README's Quick Start instead — none of this is required.
 ```
 Client (Claude Desktop)
     │
-    │ HTTPS  POST/GET/DELETE /mcp  (initialize POST includes X-B2-* headers)
+    │ HTTPS  POST/GET/DELETE /mcp  (B2 keys stay server-side by default)
     ▼
 nginx :443  ──TLS termination, rate limits, ACL, security headers──┐
     │                                                              │
@@ -26,9 +26,10 @@ api.backblazeb2.com / s3.<region>.backblazeb2.com
 ```
 
 Each session (opened by an `initialize` POST to `/mcp`) creates its own
-`McpServer` instance with its own `B2Config`. Credentials live only inside that
-session. This is the MCP **Streamable HTTP** transport (spec 2025-03-26), which
-replaced the now-deprecated HTTP+SSE transport.
+`McpServer` instance with its own `B2Config`. Credential selection is explicit:
+server-held credentials, verified-principal mapping, or opt-in header
+compatibility. This is the MCP **Streamable HTTP** transport (spec 2025-03-26),
+which replaced the now-deprecated HTTP+SSE transport.
 
 ## Prerequisites
 
@@ -46,15 +47,40 @@ two **you must set for any internet-facing HTTP deployment** are marked ⚠️.
 | ------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | --------------- |
 | **TLS**                   | Terminate at nginx with Let's Encrypt (Step 5). Never expose `:3000` directly.                                                                                                                                      | —               |
 | ⚠️ **DNS-rebinding**      | `B2_ALLOWED_HOSTS=your.domain` (+ `B2_ALLOWED_ORIGINS` if browser clients). With neither set the server accepts **only localhost** — so an internet-facing deploy must set this or it will refuse its own hostname. | localhost-only  |
-| ⚠️ **Caller auth**        | The server authenticates the _credential_, not the _caller_ — it has no user auth. Front it with SSO / Cloudflare Access / mTLS at the proxy before exposing to untrusted users.                                    | none (your job) |
+| ⚠️ **Caller auth**        | `server` mode is single-tenant. `principal` mode requires your TLS/OAuth resource-server layer to validate each request and pass verified MCP `authInfo` to the SDK handler before credential lookup.               | none (your job) |
 | **Least-privilege key**   | Use a **non-master** application key scoped to the buckets/capabilities the workload needs.                                                                                                                         | —               |
 | **Destructive-op gate**   | `B2_DESTRUCTIVE_POLICY` — `confirm` (interactive), `block` (unattended/read-mostly), `allow` (trusted).                                                                                                             | `confirm`       |
 | **`create_key` lockdown** | Rejects minting key-management or unscoped write keys. Override only if required: `B2_ALLOW_KEY_MGMT_GRANTS`, `B2_ALLOW_UNSCOPED_KEYS`, `B2_MAX_KEY_DURATION_SECONDS`.                                              | locked down     |
 | **Session / rate caps**   | `B2_MAX_SESSIONS` (1000), `B2_MAX_SESSIONS_PER_KEY` (20); per-key token-bucket rate limit.                                                                                                                          | on              |
 | **Local file access**     | On HTTP, `filePath`/`saveToPath` are off unless `B2_ALLOW_LOCAL_FILES=true` **and** `B2_FILE_ROOT=/sandbox` (paths confined to that root). Prefer base64 `content`.                                                 | off             |
+| **Capability cache**      | Capability discovery is cached only by non-secret credential fingerprint or verified principal, with `B2_CAPABILITY_CACHE_TTL_MS` bounding staleness. Lookup failures fail closed.                                  | 5 minutes       |
 | **Webhook targets**       | `b2_set_bucket_notification_rules` enforces HTTPS and rejects internal/SSRF URLs; responses redact signing secrets.                                                                                                 | enforced        |
 | **Audit log**             | Structured, values-redacted (key names only — never secrets/values). Ship stderr to journald/CloudWatch.                                                                                                            | on              |
 | **Secrets**               | Provide via the systemd unit's `Environment=` (or a secrets manager) — never commit. `.env*` is gitignored; see [`.env.example`](../.env.example).                                                                  | —               |
+
+## Credential modes
+
+Set `B2_HTTP_CREDENTIAL_MODE` explicitly for hosted deployments:
+
+| Mode        | Who holds the B2 key             | Client sends B2 key? | Notes                                                                                                                                     |
+| ----------- | -------------------------------- | -------------------- | ----------------------------------------------------------------------------------------------------------------------------------------- |
+| `server`    | Server process or secret manager | No                   | Default. Single-tenant deployment; `B2_APPLICATION_KEY_ID` and `B2_APPLICATION_KEY` are read from the server environment.                 |
+| `principal` | Customer-operated secret broker  | No                   | Requires verified MCP `authInfo`; `B2_PRINCIPAL_CREDENTIAL_MAP` maps a principal to `B2_CREDENTIAL_<REF>_*` env-injected secret material. |
+| `headers`   | MCP client or bridge             | Yes                  | Compatibility only. B2 credential headers must be supplied on every POST/GET/DELETE request and must not change within a session.         |
+
+In `server` and `principal` mode, public `X-B2-*` credential headers are
+rejected so a caller cannot select a different B2 account. In `headers` mode,
+both the explicit `X-B2-MCP-Key-Id` / `X-B2-MCP-Key` names and the legacy
+`X-B2-Key-Id` / `X-B2-Key` names are accepted for compatibility; configure your
+proxy and logs to treat them as durable secrets.
+
+For `principal` mode, this server is an MCP resource server consumer, not an
+authorization server. A customer-operated TLS/OAuth layer must validate every
+request, enforce the MCP OAuth resource-server requirements, and attach verified
+`authInfo` before the SDK handler runs. Do not pass unverified identity headers
+through from the public internet. If a trusted proxy converts identity headers
+into `authInfo`, strip inbound copies at the edge and only add trusted copies
+inside an allowlisted proxy boundary.
 
 Provide env vars to the service through systemd. To add one without touching the
 credentials in the main unit, use a drop-in:
@@ -118,6 +144,10 @@ Type=simple
 User=ec2-user
 WorkingDirectory=/home/ec2-user/b2-mcp
 ExecStart=/usr/bin/node dist/http-server.js --port 3000
+Environment=B2_HTTP_CREDENTIAL_MODE=server
+Environment=B2_ALLOWED_HOSTS=mcp.your-domain.example
+Environment=B2_APPLICATION_KEY_ID=your-application-key-id
+Environment=B2_APPLICATION_KEY=your-application-key-secret
 Restart=always
 RestartSec=5
 StandardOutput=journal
@@ -264,6 +294,21 @@ server {
         proxy_http_version 1.1;
         proxy_set_header Connection "";
         proxy_set_header Host $host;
+        # Default server/principal modes reject B2 credential headers. Strip
+        # public copies at the edge so callers cannot try to select accounts.
+        # Remove these lines only for explicit B2_HTTP_CREDENTIAL_MODE=headers.
+        proxy_set_header X-B2-Key-Id "";
+        proxy_set_header X-B2-Key "";
+        proxy_set_header X-B2-App-Key-Id "";
+        proxy_set_header X-B2-App-Key "";
+        proxy_set_header X-B2-Master-Key-Id "";
+        proxy_set_header X-B2-Master-Key "";
+        proxy_set_header X-B2-MCP-Key-Id "";
+        proxy_set_header X-B2-MCP-Key "";
+        proxy_set_header X-B2-MCP-App-Key-Id "";
+        proxy_set_header X-B2-MCP-App-Key "";
+        proxy_set_header X-B2-MCP-Master-Key-Id "";
+        proxy_set_header X-B2-MCP-Master-Key "";
         client_max_body_size 1m;
         # The GET stream is long-lived; disable buffering so events flush promptly.
         proxy_buffering off;
@@ -344,6 +389,10 @@ For a single host this is optional, but useful at scale:
 
 ## Step 9 — Connect a client
 
+In the default `B2_HTTP_CREDENTIAL_MODE=server` deployment, clients send only
+MCP traffic to `https://mcp.your-domain.example/mcp`; the B2 key is held by the
+server process or customer secret manager.
+
 ### Claude Desktop (macOS / Windows)
 
 Claude Desktop's `claude_desktop_config.json` only accepts **stdio** entries (`command` + `args`). To reach a hosted Streamable HTTP server, use the [`mcp-remote`](https://www.npmjs.com/package/mcp-remote) bridge — it runs as a local stdio process and proxies to your hosted endpoint:
@@ -353,28 +402,11 @@ Claude Desktop's `claude_desktop_config.json` only accepts **stdio** entries (`c
   "mcpServers": {
     "backblaze-b2": {
       "command": "npx",
-      "args": [
-        "-y",
-        "mcp-remote",
-        "https://mcp.your-domain.example/mcp",
-        "--header",
-        "X-B2-Key-Id:your-application-key-id",
-        "--header",
-        "X-B2-Key:your-application-key-secret"
-      ]
+      "args": ["-y", "mcp-remote", "https://mcp.your-domain.example/mcp"]
     }
   }
 }
 ```
-
-Add the additional headers only when `X-B2-Key-Id` is a **master** key (the S3 endpoint rejects master keys, so S3 tools need a separate non-master key in that case):
-
-```
-        "--header", "X-B2-App-Key-Id:your-non-master-key-id",
-        "--header", "X-B2-App-Key:your-non-master-key-secret"
-```
-
-A single application key works for both the B2 native API and the S3-compatible API; the master key is only required for Partner API and account-level key management in the Phase 1 tool surface.
 
 Quit Claude Desktop fully (`Cmd+Q` on macOS) and relaunch — the entry should load on next startup.
 
@@ -386,17 +418,42 @@ For the Claude.ai web app and the Custom Connector UI in Claude Desktop Pro/Max,
 {
   "mcpServers": {
     "backblaze-b2": {
-      "url": "https://mcp.your-domain.example/mcp",
-      "headers": {
-        "X-B2-Key-Id": "your-application-key-id",
-        "X-B2-Key": "your-application-key-secret"
-      }
+      "url": "https://mcp.your-domain.example/mcp"
     }
   }
 }
 ```
 
 Do **not** put this shape in `claude_desktop_config.json` — Claude Desktop will reject it as "not a valid MCP server configuration" and skip the entry.
+
+### Header compatibility mode
+
+Use this only when `B2_HTTP_CREDENTIAL_MODE=headers` is explicitly set and your
+proxy does not strip B2 credential headers. The headers must be sent on every
+MCP request, not only `initialize`; `mcp-remote --header` does that.
+
+```json
+{
+  "mcpServers": {
+    "backblaze-b2": {
+      "command": "npx",
+      "args": [
+        "-y",
+        "mcp-remote",
+        "https://mcp.your-domain.example/mcp",
+        "--header",
+        "X-B2-MCP-Key-Id:your-application-key-id",
+        "--header",
+        "X-B2-MCP-Key:your-application-key-secret"
+      ]
+    }
+  }
+}
+```
+
+Add `X-B2-MCP-Master-Key-Id` / `X-B2-MCP-Master-Key` only for Partner API
+tools. A single non-master application key works for the B2 native API and the
+S3-compatible API.
 
 ## Capacity planning
 

--- a/docs/V1_SCOPE.md
+++ b/docs/V1_SCOPE.md
@@ -402,15 +402,14 @@ cannot mint write-capable presigned URLs.
 
 Phase 1 supports two transports:
 
-| Transport       | Preferred era    | Phase 1 fallback                                                                           | Notes                                                                                                   |
-| --------------- | ---------------- | ------------------------------------------------------------------------------------------ | ------------------------------------------------------------------------------------------------------- |
-| `stdio`         | MCP `2026-07-28` | Stateless 2025-era compatibility for `2025-03-26` and `2025-06-18` clients                 | Local clients run the Node entry point as a subprocess.                                                 |
-| Streamable HTTP | MCP `2026-07-28` | Stateless 2025-era Streamable HTTP compatibility for `2025-03-26` and `2025-06-18` clients | Hosted deployments use a single `/mcp` endpoint behind customer-operated TLS and caller authentication. |
+| Transport | Preferred era    | Phase 1 fallback                                                           | Notes                                                                                                   |
+| --------- | ---------------- | -------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------- |
+| `stdio`   | MCP `2026-07-28` | Stateless 2025-era compatibility for `2025-03-26` and `2025-06-18` clients | Local clients run the Node entry point as a subprocess.                                                 |
+| HTTP      | MCP `2026-07-28` | 2025-era session requests are rejected in the production path              | Hosted deployments use a single `/mcp` endpoint behind customer-operated TLS and caller authentication. |
 
-MCP `2026-07-28` is the preferred era for `v0.1.0`. Stateless 2025-era fallback
-exists only to keep compatible `2025-03-26` and `2025-06-18` clients working
-during migration. No other 2025 revision is part of the Phase 1 support matrix
-unless a later decision record adds it.
+MCP `2026-07-28` is the preferred era for `v0.1.0`. Production HTTP serving is
+strictly per-request; compatibility for sessionful 2025-era HTTP must be isolated
+behind a separately named legacy path if it is ever reintroduced.
 
 At the time of this metadata pass, npm publishes `@modelcontextprotocol/sdk`
 `1.x` as the latest TypeScript SDK package. If a future upstream SDK v2 package
@@ -484,12 +483,12 @@ previously advertised tools in a later deploy.
 
 Phase 1 supports these credential modes:
 
-| Mode             | Transport                | Credential custody                                          | Phase 1 requirement                                                                                                                                |
-| ---------------- | ------------------------ | ----------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `stdio-env`      | `stdio`                  | Local process environment                                   | Read `B2_APPLICATION_KEY_ID` and `B2_APPLICATION_KEY`; optionally read `B2_MASTER_KEY_ID` and `B2_MASTER_KEY` for explicit Partner/admin profiles. |
-| `http-headers`   | Streamable HTTP fallback | MCP client or bridge                                        | Explicit opt-in compatibility mode only. Prefer credential references or short-lived tokens. Durable B2 keys in headers are disabled by default.   |
-| `http-server`    | Streamable HTTP          | Customer-operated server process or customer secret manager | The MCP client sends no B2 key. The customer-operated deployment selects the configured B2 credential.                                             |
-| `http-principal` | Streamable HTTP          | Customer-operated secret broker                             | A customer-operated MCP OAuth resource server validates the caller and passes verified principal/auth info to map to a B2 credential reference.    |
+| Mode             | Transport       | Credential custody                                          | Phase 1 requirement                                                                                                                                               |
+| ---------------- | --------------- | ----------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `stdio-env`      | `stdio`         | Local process environment                                   | Read `B2_APPLICATION_KEY_ID` and `B2_APPLICATION_KEY`; optionally read `B2_MASTER_KEY_ID` and `B2_MASTER_KEY` for explicit Partner/admin profiles.                |
+| `http-headers`   | HTTP            | MCP client or bridge                                        | Default for one-release compatibility with existing hosted clients; B2 headers are required on every request. Prefer credential references or short-lived tokens. |
+| `http-server`    | Streamable HTTP | Customer-operated server process or customer secret manager | The MCP client sends no B2 key. The customer-operated deployment selects the configured B2 credential.                                                            |
+| `http-principal` | Streamable HTTP | Customer-operated secret broker                             | A customer-operated MCP OAuth resource server validates the caller and passes verified principal/auth info to map to a B2 credential reference.                   |
 
 Credential values must never be accepted as ordinary tool input fields and must
 not appear in MCP tool content, structured content, logs, HTTP errors, snapshots,

--- a/docs/V1_SCOPE.md
+++ b/docs/V1_SCOPE.md
@@ -405,16 +405,12 @@ Phase 1 supports two transports:
 | Transport | Preferred era    | Phase 1 fallback                                                           | Notes                                                                                                   |
 | --------- | ---------------- | -------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------- |
 | `stdio`   | MCP `2026-07-28` | Stateless 2025-era compatibility for `2025-03-26` and `2025-06-18` clients | Local clients run the Node entry point as a subprocess.                                                 |
-| HTTP      | MCP `2026-07-28` | 2025-era session requests are rejected in the production path              | Hosted deployments use a single `/mcp` endpoint behind customer-operated TLS and caller authentication. |
+| HTTP      | MCP `2026-07-28` | Stateless 2025-era compatibility during the migration window               | Hosted deployments use a single `/mcp` endpoint behind customer-operated TLS and caller authentication. |
 
 MCP `2026-07-28` is the preferred era for `v0.1.0`. Production HTTP serving is
-strictly per-request; compatibility for sessionful 2025-era HTTP must be isolated
-behind a separately named legacy path if it is ever reintroduced.
-
-At the time of this metadata pass, npm publishes `@modelcontextprotocol/sdk`
-`1.x` as the latest TypeScript SDK package. If a future upstream SDK v2 package
-split becomes part of the Phase 1 baseline, that migration is release-blocking
-before the repository claims the v2 SDK contract.
+strictly per-request; 2025-era compatibility is stateless and exists only for a
+migration window. Sessionful 2025-era HTTP must be isolated behind a separately
+named legacy path if it is ever reintroduced.
 
 Phase 1 does not require HTTP+SSE, protocol-level sessions, GET streams, DELETE
 session termination, event replay, Roots, Sampling, MCP Logging, Tasks, MCP Apps,
@@ -497,11 +493,13 @@ or CI artifacts.
 If `http-headers` compatibility mode remains enabled in an implementation, it
 must meet all of these requirements:
 
-- It is disabled by default and requires an explicit operator setting.
-- It uses only the dedicated B2 MCP secret header names
+- It remains the default for one release to preserve existing hosted clients;
+  hosted operators should set `B2_HTTP_CREDENTIAL_MODE` explicitly before
+  switching to `server` or `principal`.
+- It accepts the dedicated B2 MCP secret header names
   `X-B2-MCP-Key-Id`, `X-B2-MCP-Key`, `X-B2-MCP-Master-Key-Id`, and
-  `X-B2-MCP-Master-Key`. Generic B2 environment variable names and inherited
-  `X-B2-Key-*` header names are not the Phase 1 compatibility contract.
+  `X-B2-MCP-Master-Key`; inherited `X-B2-Key-*` names remain a temporary
+  compatibility alias.
 - Those dedicated header names are classified as secrets by the HTTP server,
   reverse proxy, APM, and log redaction configuration.
 - The edge strips inbound duplicate credential headers before forwarding.

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,11 +12,11 @@
         "@aws-sdk/client-s3": "^3.1086.0",
         "@aws-sdk/s3-presigned-post": "^3.1086.0",
         "@aws-sdk/s3-request-presigner": "^3.1086.0",
-        "@modelcontextprotocol/server": "^2.0.0",
+        "@modelcontextprotocol/server": "2.0.0",
         "axios": "^1.18.1",
         "opossum": "^9.0.0",
         "pino": "^10.3.1",
-        "zod": "^4.4.3"
+        "zod": "4.4.3"
       },
       "bin": {
         "b2-mcp": "dist/index.js",

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,10 +12,11 @@
         "@aws-sdk/client-s3": "^3.1086.0",
         "@aws-sdk/s3-presigned-post": "^3.1086.0",
         "@aws-sdk/s3-request-presigner": "^3.1086.0",
-        "@modelcontextprotocol/sdk": "^1.0.0",
+        "@modelcontextprotocol/server": "^2.0.0",
         "axios": "^1.18.1",
         "opossum": "^9.0.0",
-        "pino": "^10.3.1"
+        "pino": "^10.3.1",
+        "zod": "^4.4.3"
       },
       "bin": {
         "b2-mcp": "dist/index.js",
@@ -36,7 +37,7 @@
         "typescript-eslint": "^8.64.0"
       },
       "engines": {
-        "node": ">=22.0.0"
+        "node": ">=22.3.0"
       }
     },
     "node_modules/@aws-sdk/checksums": {
@@ -1069,18 +1070,6 @@
         "node": "^20.19.0 || ^22.13.0 || >=24"
       }
     },
-    "node_modules/@hono/node-server": {
-      "version": "1.19.14",
-      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-1.19.14.tgz",
-      "integrity": "sha512-GwtvgtXxnWsucXvbQXkRgqksiH2Qed37H9xHZocE5sA3N8O8O8/8FA3uclQXxXVzc9XBZuEOMK7+r02FmSpHtw==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=18.14.1"
-      },
-      "peerDependencies": {
-        "hono": "^4"
-      }
-    },
     "node_modules/@humanfs/core": {
       "version": "0.19.2",
       "resolved": "https://registry.npmjs.org/@humanfs/core/-/core-0.19.2.tgz",
@@ -1516,44 +1505,29 @@
         "@jridgewell/sourcemap-codec": "^1.4.14"
       }
     },
-    "node_modules/@modelcontextprotocol/sdk": {
-      "version": "1.29.0",
-      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.29.0.tgz",
-      "integrity": "sha512-zo37mZA9hJWpULgkRpowewez1y6ML5GsXJPY8FI0tBBCd77HEvza4jDqRKOXgHNn867PVGCyTdzqpz0izu5ZjQ==",
+    "node_modules/@modelcontextprotocol/core": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/core/-/core-2.0.0.tgz",
+      "integrity": "sha512-pJCEwGG7Lfr/+PQp9ZTwKXNeO5wzbfKL7H3MYpCorM4oFBoQrdjnBgEoqG+RjhsvS1FKrDbKux+M1HhlnGWqcA==",
       "license": "MIT",
       "dependencies": {
-        "@hono/node-server": "^1.19.9",
-        "ajv": "^8.17.1",
-        "ajv-formats": "^3.0.1",
-        "content-type": "^1.0.5",
-        "cors": "^2.8.5",
-        "cross-spawn": "^7.0.5",
-        "eventsource": "^3.0.2",
-        "eventsource-parser": "^3.0.0",
-        "express": "^5.2.1",
-        "express-rate-limit": "^8.2.1",
-        "hono": "^4.11.4",
-        "jose": "^6.1.3",
-        "json-schema-typed": "^8.0.2",
-        "pkce-challenge": "^5.0.0",
-        "raw-body": "^3.0.0",
-        "zod": "^3.25 || ^4.0",
-        "zod-to-json-schema": "^3.25.1"
+        "zod": "^4.2.0"
       },
       "engines": {
-        "node": ">=18"
+        "node": ">=20"
+      }
+    },
+    "node_modules/@modelcontextprotocol/server": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/server/-/server-2.0.0.tgz",
+      "integrity": "sha512-YhHWdHfpFMQfd0prsEnxKeS3Qz3ytIGmsS0sth4KDjnacIT7hxk6hXHkJ9KysxlkvTM+WZAtQbbcUhdoP4Hvtw==",
+      "license": "MIT",
+      "dependencies": {
+        "@modelcontextprotocol/core": "2.0.0",
+        "zod": "^4.2.0"
       },
-      "peerDependencies": {
-        "@cfworker/json-schema": "^4.1.1",
-        "zod": "^3.25 || ^4.0"
-      },
-      "peerDependenciesMeta": {
-        "@cfworker/json-schema": {
-          "optional": true
-        },
-        "zod": {
-          "optional": false
-        }
+      "engines": {
+        "node": ">=20"
       }
     },
     "node_modules/@pinojs/redact": {
@@ -2138,19 +2112,6 @@
         "url": "https://opencollective.com/typescript-eslint"
       }
     },
-    "node_modules/accepts": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/accepts/-/accepts-2.0.0.tgz",
-      "integrity": "sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng==",
-      "license": "MIT",
-      "dependencies": {
-        "mime-types": "^3.0.0",
-        "negotiator": "^1.0.0"
-      },
-      "engines": {
-        "node": ">= 0.6"
-      }
-    },
     "node_modules/acorn": {
       "version": "8.16.0",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.16.0.tgz",
@@ -2197,39 +2158,6 @@
       },
       "engines": {
         "node": ">= 6.0.0"
-      }
-    },
-    "node_modules/ajv": {
-      "version": "8.20.0",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.20.0.tgz",
-      "integrity": "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
-      "license": "MIT",
-      "dependencies": {
-        "fast-deep-equal": "^3.1.3",
-        "fast-uri": "^3.0.1",
-        "json-schema-traverse": "^1.0.0",
-        "require-from-string": "^2.0.2"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/epoberezkin"
-      }
-    },
-    "node_modules/ajv-formats": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-3.0.1.tgz",
-      "integrity": "sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==",
-      "license": "MIT",
-      "dependencies": {
-        "ajv": "^8.0.0"
-      },
-      "peerDependencies": {
-        "ajv": "^8.0.0"
-      },
-      "peerDependenciesMeta": {
-        "ajv": {
-          "optional": true
-        }
       }
     },
     "node_modules/ansi-escapes": {
@@ -2468,30 +2396,6 @@
         "node": ">=6.0.0"
       }
     },
-    "node_modules/body-parser": {
-      "version": "2.2.2",
-      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-2.2.2.tgz",
-      "integrity": "sha512-oP5VkATKlNwcgvxi0vM0p/D3n2C3EReYVX+DNYs5TjZFn/oQt2j+4sVJtSMr18pdRr8wjTcBl6LoV+FUwzPmNA==",
-      "license": "MIT",
-      "dependencies": {
-        "bytes": "^3.1.2",
-        "content-type": "^1.0.5",
-        "debug": "^4.4.3",
-        "http-errors": "^2.0.0",
-        "iconv-lite": "^0.7.0",
-        "on-finished": "^2.4.1",
-        "qs": "^6.14.1",
-        "raw-body": "^3.0.1",
-        "type-is": "^2.0.1"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/express"
-      }
-    },
     "node_modules/bowser": {
       "version": "2.14.1",
       "resolved": "https://registry.npmjs.org/bowser/-/bowser-2.14.1.tgz",
@@ -2586,15 +2490,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/bytes": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.2.tgz",
-      "integrity": "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.8"
-      }
-    },
     "node_modules/call-bind-apply-helpers": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
@@ -2606,22 +2501,6 @@
       },
       "engines": {
         "node": ">= 0.4"
-      }
-    },
-    "node_modules/call-bound": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/call-bound/-/call-bound-1.0.4.tgz",
-      "integrity": "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==",
-      "license": "MIT",
-      "dependencies": {
-        "call-bind-apply-helpers": "^1.0.2",
-        "get-intrinsic": "^1.3.0"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/callsites": {
@@ -2787,69 +2666,12 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/content-disposition": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-1.1.0.tgz",
-      "integrity": "sha512-5jRCH9Z/+DRP7rkvY83B+yGIGX96OYdJmzngqnw2SBSxqCFPd0w2km3s5iawpGX8krnwSGmF0FW5Nhr0Hfai3g==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/express"
-      }
-    },
-    "node_modules/content-type": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.5.tgz",
-      "integrity": "sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.6"
-      }
-    },
     "node_modules/convert-source-map": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
       "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/cookie": {
-      "version": "0.7.2",
-      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.2.tgz",
-      "integrity": "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.6"
-      }
-    },
-    "node_modules/cookie-signature": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.2.2.tgz",
-      "integrity": "sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=6.6.0"
-      }
-    },
-    "node_modules/cors": {
-      "version": "2.8.6",
-      "resolved": "https://registry.npmjs.org/cors/-/cors-2.8.6.tgz",
-      "integrity": "sha512-tJtZBBHA6vjIAaF6EnIaq6laBBP9aq/Y3ouVJjEfoHbRBcHBAHYcMh/w8LDrk2PvIMMq8gmopa5D4V8RmbrxGw==",
-      "license": "MIT",
-      "dependencies": {
-        "object-assign": "^4",
-        "vary": "^1"
-      },
-      "engines": {
-        "node": ">= 0.10"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/express"
-      }
     },
     "node_modules/create-jest": {
       "version": "29.7.0",
@@ -2884,6 +2706,7 @@
       "version": "7.0.6",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
       "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "path-key": "^3.1.0",
@@ -2952,15 +2775,6 @@
         "node": ">=0.4.0"
       }
     },
-    "node_modules/depd": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
-      "integrity": "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.8"
-      }
-    },
     "node_modules/detect-newline": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/detect-newline/-/detect-newline-3.1.0.tgz",
@@ -3005,12 +2819,6 @@
         "node": ">= 0.4"
       }
     },
-    "node_modules/ee-first": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
-      "integrity": "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==",
-      "license": "MIT"
-    },
     "node_modules/electron-to-chromium": {
       "version": "1.5.349",
       "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.349.tgz",
@@ -3037,15 +2845,6 @@
       "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/encodeurl": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-2.0.0.tgz",
-      "integrity": "sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.8"
-      }
     },
     "node_modules/error-ex": {
       "version": "1.3.4",
@@ -3111,12 +2910,6 @@
       "engines": {
         "node": ">=6"
       }
-    },
-    "node_modules/escape-html": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
-      "integrity": "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==",
-      "license": "MIT"
     },
     "node_modules/escape-string-regexp": {
       "version": "2.0.0",
@@ -3438,36 +3231,6 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/etag": {
-      "version": "1.8.1",
-      "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
-      "integrity": "sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.6"
-      }
-    },
-    "node_modules/eventsource": {
-      "version": "3.0.7",
-      "resolved": "https://registry.npmjs.org/eventsource/-/eventsource-3.0.7.tgz",
-      "integrity": "sha512-CRT1WTyuQoD771GW56XEZFQ/ZoSfWid1alKGDYMmkt2yl8UXrVR4pspqWNEcqKvVIzg6PAltWjxcSSPrboA4iA==",
-      "license": "MIT",
-      "dependencies": {
-        "eventsource-parser": "^3.0.1"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/eventsource-parser": {
-      "version": "3.0.8",
-      "resolved": "https://registry.npmjs.org/eventsource-parser/-/eventsource-parser-3.0.8.tgz",
-      "integrity": "sha512-70QWGkr4snxr0OXLRWsFLeRBIRPuQOvt4s8QYjmUlmlkyTZkRqS7EDVRZtzU3TiyDbXSzaOeF0XUKy8PchzukQ==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
     "node_modules/execa": {
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/execa/-/execa-5.1.1.tgz",
@@ -3518,71 +3281,11 @@
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
       }
     },
-    "node_modules/express": {
-      "version": "5.2.1",
-      "resolved": "https://registry.npmjs.org/express/-/express-5.2.1.tgz",
-      "integrity": "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==",
-      "license": "MIT",
-      "dependencies": {
-        "accepts": "^2.0.0",
-        "body-parser": "^2.2.1",
-        "content-disposition": "^1.0.0",
-        "content-type": "^1.0.5",
-        "cookie": "^0.7.1",
-        "cookie-signature": "^1.2.1",
-        "debug": "^4.4.0",
-        "depd": "^2.0.0",
-        "encodeurl": "^2.0.0",
-        "escape-html": "^1.0.3",
-        "etag": "^1.8.1",
-        "finalhandler": "^2.1.0",
-        "fresh": "^2.0.0",
-        "http-errors": "^2.0.0",
-        "merge-descriptors": "^2.0.0",
-        "mime-types": "^3.0.0",
-        "on-finished": "^2.4.1",
-        "once": "^1.4.0",
-        "parseurl": "^1.3.3",
-        "proxy-addr": "^2.0.7",
-        "qs": "^6.14.0",
-        "range-parser": "^1.2.1",
-        "router": "^2.2.0",
-        "send": "^1.1.0",
-        "serve-static": "^2.2.0",
-        "statuses": "^2.0.1",
-        "type-is": "^2.0.1",
-        "vary": "^1.1.2"
-      },
-      "engines": {
-        "node": ">= 18"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/express"
-      }
-    },
-    "node_modules/express-rate-limit": {
-      "version": "8.5.2",
-      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.5.2.tgz",
-      "integrity": "sha512-5Kb34ipNX694DH48vN9irak1Qx30nb0PLYHXfJgw4YEjiC3ZEmZJhwOp+VfiCYwFzvFTdB9QkArYS5kXa2cx2A==",
-      "license": "MIT",
-      "dependencies": {
-        "ip-address": "^10.2.0"
-      },
-      "engines": {
-        "node": ">= 16"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/express-rate-limit"
-      },
-      "peerDependencies": {
-        "express": ">= 4.11"
-      }
-    },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
       "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/fast-json-stable-stringify": {
@@ -3598,22 +3301,6 @@
       "integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/fast-uri": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.2.tgz",
-      "integrity": "sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/fastify"
-        },
-        {
-          "type": "opencollective",
-          "url": "https://opencollective.com/fastify"
-        }
-      ],
-      "license": "BSD-3-Clause"
     },
     "node_modules/fb-watchman": {
       "version": "2.0.2",
@@ -3649,27 +3336,6 @@
       },
       "engines": {
         "node": ">=8"
-      }
-    },
-    "node_modules/finalhandler": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-2.1.1.tgz",
-      "integrity": "sha512-S8KoZgRZN+a5rNwqTxlZZePjT/4cnm0ROV70LedRHZ0p8u9fRID0hJUZQpkKLzro8LfmC8sx23bY6tVNxv8pQA==",
-      "license": "MIT",
-      "dependencies": {
-        "debug": "^4.4.0",
-        "encodeurl": "^2.0.0",
-        "escape-html": "^1.0.3",
-        "on-finished": "^2.4.1",
-        "parseurl": "^1.3.3",
-        "statuses": "^2.0.1"
-      },
-      "engines": {
-        "node": ">= 18.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/find-up": {
@@ -3762,24 +3428,6 @@
       },
       "engines": {
         "node": ">= 0.6"
-      }
-    },
-    "node_modules/forwarded": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.2.0.tgz",
-      "integrity": "sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.6"
-      }
-    },
-    "node_modules/fresh": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/fresh/-/fresh-2.0.0.tgz",
-      "integrity": "sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.8"
       }
     },
     "node_modules/fs.realpath": {
@@ -4018,41 +3666,12 @@
         "node": ">= 0.4"
       }
     },
-    "node_modules/hono": {
-      "version": "4.12.27",
-      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.27.tgz",
-      "integrity": "sha512-1yrb/+w6HWQJrUCLkJ2IF5jNIPvvFkblV5RNOYl6bV+OA6p9GLcMpHFFGTosSvHvcAUibuUukRqhlYI4z32C7Q==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=16.9.0"
-      }
-    },
     "node_modules/html-escaper": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-2.0.2.tgz",
       "integrity": "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/http-errors": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.1.tgz",
-      "integrity": "sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==",
-      "license": "MIT",
-      "dependencies": {
-        "depd": "~2.0.0",
-        "inherits": "~2.0.4",
-        "setprototypeof": "~1.2.0",
-        "statuses": "~2.0.2",
-        "toidentifier": "~1.0.1"
-      },
-      "engines": {
-        "node": ">= 0.8"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/express"
-      }
     },
     "node_modules/https-proxy-agent": {
       "version": "5.0.1",
@@ -4075,22 +3694,6 @@
       "license": "Apache-2.0",
       "engines": {
         "node": ">=10.17.0"
-      }
-    },
-    "node_modules/iconv-lite": {
-      "version": "0.7.2",
-      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.2.tgz",
-      "integrity": "sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw==",
-      "license": "MIT",
-      "dependencies": {
-        "safer-buffer": ">= 2.1.2 < 3.0.0"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/ignore": {
@@ -4149,25 +3752,8 @@
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "dev": true,
       "license": "ISC"
-    },
-    "node_modules/ip-address": {
-      "version": "10.2.0",
-      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.2.0.tgz",
-      "integrity": "sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 12"
-      }
-    },
-    "node_modules/ipaddr.js": {
-      "version": "1.9.1",
-      "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.1.tgz",
-      "integrity": "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.10"
-      }
     },
     "node_modules/is-arrayish": {
       "version": "0.2.1",
@@ -4245,12 +3831,6 @@
         "node": ">=0.12.0"
       }
     },
-    "node_modules/is-promise": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-4.0.0.tgz",
-      "integrity": "sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==",
-      "license": "MIT"
-    },
     "node_modules/is-stream": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.1.tgz",
@@ -4268,6 +3848,7 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
       "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
+      "dev": true,
       "license": "ISC"
     },
     "node_modules/istanbul-lib-coverage": {
@@ -4950,15 +4531,6 @@
         "url": "https://github.com/chalk/supports-color?sponsor=1"
       }
     },
-    "node_modules/jose": {
-      "version": "6.2.3",
-      "resolved": "https://registry.npmjs.org/jose/-/jose-6.2.3.tgz",
-      "integrity": "sha512-YYVDInQKFJfR/xa3ojUTl8c2KoTwiL1R5Wg9YCydwH0x0B9grbzlg5HC7mMjCtUJjbQ/YnGEZIhI5tCgfTb4Hw==",
-      "license": "MIT",
-      "funding": {
-        "url": "https://github.com/sponsors/panva"
-      }
-    },
     "node_modules/js-tokens": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
@@ -5006,18 +4578,6 @@
       "integrity": "sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/json-schema-traverse": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
-      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
-      "license": "MIT"
-    },
-    "node_modules/json-schema-typed": {
-      "version": "8.0.2",
-      "resolved": "https://registry.npmjs.org/json-schema-typed/-/json-schema-typed-8.0.2.tgz",
-      "integrity": "sha512-fQhoXdcvc3V28x7C7BMs4P5+kNlgUURe2jmUT1T//oBRMDrqy1QPelJimwZGo7Hg9VPV3EQV5Bnq4hbFy2vetA==",
-      "license": "BSD-2-Clause"
     },
     "node_modules/json-stable-stringify-without-jsonify": {
       "version": "1.0.1",
@@ -5175,27 +4735,6 @@
         "node": ">= 0.4"
       }
     },
-    "node_modules/media-typer": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-1.1.0.tgz",
-      "integrity": "sha512-aisnrDP4GNe06UcKFnV5bfMNPBUw4jsLGaWwWfnH3v02GnBuXX2MCVn5RbrWo0j3pczUilYblq7fQ7Nw2t5XKw==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.8"
-      }
-    },
-    "node_modules/merge-descriptors": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-2.0.0.tgz",
-      "integrity": "sha512-Snk314V5ayFLhp3fkUREub6WtjBfPdCPY1Ln8/8munuLuiYhsABgBVWsozAG+MWMbVEvcdcpbi9R7ww22l9Q3g==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/merge-stream": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-2.0.0.tgz",
@@ -5215,31 +4754,6 @@
       },
       "engines": {
         "node": ">=8.6"
-      }
-    },
-    "node_modules/mime-db": {
-      "version": "1.54.0",
-      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz",
-      "integrity": "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.6"
-      }
-    },
-    "node_modules/mime-types": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-3.0.2.tgz",
-      "integrity": "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==",
-      "license": "MIT",
-      "dependencies": {
-        "mime-db": "^1.54.0"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/mimic-fn": {
@@ -5288,15 +4802,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/negotiator": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-1.0.0.tgz",
-      "integrity": "sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.6"
-      }
-    },
     "node_modules/neo-async": {
       "version": "2.6.2",
       "resolved": "https://registry.npmjs.org/neo-async/-/neo-async-2.6.2.tgz",
@@ -5341,27 +4846,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/object-assign": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
-      "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/object-inspect": {
-      "version": "1.13.4",
-      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.4.tgz",
-      "integrity": "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
     "node_modules/on-exit-leak-free": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/on-exit-leak-free/-/on-exit-leak-free-2.1.2.tgz",
@@ -5371,22 +4855,11 @@
         "node": ">=14.0.0"
       }
     },
-    "node_modules/on-finished": {
-      "version": "2.4.1",
-      "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.4.1.tgz",
-      "integrity": "sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==",
-      "license": "MIT",
-      "dependencies": {
-        "ee-first": "1.1.1"
-      },
-      "engines": {
-        "node": ">= 0.8"
-      }
-    },
     "node_modules/once": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
       "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
+      "dev": true,
       "license": "ISC",
       "dependencies": {
         "wrappy": "1"
@@ -5509,15 +4982,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/parseurl": {
-      "version": "1.3.3",
-      "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
-      "integrity": "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.8"
-      }
-    },
     "node_modules/path-exists": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
@@ -5542,6 +5006,7 @@
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
       "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -5553,16 +5018,6 @@
       "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/path-to-regexp": {
-      "version": "8.4.2",
-      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.4.2.tgz",
-      "integrity": "sha512-qRcuIdP69NPm4qbACK+aDogI5CBDMi1jKe0ry5rSQJz8JVLsC7jV8XpiJjGRLLol3N+R5ihGYcrPLTno6pAdBA==",
-      "license": "MIT",
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/express"
-      }
     },
     "node_modules/picocolors": {
       "version": "1.1.1",
@@ -5629,15 +5084,6 @@
       "license": "MIT",
       "engines": {
         "node": ">= 6"
-      }
-    },
-    "node_modules/pkce-challenge": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/pkce-challenge/-/pkce-challenge-5.0.1.tgz",
-      "integrity": "sha512-wQ0b/W4Fr01qtpHlqSqspcj3EhBvimsdh0KlHhH8HRZnMsEa0ea2fTULOXOS9ccQr3om+GcGRk4e+isrZWV8qQ==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=16.20.0"
       }
     },
     "node_modules/pkg-dir": {
@@ -5737,19 +5183,6 @@
         "node": ">= 6"
       }
     },
-    "node_modules/proxy-addr": {
-      "version": "2.0.7",
-      "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.7.tgz",
-      "integrity": "sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==",
-      "license": "MIT",
-      "dependencies": {
-        "forwarded": "0.2.0",
-        "ipaddr.js": "1.9.1"
-      },
-      "engines": {
-        "node": ">= 0.10"
-      }
-    },
     "node_modules/proxy-from-env": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-2.1.0.tgz",
@@ -5786,50 +5219,11 @@
       ],
       "license": "MIT"
     },
-    "node_modules/qs": {
-      "version": "6.15.2",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.2.tgz",
-      "integrity": "sha512-Rzq0KEyX/w/tEybncDgdkZrJgVUsUMk3xjh3t5bv3S1HTAtg+uOYt72+ZfwiQwKdysThkTBdL/rTi6HDmX9Ddw==",
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "side-channel": "^1.1.0"
-      },
-      "engines": {
-        "node": ">=0.6"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
     "node_modules/quick-format-unescaped": {
       "version": "4.0.4",
       "resolved": "https://registry.npmjs.org/quick-format-unescaped/-/quick-format-unescaped-4.0.4.tgz",
       "integrity": "sha512-tYC1Q1hgyRuHgloV/YXs2w15unPVh8qfu/qCTfhTYamaw7fyhumKa2yGpdSo87vY32rIclj+4fWYQXUMs9EHvg==",
       "license": "MIT"
-    },
-    "node_modules/range-parser": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.1.tgz",
-      "integrity": "sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.6"
-      }
-    },
-    "node_modules/raw-body": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-3.0.2.tgz",
-      "integrity": "sha512-K5zQjDllxWkf7Z5xJdV0/B0WTNqx6vxG70zJE4N0kBs4LovmEYWJzQGxC9bS9RAKu3bgM40lrd5zoLJ12MQ5BA==",
-      "license": "MIT",
-      "dependencies": {
-        "bytes": "~3.1.2",
-        "http-errors": "~2.0.1",
-        "iconv-lite": "~0.7.0",
-        "unpipe": "~1.0.0"
-      },
-      "engines": {
-        "node": ">= 0.10"
-      }
     },
     "node_modules/react-is": {
       "version": "18.3.1",
@@ -5852,15 +5246,6 @@
       "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
       "integrity": "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==",
       "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/require-from-string": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
-      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -5921,22 +5306,6 @@
         "node": ">=10"
       }
     },
-    "node_modules/router": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/router/-/router-2.2.0.tgz",
-      "integrity": "sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ==",
-      "license": "MIT",
-      "dependencies": {
-        "debug": "^4.4.0",
-        "depd": "^2.0.0",
-        "is-promise": "^4.0.0",
-        "parseurl": "^1.3.3",
-        "path-to-regexp": "^8.0.0"
-      },
-      "engines": {
-        "node": ">= 18"
-      }
-    },
     "node_modules/safe-stable-stringify": {
       "version": "2.5.0",
       "resolved": "https://registry.npmjs.org/safe-stable-stringify/-/safe-stable-stringify-2.5.0.tgz",
@@ -5945,12 +5314,6 @@
       "engines": {
         "node": ">=10"
       }
-    },
-    "node_modules/safer-buffer": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
-      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
-      "license": "MIT"
     },
     "node_modules/semver": {
       "version": "6.3.1",
@@ -5962,61 +5325,11 @@
         "semver": "bin/semver.js"
       }
     },
-    "node_modules/send": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/send/-/send-1.2.1.tgz",
-      "integrity": "sha512-1gnZf7DFcoIcajTjTwjwuDjzuz4PPcY2StKPlsGAQ1+YH20IRVrBaXSWmdjowTJ6u8Rc01PoYOGHXfP1mYcZNQ==",
-      "license": "MIT",
-      "dependencies": {
-        "debug": "^4.4.3",
-        "encodeurl": "^2.0.0",
-        "escape-html": "^1.0.3",
-        "etag": "^1.8.1",
-        "fresh": "^2.0.0",
-        "http-errors": "^2.0.1",
-        "mime-types": "^3.0.2",
-        "ms": "^2.1.3",
-        "on-finished": "^2.4.1",
-        "range-parser": "^1.2.1",
-        "statuses": "^2.0.2"
-      },
-      "engines": {
-        "node": ">= 18"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/express"
-      }
-    },
-    "node_modules/serve-static": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-2.2.1.tgz",
-      "integrity": "sha512-xRXBn0pPqQTVQiC8wyQrKs2MOlX24zQ0POGaj0kultvoOCstBQM5yvOhAVSUwOMjQtTvsPWoNCHfPGwaaQJhTw==",
-      "license": "MIT",
-      "dependencies": {
-        "encodeurl": "^2.0.0",
-        "escape-html": "^1.0.3",
-        "parseurl": "^1.3.3",
-        "send": "^1.2.0"
-      },
-      "engines": {
-        "node": ">= 18"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/express"
-      }
-    },
-    "node_modules/setprototypeof": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
-      "integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==",
-      "license": "ISC"
-    },
     "node_modules/shebang-command": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
       "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "shebang-regex": "^3.0.0"
@@ -6029,81 +5342,10 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
       "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
-      }
-    },
-    "node_modules/side-channel": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.0.tgz",
-      "integrity": "sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==",
-      "license": "MIT",
-      "dependencies": {
-        "es-errors": "^1.3.0",
-        "object-inspect": "^1.13.3",
-        "side-channel-list": "^1.0.0",
-        "side-channel-map": "^1.0.1",
-        "side-channel-weakmap": "^1.0.2"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/side-channel-list": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.1.tgz",
-      "integrity": "sha512-mjn/0bi/oUURjc5Xl7IaWi/OJJJumuoJFQJfDDyO46+hBWsfaVM65TBHq2eoZBhzl9EchxOijpkbRC8SVBQU0w==",
-      "license": "MIT",
-      "dependencies": {
-        "es-errors": "^1.3.0",
-        "object-inspect": "^1.13.4"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/side-channel-map": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/side-channel-map/-/side-channel-map-1.0.1.tgz",
-      "integrity": "sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==",
-      "license": "MIT",
-      "dependencies": {
-        "call-bound": "^1.0.2",
-        "es-errors": "^1.3.0",
-        "get-intrinsic": "^1.2.5",
-        "object-inspect": "^1.13.3"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/side-channel-weakmap": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/side-channel-weakmap/-/side-channel-weakmap-1.0.2.tgz",
-      "integrity": "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==",
-      "license": "MIT",
-      "dependencies": {
-        "call-bound": "^1.0.2",
-        "es-errors": "^1.3.0",
-        "get-intrinsic": "^1.2.5",
-        "object-inspect": "^1.13.3",
-        "side-channel-map": "^1.0.1"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/signal-exit": {
@@ -6187,15 +5429,6 @@
       },
       "engines": {
         "node": ">=10"
-      }
-    },
-    "node_modules/statuses": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.2.tgz",
-      "integrity": "sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.8"
       }
     },
     "node_modules/string-length": {
@@ -6400,15 +5633,6 @@
         "node": ">=8.0"
       }
     },
-    "node_modules/toidentifier": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.1.tgz",
-      "integrity": "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.6"
-      }
-    },
     "node_modules/ts-api-utils": {
       "version": "2.5.0",
       "resolved": "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-2.5.0.tgz",
@@ -6587,20 +5811,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/type-is": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/type-is/-/type-is-2.0.1.tgz",
-      "integrity": "sha512-OZs6gsjF4vMp32qrCbiVSkrFmXtG/AZhY3t0iAMrMBiAZyV9oALtXO8hsrHbMXF9x6L3grlFuwW2oAz7cav+Gw==",
-      "license": "MIT",
-      "dependencies": {
-        "content-type": "^1.0.5",
-        "media-typer": "^1.1.0",
-        "mime-types": "^3.0.0"
-      },
-      "engines": {
-        "node": ">= 0.6"
-      }
-    },
     "node_modules/typescript": {
       "version": "5.9.3",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
@@ -6659,15 +5869,6 @@
       "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/unpipe": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
-      "integrity": "sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.8"
-      }
     },
     "node_modules/update-browserslist-db": {
       "version": "1.2.3",
@@ -6732,15 +5933,6 @@
         "node": ">=10.12.0"
       }
     },
-    "node_modules/vary": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
-      "integrity": "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.8"
-      }
-    },
     "node_modules/walker": {
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/walker/-/walker-1.0.8.tgz",
@@ -6755,6 +5947,7 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
       "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+      "dev": true,
       "license": "ISC",
       "dependencies": {
         "isexe": "^2.0.0"
@@ -6805,6 +5998,7 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
       "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
+      "dev": true,
       "license": "ISC"
     },
     "node_modules/write-file-atomic": {
@@ -6897,15 +6091,6 @@
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
-      }
-    },
-    "node_modules/zod-to-json-schema": {
-      "version": "3.25.2",
-      "resolved": "https://registry.npmjs.org/zod-to-json-schema/-/zod-to-json-schema-3.25.2.tgz",
-      "integrity": "sha512-O/PgfnpT1xKSDeQYSCfRI5Gy3hPf91mKVDuYLUHZJMiDFptvP41MSnWofm8dnCm0256ZNfZIM7DSzuSMAFnjHA==",
-      "license": "ISC",
-      "peerDependencies": {
-        "zod": "^3.25.28 || ^4"
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -48,11 +48,11 @@
     "@aws-sdk/client-s3": "^3.1086.0",
     "@aws-sdk/s3-presigned-post": "^3.1086.0",
     "@aws-sdk/s3-request-presigner": "^3.1086.0",
-    "@modelcontextprotocol/server": "^2.0.0",
+    "@modelcontextprotocol/server": "2.0.0",
     "axios": "^1.18.1",
     "opossum": "^9.0.0",
     "pino": "^10.3.1",
-    "zod": "^4.4.3"
+    "zod": "4.4.3"
   },
   "devDependencies": {
     "@eslint/js": "^10.0.1",

--- a/package.json
+++ b/package.json
@@ -48,10 +48,11 @@
     "@aws-sdk/client-s3": "^3.1086.0",
     "@aws-sdk/s3-presigned-post": "^3.1086.0",
     "@aws-sdk/s3-request-presigner": "^3.1086.0",
-    "@modelcontextprotocol/sdk": "^1.0.0",
+    "@modelcontextprotocol/server": "^2.0.0",
     "axios": "^1.18.1",
     "opossum": "^9.0.0",
-    "pino": "^10.3.1"
+    "pino": "^10.3.1",
+    "zod": "^4.4.3"
   },
   "devDependencies": {
     "@eslint/js": "^10.0.1",
@@ -68,7 +69,7 @@
     "typescript-eslint": "^8.64.0"
   },
   "engines": {
-    "node": ">=22.0.0"
+    "node": ">=22.3.0"
   },
   "files": [
     "dist/**/*",

--- a/scripts/smoke-test.mjs
+++ b/scripts/smoke-test.mjs
@@ -2,12 +2,12 @@
 /**
  * End-to-end smoke test against a running b2-mcp server.
  *
- * Connects via Streamable HTTP, lists tools, and exercises one tool per credential
- * scope. Intended for post-deploy verification — not a replacement for
- * the unit suite.
+ * Sends MCP 2026-07-28 HTTP requests, lists tools, and exercises one tool per
+ * credential scope. Intended for post-deploy verification — not a replacement
+ * for the unit suite.
  *
  * Required env:
- *   MCP_URL       — full Streamable HTTP endpoint, e.g. https://mcp.example.com/mcp
+ *   MCP_URL       — full MCP endpoint, e.g. https://mcp.example.com/mcp
  *   B2_KEY_ID     — value for the X-B2-Key-Id request header
  *   B2_KEY        — value for the X-B2-Key request header
  *
@@ -19,12 +19,8 @@
  * printed.
  */
 
-import { Client } from "@modelcontextprotocol/sdk/client/index.js";
-import { StreamableHTTPClientTransport } from "@modelcontextprotocol/sdk/client/streamableHttp.js";
-
-const EXPECTED_FULL_TOOL_COUNT = 40;
-
 const { MCP_URL, B2_KEY_ID, B2_KEY, B2_APP_KEY_ID, B2_APP_KEY } = process.env;
+const EXPECTED_FULL_TOOL_COUNT = 40;
 
 if (!MCP_URL || !B2_KEY_ID || !B2_KEY) {
   console.error("Missing required env: MCP_URL, B2_KEY_ID, B2_KEY");
@@ -41,28 +37,64 @@ if (B2_APP_KEY_ID && B2_APP_KEY) {
 }
 
 const failures = [];
+let nextId = 1;
+
 function check(name, ok, detail = "") {
   const mark = ok ? "PASS" : "FAIL";
   console.log(`  [${mark}] ${name}${detail ? " — " + detail : ""}`);
   if (!ok) failures.push(name);
 }
 
+async function mcp(method, params = {}) {
+  const name = method === "tools/call" ? params.name : undefined;
+  const response = await fetch(MCP_URL, {
+    method: "POST",
+    headers: {
+      ...headers,
+      "Content-Type": "application/json",
+      Accept: "application/json",
+      "Mcp-Method": method,
+      ...(name && { "Mcp-Name": name }),
+    },
+    body: JSON.stringify({
+      jsonrpc: "2.0",
+      id: nextId++,
+      method,
+      params: {
+        ...params,
+        _meta: {
+          "io.modelcontextprotocol/protocolVersion": "2026-07-28",
+          "io.modelcontextprotocol/clientCapabilities": {},
+        },
+      },
+    }),
+  });
+  const body = await response.json().catch(() => ({}));
+  if (!response.ok || body.error) {
+    throw new Error(body.error?.message ?? `HTTP ${response.status}`);
+  }
+  return body.result;
+}
+
+function parseToolJson(result) {
+  const text = result?.content?.[0]?.text ?? "";
+  try {
+    return JSON.parse(text);
+  } catch {
+    return null;
+  }
+}
+
 async function main() {
   console.log(`Connecting: ${MCP_URL}`);
 
-  const transport = new StreamableHTTPClientTransport(new URL(MCP_URL), {
-    requestInit: { headers },
-  });
-  const client = new Client({ name: "smoke-test", version: "1.0.0" }, {});
-  await client.connect(transport);
-
-  const info = client.getServerVersion();
-  check("connect & initialize", !!info?.version, `server=${info?.name} v${info?.version}`);
-
-  const instructions = client.getInstructions();
-  check("server delivers instructions", !!instructions);
-
-  const tools = await client.listTools();
+  const tools = await mcp("tools/list");
+  const info = tools?._meta?.["io.modelcontextprotocol/serverInfo"];
+  check(
+    "tools/list returns server info",
+    !!info?.version,
+    `server=${info?.name} v${info?.version}`,
+  );
   check(
     `tools/list returns at least ${EXPECTED_FULL_TOOL_COUNT} tools`,
     tools.tools.length >= EXPECTED_FULL_TOOL_COUNT,
@@ -71,15 +103,8 @@ async function main() {
 
   // b2_authorize_account — exercises the primary key path
   try {
-    const r = await client.callTool({ name: "b2_authorize_account", arguments: {} });
-    const text = r.content?.[0]?.text ?? "";
-    const parsed = (() => {
-      try {
-        return JSON.parse(text);
-      } catch {
-        return null;
-      }
-    })();
+    const r = await mcp("tools/call", { name: "b2_authorize_account", arguments: {} });
+    const parsed = parseToolJson(r);
     check("b2_authorize_account returns accountId", !!parsed?.accountId);
   } catch (e) {
     check("b2_authorize_account returns accountId", false, e.message);
@@ -87,15 +112,8 @@ async function main() {
 
   // b2_list_buckets — exercises a B2 native read
   try {
-    const r = await client.callTool({ name: "b2_list_buckets", arguments: {} });
-    const text = r.content?.[0]?.text ?? "";
-    const parsed = (() => {
-      try {
-        return JSON.parse(text);
-      } catch {
-        return null;
-      }
-    })();
+    const r = await mcp("tools/call", { name: "b2_list_buckets", arguments: {} });
+    const parsed = parseToolJson(r);
     check("b2_list_buckets returns a buckets array", Array.isArray(parsed?.buckets));
   } catch (e) {
     check("b2_list_buckets returns a buckets array", false, e.message);
@@ -104,15 +122,8 @@ async function main() {
   // s3_list_buckets — only when the app key was supplied
   if (B2_APP_KEY_ID && B2_APP_KEY) {
     try {
-      const r = await client.callTool({ name: "s3_list_buckets", arguments: {} });
-      const text = r.content?.[0]?.text ?? "";
-      const parsed = (() => {
-        try {
-          return JSON.parse(text);
-        } catch {
-          return null;
-        }
-      })();
+      const r = await mcp("tools/call", { name: "s3_list_buckets", arguments: {} });
+      const parsed = parseToolJson(r);
       check("s3_list_buckets returns a buckets array", Array.isArray(parsed?.buckets));
     } catch (e) {
       check("s3_list_buckets returns a buckets array", false, e.message);
@@ -120,8 +131,6 @@ async function main() {
   } else {
     console.log("  [SKIP] s3_list_buckets — set B2_APP_KEY_ID / B2_APP_KEY to enable");
   }
-
-  await client.close();
 
   console.log();
   if (failures.length) {

--- a/scripts/smoke-test.mjs
+++ b/scripts/smoke-test.mjs
@@ -8,6 +8,8 @@
  *
  * Required env:
  *   MCP_URL       — full MCP endpoint, e.g. https://mcp.example.com/mcp
+ *
+ * Optional env for header compatibility mode:
  *   B2_KEY_ID     — value for the X-B2-Key-Id request header
  *   B2_KEY        — value for the X-B2-Key request header
  *
@@ -15,25 +17,37 @@
  *   B2_APP_KEY_ID — value for the X-B2-App-Key-Id header
  *   B2_APP_KEY    — value for the X-B2-App-Key header
  *
+ * Optional env for a customer OAuth/resource-server edge:
+ *   MCP_AUTHORIZATION — Authorization header value, e.g. Bearer ...
+ *
  * Exits 0 on success, 1 if any check fails. Credential values are never
  * printed.
  */
 
-const { MCP_URL, B2_KEY_ID, B2_KEY, B2_APP_KEY_ID, B2_APP_KEY } = process.env;
+const { MCP_URL, B2_KEY_ID, B2_KEY, B2_APP_KEY_ID, B2_APP_KEY, MCP_AUTHORIZATION } = process.env;
 const EXPECTED_FULL_TOOL_COUNT = 40;
 
-if (!MCP_URL || !B2_KEY_ID || !B2_KEY) {
-  console.error("Missing required env: MCP_URL, B2_KEY_ID, B2_KEY");
+if (!MCP_URL) {
+  console.error("Missing required env: MCP_URL");
   process.exit(2);
 }
 
-const headers = {
-  "X-B2-Key-Id": B2_KEY_ID,
-  "X-B2-Key": B2_KEY,
-};
+if ((B2_KEY_ID && !B2_KEY) || (!B2_KEY_ID && B2_KEY)) {
+  console.error("B2_KEY_ID and B2_KEY must be set together for headers mode");
+  process.exit(2);
+}
+
+const headers = {};
+if (B2_KEY_ID && B2_KEY) {
+  headers["X-B2-Key-Id"] = B2_KEY_ID;
+  headers["X-B2-Key"] = B2_KEY;
+}
 if (B2_APP_KEY_ID && B2_APP_KEY) {
   headers["X-B2-App-Key-Id"] = B2_APP_KEY_ID;
   headers["X-B2-App-Key"] = B2_APP_KEY;
+}
+if (MCP_AUTHORIZATION) {
+  headers.Authorization = MCP_AUTHORIZATION;
 }
 
 const failures = [];

--- a/src/b2/buckets.ts
+++ b/src/b2/buckets.ts
@@ -7,6 +7,17 @@ import { toolJson, toolError } from "../utils/errors.js";
 import { assignDefined } from "../utils/payload.js";
 import { checkDestructive } from "../utils/destructive-gate.js";
 
+interface BucketNotificationRule {
+  objectNamePrefix?: string;
+  targetConfiguration: {
+    url: string;
+    hmacSha256SigningSecret?: string;
+    customHeaders?: Array<{ name: string; value: string }>;
+  };
+  isEnabled: boolean;
+  [key: string]: unknown;
+}
+
 /**
  * Redact webhook secrets from a notification-rules API response before it reaches
  * the model — B2 echoes back hmacSha256SigningSecret and custom-header values on
@@ -460,7 +471,8 @@ export function registerBucketTools(
     },
     async (args) => {
       try {
-        for (const rule of args.eventNotificationRules as Array<any>) {
+        const eventNotificationRules = args.eventNotificationRules as BucketNotificationRule[];
+        for (const rule of eventNotificationRules) {
           const reason = validateWebhookUrl(rule.targetConfiguration.url);
           if (reason) {
             return toolError(
@@ -472,7 +484,7 @@ export function registerBucketTools(
           bucketId: args.bucketId,
           // B2 requires objectNamePrefix on every rule; default to "" (matches
           // all objects) when a caller omits it, regardless of Zod default.
-          eventNotificationRules: args.eventNotificationRules.map((rule: any) => ({
+          eventNotificationRules: eventNotificationRules.map((rule) => ({
             ...rule,
             objectNamePrefix: rule.objectNamePrefix ?? "",
           })),

--- a/src/b2/buckets.ts
+++ b/src/b2/buckets.ts
@@ -1,4 +1,4 @@
-import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import type { McpServer } from "../mcp.js";
 import { z } from "zod";
 import { B2Client } from "./client.js";
 import { B2AuthManager } from "../auth.js";
@@ -460,7 +460,7 @@ export function registerBucketTools(
     },
     async (args) => {
       try {
-        for (const rule of args.eventNotificationRules) {
+        for (const rule of args.eventNotificationRules as Array<any>) {
           const reason = validateWebhookUrl(rule.targetConfiguration.url);
           if (reason) {
             return toolError(
@@ -472,7 +472,7 @@ export function registerBucketTools(
           bucketId: args.bucketId,
           // B2 requires objectNamePrefix on every rule; default to "" (matches
           // all objects) when a caller omits it, regardless of Zod default.
-          eventNotificationRules: args.eventNotificationRules.map((rule) => ({
+          eventNotificationRules: args.eventNotificationRules.map((rule: any) => ({
             ...rule,
             objectNamePrefix: rule.objectNamePrefix ?? "",
           })),

--- a/src/b2/insights.ts
+++ b/src/b2/insights.ts
@@ -11,9 +11,9 @@
  *   Phase 2 (b2_largest_files, b2_unfinished_uploads) — live, per-bucket S3
  *     listing. Works on any account; no index required.
  *
- * Everything is read-only and scoped by the caller's credential: each session
- * builds its own B2Client/S3Client from the request headers, so a partner key
- * sees its sub-accounts (one report row each) and a customer key sees only
+ * Everything is read-only and scoped by the caller's credential: HTTP builds a
+ * fresh B2Client/S3Client after per-request credential resolution, so a partner
+ * key sees its sub-accounts (one report row each) and a customer key sees only
  * itself — scope is automatic and fail-closed.
  *
  * The original handoff spec named native list tools (b2_list_file_names,
@@ -27,7 +27,7 @@ import {
   ListMultipartUploadsCommand,
   ListPartsCommand,
 } from "@aws-sdk/client-s3";
-import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import type { McpServer } from "../mcp.js";
 import { z } from "zod";
 import { B2Client } from "./client.js";
 import { B2AuthManager } from "../auth.js";

--- a/src/b2/keys.ts
+++ b/src/b2/keys.ts
@@ -1,4 +1,4 @@
-import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import type { McpServer } from "../mcp.js";
 import { z } from "zod";
 import { B2Client } from "./client.js";
 import { B2AuthManager } from "../auth.js";
@@ -81,7 +81,7 @@ export function registerKeyTools(
         const requested = args.capabilities ?? [];
 
         if (!config.allowKeyMgmtGrants) {
-          const offending = requested.filter((c) => KEY_MGMT_CAPS.includes(c));
+          const offending = requested.filter((c: string) => KEY_MGMT_CAPS.includes(c));
           if (offending.length > 0) {
             return toolError(
               new Error(
@@ -95,7 +95,7 @@ export function registerKeyTools(
 
         const isScoped = !!args.bucketId || (args.bucketIds?.length ?? 0) > 0;
         if (!config.allowUnscopedKeys && !isScoped) {
-          const writeCaps = requested.filter((c) => DATA_WRITE_CAPS.includes(c));
+          const writeCaps = requested.filter((c: string) => DATA_WRITE_CAPS.includes(c));
           if (writeCaps.length > 0) {
             return toolError(
               new Error(

--- a/src/b2/object-lock.ts
+++ b/src/b2/object-lock.ts
@@ -1,4 +1,4 @@
-import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import type { McpServer } from "../mcp.js";
 import { z } from "zod";
 import { B2Client } from "./client.js";
 import { toolJson, toolError } from "../utils/errors.js";

--- a/src/b2/partner.ts
+++ b/src/b2/partner.ts
@@ -1,4 +1,4 @@
-import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import type { McpServer } from "../mcp.js";
 import { z } from "zod";
 import { B2Client } from "./client.js";
 import { B2AuthManager } from "../auth.js";

--- a/src/credentials.ts
+++ b/src/credentials.ts
@@ -1,0 +1,401 @@
+import * as crypto from "crypto";
+import * as http from "http";
+import type { AuthInfo } from "@modelcontextprotocol/sdk/server/auth/types.js";
+import { parseIntEnv } from "./utils/config.js";
+import { logger } from "./utils/logger.js";
+import { B2Config } from "./utils/types.js";
+
+const DEFAULT_REGION = "us-west-004";
+
+const HEADER_NAMES = {
+  keyId: ["x-b2-mcp-key-id", "x-b2-key-id"],
+  key: ["x-b2-mcp-key", "x-b2-key"],
+  appKeyId: ["x-b2-mcp-app-key-id", "x-b2-app-key-id"],
+  appKey: ["x-b2-mcp-app-key", "x-b2-app-key"],
+  masterKeyId: ["x-b2-mcp-master-key-id", "x-b2-master-key-id"],
+  masterKey: ["x-b2-mcp-master-key", "x-b2-master-key"],
+} as const;
+
+const ALL_CREDENTIAL_HEADER_NAMES = new Set<string>(Object.values(HEADER_NAMES).flat());
+
+export type HttpCredentialMode = "server" | "principal" | "headers";
+
+export interface AuthenticatedIncomingMessage extends http.IncomingMessage {
+  auth?: AuthInfo;
+}
+
+export interface CredentialProviderContext {
+  req?: AuthenticatedIncomingMessage;
+}
+
+export interface CredentialResolution {
+  config: B2Config;
+  /** Non-secret cache/metrics key: either a credential fingerprint or verified principal. */
+  cacheKey: string;
+  principal?: string;
+}
+
+export interface CredentialProvider {
+  readonly name: string;
+  resolve(context?: CredentialProviderContext): CredentialResolution;
+}
+
+export class CredentialResolutionError extends Error {
+  readonly status: number;
+  readonly code: string;
+
+  constructor(message: string, status = 401, code = "credential_resolution_failed") {
+    super(message);
+    this.name = "CredentialResolutionError";
+    this.status = status;
+    this.code = code;
+  }
+}
+
+export interface CredentialMaterial {
+  applicationKeyId?: string;
+  applicationKey?: string;
+  appKeyId?: string;
+  appKey?: string;
+  masterKeyId?: string;
+  masterKey?: string;
+}
+
+interface ConfigOptions {
+  transport: "stdio" | "http";
+  allowLocalFiles: boolean;
+  fileRoot: string | null;
+  strictOptionalPairs?: boolean;
+}
+
+export function credentialFingerprint(value: string): string {
+  return crypto.createHash("sha256").update(value).digest("hex").slice(0, 16);
+}
+
+export function fingerprintConfig(
+  config: Pick<B2Config, "applicationKeyId" | "appKeyId" | "masterKeyId" | "region">,
+): string {
+  return credentialFingerprint(
+    [config.applicationKeyId, config.appKeyId, config.masterKeyId, config.region].join("\0"),
+  );
+}
+
+function resolveOptionalPair(
+  id: string | undefined,
+  key: string | undefined,
+  fallbackId: string,
+  fallbackKey: string,
+  label: string,
+  strict: boolean,
+): { id: string; key: string } {
+  if (!!id !== !!key) {
+    if (strict) {
+      throw new CredentialResolutionError(
+        `${label} must include both id and secret`,
+        400,
+        "partial_credential",
+      );
+    }
+    logger.warn({ credentialPair: label }, "credential.partial_ignored");
+    return { id: fallbackId, key: fallbackKey };
+  }
+  return id && key ? { id, key } : { id: fallbackId, key: fallbackKey };
+}
+
+function configFromMaterial(material: CredentialMaterial, options: ConfigOptions): B2Config {
+  const keyId = material.applicationKeyId;
+  const key = material.applicationKey;
+  if (!keyId || !key) {
+    throw new CredentialResolutionError(
+      "B2 application credentials are required",
+      401,
+      "missing_credentials",
+    );
+  }
+
+  const strictOptionalPairs = options.strictOptionalPairs === true;
+  const app = resolveOptionalPair(
+    material.appKeyId,
+    material.appKey,
+    keyId,
+    key,
+    "B2 app key override",
+    strictOptionalPairs,
+  );
+  const master = resolveOptionalPair(
+    material.masterKeyId,
+    material.masterKey,
+    keyId,
+    key,
+    "B2 master key",
+    strictOptionalPairs,
+  );
+
+  const config: B2Config = {
+    applicationKeyId: keyId,
+    applicationKey: key,
+    appKeyId: app.id,
+    appKey: app.key,
+    masterKeyId: master.id,
+    masterKey: master.key,
+    region: process.env.B2_REGION ?? DEFAULT_REGION,
+    allowLocalFiles: options.allowLocalFiles,
+    fileRoot: options.fileRoot,
+    maxKeyDurationSeconds: process.env.B2_MAX_KEY_DURATION_SECONDS
+      ? parseIntEnv(process.env.B2_MAX_KEY_DURATION_SECONDS, 0)
+      : null,
+    allowKeyMgmtGrants: process.env.B2_ALLOW_KEY_MGMT_GRANTS === "true",
+    allowUnscopedKeys: process.env.B2_ALLOW_UNSCOPED_KEYS === "true",
+    destructivePolicy:
+      options.transport === "http"
+        ? process.env.B2_DESTRUCTIVE_POLICY === "allow" ||
+          process.env.B2_DESTRUCTIVE_POLICY === "block" ||
+          process.env.B2_DESTRUCTIVE_POLICY === "confirm"
+          ? process.env.B2_DESTRUCTIVE_POLICY
+          : "block"
+        : process.env.B2_DESTRUCTIVE_POLICY === "allow" ||
+            process.env.B2_DESTRUCTIVE_POLICY === "block"
+          ? process.env.B2_DESTRUCTIVE_POLICY
+          : "confirm",
+    transport: options.transport,
+  };
+  config.credentialFingerprint = fingerprintConfig(config);
+  return config;
+}
+
+function envMaterial(prefix = "B2"): CredentialMaterial {
+  return {
+    applicationKeyId: process.env[`${prefix}_APPLICATION_KEY_ID`],
+    applicationKey: process.env[`${prefix}_APPLICATION_KEY`],
+    appKeyId: process.env[`${prefix}_APP_KEY_ID`],
+    appKey: process.env[`${prefix}_APP_KEY`],
+    masterKeyId: process.env[`${prefix}_MASTER_KEY_ID`],
+    masterKey: process.env[`${prefix}_MASTER_KEY`],
+  };
+}
+
+function valueFromHeader(
+  headers: http.IncomingHttpHeaders,
+  names: readonly string[],
+): string | undefined {
+  const values = names
+    .map((name) => headers[name])
+    .filter((value): value is string | string[] => value !== undefined)
+    .flatMap((value) => (Array.isArray(value) ? value : [value]));
+  const unique = [...new Set(values)];
+  if (unique.length > 1) {
+    throw new CredentialResolutionError(
+      "Conflicting B2 credential headers",
+      400,
+      "conflicting_headers",
+    );
+  }
+  return unique[0];
+}
+
+function headerMaterial(headers: http.IncomingHttpHeaders): CredentialMaterial {
+  return {
+    applicationKeyId: valueFromHeader(headers, HEADER_NAMES.keyId),
+    applicationKey: valueFromHeader(headers, HEADER_NAMES.key),
+    appKeyId: valueFromHeader(headers, HEADER_NAMES.appKeyId),
+    appKey: valueFromHeader(headers, HEADER_NAMES.appKey),
+    masterKeyId: valueFromHeader(headers, HEADER_NAMES.masterKeyId),
+    masterKey: valueFromHeader(headers, HEADER_NAMES.masterKey),
+  };
+}
+
+export function hasCredentialHeaders(headers: http.IncomingHttpHeaders): boolean {
+  return Object.keys(headers).some((name) => ALL_CREDENTIAL_HEADER_NAMES.has(name.toLowerCase()));
+}
+
+function httpConfigOptions(): ConfigOptions {
+  return {
+    transport: "http",
+    allowLocalFiles: process.env.B2_ALLOW_LOCAL_FILES === "true" && !!process.env.B2_FILE_ROOT,
+    fileRoot: process.env.B2_FILE_ROOT ?? null,
+    strictOptionalPairs: true,
+  };
+}
+
+export class StdioEnvCredentialProvider implements CredentialProvider {
+  readonly name = "stdio-env";
+
+  resolve(): CredentialResolution {
+    const config = configFromMaterial(envMaterial(), {
+      transport: "stdio",
+      allowLocalFiles: process.env.B2_ALLOW_LOCAL_FILES !== "false",
+      fileRoot: process.env.B2_FILE_ROOT ?? null,
+      strictOptionalPairs: false,
+    });
+    return { config, cacheKey: `credential:${config.credentialFingerprint}` };
+  }
+}
+
+export class HttpHeaderCredentialProvider implements CredentialProvider {
+  readonly name = "http-headers";
+
+  resolve(context?: CredentialProviderContext): CredentialResolution {
+    if (!context?.req) {
+      throw new CredentialResolutionError("HTTP request required", 500, "request_required");
+    }
+    const config = configFromMaterial(headerMaterial(context.req.headers), httpConfigOptions());
+    return { config, cacheKey: `credential:${config.credentialFingerprint}` };
+  }
+}
+
+export class HttpServerCredentialProvider implements CredentialProvider {
+  readonly name = "http-server";
+
+  resolve(context?: CredentialProviderContext): CredentialResolution {
+    if (context?.req && hasCredentialHeaders(context.req.headers)) {
+      throw new CredentialResolutionError(
+        "B2 credential headers are not accepted in this mode",
+        400,
+        "credential_headers_rejected",
+      );
+    }
+    const config = configFromMaterial(envMaterial(), httpConfigOptions());
+    return { config, cacheKey: `credential:${config.credentialFingerprint}` };
+  }
+}
+
+export interface SecretBroker {
+  resolve(ref: string): CredentialMaterial | null;
+}
+
+export class EnvSecretBroker implements SecretBroker {
+  resolve(ref: string): CredentialMaterial | null {
+    const prefix = credentialRefEnvPrefix(ref);
+    return envMaterial(prefix);
+  }
+}
+
+function credentialRefEnvPrefix(ref: string): string {
+  if (!/^[A-Za-z0-9_-]{1,80}$/.test(ref)) {
+    throw new CredentialResolutionError(
+      "Invalid credential reference",
+      500,
+      "invalid_credential_ref",
+    );
+  }
+  return `B2_CREDENTIAL_${ref.toUpperCase().replace(/[^A-Z0-9]/g, "_")}`;
+}
+
+function principalFromAuthInfo(authInfo: AuthInfo): string | null {
+  const extra = authInfo.extra ?? {};
+  for (const key of ["sub", "subject", "principal", "email"]) {
+    const value = extra[key];
+    if (typeof value === "string" && value.trim()) return value.trim();
+  }
+  return authInfo.clientId?.trim() || null;
+}
+
+function principalMap(): Record<string, string> {
+  const raw = process.env.B2_PRINCIPAL_CREDENTIAL_MAP;
+  if (!raw) return {};
+  try {
+    const parsed = JSON.parse(raw) as unknown;
+    if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
+      throw new Error("not an object");
+    }
+    return Object.fromEntries(
+      Object.entries(parsed as Record<string, unknown>).filter(
+        (entry): entry is [string, string] => typeof entry[1] === "string",
+      ),
+    );
+  } catch {
+    throw new CredentialResolutionError(
+      "Invalid principal credential map",
+      500,
+      "invalid_principal_map",
+    );
+  }
+}
+
+export class HttpPrincipalCredentialProvider implements CredentialProvider {
+  readonly name = "http-principal";
+
+  constructor(private readonly broker: SecretBroker = new EnvSecretBroker()) {}
+
+  resolve(context?: CredentialProviderContext): CredentialResolution {
+    if (!context?.req) {
+      throw new CredentialResolutionError("HTTP request required", 500, "request_required");
+    }
+    if (hasCredentialHeaders(context.req.headers)) {
+      throw new CredentialResolutionError(
+        "B2 credential headers are not accepted in this mode",
+        400,
+        "credential_headers_rejected",
+      );
+    }
+    const authInfo = context.req.auth;
+    if (!authInfo) {
+      throw new CredentialResolutionError(
+        "Verified MCP authInfo is required",
+        401,
+        "missing_auth_info",
+      );
+    }
+    const principal = principalFromAuthInfo(authInfo);
+    if (!principal) {
+      throw new CredentialResolutionError(
+        "Verified principal is required",
+        401,
+        "missing_principal",
+      );
+    }
+    const ref = principalMap()[principal];
+    if (!ref) {
+      throw new CredentialResolutionError(
+        "No credential mapping for principal",
+        403,
+        "principal_not_mapped",
+      );
+    }
+    const material = this.broker.resolve(ref);
+    if (!material) {
+      throw new CredentialResolutionError(
+        "Credential reference not found",
+        403,
+        "credential_ref_not_found",
+      );
+    }
+    const config = configFromMaterial(material, httpConfigOptions());
+    return {
+      config,
+      cacheKey: `principal:${credentialFingerprint(principal)}`,
+      principal,
+    };
+  }
+}
+
+export function getHttpCredentialMode(): HttpCredentialMode {
+  const raw = (process.env.B2_HTTP_CREDENTIAL_MODE ?? "server").trim().toLowerCase();
+  if (raw === "server" || raw === "principal" || raw === "headers") return raw;
+  throw new CredentialResolutionError(
+    "Invalid B2_HTTP_CREDENTIAL_MODE",
+    500,
+    "invalid_credential_mode",
+  );
+}
+
+export function getHttpCredentialProvider(): CredentialProvider {
+  switch (getHttpCredentialMode()) {
+    case "headers":
+      return new HttpHeaderCredentialProvider();
+    case "principal":
+      return new HttpPrincipalCredentialProvider();
+    case "server":
+      return new HttpServerCredentialProvider();
+  }
+}
+
+export function configFromHttpHeaders(req: { headers: http.IncomingHttpHeaders }): B2Config | null {
+  try {
+    return new HttpHeaderCredentialProvider().resolve({ req: req as AuthenticatedIncomingMessage })
+      .config;
+  } catch (err) {
+    if (err instanceof CredentialResolutionError && err.code === "missing_credentials") return null;
+    throw err;
+  }
+}

--- a/src/credentials.ts
+++ b/src/credentials.ts
@@ -316,7 +316,8 @@ export interface SecretBroker {
 export class EnvSecretBroker implements SecretBroker {
   resolve(ref: string): CredentialMaterial | null {
     const prefix = credentialRefEnvPrefix(ref);
-    return envMaterial(prefix);
+    const material = envMaterial(prefix);
+    return material.applicationKeyId && material.applicationKey ? material : null;
   }
 }
 

--- a/src/credentials.ts
+++ b/src/credentials.ts
@@ -30,19 +30,20 @@ export interface CredentialProviderContext {
 
 export interface CredentialResolution {
   config: B2Config;
-  /** Non-secret cache/metrics key: either a credential fingerprint or verified principal. */
+  /** Non-secret log/rate-limit key: either a credential fingerprint or verified principal. */
   cacheKey: string;
   /**
-   * Secret-bound verifier for capability-cache identity and legacy adapters.
-   * This is a one-way digest and must never be logged or returned.
+   * Secret-bound capability-cache key. This is a one-way digest and must never
+   * be logged or returned.
    */
-  verificationKey: string;
+  capabilityCacheKey: string;
   principal?: string;
 }
 
 export interface CredentialProvider {
   readonly name: string;
   resolve(context?: CredentialProviderContext): CredentialResolution;
+  validateConfiguration?(): void;
 }
 
 export class CredentialResolutionError extends Error {
@@ -111,7 +112,7 @@ export function verificationFingerprintConfig(
   );
 }
 
-function verificationKeyForConfig(prefix: string, config: B2Config): string {
+function capabilityCacheKeyForConfig(prefix: string, config: B2Config): string {
   return `${prefix}:${verificationFingerprintConfig(config)}`;
 }
 
@@ -268,7 +269,7 @@ export class StdioEnvCredentialProvider implements CredentialProvider {
     return {
       config,
       cacheKey: `credential:${config.credentialFingerprint}`,
-      verificationKey: verificationKeyForConfig("credential", config),
+      capabilityCacheKey: capabilityCacheKeyForConfig("credential", config),
     };
   }
 }
@@ -284,7 +285,7 @@ export class HttpHeaderCredentialProvider implements CredentialProvider {
     return {
       config,
       cacheKey: `credential:${config.credentialFingerprint}`,
-      verificationKey: verificationKeyForConfig("credential", config),
+      capabilityCacheKey: capabilityCacheKeyForConfig("credential", config),
     };
   }
 }
@@ -304,8 +305,12 @@ export class HttpServerCredentialProvider implements CredentialProvider {
     return {
       config,
       cacheKey: `credential:${config.credentialFingerprint}`,
-      verificationKey: verificationKeyForConfig("credential", config),
+      capabilityCacheKey: capabilityCacheKeyForConfig("credential", config),
     };
+  }
+
+  validateConfiguration(): void {
+    this.resolve({ req: { headers: {} } as AuthenticatedIncomingMessage });
   }
 }
 
@@ -334,13 +339,19 @@ function credentialRefEnvPrefix(ref: string): string {
 
 function principalFromAuthInfo(authInfo: AuthInfo): string | null {
   const extra = authInfo.extra ?? {};
-  // Keep stable subject-like claims ahead of mutable/display claims; this
-  // order defines which credential reference a verified caller resolves to.
-  for (const key of ["sub", "subject", "principal", "email"]) {
+  // This is an authorization boundary: only stable, verified subject claims can
+  // select a B2 credential. Do not fall back to mutable display/contact claims
+  // such as email, or shared application identifiers such as clientId.
+  for (const key of ["sub", "subject", "principal"]) {
     const value = extra[key];
-    if (typeof value === "string" && value.trim()) return value.trim();
+    if (typeof value !== "string" || !value.trim()) continue;
+    const issuer = extra.iss ?? extra.issuer;
+    if (typeof issuer === "string" && issuer.trim()) {
+      return `${issuer.trim()}#${value.trim()}`;
+    }
+    return value.trim();
   }
-  return authInfo.clientId?.trim() || null;
+  return null;
 }
 
 let cachedPrincipalMapRaw: string | undefined;
@@ -355,11 +366,18 @@ function principalMap(): Record<string, string> {
     if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
       throw new Error("not an object");
     }
-    const map = Object.fromEntries(
-      Object.entries(parsed as Record<string, unknown>).filter(
-        (entry): entry is [string, string] => typeof entry[1] === "string",
-      ),
-    );
+    const map: Record<string, string> = Object.create(null);
+    const prefixes = new Map<string, string>();
+    for (const [principal, refValue] of Object.entries(parsed as Record<string, unknown>)) {
+      if (typeof refValue !== "string") continue;
+      const normalized = credentialRefEnvPrefix(refValue);
+      const existing = prefixes.get(normalized);
+      if (existing && existing !== refValue) {
+        throw new Error("credential ref collision");
+      }
+      prefixes.set(normalized, refValue);
+      map[principal] = refValue;
+    }
     cachedPrincipalMapRaw = raw;
     cachedPrincipalMap = map;
     return map;
@@ -404,14 +422,15 @@ export class HttpPrincipalCredentialProvider implements CredentialProvider {
         "missing_principal",
       );
     }
-    const ref = principalMap()[principal];
-    if (!ref) {
+    const map = principalMap();
+    if (!Object.prototype.hasOwnProperty.call(map, principal)) {
       throw new CredentialResolutionError(
         "No credential mapping for principal",
         403,
         "principal_not_mapped",
       );
     }
+    const ref = map[principal];
     const material = this.broker.resolve(ref);
     if (!material) {
       throw new CredentialResolutionError(
@@ -424,11 +443,15 @@ export class HttpPrincipalCredentialProvider implements CredentialProvider {
     return {
       config,
       cacheKey: `principal:${credentialFingerprint(principal)}`,
-      verificationKey: `principal:${credentialFingerprint(
+      capabilityCacheKey: `principal:${credentialFingerprint(
         [principal, verificationFingerprintConfig(config)].join("\0"),
       )}`,
       principal,
     };
+  }
+
+  validateConfiguration(): void {
+    principalMap();
   }
 }
 
@@ -456,12 +479,7 @@ export function getHttpCredentialProvider(broker?: SecretBroker): CredentialProv
 export function validateHttpCredentialConfiguration(
   provider: CredentialProvider = getHttpCredentialProvider(),
 ): void {
-  if (provider instanceof HttpServerCredentialProvider) {
-    provider.resolve({ req: { headers: {} } as AuthenticatedIncomingMessage });
-  }
-  if (provider instanceof HttpPrincipalCredentialProvider) {
-    principalMap();
-  }
+  provider.validateConfiguration?.();
 }
 
 /**

--- a/src/credentials.ts
+++ b/src/credentials.ts
@@ -1,9 +1,9 @@
 import * as crypto from "crypto";
 import * as http from "http";
-import type { AuthInfo } from "@modelcontextprotocol/sdk/server/auth/types.js";
+import type { AuthInfo } from "@modelcontextprotocol/server";
 import { parseIntEnv } from "./utils/config.js";
 import { logger } from "./utils/logger.js";
-import { B2Config } from "./utils/types.js";
+import { B2Config, DestructivePolicy } from "./utils/types.js";
 
 const DEFAULT_REGION = "us-west-004";
 
@@ -32,6 +32,11 @@ export interface CredentialResolution {
   config: B2Config;
   /** Non-secret cache/metrics key: either a credential fingerprint or verified principal. */
   cacheKey: string;
+  /**
+   * Secret-bound verifier for capability-cache identity and legacy adapters.
+   * This is a one-way digest and must never be logged or returned.
+   */
+  verificationKey: string;
   principal?: string;
 }
 
@@ -78,6 +83,44 @@ export function fingerprintConfig(
   return credentialFingerprint(
     [config.applicationKeyId, config.appKeyId, config.masterKeyId, config.region].join("\0"),
   );
+}
+
+export function verificationFingerprintConfig(
+  config: Pick<
+    B2Config,
+    | "applicationKeyId"
+    | "applicationKey"
+    | "appKeyId"
+    | "appKey"
+    | "masterKeyId"
+    | "masterKey"
+    | "region"
+  >,
+): string {
+  return credentialFingerprint(
+    [
+      "b2-mcp-credential-verifier-v1",
+      config.applicationKeyId,
+      config.applicationKey,
+      config.appKeyId,
+      config.appKey,
+      config.masterKeyId,
+      config.masterKey,
+      config.region,
+    ].join("\0"),
+  );
+}
+
+function verificationKeyForConfig(prefix: string, config: B2Config): string {
+  return `${prefix}:${verificationFingerprintConfig(config)}`;
+}
+
+function resolveDestructivePolicy(transport: "stdio" | "http"): DestructivePolicy {
+  const value = process.env.B2_DESTRUCTIVE_POLICY;
+  if (transport === "http") {
+    return value === "allow" || value === "block" || value === "confirm" ? value : "block";
+  }
+  return value === "allow" || value === "block" ? value : "confirm";
 }
 
 function resolveOptionalPair(
@@ -146,17 +189,7 @@ function configFromMaterial(material: CredentialMaterial, options: ConfigOptions
       : null,
     allowKeyMgmtGrants: process.env.B2_ALLOW_KEY_MGMT_GRANTS === "true",
     allowUnscopedKeys: process.env.B2_ALLOW_UNSCOPED_KEYS === "true",
-    destructivePolicy:
-      options.transport === "http"
-        ? process.env.B2_DESTRUCTIVE_POLICY === "allow" ||
-          process.env.B2_DESTRUCTIVE_POLICY === "block" ||
-          process.env.B2_DESTRUCTIVE_POLICY === "confirm"
-          ? process.env.B2_DESTRUCTIVE_POLICY
-          : "block"
-        : process.env.B2_DESTRUCTIVE_POLICY === "allow" ||
-            process.env.B2_DESTRUCTIVE_POLICY === "block"
-          ? process.env.B2_DESTRUCTIVE_POLICY
-          : "confirm",
+    destructivePolicy: resolveDestructivePolicy(options.transport),
     transport: options.transport,
   };
   config.credentialFingerprint = fingerprintConfig(config);
@@ -221,13 +254,22 @@ export class StdioEnvCredentialProvider implements CredentialProvider {
   readonly name = "stdio-env";
 
   resolve(): CredentialResolution {
+    if (process.env.B2_APP_KEY_ID) {
+      logger.warn(
+        "config.deprecated: B2_APP_KEY_ID/B2_APP_KEY is deprecated. Use B2_APPLICATION_KEY_ID/B2_APPLICATION_KEY with B2_MASTER_KEY_* only when a separate master credential is required.",
+      );
+    }
     const config = configFromMaterial(envMaterial(), {
       transport: "stdio",
       allowLocalFiles: process.env.B2_ALLOW_LOCAL_FILES !== "false",
       fileRoot: process.env.B2_FILE_ROOT ?? null,
       strictOptionalPairs: false,
     });
-    return { config, cacheKey: `credential:${config.credentialFingerprint}` };
+    return {
+      config,
+      cacheKey: `credential:${config.credentialFingerprint}`,
+      verificationKey: verificationKeyForConfig("credential", config),
+    };
   }
 }
 
@@ -239,7 +281,11 @@ export class HttpHeaderCredentialProvider implements CredentialProvider {
       throw new CredentialResolutionError("HTTP request required", 500, "request_required");
     }
     const config = configFromMaterial(headerMaterial(context.req.headers), httpConfigOptions());
-    return { config, cacheKey: `credential:${config.credentialFingerprint}` };
+    return {
+      config,
+      cacheKey: `credential:${config.credentialFingerprint}`,
+      verificationKey: verificationKeyForConfig("credential", config),
+    };
   }
 }
 
@@ -255,7 +301,11 @@ export class HttpServerCredentialProvider implements CredentialProvider {
       );
     }
     const config = configFromMaterial(envMaterial(), httpConfigOptions());
-    return { config, cacheKey: `credential:${config.credentialFingerprint}` };
+    return {
+      config,
+      cacheKey: `credential:${config.credentialFingerprint}`,
+      verificationKey: verificationKeyForConfig("credential", config),
+    };
   }
 }
 
@@ -283,6 +333,8 @@ function credentialRefEnvPrefix(ref: string): string {
 
 function principalFromAuthInfo(authInfo: AuthInfo): string | null {
   const extra = authInfo.extra ?? {};
+  // Keep stable subject-like claims ahead of mutable/display claims; this
+  // order defines which credential reference a verified caller resolves to.
   for (const key of ["sub", "subject", "principal", "email"]) {
     const value = extra[key];
     if (typeof value === "string" && value.trim()) return value.trim();
@@ -290,19 +342,26 @@ function principalFromAuthInfo(authInfo: AuthInfo): string | null {
   return authInfo.clientId?.trim() || null;
 }
 
+let cachedPrincipalMapRaw: string | undefined;
+let cachedPrincipalMap: Record<string, string> | undefined;
+
 function principalMap(): Record<string, string> {
   const raw = process.env.B2_PRINCIPAL_CREDENTIAL_MAP;
   if (!raw) return {};
+  if (raw === cachedPrincipalMapRaw && cachedPrincipalMap) return cachedPrincipalMap;
   try {
     const parsed = JSON.parse(raw) as unknown;
     if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
       throw new Error("not an object");
     }
-    return Object.fromEntries(
+    const map = Object.fromEntries(
       Object.entries(parsed as Record<string, unknown>).filter(
         (entry): entry is [string, string] => typeof entry[1] === "string",
       ),
     );
+    cachedPrincipalMapRaw = raw;
+    cachedPrincipalMap = map;
+    return map;
   } catch {
     throw new CredentialResolutionError(
       "Invalid principal credential map",
@@ -364,13 +423,16 @@ export class HttpPrincipalCredentialProvider implements CredentialProvider {
     return {
       config,
       cacheKey: `principal:${credentialFingerprint(principal)}`,
+      verificationKey: `principal:${credentialFingerprint(
+        [principal, verificationFingerprintConfig(config)].join("\0"),
+      )}`,
       principal,
     };
   }
 }
 
 export function getHttpCredentialMode(): HttpCredentialMode {
-  const raw = (process.env.B2_HTTP_CREDENTIAL_MODE ?? "server").trim().toLowerCase();
+  const raw = (process.env.B2_HTTP_CREDENTIAL_MODE ?? "headers").trim().toLowerCase();
   if (raw === "server" || raw === "principal" || raw === "headers") return raw;
   throw new CredentialResolutionError(
     "Invalid B2_HTTP_CREDENTIAL_MODE",
@@ -379,17 +441,33 @@ export function getHttpCredentialMode(): HttpCredentialMode {
   );
 }
 
-export function getHttpCredentialProvider(): CredentialProvider {
+export function getHttpCredentialProvider(broker?: SecretBroker): CredentialProvider {
   switch (getHttpCredentialMode()) {
     case "headers":
       return new HttpHeaderCredentialProvider();
     case "principal":
-      return new HttpPrincipalCredentialProvider();
+      return new HttpPrincipalCredentialProvider(broker);
     case "server":
       return new HttpServerCredentialProvider();
   }
 }
 
+export function validateHttpCredentialConfiguration(
+  provider: CredentialProvider = getHttpCredentialProvider(),
+): void {
+  if (provider instanceof HttpServerCredentialProvider) {
+    provider.resolve({ req: { headers: {} } as AuthenticatedIncomingMessage });
+  }
+  if (provider instanceof HttpPrincipalCredentialProvider) {
+    principalMap();
+  }
+}
+
+/**
+ * Header-compatibility parser. Returns null only when the required primary
+ * header pair is absent/incomplete. Malformed optional pairs or conflicting
+ * duplicate headers throw CredentialResolutionError with a stable code.
+ */
 export function configFromHttpHeaders(req: { headers: http.IncomingHttpHeaders }): B2Config | null {
   try {
     return new HttpHeaderCredentialProvider().resolve({ req: req as AuthenticatedIncomingMessage })

--- a/src/http-server.ts
+++ b/src/http-server.ts
@@ -1,48 +1,35 @@
 #!/usr/bin/env node
 /**
- * Backblaze B2 MCP Server — Streamable HTTP transport entry point.
+ * Backblaze B2 MCP Server — HTTP transport entry point.
  *
- * Implements the MCP **Streamable HTTP** transport (spec 2025-03-26), which
- * replaced the now-deprecated HTTP+SSE transport. A single endpoint handles all
- * traffic:
- *   POST   /mcp   — client→server JSON-RPC (the `initialize` request opens a
- *                   session; the response carries the `Mcp-Session-Id`)
- *   GET    /mcp   — opens the server→client stream for an existing session
- *   DELETE /mcp   — terminates a session
- *   GET    /health
- *
- * Credential mode is explicit:
- *   B2_HTTP_CREDENTIAL_MODE=server    — B2 credentials come from server env
- *   B2_HTTP_CREDENTIAL_MODE=principal — verified MCP authInfo maps to a credential ref
- *   B2_HTTP_CREDENTIAL_MODE=headers   — compatibility mode; B2 headers on every request
+ * Production serving uses the MCP SDK v2 per-request HTTP handler for the
+ * 2026-07-28 protocol. The server does not create or depend on MCP sessions;
+ * every `/mcp` request resolves credentials independently.
  */
 
 import * as http from "http";
 import * as crypto from "crypto";
-import { StreamableHTTPServerTransport } from "@modelcontextprotocol/sdk/server/streamableHttp.js";
-import type { AuthInfo } from "@modelcontextprotocol/sdk/server/auth/types.js";
-import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
-import { createServer, fetchCapabilities } from "./server.js";
+import { createMcpHandler, type AuthInfo } from "@modelcontextprotocol/server";
+import { createServer, fetchCapabilities, sweepCapabilityCache } from "./server.js";
 import { B2Config } from "./utils/types.js";
-import { parseIntEnv } from "./utils/config.js";
 import { VERSION } from "./version.js";
 import { logger } from "./utils/logger.js";
 import { allowRequest, sweepIdleBuckets } from "./utils/rate-limiter.js";
 import {
   AuthenticatedIncomingMessage,
   configFromHttpHeaders,
+  CredentialProvider,
   CredentialResolution,
   CredentialResolutionError,
   getHttpCredentialProvider,
+  SecretBroker,
+  validateHttpCredentialConfiguration,
 } from "./credentials.js";
 
 const DEFAULT_PORT = 3000;
 const MAX_BODY_BYTES = 1 * 1024 * 1024; // 1 MB — MCP messages are JSON-RPC, never close to this
-const SESSION_IDLE_TIMEOUT_MS = 30 * 60 * 1000; // 30 minutes
 const IDLE_SWEEP_INTERVAL_MS = 60 * 1000; // 1 minute
 const SHUTDOWN_DRAIN_MS = 10 * 1000; // 10 seconds to drain on SIGTERM
-const MAX_SESSIONS = parseIntEnv(process.env.B2_MAX_SESSIONS, 1000); // total concurrent
-const MAX_SESSIONS_PER_KEY = parseIntEnv(process.env.B2_MAX_SESSIONS_PER_KEY, 20);
 
 /** Comma-separated allowlists for DNS-rebinding protection (empty = unset). */
 function csvEnv(name: string): string[] {
@@ -51,53 +38,29 @@ function csvEnv(name: string): string[] {
     .map((s) => s.trim())
     .filter(Boolean);
 }
+
 const ALLOWED_HOSTS = csvEnv("B2_ALLOWED_HOSTS");
 const ALLOWED_ORIGINS = csvEnv("B2_ALLOWED_ORIGINS");
 
 /**
  * DNS-rebinding protection. Validates Host / Origin against the configured
- * allowlists (the SDK transport's own options are deprecated in favor of external
- * validation). SECURE DEFAULT: with NO allowlist configured, only localhost is
- * accepted — an internet-facing HTTP deployment MUST set B2_ALLOWED_HOSTS (a
- * reverse proxy enforcing server_name is a good additional backstop). Non-browser
- * clients (mcp-remote, curl) send no Origin and connect by host, so an allowlisted
- * host is sufficient for them.
+ * allowlists. SECURE DEFAULT: with NO allowlist configured, only localhost is
+ * accepted; internet-facing deployments must set B2_ALLOWED_HOSTS.
  */
 function hostOriginAllowed(req: { headers: http.IncomingHttpHeaders }): boolean {
   const host = Array.isArray(req.headers.host) ? "" : (req.headers.host ?? "");
   const origin = Array.isArray(req.headers.origin) ? "" : (req.headers.origin ?? "");
 
-  // Configured allowlists take precedence (strict).
   if (ALLOWED_HOSTS.length > 0 && !ALLOWED_HOSTS.includes(host)) return false;
   if (ALLOWED_ORIGINS.length > 0 && origin && !ALLOWED_ORIGINS.includes(origin)) return false;
 
-  // Secure default: nothing configured → accept only localhost.
   if (ALLOWED_HOSTS.length === 0 && ALLOWED_ORIGINS.length === 0) {
-    const hostname = host.replace(/:\d+$/, ""); // strip :port
+    const hostname = host.replace(/:\d+$/, "");
     return ["localhost", "127.0.0.1", "::1", "[::1]"].includes(hostname);
   }
   return true;
 }
 
-/** True if the parsed JSON-RPC payload is (or contains) an `initialize` request. */
-function isInitialize(body: unknown): boolean {
-  const msgs = Array.isArray(body) ? body : [body];
-  return msgs.some(
-    (m) => !!m && typeof m === "object" && (m as { method?: unknown }).method === "initialize",
-  );
-}
-
-interface Session {
-  transport: StreamableHTTPServerTransport;
-  mcpServer: McpServer;
-  lastActivity: number;
-  /** Non-secret provider cache key from the credential resolution boundary. */
-  credentialCacheKey: string;
-  /** Rate-limiter key — a hash of the non-secret credential/principal cache key. */
-  rateKey: string;
-}
-
-/** Stable rate-limit/session key derived from a non-secret credential/principal cache key. */
 export function deriveRateKey(cacheKey: string): string {
   return crypto.createHash("sha256").update(cacheKey).digest("hex").slice(0, 16);
 }
@@ -119,11 +82,6 @@ export function configFromHeaders(req: { headers: http.IncomingHttpHeaders }): B
   return configFromHttpHeaders(req);
 }
 
-function sessionIdHeader(req: http.IncomingMessage): string | undefined {
-  const v = req.headers["mcp-session-id"];
-  return Array.isArray(v) ? v[0] : v;
-}
-
 function writeJson(res: http.ServerResponse, status: number, body: unknown, headers = {}): void {
   res.writeHead(status, { "Content-Type": "application/json", ...headers });
   res.end(JSON.stringify(body));
@@ -137,79 +95,101 @@ function writeCredentialError(res: http.ServerResponse, err: unknown): void {
   writeJson(res, 500, { error: "Credential resolution failed" });
 }
 
-function validateExistingRequest(req: AuthenticatedIncomingMessage, session: Session): void {
-  const resolved = getHttpCredentialProvider().resolve({ req });
-  if (resolved.cacheKey !== session.credentialCacheKey) {
-    throw new CredentialResolutionError(
-      "Request credentials do not match the MCP session",
-      403,
-      "credential_mismatch",
-    );
+function headersFromNode(headers: http.IncomingHttpHeaders): Headers {
+  const webHeaders = new Headers();
+  for (const [name, value] of Object.entries(headers)) {
+    if (value === undefined) continue;
+    if (Array.isArray(value)) {
+      for (const item of value) webHeaders.append(name, item);
+    } else {
+      webHeaders.set(name, value);
+    }
   }
+  return webHeaders;
+}
+
+function requestUrl(req: http.IncomingMessage): string {
+  const host = Array.isArray(req.headers.host) ? req.headers.host[0] : req.headers.host;
+  const proto = Array.isArray(req.headers["x-forwarded-proto"])
+    ? req.headers["x-forwarded-proto"][0]
+    : req.headers["x-forwarded-proto"];
+  return new URL(
+    req.url ?? "/",
+    `${proto === "https" ? "https" : "http"}://${host ?? "localhost"}`,
+  ).toString();
+}
+
+function toWebRequest(req: http.IncomingMessage, body?: string): Request {
+  const method = req.method ?? "GET";
+  return new Request(requestUrl(req), {
+    method,
+    headers: headersFromNode(req.headers),
+    body: method === "GET" || method === "HEAD" ? undefined : (body ?? ""),
+  });
+}
+
+async function writeFetchResponse(res: http.ServerResponse, response: Response): Promise<void> {
+  response.headers.forEach((value, name) => res.setHeader(name, value));
+  res.writeHead(response.status);
+  if (!response.body) {
+    res.end();
+    return;
+  }
+  const reader = response.body.getReader();
+  for (;;) {
+    const { done, value } = await reader.read();
+    if (done) break;
+    res.write(Buffer.from(value));
+  }
+  res.end();
 }
 
 export interface HttpServerHandle {
   server: http.Server;
-  /** Live session map — exposed for tests/observability. */
-  sessions: Map<string, Session>;
-  /** Mark draining, stop the idle sweep, and tear down all sessions. Does not exit. */
+  /** MCP v2 HTTP is stateless; this remains for tests/observability. */
+  sessions: Map<string, never>;
+  /** Mark draining and stop periodic sweeps. Does not exit. */
   drain(): void;
 }
 
 export interface HttpServerOptions {
   /** Hook for customer middleware/tests to attach verified MCP authInfo. */
   getAuthInfo?: (req: AuthenticatedIncomingMessage) => AuthInfo | null | undefined;
+  /** Explicit credential provider injection for hosted wrappers/tests. */
+  credentialProvider?: CredentialProvider;
+  /** Secret-broker injection for principal mode. */
+  secretBroker?: SecretBroker;
 }
 
-/**
- * Build the HTTP server and its session machinery without binding to a port or
- * installing signal handlers — so it can be unit-tested by listening on an
- * ephemeral port. main() wires in getPort(), listen(), and graceful shutdown.
- */
 export function buildHttpServer(options: HttpServerOptions = {}): HttpServerHandle {
-  // Map of Mcp-Session-Id → session record with last-activity timestamp
-  const sessions = new Map<string, Session>();
+  const sessions = new Map<string, never>();
   let shuttingDown = false;
 
-  function touch(sessionId: string): void {
-    const s = sessions.get(sessionId);
-    if (s) s.lastActivity = Date.now();
-  }
+  const credentialProvider =
+    options.credentialProvider ?? getHttpCredentialProvider(options.secretBroker);
 
-  // Fully tear down a session: close the transport AND the McpServer (which
-  // holds its registered tools + auth/clients) so neither leaks on disconnect.
-  function closeSession(sessionId: string): void {
-    const s = sessions.get(sessionId);
-    if (!s) return;
-    sessions.delete(sessionId);
+  function readiness(): { ok: true } | { ok: false; error: string } {
     try {
-      void s.transport.close();
-    } catch {
-      /* ignore */
-    }
-    try {
-      void s.mcpServer.close();
-    } catch {
-      /* ignore */
+      validateHttpCredentialConfiguration(credentialProvider);
+      return { ok: true };
+    } catch (err) {
+      logger.warn(
+        {
+          code: err instanceof CredentialResolutionError ? err.code : "readiness_failed",
+        },
+        "health.not_ready",
+      );
+      return { ok: false, error: "Credential configuration invalid" };
     }
   }
 
-  // Sweep idle sessions periodically — protects against stuck connections
-  // that never fired transport.onclose.
   const idleSweep = setInterval(() => {
     const now = Date.now();
-    const cutoff = now - SESSION_IDLE_TIMEOUT_MS;
-    for (const [id, s] of sessions) {
-      if (s.lastActivity < cutoff) {
-        closeSession(id);
-      }
-    }
     sweepIdleBuckets(now);
+    sweepCapabilityCache(now);
   }, IDLE_SWEEP_INTERVAL_MS);
   idleSweep.unref();
 
-  // Read the request body with a hard size cap. Resolves with the raw string,
-  // or null if the cap was exceeded (in which case a 413 has been sent).
   function readCappedBody(
     req: http.IncomingMessage,
     res: http.ServerResponse,
@@ -252,13 +232,23 @@ export function buildHttpServer(options: HttpServerOptions = {}): HttpServerHand
       return;
     }
 
-    // Health check — no auth, no session.
     if (req.method === "GET" && url.pathname === "/health") {
+      const ready = readiness();
+      if (!ready.ok) {
+        writeJson(res, 503, {
+          status: "error",
+          error: ready.error,
+          server: "backblaze-b2-mcp",
+          version: VERSION,
+          activeSessions: 0,
+        });
+        return;
+      }
       writeJson(res, 200, {
         status: "ok",
         server: "backblaze-b2-mcp",
         version: VERSION,
-        activeSessions: sessions.size,
+        activeSessions: 0,
       });
       return;
     }
@@ -268,94 +258,22 @@ export function buildHttpServer(options: HttpServerOptions = {}): HttpServerHand
       return;
     }
 
-    // DNS-rebinding protection on the MCP endpoint.
     if (!hostOriginAllowed(req)) {
       writeJson(res, 403, { error: "Host/Origin not allowed" });
       return;
     }
 
-    // ── Existing-session requests (POST follow-ups, GET stream, DELETE) ──────
-    // POST with a session id, and all GET/DELETE, route to the live transport.
-    const sessionId = sessionIdHeader(req);
-
-    if (req.method === "GET" || req.method === "DELETE") {
-      if (!sessionId || !sessions.has(sessionId)) {
-        writeJson(res, 404, { error: "Session not found" });
-        return;
-      }
-      const session = sessions.get(sessionId)!;
-      try {
-        validateExistingRequest(authedReq, session);
-      } catch (err) {
-        writeCredentialError(res, err);
-        return;
-      }
-      if (!allowRequest(session.rateKey)) {
-        writeJson(res, 429, { error: "Rate limit exceeded" }, { "Retry-After": "1" });
-        return;
-      }
-      touch(sessionId);
-      try {
-        await session.transport.handleRequest(authedReq, res);
-      } catch {
-        if (!res.headersSent) writeJson(res, 500, { error: "Internal server error" });
-      }
-      return;
-    }
-
-    if (req.method !== "POST") {
+    if (req.method !== "POST" && req.method !== "GET" && req.method !== "DELETE") {
       writeJson(res, 405, { error: "Method not allowed" });
       return;
     }
 
-    // POST — read + parse the JSON-RPC body (size-capped).
-    const raw = await readCappedBody(req, res);
-    if (raw === null) return; // 413 already sent
-    let parsed: unknown;
-    try {
-      parsed = JSON.parse(raw);
-    } catch {
-      writeJson(res, 400, { error: "Invalid JSON body" });
-      return;
-    }
-
-    // Follow-up POST on an established session.
-    if (sessionId) {
-      const session = sessions.get(sessionId);
-      if (!session) {
-        writeJson(res, 404, { error: "Session not found" });
-        return;
-      }
-      try {
-        validateExistingRequest(authedReq, session);
-      } catch (err) {
-        writeCredentialError(res, err);
-        return;
-      }
-      if (!allowRequest(session.rateKey)) {
-        writeJson(res, 429, { error: "Rate limit exceeded" }, { "Retry-After": "1" });
-        return;
-      }
-      touch(sessionId);
-      try {
-        await session.transport.handleRequest(authedReq, res, parsed);
-      } catch {
-        if (!res.headersSent) writeJson(res, 500, { error: "Internal server error" });
-      }
-      return;
-    }
-
-    // New session — must be an `initialize` request carrying credentials.
-    if (!isInitialize(parsed)) {
-      writeJson(res, 400, {
-        error: "Missing Mcp-Session-Id header (and request is not an initialize)",
-      });
-      return;
-    }
+    const rawBody = req.method === "POST" ? await readCappedBody(req, res) : undefined;
+    if (rawBody === null) return;
 
     let resolved: CredentialResolution;
     try {
-      resolved = getHttpCredentialProvider().resolve({ req: authedReq });
+      resolved = credentialProvider.resolve({ req: authedReq });
     } catch (err) {
       writeCredentialError(res, err);
       return;
@@ -366,62 +284,34 @@ export function buildHttpServer(options: HttpServerOptions = {}): HttpServerHand
       writeJson(res, 429, { error: "Rate limit exceeded" }, { "Retry-After": "1" });
       return;
     }
-    // Bound resource use: cap total and per-credential concurrent sessions.
-    if (sessions.size >= MAX_SESSIONS) {
-      writeJson(res, 503, { error: "Server at capacity, try again later" }, { "Retry-After": "5" });
-      return;
-    }
-    let perKey = 0;
-    for (const s of sessions.values()) if (s.rateKey === rateKey) perKey++;
-    if (perKey >= MAX_SESSIONS_PER_KEY) {
-      writeJson(
-        res,
-        429,
-        { error: "Too many concurrent sessions for this key" },
-        { "Retry-After": "5" },
-      );
-      return;
-    }
 
-    // Right-size this session's tool surface to the resolved credential's
-    // capabilities. Lookup failures fail closed before any tool surface is exposed.
     let capabilities: string[] | null;
     try {
-      capabilities = await fetchCapabilities(resolved.config, resolved.cacheKey);
+      capabilities = await fetchCapabilities(
+        resolved.config,
+        resolved.verificationKey,
+        resolved.cacheKey,
+      );
     } catch (err) {
       writeCredentialError(res, err);
       return;
     }
-    const mcpServer = createServer(resolved.config, capabilities);
-    const transport = new StreamableHTTPServerTransport({
-      sessionIdGenerator: () => crypto.randomUUID(),
-      onsessioninitialized: (sid) => {
-        sessions.set(sid, {
-          transport,
-          mcpServer,
-          lastActivity: Date.now(),
-          credentialCacheKey: resolved.cacheKey,
-          rateKey,
-        });
-      },
+
+    const handler = createMcpHandler(() => createServer(resolved.config, capabilities), {
+      legacy: "reject",
+      onerror: (error) => logger.warn({ err: error.message }, "mcp.http.error"),
     });
-    // When the transport closes (DELETE, client disconnect), drop the session.
-    transport.onclose = () => {
-      const sid = transport.sessionId;
-      if (sid) closeSession(sid);
-    };
 
     try {
-      await mcpServer.connect(transport);
-      await transport.handleRequest(authedReq, res, parsed);
-    } catch {
+      const response = await handler.fetch(toWebRequest(req, rawBody), {
+        authInfo: authInfo ?? undefined,
+      });
+      await writeFetchResponse(res, response);
+    } catch (err) {
+      logger.warn({ err: err instanceof Error ? err.message : String(err) }, "mcp.http.failed");
       if (!res.headersSent) writeJson(res, 500, { error: "Internal server error" });
-      try {
-        void transport.close();
-        void mcpServer.close();
-      } catch {
-        /* ignore */
-      }
+    } finally {
+      await handler.close().catch(() => undefined);
     }
   });
 
@@ -429,9 +319,6 @@ export function buildHttpServer(options: HttpServerOptions = {}): HttpServerHand
     if (shuttingDown) return;
     shuttingDown = true;
     clearInterval(idleSweep);
-    for (const id of [...sessions.keys()]) {
-      closeSession(id);
-    }
   }
 
   return { server: httpServer, sessions, drain };
@@ -445,7 +332,6 @@ async function main(): Promise<void> {
     logger.info({ transport: "http", port }, "server.started");
   });
 
-  // Graceful shutdown — stop accepting new connections, drain active sessions, exit.
   let shuttingDown = false;
   function shutdown(signal: string): void {
     if (shuttingDown) return;
@@ -459,7 +345,6 @@ async function main(): Promise<void> {
       logger.info("server.closed");
       process.exit(0);
     });
-    // Hard exit if drain takes too long
     setTimeout(() => {
       logger.error("server.drainTimeout");
       process.exit(1);
@@ -470,7 +355,6 @@ async function main(): Promise<void> {
   process.on("SIGINT", () => shutdown("SIGINT"));
 }
 
-// Only run main() when invoked directly (not when imported by tests)
 if (require.main === module) {
   main().catch((err) => {
     logger.fatal({ err: err instanceof Error ? err.message : String(err) }, "server.fatal");

--- a/src/http-server.ts
+++ b/src/http-server.ts
@@ -9,8 +9,14 @@
 
 import * as http from "http";
 import * as crypto from "crypto";
+import { parseIntEnv } from "./utils/config.js";
 import { createMcpHandler, type AuthInfo } from "@modelcontextprotocol/server";
-import { createServer, fetchCapabilities, sweepCapabilityCache } from "./server.js";
+import {
+  createServer,
+  fetchCapabilities,
+  sweepAuthManagerCache,
+  sweepCapabilityCache,
+} from "./server.js";
 import { B2Config } from "./utils/types.js";
 import { VERSION } from "./version.js";
 import { logger } from "./utils/logger.js";
@@ -18,6 +24,7 @@ import { allowRequest, sweepIdleBuckets } from "./utils/rate-limiter.js";
 import {
   AuthenticatedIncomingMessage,
   configFromHttpHeaders,
+  credentialFingerprint,
   CredentialProvider,
   CredentialResolution,
   CredentialResolutionError,
@@ -30,6 +37,8 @@ const DEFAULT_PORT = 3000;
 const MAX_BODY_BYTES = 1 * 1024 * 1024; // 1 MB — MCP messages are JSON-RPC, never close to this
 const IDLE_SWEEP_INTERVAL_MS = 60 * 1000; // 1 minute
 const SHUTDOWN_DRAIN_MS = 10 * 1000; // 10 seconds to drain on SIGTERM
+const DEFAULT_MAX_IN_FLIGHT = 1000;
+const DEFAULT_MAX_IN_FLIGHT_PER_KEY = 20;
 
 /** Comma-separated allowlists for DNS-rebinding protection (empty = unset). */
 function csvEnv(name: string): string[] {
@@ -95,9 +104,24 @@ function writeCredentialError(res: http.ServerResponse, err: unknown): void {
   writeJson(res, 500, { error: "Credential resolution failed" });
 }
 
-function headersFromNode(headers: http.IncomingHttpHeaders): Headers {
+const SDK_HEADER_ALLOWLIST = new Set([
+  "accept",
+  "content-type",
+  "content-length",
+  "last-event-id",
+  "traceparent",
+  "tracestate",
+]);
+
+function sdkHeaderAllowed(name: string): boolean {
+  const lower = name.toLowerCase();
+  return SDK_HEADER_ALLOWLIST.has(lower) || lower.startsWith("mcp-");
+}
+
+export function headersFromNode(headers: http.IncomingHttpHeaders): Headers {
   const webHeaders = new Headers();
   for (const [name, value] of Object.entries(headers)) {
+    if (!sdkHeaderAllowed(name)) continue;
     if (value === undefined) continue;
     if (Array.isArray(value)) {
       for (const item of value) webHeaders.append(name, item);
@@ -119,12 +143,44 @@ function requestUrl(req: http.IncomingMessage): string {
   ).toString();
 }
 
-function toWebRequest(req: http.IncomingMessage, body?: string): Request {
+export function toWebRequest(
+  req: http.IncomingMessage,
+  body?: string,
+  signal?: AbortSignal,
+): Request {
   const method = req.method ?? "GET";
   return new Request(requestUrl(req), {
     method,
     headers: headersFromNode(req.headers),
     body: method === "GET" || method === "HEAD" ? undefined : (body ?? ""),
+    signal,
+  });
+}
+
+function writeChunk(res: http.ServerResponse, chunk: Buffer): Promise<void> {
+  if (res.destroyed) return Promise.reject(new Error("Client disconnected"));
+  if (res.write(chunk)) return Promise.resolve();
+  return new Promise((resolve, reject) => {
+    function cleanup(): void {
+      res.off("drain", onDrain);
+      res.off("error", onError);
+      res.off("close", onClose);
+    }
+    function onDrain(): void {
+      cleanup();
+      resolve();
+    }
+    function onError(err: Error): void {
+      cleanup();
+      reject(err);
+    }
+    function onClose(): void {
+      cleanup();
+      reject(new Error("Client disconnected"));
+    }
+    res.once("drain", onDrain);
+    res.once("error", onError);
+    res.once("close", onClose);
   });
 }
 
@@ -136,12 +192,103 @@ async function writeFetchResponse(res: http.ServerResponse, response: Response):
     return;
   }
   const reader = response.body.getReader();
-  for (;;) {
-    const { done, value } = await reader.read();
-    if (done) break;
-    res.write(Buffer.from(value));
+  try {
+    for (;;) {
+      const { done, value } = await reader.read();
+      if (done) break;
+      await writeChunk(res, Buffer.from(value));
+    }
+    res.end();
+  } catch (err) {
+    res.destroy(err instanceof Error ? err : undefined);
+    throw err;
+  } finally {
+    reader.releaseLock();
   }
-  res.end();
+}
+
+function intEnv(name: string, fallback: number): number {
+  return Math.max(1, parseIntEnv(process.env[name], fallback));
+}
+
+export interface InFlightLimiter {
+  readonly active: number;
+  acquire(cacheKey: string): { ok: true } | { ok: false; status: number; error: string };
+  release(cacheKey: string): void;
+}
+
+export function createInFlightLimiter(
+  maxTotal = intEnv("B2_MAX_SESSIONS", DEFAULT_MAX_IN_FLIGHT),
+  maxPerKey = intEnv("B2_MAX_SESSIONS_PER_KEY", DEFAULT_MAX_IN_FLIGHT_PER_KEY),
+): InFlightLimiter {
+  let active = 0;
+  const byKey = new Map<string, number>();
+  return {
+    get active() {
+      return active;
+    },
+    acquire(cacheKey: string) {
+      if (active >= maxTotal) {
+        return { ok: false, status: 503, error: "Too many in-flight MCP requests" };
+      }
+      const current = byKey.get(cacheKey) ?? 0;
+      if (current >= maxPerKey) {
+        return { ok: false, status: 429, error: "Too many in-flight MCP requests for credential" };
+      }
+      active++;
+      byKey.set(cacheKey, current + 1);
+      return { ok: true };
+    },
+    release(cacheKey: string) {
+      const current = byKey.get(cacheKey) ?? 0;
+      if (current <= 1) byKey.delete(cacheKey);
+      else byKey.set(cacheKey, current - 1);
+      active = Math.max(0, active - 1);
+    },
+  };
+}
+
+function authPrincipalLabel(authInfo: AuthInfo | null | undefined): string | undefined {
+  const extra = authInfo?.extra ?? {};
+  const subject =
+    typeof extra.sub === "string"
+      ? extra.sub
+      : typeof extra.subject === "string"
+        ? extra.subject
+        : typeof extra.principal === "string"
+          ? extra.principal
+          : undefined;
+  if (!subject?.trim()) return undefined;
+  const issuer =
+    typeof extra.iss === "string"
+      ? extra.iss
+      : typeof extra.issuer === "string"
+        ? extra.issuer
+        : undefined;
+  const label = issuer?.trim() ? `${issuer.trim()}#${subject.trim()}` : subject.trim();
+  return credentialFingerprint(label);
+}
+
+function logCredentialResolutionFailure(
+  provider: CredentialProvider,
+  req: http.IncomingMessage,
+  authInfo: AuthInfo | null | undefined,
+  err: unknown,
+): void {
+  const status = err instanceof CredentialResolutionError ? err.status : 500;
+  const code = err instanceof CredentialResolutionError ? err.code : "credential_resolution_failed";
+  const principal = authPrincipalLabel(authInfo);
+  logger.warn(
+    {
+      provider: provider.name,
+      status,
+      code,
+      method: req.method,
+      path: new URL(req.url ?? "/", "http://localhost").pathname,
+      ...(principal && { principal }),
+    },
+    "credential.resolve.failed",
+  );
 }
 
 export interface HttpServerHandle {
@@ -163,6 +310,7 @@ export interface HttpServerOptions {
 
 export function buildHttpServer(options: HttpServerOptions = {}): HttpServerHandle {
   const sessions = new Map<string, never>();
+  const inFlight = createInFlightLimiter();
   let shuttingDown = false;
 
   const credentialProvider =
@@ -187,6 +335,7 @@ export function buildHttpServer(options: HttpServerOptions = {}): HttpServerHand
     const now = Date.now();
     sweepIdleBuckets(now);
     sweepCapabilityCache(now);
+    sweepAuthManagerCache(now);
   }, IDLE_SWEEP_INTERVAL_MS);
   idleSweep.unref();
 
@@ -275,43 +424,65 @@ export function buildHttpServer(options: HttpServerOptions = {}): HttpServerHand
     try {
       resolved = credentialProvider.resolve({ req: authedReq });
     } catch (err) {
+      logCredentialResolutionFailure(credentialProvider, req, authInfo, err);
       writeCredentialError(res, err);
+      return;
+    }
+
+    const inFlightPermit = inFlight.acquire(resolved.cacheKey);
+    if (!inFlightPermit.ok) {
+      writeJson(
+        res,
+        inFlightPermit.status,
+        { error: inFlightPermit.error },
+        { "Retry-After": "1" },
+      );
       return;
     }
 
     const rateKey = deriveRateKey(resolved.cacheKey);
-    if (!allowRequest(rateKey)) {
-      writeJson(res, 429, { error: "Rate limit exceeded" }, { "Retry-After": "1" });
-      return;
-    }
-
-    let capabilities: string[] | null;
     try {
-      capabilities = await fetchCapabilities(
-        resolved.config,
-        resolved.verificationKey,
-        resolved.cacheKey,
-      );
-    } catch (err) {
-      writeCredentialError(res, err);
-      return;
-    }
+      if (!allowRequest(rateKey)) {
+        writeJson(res, 429, { error: "Rate limit exceeded" }, { "Retry-After": "1" });
+        return;
+      }
 
-    const handler = createMcpHandler(() => createServer(resolved.config, capabilities), {
-      legacy: "reject",
-      onerror: (error) => logger.warn({ err: error.message }, "mcp.http.error"),
-    });
+      let capabilities: string[] | null;
+      try {
+        capabilities = await fetchCapabilities(
+          resolved.config,
+          resolved.capabilityCacheKey,
+          resolved.cacheKey,
+        );
+      } catch (err) {
+        writeCredentialError(res, err);
+        return;
+      }
 
-    try {
-      const response = await handler.fetch(toWebRequest(req, rawBody), {
-        authInfo: authInfo ?? undefined,
+      const handler = createMcpHandler(() => createServer(resolved.config, capabilities), {
+        legacy: "stateless",
+        onerror: (error) => logger.warn({ err: error.message }, "mcp.http.error"),
       });
-      await writeFetchResponse(res, response);
-    } catch (err) {
-      logger.warn({ err: err instanceof Error ? err.message : String(err) }, "mcp.http.failed");
-      if (!res.headersSent) writeJson(res, 500, { error: "Internal server error" });
+
+      const abortController = new AbortController();
+      req.on("aborted", () => abortController.abort());
+      res.on("close", () => {
+        if (!res.writableEnded) abortController.abort();
+      });
+
+      try {
+        const response = await handler.fetch(toWebRequest(req, rawBody, abortController.signal), {
+          authInfo: authInfo ?? undefined,
+        });
+        await writeFetchResponse(res, response);
+      } catch (err) {
+        logger.warn({ err: err instanceof Error ? err.message : String(err) }, "mcp.http.failed");
+        if (!res.headersSent) writeJson(res, 500, { error: "Internal server error" });
+      } finally {
+        await handler.close().catch(() => undefined);
+      }
     } finally {
-      await handler.close().catch(() => undefined);
+      inFlight.release(resolved.cacheKey);
     }
   });
 

--- a/src/http-server.ts
+++ b/src/http-server.ts
@@ -11,19 +11,16 @@
  *   DELETE /mcp   — terminates a session
  *   GET    /health
  *
- * Credentials are read per-connection from the headers on the `initialize` POST
- * (the transport then binds them to that session for its lifetime):
- *   X-B2-Key-Id          — application key ID (the workhorse: native + S3 + key mgmt)
- *   X-B2-Key             — application key secret
- *   X-B2-Master-Key-Id   — master key ID, ONLY for Partner API tools (optional)
- *   X-B2-Master-Key      — master key secret (optional)
- *   X-B2-App-Key-Id      — DEPRECATED non-master S3 override for legacy master-primary setups
- *   X-B2-App-Key         — DEPRECATED (see above)
+ * Credential mode is explicit:
+ *   B2_HTTP_CREDENTIAL_MODE=server    — B2 credentials come from server env
+ *   B2_HTTP_CREDENTIAL_MODE=principal — verified MCP authInfo maps to a credential ref
+ *   B2_HTTP_CREDENTIAL_MODE=headers   — compatibility mode; B2 headers on every request
  */
 
 import * as http from "http";
 import * as crypto from "crypto";
 import { StreamableHTTPServerTransport } from "@modelcontextprotocol/sdk/server/streamableHttp.js";
+import type { AuthInfo } from "@modelcontextprotocol/sdk/server/auth/types.js";
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { createServer, fetchCapabilities } from "./server.js";
 import { B2Config } from "./utils/types.js";
@@ -31,9 +28,15 @@ import { parseIntEnv } from "./utils/config.js";
 import { VERSION } from "./version.js";
 import { logger } from "./utils/logger.js";
 import { allowRequest, sweepIdleBuckets } from "./utils/rate-limiter.js";
+import {
+  AuthenticatedIncomingMessage,
+  configFromHttpHeaders,
+  CredentialResolution,
+  CredentialResolutionError,
+  getHttpCredentialProvider,
+} from "./credentials.js";
 
 const DEFAULT_PORT = 3000;
-const DEFAULT_REGION = "us-west-004";
 const MAX_BODY_BYTES = 1 * 1024 * 1024; // 1 MB — MCP messages are JSON-RPC, never close to this
 const SESSION_IDLE_TIMEOUT_MS = 30 * 60 * 1000; // 30 minutes
 const IDLE_SWEEP_INTERVAL_MS = 60 * 1000; // 1 minute
@@ -88,13 +91,15 @@ interface Session {
   transport: StreamableHTTPServerTransport;
   mcpServer: McpServer;
   lastActivity: number;
-  /** Rate-limiter key — a hash of the X-B2-Key-Id used to connect (not a prefix). */
+  /** Non-secret provider cache key from the credential resolution boundary. */
+  credentialCacheKey: string;
+  /** Rate-limiter key — a hash of the non-secret credential/principal cache key. */
   rateKey: string;
 }
 
-/** Stable, collision-resistant rate-limit/session key derived from the full key id. */
-export function deriveRateKey(applicationKeyId: string): string {
-  return crypto.createHash("sha256").update(applicationKeyId).digest("hex").slice(0, 16);
+/** Stable rate-limit/session key derived from a non-secret credential/principal cache key. */
+export function deriveRateKey(cacheKey: string): string {
+  return crypto.createHash("sha256").update(cacheKey).digest("hex").slice(0, 16);
 }
 
 export function getPort(): number {
@@ -111,53 +116,7 @@ export function getPort(): number {
 }
 
 export function configFromHeaders(req: { headers: http.IncomingHttpHeaders }): B2Config | null {
-  const keyId = req.headers["x-b2-key-id"];
-  const key = req.headers["x-b2-key"];
-  if (!keyId || !key || Array.isArray(keyId) || Array.isArray(key)) return null;
-  const appKeyId = req.headers["x-b2-app-key-id"];
-  const appKey = req.headers["x-b2-app-key"];
-  const resolvedAppKeyId = !Array.isArray(appKeyId) && appKeyId ? appKeyId : keyId;
-  const resolvedAppKey = !Array.isArray(appKey) && appKey ? appKey : key;
-  // Optional master key — used only by the Partner API tools. Falls
-  // back to the application key, so a single key remains a complete config.
-  const masterKeyId = req.headers["x-b2-master-key-id"];
-  const masterKey = req.headers["x-b2-master-key"];
-  const resolvedMasterKeyId = !Array.isArray(masterKeyId) && masterKeyId ? masterKeyId : keyId;
-  const resolvedMasterKey = !Array.isArray(masterKey) && masterKey ? masterKey : key;
-  return {
-    applicationKeyId: keyId,
-    applicationKey: key,
-    appKeyId: resolvedAppKeyId,
-    appKey: resolvedAppKey,
-    masterKeyId: resolvedMasterKeyId,
-    masterKey: resolvedMasterKey,
-    region: process.env.B2_REGION ?? DEFAULT_REGION,
-    // Local disk access is OFF by default on the internet-facing transport — a
-    // remote caller must not reference server-local paths (use base64 content).
-    // An operator may opt in, but ONLY confined to a sandbox root (never
-    // unrestricted over HTTP).
-    allowLocalFiles: process.env.B2_ALLOW_LOCAL_FILES === "true" && !!process.env.B2_FILE_ROOT,
-    fileRoot: process.env.B2_FILE_ROOT ?? null,
-    // b2_create_key lockdown (see B2Config). Operator policy from env; safe by default.
-    maxKeyDurationSeconds: process.env.B2_MAX_KEY_DURATION_SECONDS
-      ? parseIntEnv(process.env.B2_MAX_KEY_DURATION_SECONDS, 0)
-      : null,
-    allowKeyMgmtGrants: process.env.B2_ALLOW_KEY_MGMT_GRANTS === "true",
-    allowUnscopedKeys: process.env.B2_ALLOW_UNSCOPED_KEYS === "true",
-    // Internet-facing transport is safe-by-default: destructive operations are
-    // BLOCKED unless the operator explicitly opts down. `confirm` is satisfiable
-    // by a prompt-injected model, so it is not the default for a hosted server;
-    // an operator who needs destructive ops sets B2_DESTRUCTIVE_POLICY=confirm
-    // (paired with host consent) or =allow. stdio defaults to confirm (trusted
-    // local user) — see loadConfig in server.ts.
-    destructivePolicy:
-      process.env.B2_DESTRUCTIVE_POLICY === "allow" ||
-      process.env.B2_DESTRUCTIVE_POLICY === "block" ||
-      process.env.B2_DESTRUCTIVE_POLICY === "confirm"
-        ? process.env.B2_DESTRUCTIVE_POLICY
-        : "block",
-    transport: "http",
-  };
+  return configFromHttpHeaders(req);
 }
 
 function sessionIdHeader(req: http.IncomingMessage): string | undefined {
@@ -170,6 +129,25 @@ function writeJson(res: http.ServerResponse, status: number, body: unknown, head
   res.end(JSON.stringify(body));
 }
 
+function writeCredentialError(res: http.ServerResponse, err: unknown): void {
+  if (err instanceof CredentialResolutionError) {
+    writeJson(res, err.status, { error: err.message });
+    return;
+  }
+  writeJson(res, 500, { error: "Credential resolution failed" });
+}
+
+function validateExistingRequest(req: AuthenticatedIncomingMessage, session: Session): void {
+  const resolved = getHttpCredentialProvider().resolve({ req });
+  if (resolved.cacheKey !== session.credentialCacheKey) {
+    throw new CredentialResolutionError(
+      "Request credentials do not match the MCP session",
+      403,
+      "credential_mismatch",
+    );
+  }
+}
+
 export interface HttpServerHandle {
   server: http.Server;
   /** Live session map — exposed for tests/observability. */
@@ -178,12 +156,17 @@ export interface HttpServerHandle {
   drain(): void;
 }
 
+export interface HttpServerOptions {
+  /** Hook for customer middleware/tests to attach verified MCP authInfo. */
+  getAuthInfo?: (req: AuthenticatedIncomingMessage) => AuthInfo | null | undefined;
+}
+
 /**
  * Build the HTTP server and its session machinery without binding to a port or
  * installing signal handlers — so it can be unit-tested by listening on an
  * ephemeral port. main() wires in getPort(), listen(), and graceful shutdown.
  */
-export function buildHttpServer(): HttpServerHandle {
+export function buildHttpServer(options: HttpServerOptions = {}): HttpServerHandle {
   // Map of Mcp-Session-Id → session record with last-activity timestamp
   const sessions = new Map<string, Session>();
   let shuttingDown = false;
@@ -259,6 +242,9 @@ export function buildHttpServer(): HttpServerHandle {
   }
 
   const httpServer = http.createServer(async (req, res) => {
+    const authedReq = req as AuthenticatedIncomingMessage;
+    const authInfo = options.getAuthInfo?.(authedReq);
+    if (authInfo) authedReq.auth = authInfo;
     const url = new URL(req.url ?? "/", "http://localhost");
 
     if (shuttingDown) {
@@ -298,13 +284,19 @@ export function buildHttpServer(): HttpServerHandle {
         return;
       }
       const session = sessions.get(sessionId)!;
+      try {
+        validateExistingRequest(authedReq, session);
+      } catch (err) {
+        writeCredentialError(res, err);
+        return;
+      }
       if (!allowRequest(session.rateKey)) {
         writeJson(res, 429, { error: "Rate limit exceeded" }, { "Retry-After": "1" });
         return;
       }
       touch(sessionId);
       try {
-        await session.transport.handleRequest(req, res);
+        await session.transport.handleRequest(authedReq, res);
       } catch {
         if (!res.headersSent) writeJson(res, 500, { error: "Internal server error" });
       }
@@ -334,13 +326,19 @@ export function buildHttpServer(): HttpServerHandle {
         writeJson(res, 404, { error: "Session not found" });
         return;
       }
+      try {
+        validateExistingRequest(authedReq, session);
+      } catch (err) {
+        writeCredentialError(res, err);
+        return;
+      }
       if (!allowRequest(session.rateKey)) {
         writeJson(res, 429, { error: "Rate limit exceeded" }, { "Retry-After": "1" });
         return;
       }
       touch(sessionId);
       try {
-        await session.transport.handleRequest(req, res, parsed);
+        await session.transport.handleRequest(authedReq, res, parsed);
       } catch {
         if (!res.headersSent) writeJson(res, 500, { error: "Internal server error" });
       }
@@ -355,15 +353,15 @@ export function buildHttpServer(): HttpServerHandle {
       return;
     }
 
-    const config = configFromHeaders(req);
-    if (!config) {
-      writeJson(res, 401, {
-        error: "Missing credentials: X-B2-Key-Id and X-B2-Key headers are required",
-      });
+    let resolved: CredentialResolution;
+    try {
+      resolved = getHttpCredentialProvider().resolve({ req: authedReq });
+    } catch (err) {
+      writeCredentialError(res, err);
       return;
     }
 
-    const rateKey = deriveRateKey(config.applicationKeyId);
+    const rateKey = deriveRateKey(resolved.cacheKey);
     if (!allowRequest(rateKey)) {
       writeJson(res, 429, { error: "Rate limit exceeded" }, { "Retry-After": "1" });
       return;
@@ -385,14 +383,26 @@ export function buildHttpServer(): HttpServerHandle {
       return;
     }
 
-    // Right-size this session's tool surface to the connected key's
-    // capabilities (null → full surface; never blocks session creation).
-    const capabilities = await fetchCapabilities(config);
-    const mcpServer = createServer(config, capabilities);
+    // Right-size this session's tool surface to the resolved credential's
+    // capabilities. Lookup failures fail closed before any tool surface is exposed.
+    let capabilities: string[] | null;
+    try {
+      capabilities = await fetchCapabilities(resolved.config, resolved.cacheKey);
+    } catch (err) {
+      writeCredentialError(res, err);
+      return;
+    }
+    const mcpServer = createServer(resolved.config, capabilities);
     const transport = new StreamableHTTPServerTransport({
       sessionIdGenerator: () => crypto.randomUUID(),
       onsessioninitialized: (sid) => {
-        sessions.set(sid, { transport, mcpServer, lastActivity: Date.now(), rateKey });
+        sessions.set(sid, {
+          transport,
+          mcpServer,
+          lastActivity: Date.now(),
+          credentialCacheKey: resolved.cacheKey,
+          rateKey,
+        });
       },
     });
     // When the transport closes (DELETE, client disconnect), drop the session.
@@ -403,7 +413,7 @@ export function buildHttpServer(): HttpServerHandle {
 
     try {
       await mcpServer.connect(transport);
-      await transport.handleRequest(req, res, parsed);
+      await transport.handleRequest(authedReq, res, parsed);
     } catch {
       if (!res.headersSent) writeJson(res, 500, { error: "Internal server error" });
       try {

--- a/src/index.ts
+++ b/src/index.ts
@@ -32,9 +32,15 @@ export async function startStdio(): Promise<void> {
   try {
     capabilities = await fetchCapabilities(config);
   } catch (err) {
+    if (
+      !(err instanceof CredentialResolutionError) ||
+      err.code !== "capability_upstream_unavailable"
+    ) {
+      throw err;
+    }
     logger.warn(
       {
-        code: err instanceof CredentialResolutionError ? err.code : "capability_resolution_failed",
+        code: err.code,
       },
       "capability.fetch.stdio_degraded",
     );

--- a/src/index.ts
+++ b/src/index.ts
@@ -20,18 +20,29 @@
  *   }
  */
 
-import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
+import { serveStdio } from "@modelcontextprotocol/server/stdio";
 import { createServer, fetchCapabilities, loadConfig } from "./server.js";
+import { CredentialResolutionError } from "./credentials.js";
 import { logger } from "./utils/logger.js";
 
 export async function startStdio(): Promise<void> {
   const config = loadConfig();
   // Right-size the surface to the key's capabilities (null → full surface).
-  const capabilities = await fetchCapabilities(config);
-  const server = createServer(config, capabilities);
-  const transport = new StdioServerTransport();
-
-  await server.connect(transport);
+  let capabilities: string[] | null;
+  try {
+    capabilities = await fetchCapabilities(config);
+  } catch (err) {
+    logger.warn(
+      {
+        code: err instanceof CredentialResolutionError ? err.code : "capability_resolution_failed",
+      },
+      "capability.fetch.stdio_degraded",
+    );
+    capabilities = null;
+  }
+  serveStdio(() => createServer(config, capabilities), {
+    onerror: (error) => logger.warn({ err: error.message }, "mcp.stdio.error"),
+  });
 
   logger.info({ transport: "stdio" }, "server.started");
 }

--- a/src/mcp.ts
+++ b/src/mcp.ts
@@ -1,13 +1,19 @@
 import { McpServer as V2McpServer } from "@modelcontextprotocol/server";
 
-type LegacyToolArgs = [string, string, Record<string, unknown>, (...args: any[]) => any];
+type LegacyToolCallback<TArgs = any> = (args: TArgs, extra: unknown) => unknown | Promise<unknown>;
+type LegacyToolArgs<TArgs = any> = [
+  string,
+  string,
+  Record<string, unknown>,
+  LegacyToolCallback<TArgs>,
+];
 
 export type McpServer = V2McpServer & {
-  tool(
+  tool<TArgs = any>(
     name: string,
     description: string,
     inputSchema: Record<string, unknown>,
-    cb: (...args: any[]) => any,
+    cb: LegacyToolCallback<TArgs>,
   ): unknown;
 };
 
@@ -17,8 +23,11 @@ export type McpServer = V2McpServer & {
  */
 export function createMcpServer(...args: ConstructorParameters<typeof V2McpServer>): McpServer {
   const server = new V2McpServer(...args) as McpServer;
-  server.tool = (...toolArgs: LegacyToolArgs) => {
+  server.tool = <TArgs = any>(...toolArgs: LegacyToolArgs<TArgs>) => {
     const [name, description, inputSchema, cb] = toolArgs;
+    // The SDK v2 registerTool surface accepts its own schema representation.
+    // This adapter is the only place that bridges the repo's legacy zod-shaped
+    // tool declarations into that surface.
     return server.registerTool(name, { description, inputSchema: inputSchema as any }, cb as any);
   };
   return server;

--- a/src/mcp.ts
+++ b/src/mcp.ts
@@ -1,0 +1,27 @@
+import { McpServer as V2McpServer } from "@modelcontextprotocol/server";
+
+type LegacyToolArgs = [string, string, Record<string, unknown>, (...args: any[]) => any];
+
+export type McpServer = V2McpServer & {
+  tool(
+    name: string,
+    description: string,
+    inputSchema: Record<string, unknown>,
+    cb: (...args: any[]) => any,
+  ): unknown;
+};
+
+/**
+ * Keep the local tool modules on their v1-style `server.tool(...)` registration
+ * shape while the production transports use the MCP SDK v2 entry points.
+ */
+export function createMcpServer(...args: ConstructorParameters<typeof V2McpServer>): McpServer {
+  const server = new V2McpServer(...args) as McpServer;
+  server.tool = (...toolArgs: LegacyToolArgs) => {
+    const [name, description, inputSchema, cb] = toolArgs;
+    return server.registerTool(name, { description, inputSchema: inputSchema as any }, cb as any);
+  };
+  return server;
+}
+
+export { V2McpServer };

--- a/src/s3/buckets.ts
+++ b/src/s3/buckets.ts
@@ -3,7 +3,7 @@ import {
   HeadBucketCommand,
   PutBucketLifecycleConfigurationCommand,
 } from "@aws-sdk/client-s3";
-import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import type { McpServer } from "../mcp.js";
 import { z } from "zod";
 import { toolError, toolSuccess } from "../utils/errors.js";
 import { B2Config } from "../utils/types.js";
@@ -92,7 +92,7 @@ export function registerS3BucketTools(server: McpServer, s3: S3Client, config: B
           new PutBucketLifecycleConfigurationCommand({
             Bucket: args.bucket,
             LifecycleConfiguration: {
-              Rules: args.rules.map((r) => ({
+              Rules: args.rules.map((r: any) => ({
                 ID: r.id,
                 Status: r.status,
                 Filter: r.filter ? { Prefix: r.filter.prefix ?? "" } : { Prefix: "" },

--- a/src/s3/buckets.ts
+++ b/src/s3/buckets.ts
@@ -9,6 +9,15 @@ import { toolError, toolSuccess } from "../utils/errors.js";
 import { B2Config } from "../utils/types.js";
 import { checkDestructive } from "../utils/destructive-gate.js";
 
+interface S3LifecycleRule {
+  id: string;
+  status: "Enabled" | "Disabled";
+  filter?: { prefix?: string };
+  expiration?: { days?: number; expiredObjectDeleteMarker?: boolean };
+  noncurrentVersionExpiration?: { noncurrentDays: number };
+  abortIncompleteMultipartUpload?: { daysAfterInitiation: number };
+}
+
 // S3-compatible bucket tools are intentionally minimal: anything with a native
 // b2_* equivalent has been removed to keep the tool surface small. Only the two
 // tools below are kept because they cover capabilities with no native analogue:
@@ -92,7 +101,7 @@ export function registerS3BucketTools(server: McpServer, s3: S3Client, config: B
           new PutBucketLifecycleConfigurationCommand({
             Bucket: args.bucket,
             LifecycleConfiguration: {
-              Rules: args.rules.map((r: any) => ({
+              Rules: (args.rules as S3LifecycleRule[]).map((r) => ({
                 ID: r.id,
                 Status: r.status,
                 Filter: r.filter ? { Prefix: r.filter.prefix ?? "" } : { Prefix: "" },

--- a/src/s3/extras.ts
+++ b/src/s3/extras.ts
@@ -1,5 +1,5 @@
 import { S3Client, GetBucketLocationCommand } from "@aws-sdk/client-s3";
-import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import type { McpServer } from "../mcp.js";
 import { z } from "zod";
 import { toolJson, toolError } from "../utils/errors.js";
 

--- a/src/s3/multipart.ts
+++ b/src/s3/multipart.ts
@@ -9,7 +9,7 @@ import {
   UploadPartCopyCommand,
 } from "@aws-sdk/client-s3";
 import { getSignedUrl } from "@aws-sdk/s3-request-presigner";
-import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import type { McpServer } from "../mcp.js";
 import { z } from "zod";
 import { toolJson, toolError, toolSuccess } from "../utils/errors.js";
 import { B2Config } from "../utils/types.js";
@@ -79,7 +79,7 @@ export function registerS3MultipartTools(server: McpServer, s3: S3Client, config
       try {
         const expiresIn = args.expiresIn ?? 3600;
         const parts = await Promise.all(
-          args.partNumbers.map(async (partNumber) => {
+          args.partNumbers.map(async (partNumber: number) => {
             const url = await getSignedUrl(
               s3,
               new UploadPartCommand({
@@ -135,7 +135,7 @@ export function registerS3MultipartTools(server: McpServer, s3: S3Client, config
             Key: args.key,
             UploadId: args.uploadId,
             MultipartUpload: {
-              Parts: args.parts.map((p) => ({ PartNumber: p.partNumber, ETag: p.etag })),
+              Parts: args.parts.map((p: any) => ({ PartNumber: p.partNumber, ETag: p.etag })),
             },
           }),
         );

--- a/src/s3/multipart.ts
+++ b/src/s3/multipart.ts
@@ -15,6 +15,11 @@ import { toolJson, toolError, toolSuccess } from "../utils/errors.js";
 import { B2Config } from "../utils/types.js";
 import { checkDestructive } from "../utils/destructive-gate.js";
 
+interface CompletedMultipartPart {
+  partNumber: number;
+  etag: string;
+}
+
 export function registerS3MultipartTools(server: McpServer, s3: S3Client, config: B2Config): void {
   server.tool(
     "s3_create_multipart_upload",
@@ -135,7 +140,10 @@ export function registerS3MultipartTools(server: McpServer, s3: S3Client, config
             Key: args.key,
             UploadId: args.uploadId,
             MultipartUpload: {
-              Parts: args.parts.map((p: any) => ({ PartNumber: p.partNumber, ETag: p.etag })),
+              Parts: (args.parts as CompletedMultipartPart[]).map((p) => ({
+                PartNumber: p.partNumber,
+                ETag: p.etag,
+              })),
             },
           }),
         );

--- a/src/s3/objects.ts
+++ b/src/s3/objects.ts
@@ -23,6 +23,11 @@ import { checkDestructive } from "../utils/destructive-gate.js";
 const CONFIRM_DESC =
   "Confirm this destructive/irreversible operation. Required when the server destructive policy is 'confirm' (the default).";
 
+interface DeleteObjectEntry {
+  key: string;
+  versionId?: string;
+}
+
 // Inline object content moves bytes *through* the server — and, for base64,
 // through the model's context window. Keep that path for small control-plane
 // payloads only (manifests, sidecars, tiny configs the agent must inspect or
@@ -238,7 +243,10 @@ export function registerS3ObjectTools(server: McpServer, s3: S3Client, config: B
           new DeleteObjectsCommand({
             Bucket: args.bucket,
             Delete: {
-              Objects: args.objects.map((o: any) => ({ Key: o.key, VersionId: o.versionId })),
+              Objects: (args.objects as DeleteObjectEntry[]).map((o) => ({
+                Key: o.key,
+                VersionId: o.versionId,
+              })),
               Quiet: args.quiet ?? true,
             },
           }),

--- a/src/s3/objects.ts
+++ b/src/s3/objects.ts
@@ -9,7 +9,7 @@ import {
   ListObjectsV2Command,
   ListObjectVersionsCommand,
 } from "@aws-sdk/client-s3";
-import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import type { McpServer } from "../mcp.js";
 import { z } from "zod";
 import * as fs from "fs";
 import * as path from "path";
@@ -238,7 +238,7 @@ export function registerS3ObjectTools(server: McpServer, s3: S3Client, config: B
           new DeleteObjectsCommand({
             Bucket: args.bucket,
             Delete: {
-              Objects: args.objects.map((o) => ({ Key: o.key, VersionId: o.versionId })),
+              Objects: args.objects.map((o: any) => ({ Key: o.key, VersionId: o.versionId })),
               Quiet: args.quiet ?? true,
             },
           }),

--- a/src/s3/presigned.ts
+++ b/src/s3/presigned.ts
@@ -1,6 +1,6 @@
 import { S3Client, GetObjectCommand, PutObjectCommand } from "@aws-sdk/client-s3";
 import { getSignedUrl } from "@aws-sdk/s3-request-presigner";
-import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import type { McpServer } from "../mcp.js";
 import { z } from "zod";
 import { toolError, toolJson } from "../utils/errors.js";
 

--- a/src/server.ts
+++ b/src/server.ts
@@ -121,17 +121,21 @@ export function createServer(config: B2Config, capabilities?: string[] | null): 
   // API, S3, and key management. The Partner API tools use the master
   // key; when no distinct master key is configured they fall back to the same
   // application-key client, so a single non-master key needs no extra wiring.
-  const auth = new B2AuthManager(config);
+  const auth = getCachedAuthManager(`credential:${verificationFingerprintConfig(config)}`, config);
   const b2Client = new B2Client(auth, buildUserAgent(config));
   const s3Client = createS3Client(config);
 
   const masterIsDistinct = config.masterKeyId !== config.applicationKeyId;
+  const masterConfig = {
+    ...config,
+    applicationKeyId: config.masterKeyId,
+    applicationKey: config.masterKey,
+  };
   const masterAuth = masterIsDistinct
-    ? new B2AuthManager({
-        ...config,
-        applicationKeyId: config.masterKeyId,
-        applicationKey: config.masterKey,
-      })
+    ? getCachedAuthManager(
+        `credential:${verificationFingerprintConfig(masterConfig)}`,
+        masterConfig,
+      )
     : auth;
   const masterClient = masterIsDistinct
     ? new B2Client(masterAuth, buildUserAgent(config))
@@ -182,12 +186,31 @@ interface CapabilityCacheEntry {
 }
 
 const capabilityCache = new Map<string, CapabilityCacheEntry>();
+const capabilityInflight = new Map<string, Promise<string[]>>();
 const DEFAULT_CAPABILITY_CACHE_TTL_MS = 5 * 60 * 1000;
-const DEFAULT_CAPABILITY_CACHE_MAX_ENTRIES = 1000;
+const DEFAULT_CAPABILITY_CACHE_MAX_ENTRIES = 10_000;
+const DEFAULT_AUTH_MANAGER_CACHE_TTL_MS = 23 * 60 * 60 * 1000;
+
+interface AuthManagerCacheEntry {
+  manager: B2AuthManager;
+  expiresAt: number;
+}
+
+const authManagerCache = new Map<string, AuthManagerCacheEntry>();
 
 export function invalidateCapabilityCache(cacheKey?: string): void {
-  if (cacheKey) capabilityCache.delete(cacheKey);
-  else capabilityCache.clear();
+  if (cacheKey) {
+    capabilityCache.delete(cacheKey);
+    capabilityInflight.delete(cacheKey);
+  } else {
+    capabilityCache.clear();
+    capabilityInflight.clear();
+  }
+}
+
+export function invalidateAuthManagerCache(cacheKey?: string): void {
+  if (cacheKey) authManagerCache.delete(cacheKey);
+  else authManagerCache.clear();
 }
 
 function capabilityCacheTtlMs(): number {
@@ -210,6 +233,43 @@ export function sweepCapabilityCache(now = Date.now()): void {
   }
 }
 
+export function sweepAuthManagerCache(now = Date.now()): void {
+  for (const [key, entry] of authManagerCache) {
+    if (entry.expiresAt <= now) authManagerCache.delete(key);
+  }
+}
+
+function enforceCacheMax<T>(cache: Map<string, T>, maxEntries: number, cacheName: string): void {
+  let evicted = 0;
+  while (cache.size > maxEntries) {
+    const oldest = cache.keys().next().value as string | undefined;
+    if (!oldest) break;
+    cache.delete(oldest);
+    evicted++;
+  }
+  if (evicted > 0) {
+    logger.info({ cache: cacheName, evicted, size: cache.size, maxEntries }, "cache.evicted");
+  }
+}
+
+function getCachedAuthManager(cacheKey: string, config: B2Config): B2AuthManager {
+  const now = Date.now();
+  sweepAuthManagerCache(now);
+  const cached = authManagerCache.get(cacheKey);
+  if (cached && cached.expiresAt > now) {
+    authManagerCache.delete(cacheKey);
+    authManagerCache.set(cacheKey, cached);
+    return cached.manager;
+  }
+  const manager = new B2AuthManager(config);
+  authManagerCache.set(cacheKey, {
+    manager,
+    expiresAt: now + DEFAULT_AUTH_MANAGER_CACHE_TTL_MS,
+  });
+  enforceCacheMax(authManagerCache, capabilityCacheMaxEntries(), "b2-auth-manager");
+  return manager;
+}
+
 function rememberCapabilities(cacheKey: string, capabilities: string[], now: number): void {
   const ttl = capabilityCacheTtlMs();
   if (ttl <= 0 || capabilities.length === 0) return;
@@ -218,12 +278,7 @@ function rememberCapabilities(cacheKey: string, capabilities: string[], now: num
     capabilities: [...capabilities],
     expiresAt: now + ttl,
   });
-  const maxEntries = capabilityCacheMaxEntries();
-  while (capabilityCache.size > maxEntries) {
-    const oldest = capabilityCache.keys().next().value as string | undefined;
-    if (!oldest) break;
-    capabilityCache.delete(oldest);
-  }
+  enforceCacheMax(capabilityCache, capabilityCacheMaxEntries(), "b2-capability");
 }
 
 export function capabilityCacheSizeForTests(): number {
@@ -306,11 +361,12 @@ function capabilityFailureDetails(
 
 export async function fetchCapabilities(
   config: B2Config,
-  cacheKey?: string,
+  capabilityCacheKey?: string,
   logKey?: string,
 ): Promise<string[] | null> {
   if (process.env.B2_REGISTER_ALL_TOOLS === "true") return null;
-  const resolvedCacheKey = cacheKey ?? `credential:${verificationFingerprintConfig(config)}`;
+  const resolvedCacheKey =
+    capabilityCacheKey ?? `credential:${verificationFingerprintConfig(config)}`;
   const credentialLogKey =
     logKey ?? `credential:${config.credentialFingerprint ?? fingerprintConfig(config)}`;
   const now = Date.now();
@@ -322,16 +378,26 @@ export async function fetchCapabilities(
     return [...cached.capabilities];
   }
 
-  try {
+  const existingInflight = capabilityInflight.get(resolvedCacheKey);
+  if (existingInflight) return [...(await existingInflight)];
+
+  const discovery = (async () => {
     const auth = new B2AuthManager(config);
     const info = await auth.getAuth();
     const capabilities = info.capabilities ?? [];
     rememberCapabilities(resolvedCacheKey, capabilities, now);
     return capabilities;
+  })();
+  capabilityInflight.set(resolvedCacheKey, discovery);
+
+  try {
+    return [...(await discovery)];
   } catch (err) {
     const details = capabilityFailureDetails(err, config);
     logger.warn({ credential: credentialLogKey, ...details.log }, "capability.fetch.failed");
     throw new CredentialResolutionError(details.message, details.status, details.code);
+  } finally {
+    capabilityInflight.delete(resolvedCacheKey);
   }
 }
 

--- a/src/server.ts
+++ b/src/server.ts
@@ -1,4 +1,4 @@
-import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { createMcpServer, type McpServer } from "./mcp.js";
 import { B2Config } from "./utils/types.js";
 import { parseIntEnv } from "./utils/config.js";
 import { buildUserAgent } from "./utils/user-agent.js";
@@ -13,6 +13,7 @@ import {
   CredentialResolutionError,
   fingerprintConfig,
   StdioEnvCredentialProvider,
+  verificationFingerprintConfig,
 } from "./credentials.js";
 
 import { registerBucketTools } from "./b2/buckets.js";
@@ -68,7 +69,7 @@ export function loadConfig(): B2Config {
  * is a fail-closed capability set, not "unknown".
  */
 export function createServer(config: B2Config, capabilities?: string[] | null): McpServer {
-  const server = new McpServer(
+  const server = createMcpServer(
     {
       name: "backblaze-b2",
       version: VERSION,
@@ -170,10 +171,10 @@ export function createServer(config: B2Config, capabilities?: string[] | null): 
 
 /**
  * One-shot authorize to read the key's capabilities for capability-aware
- * registration. Returns the capability list and caches it by a non-secret
- * fingerprint/principal cache key. Capability lookup failures throw so callers
- * fail closed instead of exposing the full tool surface. Set
- * B2_REGISTER_ALL_TOOLS=true to explicitly skip discovery and register all.
+ * registration. Returns null only when discovery is explicitly skipped via
+ * B2_REGISTER_ALL_TOOLS=true. Lookup failures throw so callers fail closed
+ * instead of exposing the full tool surface; an empty array is a fail-closed
+ * capability set and is deliberately not cached at the positive TTL.
  */
 interface CapabilityCacheEntry {
   capabilities: string[];
@@ -182,6 +183,7 @@ interface CapabilityCacheEntry {
 
 const capabilityCache = new Map<string, CapabilityCacheEntry>();
 const DEFAULT_CAPABILITY_CACHE_TTL_MS = 5 * 60 * 1000;
+const DEFAULT_CAPABILITY_CACHE_MAX_ENTRIES = 1000;
 
 export function invalidateCapabilityCache(cacheKey?: string): void {
   if (cacheKey) capabilityCache.delete(cacheKey);
@@ -195,33 +197,141 @@ function capabilityCacheTtlMs(): number {
   return Math.max(0, ttl);
 }
 
+function capabilityCacheMaxEntries(): number {
+  const max = process.env.B2_CAPABILITY_CACHE_MAX_ENTRIES
+    ? parseIntEnv(process.env.B2_CAPABILITY_CACHE_MAX_ENTRIES, DEFAULT_CAPABILITY_CACHE_MAX_ENTRIES)
+    : DEFAULT_CAPABILITY_CACHE_MAX_ENTRIES;
+  return Math.max(1, max);
+}
+
+export function sweepCapabilityCache(now = Date.now()): void {
+  for (const [key, entry] of capabilityCache) {
+    if (entry.expiresAt <= now) capabilityCache.delete(key);
+  }
+}
+
+function rememberCapabilities(cacheKey: string, capabilities: string[], now: number): void {
+  const ttl = capabilityCacheTtlMs();
+  if (ttl <= 0 || capabilities.length === 0) return;
+  sweepCapabilityCache(now);
+  capabilityCache.set(cacheKey, {
+    capabilities: [...capabilities],
+    expiresAt: now + ttl,
+  });
+  const maxEntries = capabilityCacheMaxEntries();
+  while (capabilityCache.size > maxEntries) {
+    const oldest = capabilityCache.keys().next().value as string | undefined;
+    if (!oldest) break;
+    capabilityCache.delete(oldest);
+  }
+}
+
+export function capabilityCacheSizeForTests(): number {
+  return capabilityCache.size;
+}
+
+function redactedCapabilityMessage(err: unknown, config: B2Config): string {
+  let message = err instanceof Error ? err.message : String(err);
+  for (const value of [
+    config.applicationKeyId,
+    config.applicationKey,
+    config.appKeyId,
+    config.appKey,
+    config.masterKeyId,
+    config.masterKey,
+  ]) {
+    if (value) message = message.split(value).join("[redacted]");
+  }
+  return message;
+}
+
+function capabilityFailureDetails(
+  err: unknown,
+  config: B2Config,
+): {
+  status: number;
+  code: string;
+  log: Record<string, unknown>;
+  message: string;
+} {
+  const anyErr = err as {
+    code?: unknown;
+    response?: { status?: unknown; headers?: Record<string, unknown> };
+  };
+  const upstreamStatus =
+    typeof anyErr.response?.status === "number" ? anyErr.response.status : undefined;
+  const upstreamCode = typeof anyErr.code === "string" ? anyErr.code : undefined;
+  const requestIdHeader =
+    anyErr.response?.headers?.["x-bz-request-id"] ?? anyErr.response?.headers?.["x-b2-request-id"];
+  const requestId = typeof requestIdHeader === "string" ? requestIdHeader : undefined;
+  const authFailure = upstreamStatus === 401 || upstreamStatus === 403;
+  const retryable =
+    !authFailure &&
+    (upstreamStatus === undefined ||
+      upstreamStatus === 429 ||
+      upstreamStatus >= 500 ||
+      upstreamCode === "ECONNABORTED" ||
+      upstreamCode === "ETIMEDOUT" ||
+      upstreamCode === "ECONNRESET" ||
+      upstreamCode === "ENOTFOUND");
+
+  if (authFailure) {
+    return {
+      status: upstreamStatus,
+      code: "capability_auth_failed",
+      message: "Credential or capability resolution failed",
+      log: {
+        upstreamStatus,
+        upstreamCode,
+        retryable: false,
+        message: redactedCapabilityMessage(err, config),
+        ...(requestId && { requestId }),
+      },
+    };
+  }
+
+  return {
+    status: retryable ? 503 : 502,
+    code: retryable ? "capability_upstream_unavailable" : "capability_upstream_failed",
+    message: "B2 capability service temporarily unavailable",
+    log: {
+      upstreamStatus,
+      upstreamCode,
+      retryable,
+      message: redactedCapabilityMessage(err, config),
+      ...(requestId && { requestId }),
+    },
+  };
+}
+
 export async function fetchCapabilities(
   config: B2Config,
   cacheKey?: string,
+  logKey?: string,
 ): Promise<string[] | null> {
   if (process.env.B2_REGISTER_ALL_TOOLS === "true") return null;
-  const resolvedCacheKey =
-    cacheKey ?? `credential:${config.credentialFingerprint ?? fingerprintConfig(config)}`;
+  const resolvedCacheKey = cacheKey ?? `credential:${verificationFingerprintConfig(config)}`;
+  const credentialLogKey =
+    logKey ?? `credential:${config.credentialFingerprint ?? fingerprintConfig(config)}`;
   const now = Date.now();
+  sweepCapabilityCache(now);
   const cached = capabilityCache.get(resolvedCacheKey);
-  if (cached && cached.expiresAt > now) return [...cached.capabilities];
+  if (cached && cached.expiresAt > now) {
+    capabilityCache.delete(resolvedCacheKey);
+    capabilityCache.set(resolvedCacheKey, cached);
+    return [...cached.capabilities];
+  }
 
   try {
     const auth = new B2AuthManager(config);
     const info = await auth.getAuth();
     const capabilities = info.capabilities ?? [];
-    capabilityCache.set(resolvedCacheKey, {
-      capabilities: [...capabilities],
-      expiresAt: now + capabilityCacheTtlMs(),
-    });
+    rememberCapabilities(resolvedCacheKey, capabilities, now);
     return capabilities;
-  } catch {
-    logger.warn({ credential: resolvedCacheKey }, "capability.fetch.failed");
-    throw new CredentialResolutionError(
-      "Credential or capability resolution failed",
-      401,
-      "capability_resolution_failed",
-    );
+  } catch (err) {
+    const details = capabilityFailureDetails(err, config);
+    logger.warn({ credential: credentialLogKey, ...details.log }, "capability.fetch.failed");
+    throw new CredentialResolutionError(details.message, details.status, details.code);
   }
 }
 

--- a/src/server.ts
+++ b/src/server.ts
@@ -9,6 +9,11 @@ import { B2AuthManager } from "./auth.js";
 import { B2Client } from "./b2/client.js";
 import { createS3Client } from "./s3/client.js";
 import { isToolEnabled } from "./utils/tool-capabilities.js";
+import {
+  CredentialResolutionError,
+  fingerprintConfig,
+  StdioEnvCredentialProvider,
+} from "./credentials.js";
 
 import { registerBucketTools } from "./b2/buckets.js";
 import { registerKeyTools } from "./b2/keys.js";
@@ -26,64 +31,13 @@ import { registerS3ExtraTools } from "./s3/extras.js";
  * Load and validate configuration from environment variables.
  */
 export function loadConfig(): B2Config {
-  const keyId = process.env.B2_APPLICATION_KEY_ID;
-  const key = process.env.B2_APPLICATION_KEY;
-
-  if (!keyId || !key) {
+  try {
+    return new StdioEnvCredentialProvider().resolve().config;
+  } catch (err) {
+    if (!(err instanceof CredentialResolutionError)) throw err;
     logger.fatal("config.missing: B2_APPLICATION_KEY_ID and B2_APPLICATION_KEY are required");
     process.exit(1);
   }
-
-  // Optional master key — only the Partner API tools need it. Falls
-  // back to the application key so a single non-master key is a complete config
-  // for everything else. Require both halves or neither.
-  const masterId = process.env.B2_MASTER_KEY_ID;
-  const masterKey = process.env.B2_MASTER_KEY;
-  if (!!masterId !== !!masterKey) {
-    logger.warn(
-      "config: B2_MASTER_KEY_ID and B2_MASTER_KEY must both be set; ignoring the partial master key and using the application key for Partner API tools",
-    );
-  }
-  // B2_APP_KEY was the old way to supply a non-master S3 key when the primary
-  // was a master key. The current model is the reverse — make the application
-  // key the (non-master) workhorse and set B2_MASTER_KEY only for the Partner API.
-  if (process.env.B2_APP_KEY_ID) {
-    logger.warn(
-      "config: B2_APP_KEY_ID/B2_APP_KEY is deprecated. Set B2_APPLICATION_KEY_ID to a non-master application key (it handles the S3 API too) and use B2_MASTER_KEY_ID/B2_MASTER_KEY only for Partner API tools.",
-    );
-  }
-
-  return {
-    applicationKeyId: keyId,
-    applicationKey: key,
-    // S3-compatible API: B2 rejects master keys on the S3 endpoint but accepts
-    // ordinary application keys, so this should be the application key. The
-    // deprecated B2_APP_KEY override remains only for legacy master-primary setups.
-    appKeyId: process.env.B2_APP_KEY_ID ?? keyId,
-    appKey: process.env.B2_APP_KEY ?? key,
-    masterKeyId: (masterId && masterKey ? masterId : undefined) ?? keyId,
-    masterKey: (masterId && masterKey ? masterKey : undefined) ?? key,
-    region: process.env.B2_REGION ?? "us-west-004",
-    // Local stdio is a trusted single-user process, so disk access is on by
-    // default. Set B2_ALLOW_LOCAL_FILES=false to disable, or B2_FILE_ROOT to
-    // confine all file paths to one directory.
-    allowLocalFiles: process.env.B2_ALLOW_LOCAL_FILES !== "false",
-    fileRoot: process.env.B2_FILE_ROOT ?? null,
-    // b2_create_key lockdown (see B2Config). Opt-in overrides; safe by default.
-    maxKeyDurationSeconds: process.env.B2_MAX_KEY_DURATION_SECONDS
-      ? parseIntEnv(process.env.B2_MAX_KEY_DURATION_SECONDS, 0)
-      : null,
-    allowKeyMgmtGrants: process.env.B2_ALLOW_KEY_MGMT_GRANTS === "true",
-    allowUnscopedKeys: process.env.B2_ALLOW_UNSCOPED_KEYS === "true",
-    // stdio is a trusted local single-user session, so it defaults to `confirm`.
-    // The internet-facing HTTP transport defaults to `block` instead — see
-    // configFromHeaders in http-server.ts.
-    destructivePolicy:
-      process.env.B2_DESTRUCTIVE_POLICY === "allow" || process.env.B2_DESTRUCTIVE_POLICY === "block"
-        ? process.env.B2_DESTRUCTIVE_POLICY
-        : "confirm",
-    transport: "stdio",
-  };
 }
 
 /**
@@ -109,9 +63,9 @@ export function loadConfig(): B2Config {
  * Build the MCP server. When `capabilities` is a non-null array, registration is
  * capability-aware: only tools the key can use (per src/utils/tool-capabilities)
  * are registered, and Partner tools register only with a distinct master key.
- * When `capabilities` is null/undefined (the default, and all unit tests), the
- * full surface is registered — no behavior change. The entry points fetch the
- * key's capabilities (see fetchCapabilities) and pass them in.
+ * When `capabilities` is null/undefined, the full surface is registered; this is
+ * reserved for explicit operator override and legacy unit tests. An empty array
+ * is a fail-closed capability set, not "unknown".
  */
 export function createServer(config: B2Config, capabilities?: string[] | null): McpServer {
   const server = new McpServer(
@@ -151,14 +105,13 @@ export function createServer(config: B2Config, capabilities?: string[] | null): 
   // server.tool so a tool is only registered if the key can use it. Tools not in
   // the capability map (b2_authorize_account, Partner tools) are always allowed
   // through here; Partner tools are additionally gated on a master key below.
-  // Filter only when we actually have a non-empty capability list. An empty
-  // array is treated as "unknown" → full surface (defensive belt-and-suspenders
-  // with fetchCapabilities, so the surface can never collapse to one tool).
-  const filterActive = Array.isArray(capabilities) && capabilities.length > 0;
+  // Filter whenever capabilities are supplied. null/undefined remains the
+  // explicit full-surface path, while an empty array is fail-closed rather than
+  // "unknown".
+  const filterActive = Array.isArray(capabilities);
   if (filterActive) {
     const capsSet = new Set(capabilities);
     const originalTool = server.tool.bind(server);
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
     (server as any).tool = (name: string, ...rest: any[]) =>
       isToolEnabled(name, capsSet) ? (originalTool as any)(name, ...rest) : undefined;
   }
@@ -217,27 +170,58 @@ export function createServer(config: B2Config, capabilities?: string[] | null): 
 
 /**
  * One-shot authorize to read the key's capabilities for capability-aware
- * registration. Returns the capability list, or null if it can't be determined
- * (auth failure or B2_REGISTER_ALL_TOOLS=true) — callers treat null as
- * "register the full surface", so a transient auth hiccup never yields an empty
- * server. Set B2_REGISTER_ALL_TOOLS=true to skip this and always register all.
+ * registration. Returns the capability list and caches it by a non-secret
+ * fingerprint/principal cache key. Capability lookup failures throw so callers
+ * fail closed instead of exposing the full tool surface. Set
+ * B2_REGISTER_ALL_TOOLS=true to explicitly skip discovery and register all.
  */
-export async function fetchCapabilities(config: B2Config): Promise<string[] | null> {
+interface CapabilityCacheEntry {
+  capabilities: string[];
+  expiresAt: number;
+}
+
+const capabilityCache = new Map<string, CapabilityCacheEntry>();
+const DEFAULT_CAPABILITY_CACHE_TTL_MS = 5 * 60 * 1000;
+
+export function invalidateCapabilityCache(cacheKey?: string): void {
+  if (cacheKey) capabilityCache.delete(cacheKey);
+  else capabilityCache.clear();
+}
+
+function capabilityCacheTtlMs(): number {
+  const ttl = process.env.B2_CAPABILITY_CACHE_TTL_MS
+    ? parseIntEnv(process.env.B2_CAPABILITY_CACHE_TTL_MS, DEFAULT_CAPABILITY_CACHE_TTL_MS)
+    : DEFAULT_CAPABILITY_CACHE_TTL_MS;
+  return Math.max(0, ttl);
+}
+
+export async function fetchCapabilities(
+  config: B2Config,
+  cacheKey?: string,
+): Promise<string[] | null> {
   if (process.env.B2_REGISTER_ALL_TOOLS === "true") return null;
+  const resolvedCacheKey =
+    cacheKey ?? `credential:${config.credentialFingerprint ?? fingerprintConfig(config)}`;
+  const now = Date.now();
+  const cached = capabilityCache.get(resolvedCacheKey);
+  if (cached && cached.expiresAt > now) return [...cached.capabilities];
+
   try {
     const auth = new B2AuthManager(config);
     const info = await auth.getAuth();
-    // Empty/unknown capabilities → null → full surface. NEVER filter to nothing:
-    // an empty list almost always means we couldn't read them, not a key that
-    // can do nothing, and stripping the surface to just b2_authorize_account is
-    // a far worse failure than showing a tool the key can't use.
-    return info.capabilities && info.capabilities.length ? info.capabilities : null;
-  } catch (err) {
-    logger.warn(
-      { err: err instanceof Error ? err.message : String(err) },
-      "capability fetch failed; registering full tool surface",
+    const capabilities = info.capabilities ?? [];
+    capabilityCache.set(resolvedCacheKey, {
+      capabilities: [...capabilities],
+      expiresAt: now + capabilityCacheTtlMs(),
+    });
+    return capabilities;
+  } catch {
+    logger.warn({ credential: resolvedCacheKey }, "capability.fetch.failed");
+    throw new CredentialResolutionError(
+      "Credential or capability resolution failed",
+      401,
+      "capability_resolution_failed",
     );
-    return null;
   }
 }
 
@@ -261,9 +245,9 @@ export function getRegisteredTools(server: McpServer): Record<string, Registered
 
 /**
  * Wrap every registered tool handler to emit an audit log entry on
- * invocation: tool name, key-id prefix (not the full key), top-level
- * arg keys, duration, and success/error. Argument *values* are not
- * logged to avoid leaking file content, bucket data, etc.
+ * invocation: tool name, non-secret credential fingerprint, top-level arg keys,
+ * duration, and success/error. Argument *values* are not logged to avoid leaking
+ * file content, bucket data, etc.
  *
  * Returns the number of tools successfully wrapped. If the SDK internal is
  * missing, audit logging is skipped but a warning is logged so the degradation
@@ -278,7 +262,7 @@ export function wrapToolsWithAudit(server: McpServer, config: B2Config): number 
     );
     return 0;
   }
-  const keyPrefix = config.applicationKeyId.slice(0, 8);
+  const keyFingerprint = config.credentialFingerprint ?? fingerprintConfig(config);
   let wrapped = 0;
 
   for (const name of Object.keys(tools)) {
@@ -313,7 +297,7 @@ export function wrapToolsWithAudit(server: McpServer, config: B2Config): number 
         logger.info(
           {
             tool: name,
-            key: keyPrefix,
+            credential: keyFingerprint,
             argKeys,
             durationMs,
             error: isError,
@@ -331,7 +315,7 @@ export function wrapToolsWithAudit(server: McpServer, config: B2Config): number 
         logger.warn(
           {
             tool: name,
-            key: keyPrefix,
+            credential: keyFingerprint,
             argKeys,
             durationMs,
             err: err instanceof Error ? err.message : String(err),

--- a/src/utils/rate-limiter.ts
+++ b/src/utils/rate-limiter.ts
@@ -5,7 +5,8 @@
  * key (runaway client loop) gets throttled even when its IP is fine. The
  * rate key is a SHA-256 hash of the provider's non-secret credential/principal
  * cache key (see deriveRateKey in http-server.ts), so raw credentials and key
- * IDs never become metrics/log labels. We look it up from the session record.
+ * IDs never become metrics/log labels. The HTTP entry derives it after
+ * per-request credential resolution.
  *
  * Defaults: 60 requests/sec sustained, burst capacity 120. Override via
  * B2_MCP_RATE_LIMIT_RPS and B2_MCP_RATE_LIMIT_BURST env vars.

--- a/src/utils/rate-limiter.ts
+++ b/src/utils/rate-limiter.ts
@@ -3,9 +3,9 @@
  *
  * Nginx already rate-limits by IP. This is the second tier: a misbehaving
  * key (runaway client loop) gets throttled even when its IP is fine. The
- * rate key is a SHA-256 hash of the full X-B2-Key-Id (see deriveRateKey in
- * http-server.ts) — not a prefix, so distinct tenants can't collide. We look
- * it up from the session record.
+ * rate key is a SHA-256 hash of the provider's non-secret credential/principal
+ * cache key (see deriveRateKey in http-server.ts), so raw credentials and key
+ * IDs never become metrics/log labels. We look it up from the session record.
  *
  * Defaults: 60 requests/sec sustained, burst capacity 120. Override via
  * B2_MCP_RATE_LIMIT_RPS and B2_MCP_RATE_LIMIT_BURST env vars.

--- a/src/utils/tool-capabilities.ts
+++ b/src/utils/tool-capabilities.ts
@@ -1,9 +1,9 @@
 /**
  * Capability-aware tool registration.
  *
- * Maps each tool to the B2 key capability it needs. At session start the server
- * reads the key's `allowed.capabilities` (from b2_authorize_account) and only
- * registers the tools the key can actually use — so the surface auto-right-sizes
+ * Maps each tool to the B2 key capability it needs. Before serving a request,
+ * the server reads the key's `allowed.capabilities` (from b2_authorize_account)
+ * and only registers the tools the key can actually use — so the surface auto-right-sizes
  * to the credential: smaller context, no dead tools, and a surface that matches
  * the key's real power. This is a layer below the destructive gate (the key
  * decides what is *possible*; the gate decides what is *permitted*).

--- a/src/utils/types.ts
+++ b/src/utils/types.ts
@@ -59,6 +59,8 @@ export interface B2Config {
   destructivePolicy?: DestructivePolicy;
   /** Which transport launched this server — surfaced in the outbound User-Agent. */
   transport?: "stdio" | "http";
+  /** Non-secret SHA-256-derived fingerprint used for logs, metrics, and caches. */
+  credentialFingerprint?: string;
 }
 
 export interface B2AuthResponse {

--- a/tests/integration/contract.test.ts
+++ b/tests/integration/contract.test.ts
@@ -16,7 +16,7 @@
  */
 
 import { loadConfig, createServer } from "../../src/server";
-import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import type { McpServer } from "../../src/mcp";
 
 const HAS_CREDS = !!(process.env.B2_APPLICATION_KEY_ID && process.env.B2_APPLICATION_KEY);
 const liveIt = HAS_CREDS ? test : test.skip;

--- a/tests/integration/live.test.ts
+++ b/tests/integration/live.test.ts
@@ -22,7 +22,7 @@ import * as os from "os";
 import * as path from "path";
 import * as crypto from "crypto";
 import { loadConfig, createServer } from "../../src/server";
-import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import type { McpServer } from "../../src/mcp";
 
 const HAS_CREDS = !!(process.env.B2_APPLICATION_KEY_ID && process.env.B2_APPLICATION_KEY);
 // S3-compatible API requires a non-master application key (set B2_APP_KEY_ID).

--- a/tests/unit/audit-wrapper.test.ts
+++ b/tests/unit/audit-wrapper.test.ts
@@ -5,7 +5,7 @@
  * silently, and the wrapper reports how many tools it wrapped.
  */
 
-import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import type { McpServer } from "../../src/mcp";
 import { wrapToolsWithAudit, getRegisteredTools } from "../../src/server";
 import { logger } from "../../src/utils/logger";
 import { B2Config } from "../../src/utils/types";

--- a/tests/unit/b2-error-paths.test.ts
+++ b/tests/unit/b2-error-paths.test.ts
@@ -6,7 +6,7 @@
 
 import axios from "axios";
 import { createServer } from "../../src/server";
-import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import type { McpServer } from "../../src/mcp";
 import { B2Config } from "../../src/utils/types";
 
 jest.mock("axios");

--- a/tests/unit/b2-tools.test.ts
+++ b/tests/unit/b2-tools.test.ts
@@ -9,7 +9,7 @@
 
 import axios from "axios";
 import { createServer } from "../../src/server";
-import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import type { McpServer } from "../../src/mcp";
 
 // ── Mock axios ────────────────────────────────────────────────────────────────
 

--- a/tests/unit/b2-tools.test.ts
+++ b/tests/unit/b2-tools.test.ts
@@ -8,7 +8,7 @@
  */
 
 import axios from "axios";
-import { createServer } from "../../src/server";
+import { createServer, invalidateAuthManagerCache } from "../../src/server";
 import type { McpServer } from "../../src/mcp";
 
 // ── Mock axios ────────────────────────────────────────────────────────────────
@@ -79,11 +79,12 @@ function setupMocks(apiResponseData: Record<string, unknown>) {
 }
 
 beforeEach(() => {
-  server = createServer(testConfig);
+  invalidateAuthManagerCache();
   jest.clearAllMocks();
   // Default: auth succeeds, API returns empty object
   mockedAxios.get = jest.fn().mockResolvedValue({ data: mockAuthData });
   mockedAxios.mockResolvedValue({ data: {} } as any);
+  server = createServer(testConfig);
 });
 
 // ── b2_authorize_account ──────────────────────────────────────────────────────

--- a/tests/unit/capability-registration.test.ts
+++ b/tests/unit/capability-registration.test.ts
@@ -4,7 +4,13 @@
  * network-free; fetchCapabilities is tested against a mocked authorize.
  */
 import axios from "axios";
-import { createServer, fetchCapabilities, invalidateCapabilityCache } from "../../src/server";
+import {
+  capabilityCacheSizeForTests,
+  createServer,
+  fetchCapabilities,
+  invalidateCapabilityCache,
+} from "../../src/server";
+import { verificationFingerprintConfig } from "../../src/credentials";
 import { isToolEnabled, TOOL_CAPABILITIES } from "../../src/utils/tool-capabilities";
 import { B2Config } from "../../src/utils/types";
 
@@ -127,6 +133,7 @@ describe("fetchCapabilities", () => {
     invalidateCapabilityCache();
     delete process.env.B2_REGISTER_ALL_TOOLS;
     delete process.env.B2_CAPABILITY_CACHE_TTL_MS;
+    delete process.env.B2_CAPABILITY_CACHE_MAX_ENTRIES;
   });
 
   // v4 puts capabilities at apiInfo.storageApi.allowed.capabilities.
@@ -161,7 +168,20 @@ describe("fetchCapabilities", () => {
     jest
       .spyOn(axios, "get")
       .mockRejectedValue(Object.assign(new Error("denied"), { response: { status: 401 } }));
-    await expect(fetchCapabilities(baseConfig)).rejects.toThrow(/credential or capability/i);
+    await expect(fetchCapabilities(baseConfig)).rejects.toMatchObject({
+      status: 401,
+      code: "capability_auth_failed",
+    });
+  });
+
+  it("returns retryable status for upstream capability failures", async () => {
+    jest
+      .spyOn(axios, "get")
+      .mockRejectedValue(Object.assign(new Error("B2 500"), { response: { status: 500 } }));
+    await expect(fetchCapabilities(baseConfig)).rejects.toMatchObject({
+      status: 503,
+      code: "capability_upstream_unavailable",
+    });
   });
 
   it("returns null without any network call when B2_REGISTER_ALL_TOOLS=true", async () => {
@@ -171,7 +191,7 @@ describe("fetchCapabilities", () => {
     expect(spy).not.toHaveBeenCalled();
   });
 
-  it("caches by explicit non-secret cache key and supports invalidation", async () => {
+  it("caches by explicit secret-bound cache key and supports invalidation", async () => {
     process.env.B2_CAPABILITY_CACHE_TTL_MS = "60000";
     const spy = jest.spyOn(axios, "get").mockResolvedValue(authData(["readFiles"]) as never);
 
@@ -185,5 +205,55 @@ describe("fetchCapabilities", () => {
     invalidateCapabilityCache("credential:a");
     await expect(fetchCapabilities(baseConfig, "credential:a")).resolves.toEqual(["readFiles"]);
     expect(spy).toHaveBeenCalledTimes(3);
+  });
+
+  it("does not reuse a warm cache entry for the same key id with a wrong secret", async () => {
+    process.env.B2_CAPABILITY_CACHE_TTL_MS = "60000";
+    const wrongSecret = {
+      ...baseConfig,
+      applicationKey: "wrong",
+      appKey: "wrong",
+      masterKey: "wrong",
+    };
+    const spy = jest
+      .spyOn(axios, "get")
+      .mockResolvedValueOnce(authData(["readFiles"]) as never)
+      .mockRejectedValueOnce(Object.assign(new Error("denied"), { response: { status: 401 } }));
+
+    await expect(
+      fetchCapabilities(
+        baseConfig,
+        `credential:${verificationFingerprintConfig(baseConfig)}`,
+        "credential:non-secret",
+      ),
+    ).resolves.toEqual(["readFiles"]);
+
+    await expect(
+      fetchCapabilities(
+        wrongSecret,
+        `credential:${verificationFingerprintConfig(wrongSecret)}`,
+        "credential:non-secret",
+      ),
+    ).rejects.toMatchObject({ status: 401 });
+    expect(spy).toHaveBeenCalledTimes(2);
+  });
+
+  it("does not cache an empty capability response at the positive TTL", async () => {
+    process.env.B2_CAPABILITY_CACHE_TTL_MS = "60000";
+    const spy = jest.spyOn(axios, "get").mockResolvedValue(authData(undefined) as never);
+    await expect(fetchCapabilities(baseConfig, "credential:empty")).resolves.toEqual([]);
+    await expect(fetchCapabilities(baseConfig, "credential:empty")).resolves.toEqual([]);
+    expect(spy).toHaveBeenCalledTimes(2);
+  });
+
+  it("bounds capability-cache growth as distinct credentials connect", async () => {
+    process.env.B2_CAPABILITY_CACHE_TTL_MS = "60000";
+    process.env.B2_CAPABILITY_CACHE_MAX_ENTRIES = "2";
+    jest.spyOn(axios, "get").mockResolvedValue(authData(["readFiles"]) as never);
+
+    for (let i = 0; i < 5; i++) {
+      await fetchCapabilities({ ...baseConfig, applicationKey: `s-${i}` }, `credential:${i}`);
+    }
+    expect(capabilityCacheSizeForTests()).toBeLessThanOrEqual(2);
   });
 });

--- a/tests/unit/capability-registration.test.ts
+++ b/tests/unit/capability-registration.test.ts
@@ -4,7 +4,7 @@
  * network-free; fetchCapabilities is tested against a mocked authorize.
  */
 import axios from "axios";
-import { createServer, fetchCapabilities } from "../../src/server";
+import { createServer, fetchCapabilities, invalidateCapabilityCache } from "../../src/server";
 import { isToolEnabled, TOOL_CAPABILITIES } from "../../src/utils/tool-capabilities";
 import { B2Config } from "../../src/utils/types";
 
@@ -49,12 +49,11 @@ describe("capability-aware registration", () => {
     expect(toolNames(null).length).toBe(40);
   });
 
-  it("EMPTY capabilities → full surface, never collapses to one tool (regression)", () => {
-    // The bug that shipped to the box: empty caps wrongly filtered everything,
-    // leaving only b2_authorize_account. Empty must mean 'unknown' → full surface.
+  it("EMPTY capabilities → fail closed instead of full surface", () => {
     const names = toolNames([]);
-    expect(names.length).toBe(40);
-    expect(names).toContain("b2_usage_growth");
+    expect(names.length).toBeLessThan(40);
+    expect(names).toContain("b2_authorize_account");
+    expect(names).not.toContain("b2_usage_growth");
   });
 
   it("read-only key drops every write/delete/admin tool", () => {
@@ -125,7 +124,9 @@ describe("capability-aware registration", () => {
 describe("fetchCapabilities", () => {
   afterEach(() => {
     jest.restoreAllMocks();
+    invalidateCapabilityCache();
     delete process.env.B2_REGISTER_ALL_TOOLS;
+    delete process.env.B2_CAPABILITY_CACHE_TTL_MS;
   });
 
   // v4 puts capabilities at apiInfo.storageApi.allowed.capabilities.
@@ -151,16 +152,16 @@ describe("fetchCapabilities", () => {
     expect(await fetchCapabilities(baseConfig)).toEqual(["readFiles", "listBuckets"]);
   });
 
-  it("returns null (→ full surface) when capabilities are empty or absent", async () => {
+  it("returns an empty list when capabilities are empty or absent", async () => {
     jest.spyOn(axios, "get").mockResolvedValue(authData(undefined) as never);
-    expect(await fetchCapabilities(baseConfig)).toBeNull();
+    expect(await fetchCapabilities(baseConfig)).toEqual([]);
   });
 
-  it("returns null on auth failure so callers fall back to the full surface", async () => {
+  it("rejects on auth failure so callers fail closed", async () => {
     jest
       .spyOn(axios, "get")
       .mockRejectedValue(Object.assign(new Error("denied"), { response: { status: 401 } }));
-    expect(await fetchCapabilities(baseConfig)).toBeNull();
+    await expect(fetchCapabilities(baseConfig)).rejects.toThrow(/credential or capability/i);
   });
 
   it("returns null without any network call when B2_REGISTER_ALL_TOOLS=true", async () => {
@@ -168,5 +169,21 @@ describe("fetchCapabilities", () => {
     process.env.B2_REGISTER_ALL_TOOLS = "true";
     expect(await fetchCapabilities(baseConfig)).toBeNull();
     expect(spy).not.toHaveBeenCalled();
+  });
+
+  it("caches by explicit non-secret cache key and supports invalidation", async () => {
+    process.env.B2_CAPABILITY_CACHE_TTL_MS = "60000";
+    const spy = jest.spyOn(axios, "get").mockResolvedValue(authData(["readFiles"]) as never);
+
+    await expect(fetchCapabilities(baseConfig, "credential:a")).resolves.toEqual(["readFiles"]);
+    await expect(fetchCapabilities(baseConfig, "credential:a")).resolves.toEqual(["readFiles"]);
+    expect(spy).toHaveBeenCalledTimes(1);
+
+    await expect(fetchCapabilities(baseConfig, "credential:b")).resolves.toEqual(["readFiles"]);
+    expect(spy).toHaveBeenCalledTimes(2);
+
+    invalidateCapabilityCache("credential:a");
+    await expect(fetchCapabilities(baseConfig, "credential:a")).resolves.toEqual(["readFiles"]);
+    expect(spy).toHaveBeenCalledTimes(3);
   });
 });

--- a/tests/unit/capability-registration.test.ts
+++ b/tests/unit/capability-registration.test.ts
@@ -246,6 +246,20 @@ describe("fetchCapabilities", () => {
     expect(spy).toHaveBeenCalledTimes(2);
   });
 
+  it("deduplicates concurrent cold-cache capability lookups", async () => {
+    process.env.B2_CAPABILITY_CACHE_TTL_MS = "60000";
+    const spy = jest.spyOn(axios, "get").mockResolvedValue(authData(["readFiles"]) as never);
+
+    await expect(
+      Promise.all([
+        fetchCapabilities(baseConfig, "credential:singleflight"),
+        fetchCapabilities(baseConfig, "credential:singleflight"),
+        fetchCapabilities(baseConfig, "credential:singleflight"),
+      ]),
+    ).resolves.toEqual([["readFiles"], ["readFiles"], ["readFiles"]]);
+    expect(spy).toHaveBeenCalledTimes(1);
+  });
+
   it("bounds capability-cache growth as distinct credentials connect", async () => {
     process.env.B2_CAPABILITY_CACHE_TTL_MS = "60000";
     process.env.B2_CAPABILITY_CACHE_MAX_ENTRIES = "2";

--- a/tests/unit/credentials.test.ts
+++ b/tests/unit/credentials.test.ts
@@ -118,6 +118,26 @@ describe("credential providers", () => {
     expect(resolved.cacheKey).not.toContain("tenant-id");
   });
 
+  it("principal provider reports an unmapped secret reference when env material is absent", () => {
+    process.env.B2_PRINCIPAL_CREDENTIAL_MAP = JSON.stringify({ alice: "tenant_a" });
+
+    let caught: unknown;
+    try {
+      new HttpPrincipalCredentialProvider().resolve({
+        req: {
+          headers: {},
+          auth: { token: "verified", clientId: "client-a", scopes: [], extra: { sub: "alice" } },
+        } as any,
+      });
+    } catch (err) {
+      caught = err;
+    }
+    expect(caught).toMatchObject({
+      code: "credential_ref_not_found",
+      status: 403,
+    });
+  });
+
   it("uses the secret in verification identity without changing log identity", () => {
     const provider = new HttpHeaderCredentialProvider();
     const first = provider.resolve({

--- a/tests/unit/credentials.test.ts
+++ b/tests/unit/credentials.test.ts
@@ -41,7 +41,7 @@ describe("credential providers", () => {
     expect(resolved.config.transport).toBe("stdio");
     expect(resolved.config.credentialFingerprint).toMatch(/^[a-f0-9]{16}$/);
     expect(resolved.cacheKey).not.toContain("stdio-id");
-    expect(resolved.verificationKey).toMatch(/^credential:[a-f0-9]{16}$/);
+    expect(resolved.capabilityCacheKey).toMatch(/^credential:[a-f0-9]{16}$/);
   });
 
   it("fails closed when required stdio credentials are missing", () => {
@@ -70,7 +70,7 @@ describe("credential providers", () => {
     expect(resolved.config.transport).toBe("http");
     expect(resolved.cacheKey).not.toContain("header-id");
     expect(resolved.cacheKey).not.toContain("header-secret");
-    expect(resolved.verificationKey).not.toBe(resolved.cacheKey);
+    expect(resolved.capabilityCacheKey).not.toBe(resolved.cacheKey);
   });
 
   it("rejects partial optional header credentials", () => {
@@ -113,7 +113,7 @@ describe("credential providers", () => {
     expect(resolved.config.applicationKeyId).toBe("tenant-id");
     expect(resolved.principal).toBe("alice");
     expect(resolved.cacheKey).toMatch(/^principal:[a-f0-9]{16}$/);
-    expect(resolved.verificationKey).toMatch(/^principal:[a-f0-9]{16}$/);
+    expect(resolved.capabilityCacheKey).toMatch(/^principal:[a-f0-9]{16}$/);
     expect(resolved.cacheKey).not.toContain("alice");
     expect(resolved.cacheKey).not.toContain("tenant-id");
   });
@@ -138,7 +138,7 @@ describe("credential providers", () => {
     });
   });
 
-  it("uses the secret in verification identity without changing log identity", () => {
+  it("uses the secret in capability-cache identity without changing log identity", () => {
     const provider = new HttpHeaderCredentialProvider();
     const first = provider.resolve({
       req: { headers: { "x-b2-key-id": "header-id", "x-b2-key": "secret-a" } } as any,
@@ -147,7 +147,94 @@ describe("credential providers", () => {
       req: { headers: { "x-b2-key-id": "header-id", "x-b2-key": "secret-b" } } as any,
     });
     expect(first.cacheKey).toBe(second.cacheKey);
-    expect(first.verificationKey).not.toBe(second.verificationKey);
+    expect(first.capabilityCacheKey).not.toBe(second.capabilityCacheKey);
+  });
+
+  it("principal provider rejects mutable email-only and clientId-only identities", () => {
+    process.env.B2_PRINCIPAL_CREDENTIAL_MAP = JSON.stringify({
+      "alice@example.com": "tenant_a",
+      "client-a": "tenant_a",
+    });
+    process.env.B2_CREDENTIAL_TENANT_A_APPLICATION_KEY_ID = "tenant-id";
+    process.env.B2_CREDENTIAL_TENANT_A_APPLICATION_KEY = "tenant-secret";
+    const provider = new HttpPrincipalCredentialProvider();
+
+    expect(() =>
+      provider.resolve({
+        req: {
+          headers: {},
+          auth: {
+            token: "verified",
+            clientId: "client-a",
+            scopes: [],
+            extra: { email: "alice@example.com" },
+          },
+        } as any,
+      }),
+    ).toThrow(/principal/i);
+
+    expect(() =>
+      provider.resolve({
+        req: {
+          headers: {},
+          auth: { token: "verified", clientId: "client-a", scopes: [], extra: {} },
+        } as any,
+      }),
+    ).toThrow(/principal/i);
+  });
+
+  it("principal provider qualifies subjects with issuer when present", () => {
+    process.env.B2_PRINCIPAL_CREDENTIAL_MAP = JSON.stringify({
+      "https://issuer.example#alice": "tenant_a",
+    });
+    process.env.B2_CREDENTIAL_TENANT_A_APPLICATION_KEY_ID = "tenant-id";
+    process.env.B2_CREDENTIAL_TENANT_A_APPLICATION_KEY = "tenant-secret";
+
+    const resolved = new HttpPrincipalCredentialProvider().resolve({
+      req: {
+        headers: {},
+        auth: {
+          token: "verified",
+          clientId: "client-a",
+          scopes: [],
+          extra: { iss: "https://issuer.example", sub: "alice" },
+        },
+      } as any,
+    });
+    expect(resolved.principal).toBe("https://issuer.example#alice");
+  });
+
+  it("rejects principal maps with credential ref normalization collisions", () => {
+    process.env.B2_PRINCIPAL_CREDENTIAL_MAP = JSON.stringify({
+      alice: "tenant-a",
+      mallory: "tenant_a",
+    });
+    expect(() =>
+      new HttpPrincipalCredentialProvider().resolve({
+        req: {
+          headers: {},
+          auth: { token: "verified", clientId: "client-a", scopes: [], extra: { sub: "alice" } },
+        } as any,
+      }),
+    ).toThrow(/principal credential map/i);
+  });
+
+  it("does not map inherited object property names as principals", () => {
+    process.env.B2_PRINCIPAL_CREDENTIAL_MAP = JSON.stringify({ alice: "tenant_a" });
+    const provider = new HttpPrincipalCredentialProvider();
+    expect(() =>
+      provider.resolve({
+        req: {
+          headers: {},
+          auth: {
+            token: "verified",
+            clientId: "client-a",
+            scopes: [],
+            extra: { sub: "constructor" },
+          },
+        } as any,
+      }),
+    ).toThrow(/No credential mapping/i);
   });
 
   it("principal provider rejects unauthenticated requests and B2 header spoofing", () => {

--- a/tests/unit/credentials.test.ts
+++ b/tests/unit/credentials.test.ts
@@ -1,0 +1,167 @@
+import {
+  CredentialResolutionError,
+  fingerprintConfig,
+  getHttpCredentialMode,
+  getHttpCredentialProvider,
+  hasCredentialHeaders,
+  HttpHeaderCredentialProvider,
+  HttpPrincipalCredentialProvider,
+  HttpServerCredentialProvider,
+  StdioEnvCredentialProvider,
+} from "../../src/credentials";
+
+const savedEnv = process.env;
+
+beforeEach(() => {
+  process.env = { ...savedEnv };
+  delete process.env.B2_HTTP_CREDENTIAL_MODE;
+  delete process.env.B2_APPLICATION_KEY_ID;
+  delete process.env.B2_APPLICATION_KEY;
+  delete process.env.B2_APP_KEY_ID;
+  delete process.env.B2_APP_KEY;
+  delete process.env.B2_MASTER_KEY_ID;
+  delete process.env.B2_MASTER_KEY;
+  delete process.env.B2_PRINCIPAL_CREDENTIAL_MAP;
+  delete process.env.B2_CREDENTIAL_TENANT_A_APPLICATION_KEY_ID;
+  delete process.env.B2_CREDENTIAL_TENANT_A_APPLICATION_KEY;
+});
+
+afterEach(() => {
+  process.env = savedEnv;
+});
+
+describe("credential providers", () => {
+  it("loads stdio credentials from the existing environment variables", () => {
+    process.env.B2_APPLICATION_KEY_ID = "stdio-id";
+    process.env.B2_APPLICATION_KEY = "stdio-secret";
+    const resolved = new StdioEnvCredentialProvider().resolve();
+    expect(resolved.config.applicationKeyId).toBe("stdio-id");
+    expect(resolved.config.applicationKey).toBe("stdio-secret");
+    expect(resolved.config.transport).toBe("stdio");
+    expect(resolved.config.credentialFingerprint).toMatch(/^[a-f0-9]{16}$/);
+    expect(resolved.cacheKey).not.toContain("stdio-id");
+  });
+
+  it("fails closed when required stdio credentials are missing", () => {
+    expect(() => new StdioEnvCredentialProvider().resolve()).toThrow(CredentialResolutionError);
+  });
+
+  it("ignores partial optional stdio master credentials and falls back to the app key", () => {
+    process.env.B2_APPLICATION_KEY_ID = "stdio-id";
+    process.env.B2_APPLICATION_KEY = "stdio-secret";
+    process.env.B2_MASTER_KEY_ID = "master-id";
+    const resolved = new StdioEnvCredentialProvider().resolve();
+    expect(resolved.config.masterKeyId).toBe("stdio-id");
+    expect(resolved.config.masterKey).toBe("stdio-secret");
+  });
+
+  it("resolves header compatibility credentials per request", () => {
+    const resolved = new HttpHeaderCredentialProvider().resolve({
+      req: {
+        headers: {
+          "x-b2-key-id": "header-id",
+          "x-b2-key": "header-secret",
+        },
+      } as any,
+    });
+    expect(resolved.config.applicationKeyId).toBe("header-id");
+    expect(resolved.config.transport).toBe("http");
+    expect(resolved.cacheKey).not.toContain("header-id");
+    expect(resolved.cacheKey).not.toContain("header-secret");
+  });
+
+  it("rejects partial optional header credentials", () => {
+    expect(() =>
+      new HttpHeaderCredentialProvider().resolve({
+        req: {
+          headers: {
+            "x-b2-key-id": "header-id",
+            "x-b2-key": "header-secret",
+            "x-b2-app-key-id": "s3-id",
+          },
+        } as any,
+      }),
+    ).toThrow(/both id and secret/i);
+  });
+
+  it("server provider uses process credentials and blocks public B2 headers", () => {
+    process.env.B2_APPLICATION_KEY_ID = "server-id";
+    process.env.B2_APPLICATION_KEY = "server-secret";
+    const provider = new HttpServerCredentialProvider();
+    const resolved = provider.resolve({ req: { headers: {} } as any });
+    expect(resolved.config.applicationKeyId).toBe("server-id");
+    expect(() =>
+      provider.resolve({
+        req: { headers: { "x-b2-key-id": "spoof", "x-b2-key": "spoof-secret" } } as any,
+      }),
+    ).toThrow(/not accepted/i);
+  });
+
+  it("principal provider maps verified authInfo to an env-backed credential reference", () => {
+    process.env.B2_PRINCIPAL_CREDENTIAL_MAP = JSON.stringify({ alice: "tenant_a" });
+    process.env.B2_CREDENTIAL_TENANT_A_APPLICATION_KEY_ID = "tenant-id";
+    process.env.B2_CREDENTIAL_TENANT_A_APPLICATION_KEY = "tenant-secret";
+    const resolved = new HttpPrincipalCredentialProvider().resolve({
+      req: {
+        headers: {},
+        auth: { token: "verified", clientId: "client-a", scopes: [], extra: { sub: "alice" } },
+      } as any,
+    });
+    expect(resolved.config.applicationKeyId).toBe("tenant-id");
+    expect(resolved.principal).toBe("alice");
+    expect(resolved.cacheKey).toMatch(/^principal:[a-f0-9]{16}$/);
+    expect(resolved.cacheKey).not.toContain("alice");
+    expect(resolved.cacheKey).not.toContain("tenant-id");
+  });
+
+  it("principal provider rejects unauthenticated requests and B2 header spoofing", () => {
+    const provider = new HttpPrincipalCredentialProvider();
+    expect(() => provider.resolve({ req: { headers: {} } as any })).toThrow(/authInfo/i);
+    expect(() =>
+      provider.resolve({
+        req: {
+          headers: { "x-b2-key-id": "spoof", "x-b2-key": "spoof-secret" },
+          auth: { token: "verified", clientId: "client-a", scopes: [] },
+        } as any,
+      }),
+    ).toThrow(/not accepted/i);
+  });
+});
+
+describe("credential mode parsing", () => {
+  it("defaults HTTP credential mode to server", () => {
+    expect(getHttpCredentialMode()).toBe("server");
+    expect(getHttpCredentialProvider()).toBeInstanceOf(HttpServerCredentialProvider);
+  });
+
+  it("selects explicit header and principal providers", () => {
+    process.env.B2_HTTP_CREDENTIAL_MODE = "headers";
+    expect(getHttpCredentialProvider()).toBeInstanceOf(HttpHeaderCredentialProvider);
+    process.env.B2_HTTP_CREDENTIAL_MODE = "principal";
+    expect(getHttpCredentialProvider()).toBeInstanceOf(HttpPrincipalCredentialProvider);
+  });
+
+  it("rejects invalid modes", () => {
+    process.env.B2_HTTP_CREDENTIAL_MODE = "session";
+    expect(() => getHttpCredentialMode()).toThrow(/invalid/i);
+  });
+});
+
+describe("credential fingerprints and header detection", () => {
+  it("uses a non-secret fingerprint for cache/log identity", () => {
+    const fingerprint = fingerprintConfig({
+      applicationKeyId: "key-id",
+      appKeyId: "app-id",
+      masterKeyId: "master-id",
+      region: "us-west-004",
+    });
+    expect(fingerprint).toMatch(/^[a-f0-9]{16}$/);
+    expect(fingerprint).not.toContain("key-id");
+  });
+
+  it("detects legacy and explicit B2 credential headers", () => {
+    expect(hasCredentialHeaders({ "x-b2-key-id": "k" })).toBe(true);
+    expect(hasCredentialHeaders({ "x-b2-mcp-key-id": "k" })).toBe(true);
+    expect(hasCredentialHeaders({ authorization: "Bearer t" })).toBe(false);
+  });
+});

--- a/tests/unit/credentials.test.ts
+++ b/tests/unit/credentials.test.ts
@@ -8,6 +8,7 @@ import {
   HttpPrincipalCredentialProvider,
   HttpServerCredentialProvider,
   StdioEnvCredentialProvider,
+  verificationFingerprintConfig,
 } from "../../src/credentials";
 
 const savedEnv = process.env;
@@ -40,6 +41,7 @@ describe("credential providers", () => {
     expect(resolved.config.transport).toBe("stdio");
     expect(resolved.config.credentialFingerprint).toMatch(/^[a-f0-9]{16}$/);
     expect(resolved.cacheKey).not.toContain("stdio-id");
+    expect(resolved.verificationKey).toMatch(/^credential:[a-f0-9]{16}$/);
   });
 
   it("fails closed when required stdio credentials are missing", () => {
@@ -68,6 +70,7 @@ describe("credential providers", () => {
     expect(resolved.config.transport).toBe("http");
     expect(resolved.cacheKey).not.toContain("header-id");
     expect(resolved.cacheKey).not.toContain("header-secret");
+    expect(resolved.verificationKey).not.toBe(resolved.cacheKey);
   });
 
   it("rejects partial optional header credentials", () => {
@@ -110,8 +113,21 @@ describe("credential providers", () => {
     expect(resolved.config.applicationKeyId).toBe("tenant-id");
     expect(resolved.principal).toBe("alice");
     expect(resolved.cacheKey).toMatch(/^principal:[a-f0-9]{16}$/);
+    expect(resolved.verificationKey).toMatch(/^principal:[a-f0-9]{16}$/);
     expect(resolved.cacheKey).not.toContain("alice");
     expect(resolved.cacheKey).not.toContain("tenant-id");
+  });
+
+  it("uses the secret in verification identity without changing log identity", () => {
+    const provider = new HttpHeaderCredentialProvider();
+    const first = provider.resolve({
+      req: { headers: { "x-b2-key-id": "header-id", "x-b2-key": "secret-a" } } as any,
+    });
+    const second = provider.resolve({
+      req: { headers: { "x-b2-key-id": "header-id", "x-b2-key": "secret-b" } } as any,
+    });
+    expect(first.cacheKey).toBe(second.cacheKey);
+    expect(first.verificationKey).not.toBe(second.verificationKey);
   });
 
   it("principal provider rejects unauthenticated requests and B2 header spoofing", () => {
@@ -129,9 +145,9 @@ describe("credential providers", () => {
 });
 
 describe("credential mode parsing", () => {
-  it("defaults HTTP credential mode to server", () => {
-    expect(getHttpCredentialMode()).toBe("server");
-    expect(getHttpCredentialProvider()).toBeInstanceOf(HttpServerCredentialProvider);
+  it("defaults HTTP credential mode to header compatibility", () => {
+    expect(getHttpCredentialMode()).toBe("headers");
+    expect(getHttpCredentialProvider()).toBeInstanceOf(HttpHeaderCredentialProvider);
   });
 
   it("selects explicit header and principal providers", () => {
@@ -157,6 +173,29 @@ describe("credential fingerprints and header detection", () => {
     });
     expect(fingerprint).toMatch(/^[a-f0-9]{16}$/);
     expect(fingerprint).not.toContain("key-id");
+  });
+
+  it("uses a separate secret-bound verifier", () => {
+    const a = verificationFingerprintConfig({
+      applicationKeyId: "key-id",
+      applicationKey: "secret-a",
+      appKeyId: "app-id",
+      appKey: "secret-a",
+      masterKeyId: "master-id",
+      masterKey: "secret-a",
+      region: "us-west-004",
+    });
+    const b = verificationFingerprintConfig({
+      applicationKeyId: "key-id",
+      applicationKey: "secret-b",
+      appKeyId: "app-id",
+      appKey: "secret-b",
+      masterKeyId: "master-id",
+      masterKey: "secret-b",
+      region: "us-west-004",
+    });
+    expect(a).not.toBe(b);
+    expect(a).not.toContain("secret-a");
   });
 
   it("detects legacy and explicit B2 credential headers", () => {

--- a/tests/unit/http-handler.test.ts
+++ b/tests/unit/http-handler.test.ts
@@ -7,6 +7,7 @@
 
 import * as http from "http";
 import type { AddressInfo } from "net";
+import type { AuthInfo } from "@modelcontextprotocol/sdk/server/auth/types";
 import {
   buildHttpServer,
   configFromHeaders,
@@ -98,15 +99,25 @@ let port: number;
 // full-surface registration so session creation never reaches the network to
 // fetch the key's capabilities (which would be a real authorize call).
 const savedRegisterAll = process.env.B2_REGISTER_ALL_TOOLS;
+const savedCredentialMode = process.env.B2_HTTP_CREDENTIAL_MODE;
 beforeAll(() => {
   process.env.B2_REGISTER_ALL_TOOLS = "true";
+  process.env.B2_HTTP_CREDENTIAL_MODE = "headers";
 });
 afterAll(() => {
   if (savedRegisterAll === undefined) delete process.env.B2_REGISTER_ALL_TOOLS;
   else process.env.B2_REGISTER_ALL_TOOLS = savedRegisterAll;
+  if (savedCredentialMode === undefined) delete process.env.B2_HTTP_CREDENTIAL_MODE;
+  else process.env.B2_HTTP_CREDENTIAL_MODE = savedCredentialMode;
 });
 
 beforeEach(async () => {
+  process.env.B2_HTTP_CREDENTIAL_MODE = "headers";
+  delete process.env.B2_APPLICATION_KEY_ID;
+  delete process.env.B2_APPLICATION_KEY;
+  delete process.env.B2_PRINCIPAL_CREDENTIAL_MAP;
+  delete process.env.B2_CREDENTIAL_TENANT_A_APPLICATION_KEY_ID;
+  delete process.env.B2_CREDENTIAL_TENANT_A_APPLICATION_KEY;
   handle = buildHttpServer();
   await new Promise<void>((r) => handle.server.listen(0, "127.0.0.1", r));
   port = (handle.server.address() as AddressInfo).port;
@@ -132,6 +143,43 @@ const INIT = JSON.stringify({
     clientInfo: { name: "test", version: "1" },
   },
 });
+
+async function replaceHandle(getAuthInfo?: (req: any) => AuthInfo | null): Promise<void> {
+  handle.drain();
+  await new Promise<void>((r) => handle.server.close(() => r()));
+  handle = buildHttpServer({ getAuthInfo });
+  await new Promise<void>((r) => handle.server.listen(0, "127.0.0.1", r));
+  port = (handle.server.address() as AddressInfo).port;
+}
+
+function initializeSession(headers: Record<string, string> = creds): Promise<{
+  status: number;
+  sessionId?: string;
+}> {
+  return new Promise((resolve, reject) => {
+    const req = http.request(
+      {
+        host: "127.0.0.1",
+        port,
+        method: "POST",
+        path: "/mcp",
+        headers: { ...headers, ...JSON_HEADERS },
+      },
+      (res) => {
+        const rawSessionId = res.headers["mcp-session-id"];
+        const sessionId = Array.isArray(rawSessionId) ? rawSessionId[0] : rawSessionId;
+        resolve({ status: res.statusCode ?? 0, sessionId });
+        res.destroy();
+        req.destroy();
+      },
+    );
+    req.on("error", () => undefined);
+    const t = setTimeout(() => reject(new Error("init timeout")), 3000);
+    t.unref();
+    req.write(INIT);
+    req.end();
+  });
+}
 
 describe("HTTP handler (Streamable HTTP)", () => {
   it("returns 401 on POST /mcp initialize without credentials", async () => {
@@ -187,7 +235,8 @@ describe("HTTP handler (Streamable HTTP)", () => {
   });
 
   it("returns 429 when per-key session capacity is reached", async () => {
-    const rk = deriveRateKey("key-abc");
+    const cfg = configFromHeaders({ headers: creds });
+    const rk = deriveRateKey(`credential:${cfg?.credentialFingerprint}`);
     for (let i = 0; i < 20; i++) handle.sessions.set(`k${i}`, fakeSession(rk));
     const res = await request(port, "POST", "/mcp", {
       headers: { ...creds, ...JSON_HEADERS },
@@ -200,30 +249,75 @@ describe("HTTP handler (Streamable HTTP)", () => {
     // Drive a real initialize handshake (createServer → transport → connect). The
     // init response may be an open SSE stream, so resolve on response headers
     // (which already carry Mcp-Session-Id) and tear down.
-    const status = await new Promise<number>((resolve, reject) => {
-      const req = http.request(
-        {
-          host: "127.0.0.1",
-          port,
-          method: "POST",
-          path: "/mcp",
-          headers: { ...creds, ...JSON_HEADERS },
-        },
-        (res) => {
-          resolve(res.statusCode ?? 0);
-          res.destroy();
-          req.destroy();
-        },
-      );
-      req.on("error", () => undefined);
-      const t = setTimeout(() => reject(new Error("init timeout")), 3000);
-      t.unref();
-      req.write(INIT);
-      req.end();
-    });
+    const { status } = await initializeSession();
     expect(status).toBe(200);
     await new Promise((r) => setTimeout(r, 50)); // let onsessioninitialized fire
     expect(handle.sessions.size).toBeGreaterThanOrEqual(1);
+  });
+
+  it("requires the same header credentials on follow-up requests in headers mode", async () => {
+    const { status, sessionId } = await initializeSession();
+    expect(status).toBe(200);
+    expect(sessionId).toBeDefined();
+
+    const missing = await request(port, "POST", "/mcp", {
+      headers: { "mcp-session-id": sessionId!, ...JSON_HEADERS },
+      body: JSON.stringify({ jsonrpc: "2.0", id: 2, method: "tools/list" }),
+    });
+    expect(missing.status).toBe(401);
+
+    const switched = await request(port, "POST", "/mcp", {
+      headers: {
+        "mcp-session-id": sessionId!,
+        "x-b2-key-id": "other-key",
+        "x-b2-key": "other-secret",
+        ...JSON_HEADERS,
+      },
+      body: JSON.stringify({ jsonrpc: "2.0", id: 3, method: "tools/list" }),
+    });
+    expect(switched.status).toBe(403);
+  });
+
+  it("server mode uses process credentials and rejects public B2 credential headers", async () => {
+    process.env.B2_HTTP_CREDENTIAL_MODE = "server";
+    process.env.B2_APPLICATION_KEY_ID = "server-key";
+    process.env.B2_APPLICATION_KEY = "server-secret";
+
+    const spoofed = await request(port, "POST", "/mcp", {
+      headers: { ...creds, ...JSON_HEADERS },
+      body: INIT,
+    });
+    expect(spoofed.status).toBe(400);
+    expect(spoofed.body).not.toContain("server-secret");
+
+    const { status } = await initializeSession({});
+    expect(status).toBe(200);
+  });
+
+  it("principal mode requires verified authInfo and rejects B2 credential headers", async () => {
+    process.env.B2_HTTP_CREDENTIAL_MODE = "principal";
+    process.env.B2_PRINCIPAL_CREDENTIAL_MAP = JSON.stringify({ alice: "tenant_a" });
+    process.env.B2_CREDENTIAL_TENANT_A_APPLICATION_KEY_ID = "tenant-key";
+    process.env.B2_CREDENTIAL_TENANT_A_APPLICATION_KEY = "tenant-secret";
+
+    const missingAuth = await request(port, "POST", "/mcp", { headers: JSON_HEADERS, body: INIT });
+    expect(missingAuth.status).toBe(401);
+
+    await replaceHandle(() => ({
+      token: "verified-token",
+      clientId: "client-a",
+      scopes: [],
+      extra: { sub: "alice" },
+    }));
+
+    const spoofed = await request(port, "POST", "/mcp", {
+      headers: { ...creds, ...JSON_HEADERS },
+      body: INIT,
+    });
+    expect(spoofed.status).toBe(400);
+
+    const { status } = await initializeSession({});
+    expect(status).toBe(200);
   });
 });
 
@@ -275,6 +369,18 @@ describe("configFromHeaders — credential model", () => {
     expect(cfg?.masterKey).toBe("master-secret");
   });
 
+  it("rejects partial master credential headers", () => {
+    expect(() =>
+      configFromHeaders({
+        headers: {
+          "x-b2-key-id": "app-id",
+          "x-b2-key": "app-secret",
+          "x-b2-master-key-id": "master-id",
+        },
+      }),
+    ).toThrow(/both id and secret/i);
+  });
+
   it("still honors the deprecated X-B2-App-Key-* S3 override", () => {
     const cfg = configFromHeaders({
       headers: {
@@ -286,6 +392,14 @@ describe("configFromHeaders — credential model", () => {
     });
     expect(cfg?.appKeyId).toBe("s3-id"); // legacy: S3 signs with the non-master override
     expect(cfg?.applicationKeyId).toBe("master-id");
+  });
+
+  it("accepts the explicit X-B2-MCP-* header names", () => {
+    const cfg = configFromHeaders({
+      headers: { "x-b2-mcp-key-id": "app-id", "x-b2-mcp-key": "app-secret" },
+    });
+    expect(cfg?.applicationKeyId).toBe("app-id");
+    expect(cfg?.appKeyId).toBe("app-id");
   });
 });
 

--- a/tests/unit/http-handler.test.ts
+++ b/tests/unit/http-handler.test.ts
@@ -1,13 +1,12 @@
 /**
- * Request-level tests for the HTTP transport. buildHttpServer() lets us listen
- * on an ephemeral port and exercise the handler branches that were previously
- * untested: auth rejection, malformed requests, body-size cap, and the
- * session/rate caps that protect the internet-facing server.
+ * Request-level tests for the HTTP entry point. Production HTTP serving is the
+ * SDK v2 per-request handler, so these tests use the 2026-07-28 envelope and
+ * assert that no MCP session state or Mcp-Session-Id is required.
  */
 
 import * as http from "http";
 import type { AddressInfo } from "net";
-import type { AuthInfo } from "@modelcontextprotocol/sdk/server/auth/types";
+import type { AuthInfo } from "@modelcontextprotocol/server";
 import {
   buildHttpServer,
   configFromHeaders,
@@ -19,6 +18,7 @@ import { getDestructivePolicy } from "../../src/utils/destructive-gate";
 interface Resp {
   status: number;
   body: string;
+  headers: http.IncomingHttpHeaders;
 }
 
 function request(
@@ -33,16 +33,12 @@ function request(
       (res) => {
         let data = "";
         const status = res.statusCode ?? 0;
-        const done = () => resolve({ status, body: data });
+        const done = () => resolve({ status, body: data, headers: res.headers });
         res.on("data", (c) => (data += c));
-        // Resolve on end OR close — the server may reset the request socket
-        // right after sending an early response (e.g. a 413).
         res.on("end", done);
         res.on("close", done);
       },
     );
-    // The server may destroy the request socket after a 413; ignore that —
-    // the response has already been flushed.
     req.on("error", () => undefined);
     const t = setTimeout(() => reject(new Error("request timed out")), 4000);
     t.unref();
@@ -51,8 +47,6 @@ function request(
   });
 }
 
-// Stream a large body and resolve as soon as the server sends response
-// headers (it responds early with 413 and closes), stopping further writes.
 function postLargeBody(port: number, pathname: string): Promise<number> {
   return new Promise((resolve, reject) => {
     const req = http.request({ host: "127.0.0.1", port, method: "POST", path: pathname }, (res) => {
@@ -60,7 +54,7 @@ function postLargeBody(port: number, pathname: string): Promise<number> {
       resolve(res.statusCode ?? 0);
       req.destroy();
     });
-    req.on("error", () => undefined); // ignore the reset once we have the response
+    req.on("error", () => undefined);
     const t = setTimeout(() => reject(new Error("request timed out")), 4000);
     t.unref();
     const chunk = Buffer.alloc(64 * 1024, 0x78);
@@ -82,28 +76,17 @@ function postLargeBody(port: number, pathname: string): Promise<number> {
   });
 }
 
-// Minimal stand-in for a Session — enough for cap checks and teardown.
-function fakeSession(rateKey: string): any {
-  return {
-    transport: { close() {}, sessionId: "x", async handleRequest() {} },
-    mcpServer: { async close() {} },
-    lastActivity: Date.now(),
-    rateKey,
-  };
-}
-
 let handle: HttpServerHandle;
 let port: number;
 
-// These tests exercise transport mechanics, not capability filtering. Force
-// full-surface registration so session creation never reaches the network to
-// fetch the key's capabilities (which would be a real authorize call).
 const savedRegisterAll = process.env.B2_REGISTER_ALL_TOOLS;
 const savedCredentialMode = process.env.B2_HTTP_CREDENTIAL_MODE;
+
 beforeAll(() => {
   process.env.B2_REGISTER_ALL_TOOLS = "true";
   process.env.B2_HTTP_CREDENTIAL_MODE = "headers";
 });
+
 afterAll(() => {
   if (savedRegisterAll === undefined) delete process.env.B2_REGISTER_ALL_TOOLS;
   else process.env.B2_REGISTER_ALL_TOOLS = savedRegisterAll;
@@ -129,11 +112,34 @@ afterEach(async () => {
 });
 
 const creds = { "x-b2-key-id": "key-abc", "x-b2-key": "secret-xyz" };
+const META = {
+  "io.modelcontextprotocol/protocolVersion": "2026-07-28",
+  "io.modelcontextprotocol/clientCapabilities": {},
+};
 const JSON_HEADERS = {
   "content-type": "application/json",
   accept: "application/json, text/event-stream",
 };
-const INIT = JSON.stringify({
+
+function modernBody(method: string, params: Record<string, unknown> = {}, id = 1): string {
+  return JSON.stringify({
+    jsonrpc: "2.0",
+    id,
+    method,
+    params: { ...params, _meta: META },
+  });
+}
+
+function modernHeaders(method: string, name?: string): Record<string, string> {
+  return {
+    ...JSON_HEADERS,
+    "mcp-method": method,
+    ...(name && { "mcp-name": name }),
+  };
+}
+
+const LIST_TOOLS = modernBody("tools/list");
+const LEGACY_INIT = JSON.stringify({
   jsonrpc: "2.0",
   id: 1,
   method: "initialize",
@@ -152,46 +158,41 @@ async function replaceHandle(getAuthInfo?: (req: any) => AuthInfo | null): Promi
   port = (handle.server.address() as AddressInfo).port;
 }
 
-function initializeSession(headers: Record<string, string> = creds): Promise<{
-  status: number;
-  sessionId?: string;
-}> {
-  return new Promise((resolve, reject) => {
-    const req = http.request(
-      {
-        host: "127.0.0.1",
-        port,
-        method: "POST",
-        path: "/mcp",
-        headers: { ...headers, ...JSON_HEADERS },
-      },
-      (res) => {
-        const rawSessionId = res.headers["mcp-session-id"];
-        const sessionId = Array.isArray(rawSessionId) ? rawSessionId[0] : rawSessionId;
-        resolve({ status: res.statusCode ?? 0, sessionId });
-        res.destroy();
-        req.destroy();
-      },
-    );
-    req.on("error", () => undefined);
-    const t = setTimeout(() => reject(new Error("init timeout")), 3000);
-    t.unref();
-    req.write(INIT);
-    req.end();
-  });
-}
-
-describe("HTTP handler (Streamable HTTP)", () => {
-  it("returns 401 on POST /mcp initialize without credentials", async () => {
-    const res = await request(port, "POST", "/mcp", { headers: JSON_HEADERS, body: INIT });
+describe("HTTP handler (MCP 2026-07-28)", () => {
+  it("returns 401 on modern /mcp without credentials", async () => {
+    const res = await request(port, "POST", "/mcp", {
+      headers: modernHeaders("tools/list"),
+      body: LIST_TOOLS,
+    });
     expect(res.status).toBe(401);
     expect(res.body).toMatch(/credentials/i);
   });
 
-  it("returns 200 on /health", async () => {
+  it("returns 200 on /health when default header mode needs no static B2 env", async () => {
+    delete process.env.B2_HTTP_CREDENTIAL_MODE;
+    await replaceHandle();
     const res = await request(port, "GET", "/health");
     expect(res.status).toBe(200);
     expect(JSON.parse(res.body).status).toBe("ok");
+  });
+
+  it("returns 503 on /health when server mode is missing static credentials", async () => {
+    process.env.B2_HTTP_CREDENTIAL_MODE = "server";
+    await replaceHandle();
+    const res = await request(port, "GET", "/health");
+    expect(res.status).toBe(503);
+    expect(JSON.parse(res.body).status).toBe("error");
+  });
+
+  it("fails startup on an invalid credential mode", async () => {
+    process.env.B2_HTTP_CREDENTIAL_MODE = "session";
+    handle.drain();
+    await new Promise<void>((r) => handle.server.close(() => r()));
+    expect(() => buildHttpServer()).toThrow(/invalid/i);
+    process.env.B2_HTTP_CREDENTIAL_MODE = "headers";
+    handle = buildHttpServer();
+    await new Promise<void>((r) => handle.server.listen(0, "127.0.0.1", r));
+    port = (handle.server.address() as AddressInfo).port;
   });
 
   it("returns 404 on an unknown path", async () => {
@@ -199,125 +200,144 @@ describe("HTTP handler (Streamable HTTP)", () => {
     expect(res.status).toBe(404);
   });
 
-  it("rejects a non-localhost Host on /mcp when no allowlist is configured (DNS-rebinding default)", async () => {
-    // No B2_ALLOWED_HOSTS/ORIGINS set in the test env → secure default: localhost only.
+  it("rejects a non-localhost Host on /mcp when no allowlist is configured", async () => {
     const res = await request(port, "GET", "/mcp", { headers: { host: "evil.example" } });
     expect(res.status).toBe(403);
     expect(res.body).toMatch(/host\/origin/i);
   });
 
-  it("returns 400 on POST /mcp with no session when the request is not an initialize", async () => {
+  it("rejects legacy initialize instead of creating a session", async () => {
     const res = await request(port, "POST", "/mcp", {
       headers: { ...creds, ...JSON_HEADERS },
-      body: JSON.stringify({ jsonrpc: "2.0", id: 2, method: "tools/list" }),
+      body: LEGACY_INIT,
     });
     expect(res.status).toBe(400);
+    expect(res.body).toMatch(/unsupported protocol/i);
+    expect(res.headers["mcp-session-id"]).toBeUndefined();
+    expect(handle.sessions.size).toBe(0);
   });
 
-  it("returns 404 on GET /mcp for an unknown session", async () => {
-    const res = await request(port, "GET", "/mcp", { headers: { "mcp-session-id": "ghost" } });
-    expect(res.status).toBe(404);
+  it("does not route Mcp-Session-Id requests to stateful session storage", async () => {
+    const res = await request(port, "GET", "/mcp", {
+      headers: { ...creds, "mcp-session-id": "ghost" },
+    });
+    expect(res.status).not.toBe(200);
+    expect(handle.sessions.size).toBe(0);
   });
 
   it("returns 413 when the request body exceeds the cap", async () => {
-    // The body cap fires during read, before session routing, on any POST /mcp.
     const status = await postLargeBody(port, "/mcp");
     expect(status).toBe(413);
   });
 
-  it("returns 503 when total session capacity is reached", async () => {
-    for (let i = 0; i < 1000; i++) handle.sessions.set(`s${i}`, fakeSession(`rk${i}`));
+  it("serves a modern tools/list request without a session id", async () => {
     const res = await request(port, "POST", "/mcp", {
-      headers: { ...creds, ...JSON_HEADERS },
-      body: INIT,
+      headers: { ...creds, ...modernHeaders("tools/list") },
+      body: LIST_TOOLS,
     });
-    expect(res.status).toBe(503);
+    expect(res.status).toBe(200);
+    expect(res.headers["mcp-session-id"]).toBeUndefined();
+    expect(handle.sessions.size).toBe(0);
+    expect(JSON.parse(res.body).result.tools.length).toBeGreaterThan(0);
   });
 
-  it("returns 429 when per-key session capacity is reached", async () => {
-    const cfg = configFromHeaders({ headers: creds });
-    const rk = deriveRateKey(`credential:${cfg?.credentialFingerprint}`);
-    for (let i = 0; i < 20; i++) handle.sessions.set(`k${i}`, fakeSession(rk));
+  it("defaults unset B2_HTTP_CREDENTIAL_MODE to header compatibility", async () => {
+    delete process.env.B2_HTTP_CREDENTIAL_MODE;
+    await replaceHandle();
     const res = await request(port, "POST", "/mcp", {
-      headers: { ...creds, ...JSON_HEADERS },
-      body: INIT,
+      headers: { ...creds, ...modernHeaders("tools/list") },
+      body: LIST_TOOLS,
     });
-    expect(res.status).toBe(429);
+    expect(res.status).toBe(200);
   });
 
-  it("creates a session on POST /mcp initialize with valid credentials", async () => {
-    // Drive a real initialize handshake (createServer → transport → connect). The
-    // init response may be an open SSE stream, so resolve on response headers
-    // (which already carry Mcp-Session-Id) and tear down.
-    const { status } = await initializeSession();
-    expect(status).toBe(200);
-    await new Promise((r) => setTimeout(r, 50)); // let onsessioninitialized fire
-    expect(handle.sessions.size).toBeGreaterThanOrEqual(1);
-  });
-
-  it("requires the same header credentials on follow-up requests in headers mode", async () => {
-    const { status, sessionId } = await initializeSession();
-    expect(status).toBe(200);
-    expect(sessionId).toBeDefined();
+  it("requires headers on every request in header compatibility mode", async () => {
+    const ok = await request(port, "POST", "/mcp", {
+      headers: { ...creds, ...modernHeaders("tools/list") },
+      body: LIST_TOOLS,
+    });
+    expect(ok.status).toBe(200);
 
     const missing = await request(port, "POST", "/mcp", {
-      headers: { "mcp-session-id": sessionId!, ...JSON_HEADERS },
-      body: JSON.stringify({ jsonrpc: "2.0", id: 2, method: "tools/list" }),
+      headers: modernHeaders("tools/list"),
+      body: LIST_TOOLS,
     });
     expect(missing.status).toBe(401);
-
-    const switched = await request(port, "POST", "/mcp", {
-      headers: {
-        "mcp-session-id": sessionId!,
-        "x-b2-key-id": "other-key",
-        "x-b2-key": "other-secret",
-        ...JSON_HEADERS,
-      },
-      body: JSON.stringify({ jsonrpc: "2.0", id: 3, method: "tools/list" }),
-    });
-    expect(switched.status).toBe(403);
   });
 
   it("server mode uses process credentials and rejects public B2 credential headers", async () => {
     process.env.B2_HTTP_CREDENTIAL_MODE = "server";
     process.env.B2_APPLICATION_KEY_ID = "server-key";
     process.env.B2_APPLICATION_KEY = "server-secret";
+    await replaceHandle();
 
     const spoofed = await request(port, "POST", "/mcp", {
-      headers: { ...creds, ...JSON_HEADERS },
-      body: INIT,
+      headers: { ...creds, ...modernHeaders("tools/list") },
+      body: LIST_TOOLS,
     });
     expect(spoofed.status).toBe(400);
     expect(spoofed.body).not.toContain("server-secret");
 
-    const { status } = await initializeSession({});
-    expect(status).toBe(200);
+    const ok = await request(port, "POST", "/mcp", {
+      headers: modernHeaders("tools/list"),
+      body: LIST_TOOLS,
+    });
+    expect(ok.status).toBe(200);
   });
 
-  it("principal mode requires verified authInfo and rejects B2 credential headers", async () => {
+  it("principal mode supports broker injection and rejects B2 header spoofing", async () => {
     process.env.B2_HTTP_CREDENTIAL_MODE = "principal";
     process.env.B2_PRINCIPAL_CREDENTIAL_MAP = JSON.stringify({ alice: "tenant_a" });
-    process.env.B2_CREDENTIAL_TENANT_A_APPLICATION_KEY_ID = "tenant-key";
-    process.env.B2_CREDENTIAL_TENANT_A_APPLICATION_KEY = "tenant-secret";
-
-    const missingAuth = await request(port, "POST", "/mcp", { headers: JSON_HEADERS, body: INIT });
-    expect(missingAuth.status).toBe(401);
-
     await replaceHandle(() => ({
       token: "verified-token",
       clientId: "client-a",
       scopes: [],
       extra: { sub: "alice" },
     }));
+    handle.drain();
+    await new Promise<void>((r) => handle.server.close(() => r()));
+    handle = buildHttpServer({
+      getAuthInfo: () => ({
+        token: "verified-token",
+        clientId: "client-a",
+        scopes: [],
+        extra: { sub: "alice" },
+      }),
+      secretBroker: {
+        resolve: (ref) =>
+          ref === "tenant_a"
+            ? { applicationKeyId: "tenant-key", applicationKey: "tenant-secret" }
+            : null,
+      },
+    });
+    await new Promise<void>((r) => handle.server.listen(0, "127.0.0.1", r));
+    port = (handle.server.address() as AddressInfo).port;
 
     const spoofed = await request(port, "POST", "/mcp", {
-      headers: { ...creds, ...JSON_HEADERS },
-      body: INIT,
+      headers: { ...creds, ...modernHeaders("tools/list") },
+      body: LIST_TOOLS,
     });
     expect(spoofed.status).toBe(400);
 
-    const { status } = await initializeSession({});
-    expect(status).toBe(200);
+    const ok = await request(port, "POST", "/mcp", {
+      headers: modernHeaders("tools/list"),
+      body: LIST_TOOLS,
+    });
+    expect(ok.status).toBe(200);
+  });
+
+  it("principal mode requires verified authInfo", async () => {
+    process.env.B2_HTTP_CREDENTIAL_MODE = "principal";
+    process.env.B2_PRINCIPAL_CREDENTIAL_MAP = JSON.stringify({ alice: "tenant_a" });
+    process.env.B2_CREDENTIAL_TENANT_A_APPLICATION_KEY_ID = "tenant-key";
+    process.env.B2_CREDENTIAL_TENANT_A_APPLICATION_KEY = "tenant-secret";
+    await replaceHandle();
+
+    const missingAuth = await request(port, "POST", "/mcp", {
+      headers: modernHeaders("tools/list"),
+      body: LIST_TOOLS,
+    });
+    expect(missingAuth.status).toBe(401);
   });
 });
 
@@ -336,7 +356,7 @@ describe("configFromHeaders — filesystem policy", () => {
 
   it("only enables local files when explicitly opted in AND given a root", () => {
     process.env.B2_ALLOW_LOCAL_FILES = "true";
-    expect(configFromHeaders(baseReq)?.allowLocalFiles).toBe(false); // no root → still off
+    expect(configFromHeaders(baseReq)?.allowLocalFiles).toBe(false);
     process.env.B2_FILE_ROOT = "/srv/uploads";
     const cfg = configFromHeaders(baseReq);
     expect(cfg?.allowLocalFiles).toBe(true);
@@ -350,8 +370,8 @@ describe("configFromHeaders — credential model", () => {
       headers: { "x-b2-key-id": "app-id", "x-b2-key": "app-secret" },
     });
     expect(cfg?.applicationKeyId).toBe("app-id");
-    expect(cfg?.appKeyId).toBe("app-id"); // S3 uses the application key
-    expect(cfg?.masterKeyId).toBe("app-id"); // master falls back to the application key
+    expect(cfg?.appKeyId).toBe("app-id");
+    expect(cfg?.masterKeyId).toBe("app-id");
     expect(cfg?.masterKey).toBe("app-secret");
   });
 
@@ -364,8 +384,8 @@ describe("configFromHeaders — credential model", () => {
         "x-b2-master-key": "master-secret",
       },
     });
-    expect(cfg?.applicationKeyId).toBe("app-id"); // workhorse stays the app key
-    expect(cfg?.masterKeyId).toBe("master-id"); // Partner/bz_* use the master key
+    expect(cfg?.applicationKeyId).toBe("app-id");
+    expect(cfg?.masterKeyId).toBe("master-id");
     expect(cfg?.masterKey).toBe("master-secret");
   });
 
@@ -390,7 +410,7 @@ describe("configFromHeaders — credential model", () => {
         "x-b2-app-key": "s3-secret",
       },
     });
-    expect(cfg?.appKeyId).toBe("s3-id"); // legacy: S3 signs with the non-master override
+    expect(cfg?.appKeyId).toBe("s3-id");
     expect(cfg?.applicationKeyId).toBe("master-id");
   });
 
@@ -407,7 +427,6 @@ describe("deriveRateKey", () => {
   it("is deterministic and distinct per key id", () => {
     expect(deriveRateKey("abc")).toBe(deriveRateKey("abc"));
     expect(deriveRateKey("abc")).not.toBe(deriveRateKey("abd"));
-    // Not a raw prefix of the input.
     expect(deriveRateKey("abcdefgh")).not.toContain("abcdefgh");
   });
 });

--- a/tests/unit/http-handler.test.ts
+++ b/tests/unit/http-handler.test.ts
@@ -6,14 +6,24 @@
 
 import * as http from "http";
 import type { AddressInfo } from "net";
+import axios from "axios";
 import type { AuthInfo } from "@modelcontextprotocol/server";
 import {
   buildHttpServer,
   configFromHeaders,
+  createInFlightLimiter,
   deriveRateKey,
+  headersFromNode,
   HttpServerHandle,
+  toWebRequest,
 } from "../../src/http-server";
+import { invalidateAuthManagerCache } from "../../src/server";
 import { getDestructivePolicy } from "../../src/utils/destructive-gate";
+
+jest.mock("axios");
+const mockedAxios = axios as jest.MockedFunction<typeof axios> & {
+  get: jest.MockedFunction<typeof axios.get>;
+};
 
 interface Resp {
   status: number;
@@ -107,6 +117,10 @@ beforeEach(async () => {
 });
 
 afterEach(async () => {
+  jest.clearAllMocks();
+  mockedAxios.mockReset();
+  mockedAxios.get = jest.fn() as jest.MockedFunction<typeof axios.get>;
+  invalidateAuthManagerCache();
   handle.drain();
   await new Promise<void>((r) => handle.server.close(() => r()));
 });
@@ -149,6 +163,29 @@ const LEGACY_INIT = JSON.stringify({
     clientInfo: { name: "test", version: "1" },
   },
 });
+
+function callToolBody(name: string, args: Record<string, unknown> = {}, id = 1): string {
+  return modernBody("tools/call", { name, arguments: args }, id);
+}
+
+function authData() {
+  return {
+    data: {
+      accountId: "account-1",
+      authorizationToken: "token-1",
+      apiInfo: {
+        storageApi: {
+          apiUrl: "https://api.example",
+          downloadUrl: "https://download.example",
+          s3ApiUrl: "https://s3.example",
+          recommendedPartSize: 100,
+          absoluteMinimumPartSize: 100,
+          allowed: { capabilities: ["listBuckets"] },
+        },
+      },
+    },
+  };
+}
 
 async function replaceHandle(getAuthInfo?: (req: any) => AuthInfo | null): Promise<void> {
   handle.drain();
@@ -206,13 +243,12 @@ describe("HTTP handler (MCP 2026-07-28)", () => {
     expect(res.body).toMatch(/host\/origin/i);
   });
 
-  it("rejects legacy initialize instead of creating a session", async () => {
+  it("serves legacy initialize through the stateless transition fallback", async () => {
     const res = await request(port, "POST", "/mcp", {
       headers: { ...creds, ...JSON_HEADERS },
       body: LEGACY_INIT,
     });
-    expect(res.status).toBe(400);
-    expect(res.body).toMatch(/unsupported protocol/i);
+    expect(res.status).toBe(200);
     expect(res.headers["mcp-session-id"]).toBeUndefined();
     expect(handle.sessions.size).toBe(0);
   });
@@ -263,6 +299,90 @@ describe("HTTP handler (MCP 2026-07-28)", () => {
       body: LIST_TOOLS,
     });
     expect(missing.status).toBe(401);
+  });
+
+  it("does not forward B2 credential or Authorization headers to the SDK request", () => {
+    const req = {
+      method: "POST",
+      url: "/mcp",
+      headers: {
+        ...creds,
+        "x-b2-mcp-key-id": "key",
+        "x-b2-mcp-key": "secret",
+        "x-b2-mcp-app-key-id": "app-key",
+        "x-b2-mcp-app-key": "app-secret",
+        "x-b2-mcp-master-key-id": "master-key",
+        "x-b2-mcp-master-key": "master-secret",
+        authorization: "Bearer caller-token",
+        "content-type": "application/json",
+        accept: "application/json",
+        "mcp-method": "tools/list",
+      },
+    } as unknown as http.IncomingMessage;
+
+    const webReq = toWebRequest(req, LIST_TOOLS);
+    expect(webReq.headers.get("content-type")).toBe("application/json");
+    expect(webReq.headers.get("mcp-method")).toBe("tools/list");
+    for (const name of [
+      "x-b2-key-id",
+      "x-b2-key",
+      "x-b2-mcp-key-id",
+      "x-b2-mcp-key",
+      "x-b2-mcp-app-key-id",
+      "x-b2-mcp-app-key",
+      "x-b2-mcp-master-key-id",
+      "x-b2-mcp-master-key",
+      "authorization",
+    ]) {
+      expect(webReq.headers.has(name)).toBe(false);
+    }
+    expect(headersFromNode(req.headers).has("authorization")).toBe(false);
+  });
+
+  it("reuses a B2 auth manager across stateless requests for the same credential", async () => {
+    mockedAxios.get = jest.fn().mockResolvedValue(authData());
+    mockedAxios.mockResolvedValue({ data: { buckets: [] } } as never);
+
+    for (let i = 0; i < 2; i++) {
+      const res = await request(port, "POST", "/mcp", {
+        headers: { ...creds, ...modernHeaders("tools/call", "b2_list_buckets") },
+        body: callToolBody("b2_list_buckets", {}, i + 1),
+      });
+      expect(res.status).toBe(200);
+    }
+    expect(mockedAxios.get).toHaveBeenCalledTimes(1);
+    expect(mockedAxios).toHaveBeenCalledTimes(2);
+  });
+
+  it("does not reuse the B2 auth cache when a header secret changes", async () => {
+    mockedAxios.get = jest.fn().mockResolvedValue(authData());
+    mockedAxios.mockResolvedValue({ data: { buckets: [] } } as never);
+
+    const first = await request(port, "POST", "/mcp", {
+      headers: { ...creds, ...modernHeaders("tools/call", "b2_list_buckets") },
+      body: callToolBody("b2_list_buckets", {}, 1),
+    });
+    const second = await request(port, "POST", "/mcp", {
+      headers: {
+        "x-b2-key-id": creds["x-b2-key-id"],
+        "x-b2-key": "different-secret",
+        ...modernHeaders("tools/call", "b2_list_buckets"),
+      },
+      body: callToolBody("b2_list_buckets", {}, 2),
+    });
+    expect(first.status).toBe(200);
+    expect(second.status).toBe(200);
+    expect(mockedAxios.get).toHaveBeenCalledTimes(2);
+  });
+
+  it("bounds in-flight requests globally and per credential", () => {
+    const limiter = createInFlightLimiter(2, 1);
+    expect(limiter.acquire("credential:a")).toEqual({ ok: true });
+    expect(limiter.acquire("credential:a")).toMatchObject({ ok: false, status: 429 });
+    expect(limiter.acquire("credential:b")).toEqual({ ok: true });
+    expect(limiter.acquire("credential:c")).toMatchObject({ ok: false, status: 503 });
+    limiter.release("credential:a");
+    expect(limiter.acquire("credential:c")).toEqual({ ok: true });
   });
 
   it("server mode uses process credentials and rejects public B2 credential headers", async () => {

--- a/tests/unit/http-server.test.ts
+++ b/tests/unit/http-server.test.ts
@@ -24,9 +24,9 @@ describe("configFromHeaders", () => {
     expect(configFromHeaders(req)).toBeNull();
   });
 
-  it("returns null when header values are arrays (header sent multiple times)", () => {
+  it("rejects conflicting duplicate credential header values", () => {
     const req = { headers: { "x-b2-key-id": ["a", "b"], "x-b2-key": "secret" } };
-    expect(configFromHeaders(req)).toBeNull();
+    expect(() => configFromHeaders(req)).toThrow(/conflicting/i);
   });
 
   it("falls back to primary key when app key headers are absent", () => {

--- a/tests/unit/index.test.ts
+++ b/tests/unit/index.test.ts
@@ -1,20 +1,21 @@
 /**
- * Tests for the stdio entry point. Mocks the SDK transport so no real stdin/
- * stdout wiring happens, and exercises startStdio() end-to-end (loadConfig →
- * createServer → connect).
+ * Tests for the stdio entry point. Mocks SDK v2 serveStdio so no real stdin/
+ * stdout wiring happens, and exercises startStdio() end-to-end.
  */
 
-import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
+import axios from "axios";
+import { serveStdio } from "@modelcontextprotocol/server/stdio";
 
-jest.mock("@modelcontextprotocol/sdk/server/stdio.js", () => ({
-  StdioServerTransport: jest.fn().mockImplementation(() => ({
-    start: jest.fn().mockResolvedValue(undefined),
-    close: jest.fn().mockResolvedValue(undefined),
-    send: jest.fn().mockResolvedValue(undefined),
-  })),
+jest.mock("axios");
+jest.mock("@modelcontextprotocol/server/stdio", () => ({
+  serveStdio: jest.fn(),
 }));
 
 import { startStdio } from "../../src/index";
+
+const mockedAxios = axios as jest.MockedFunction<typeof axios> & {
+  get: jest.MockedFunction<typeof axios.get>;
+};
 
 describe("startStdio", () => {
   const saved = { ...process.env };
@@ -30,7 +31,17 @@ describe("startStdio", () => {
     process.env.B2_REGISTER_ALL_TOOLS = "true";
 
     await expect(startStdio()).resolves.toBeUndefined();
-    expect(StdioServerTransport).toHaveBeenCalledTimes(1);
+    expect(serveStdio).toHaveBeenCalledTimes(1);
+  });
+
+  it("starts stdio with full surface when capability discovery is transiently unavailable", async () => {
+    process.env.B2_APPLICATION_KEY_ID = "test-key-id";
+    process.env.B2_APPLICATION_KEY = "test-key-secret";
+    delete process.env.B2_REGISTER_ALL_TOOLS;
+    mockedAxios.get.mockRejectedValue(Object.assign(new Error("timeout"), { code: "ETIMEDOUT" }));
+
+    await expect(startStdio()).resolves.toBeUndefined();
+    expect(serveStdio).toHaveBeenCalledTimes(1);
   });
 
   it("exits the process when required credentials are missing", async () => {

--- a/tests/unit/index.test.ts
+++ b/tests/unit/index.test.ts
@@ -44,6 +44,18 @@ describe("startStdio", () => {
     expect(serveStdio).toHaveBeenCalledTimes(1);
   });
 
+  it("fails closed when stdio capability discovery rejects the credential", async () => {
+    process.env.B2_APPLICATION_KEY_ID = "test-key-id";
+    process.env.B2_APPLICATION_KEY = "test-key-secret";
+    delete process.env.B2_REGISTER_ALL_TOOLS;
+    mockedAxios.get.mockRejectedValue(
+      Object.assign(new Error("denied"), { response: { status: 401 } }),
+    );
+
+    await expect(startStdio()).rejects.toMatchObject({ code: "capability_auth_failed" });
+    expect(serveStdio).not.toHaveBeenCalled();
+  });
+
   it("exits the process when required credentials are missing", async () => {
     delete process.env.B2_APPLICATION_KEY_ID;
     delete process.env.B2_APPLICATION_KEY;

--- a/tests/unit/index.test.ts
+++ b/tests/unit/index.test.ts
@@ -27,6 +27,7 @@ describe("startStdio", () => {
   it("loads config, builds the server, and connects the stdio transport", async () => {
     process.env.B2_APPLICATION_KEY_ID = "test-key-id";
     process.env.B2_APPLICATION_KEY = "test-key-secret";
+    process.env.B2_REGISTER_ALL_TOOLS = "true";
 
     await expect(startStdio()).resolves.toBeUndefined();
     expect(StdioServerTransport).toHaveBeenCalledTimes(1);

--- a/tests/unit/insights-bounds.test.ts
+++ b/tests/unit/insights-bounds.test.ts
@@ -24,7 +24,7 @@ import {
   ListPartsCommand,
 } from "@aws-sdk/client-s3";
 import { createServer } from "../../src/server";
-import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import type { McpServer } from "../../src/mcp";
 
 jest.mock("axios");
 

--- a/tests/unit/s3-coverage.test.ts
+++ b/tests/unit/s3-coverage.test.ts
@@ -5,7 +5,7 @@
 
 import { S3Client } from "@aws-sdk/client-s3";
 import { createServer } from "../../src/server";
-import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import type { McpServer } from "../../src/mcp";
 import { B2Config } from "../../src/utils/types";
 
 const testConfig: B2Config = {

--- a/tests/unit/s3-tools.test.ts
+++ b/tests/unit/s3-tools.test.ts
@@ -10,7 +10,7 @@
 
 import { S3Client } from "@aws-sdk/client-s3";
 import { createServer } from "../../src/server";
-import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import type { McpServer } from "../../src/mcp";
 
 // ── Helpers ───────────────────────────────────────────────────────────────────
 

--- a/tests/unit/smoke-script-policy.test.ts
+++ b/tests/unit/smoke-script-policy.test.ts
@@ -4,9 +4,11 @@ import { join } from "path";
 const smokeScript = readFileSync(join(__dirname, "../../scripts/smoke-test.mjs"), "utf8");
 
 describe("smoke script release contract", () => {
-  it("uses Streamable HTTP rather than the legacy SSE transport", () => {
-    expect(smokeScript).toContain("StreamableHTTPClientTransport");
-    expect(smokeScript).toContain("@modelcontextprotocol/sdk/client/streamableHttp.js");
+  it("uses MCP 2026-07-28 HTTP rather than an SDK v1 or SSE transport", () => {
+    expect(smokeScript).toContain('"io.modelcontextprotocol/protocolVersion": "2026-07-28"');
+    expect(smokeScript).toContain('"Mcp-Method": method');
+    expect(smokeScript).toContain('method: "POST"');
+    expect(smokeScript).not.toContain("@modelcontextprotocol/sdk");
     expect(smokeScript).not.toContain("SSEClientTransport");
     expect(smokeScript).not.toContain("@modelcontextprotocol/sdk/client/sse.js");
     expect(smokeScript).not.toContain("https://mcp.example.com/sse");

--- a/tests/unit/tools-schema.test.ts
+++ b/tests/unit/tools-schema.test.ts
@@ -15,7 +15,7 @@
  */
 
 import { createServer } from "../../src/server";
-import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import type { McpServer } from "../../src/mcp";
 
 // ── Zod-mini schema helpers ───────────────────────────────────────────────────
 


### PR DESCRIPTION
## Summary
- introduce explicit B2 credential providers for stdio env, HTTP header compatibility, server-managed env credentials, and verified-principal secret-broker resolution
- migrate production HTTP serving to the MCP SDK v2 per-request `createMcpHandler` path for MCP 2026-07-28, switch stdio startup to `serveStdio`, and keep stateless 2025-era fallback enabled for rollout compatibility
- keep unset `B2_HTTP_CREDENTIAL_MODE` on header compatibility for rolling deploy safety; make `server` and `principal` explicit opt-in modes that reject public B2 credential headers
- strip B2 credential and Authorization headers before requests cross into the MCP SDK boundary; pass verified identity only via `authInfo`
- require stable subject-style principal claims, reject email/clientId-only identity fallback, detect credential-ref normalization collisions, and log credential-resolution failures with non-secret structured fields
- add secret-bound session/capability identity, B2 auth-manager reuse across stateless requests, bounded cache eviction with observability, single-flight capability discovery, and no positive-TTL caching for empty capability results
- add HTTP in-flight request caps, readiness validation through the credential-provider contract, backpressure-aware response forwarding, client disconnect aborts, server-mode smoke testing, and Node 22 runtime documentation
- pin the official `@modelcontextprotocol/server` v2 package from `github.com/modelcontextprotocol/typescript-sdk` and `zod` to exact versions in `package.json` and `package-lock.json`

## Linked issue
Closes #57

## Tests run
- `npm run build`
- `npm run typecheck`
- `npm run lint`
- `npm run format:check`
- `npm test -- --runInBand`

## Follow-up notes
- SDK v2 requires Node >=20; this PR sets the repository runtime floor to Node 22 to match the Phase 1 deployment docs and decision record.
- Principal mode still expects customer middleware or a deployment wrapper to validate OAuth and attach verified MCP `authInfo`; this does not add a Backblaze-hosted authorization server.
