### PR TITLE
fix: remediate all open repository security alerts

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [main]
 
+permissions:
+  contents: read
+
 jobs:
   engine-floor:
     runs-on: ubuntu-latest

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -63,6 +63,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - HTTP readiness now rejects unsupported `B2_MCP_OUTPUT_FORMAT` values and TOON
   preflight failures in every credential mode before serving traffic.
 
+### Security
+- Patched all currently reported npm advisories by updating `brace-expansion`,
+  `js-yaml`, and Babel core, and replaced the MCP Node adapter with a minimal
+  platform-only bridge so vulnerable `@hono/node-server` code is absent from
+  both development and published dependency graphs.
+- Added explicit read-only workflow permissions and consolidated the safe AWS
+  SDK, Axios, and TypeScript dependency updates from superseded Dependabot PRs.
+
 ### Removed
 - Removed the `b2_create_key` lockdown toggles
   `B2_ALLOW_KEY_MGMT_GRANTS`, `B2_ALLOW_UNSCOPED_KEYS`, and

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -32,9 +32,15 @@ the stable SDK v2 package split pinned at `2.0.0`:
 
 - `@modelcontextprotocol/server` for `McpServer`, `createMcpHandler`, and
   `serveStdio`;
-- `@modelcontextprotocol/node` for the single Node HTTP adapter wrapping the MCP
-  handler with `toNodeHandler`;
 - `@modelcontextprotocol/client` for protocol/package tests.
+
+`src/node-http-adapter.ts` is the repository-owned bridge between Node HTTP and
+the server SDK's web-standard `fetch` handler. It uses only Node and Web
+platform APIs and preserves request aborts, auth metadata, streamed responses,
+and response backpressure. `@modelcontextprotocol/node` is intentionally absent:
+its `2.0.0` release pulls a vulnerable Node adapter transitively, and a package
+manager override would protect this checkout without protecting consumers of
+the published package.
 
 The monolithic `@modelcontextprotocol/sdk` v1 package is not a dependency and
 must not be imported by production or test code. HTTP serving is stateless and
@@ -43,7 +49,8 @@ rate/concurrency limits, body-size limits, drain, and shutdown checks run
 outside the SDK handler; protocol header/body validation remains inside
 `createMcpHandler`.
 
-The Node request adapter receives only an allowlisted MCP/header set; B2
+The repository-owned Node request adapter receives only an allowlisted
+MCP/header set; B2
 credential headers and caller `Authorization` are consumed by repository-owned
 credential resolution before the adapter boundary. Per-request credential state
 is then carried into the SDK factory by `AsyncLocalStorage` and fails closed when

--- a/docs/SDK_ADOPTION_CONTRACT.md
+++ b/docs/SDK_ADOPTION_CONTRACT.md
@@ -30,9 +30,10 @@ for Phase 1 migration and for the public MCP tool contract freeze.
   SDK release before the MCP release can claim that capability as an SDK-backed
   contract.
 - The MCP protocol baseline remains `2026-07-28`. The modern MCP runtime uses
-  the stable v2 package split through `createMcpHandler`, `toNodeHandler`, and
-  `serveStdio`. The monolithic `@modelcontextprotocol/sdk` v1 package is not an
-  allowed dependency.
+  the stable v2 server entry points through `createMcpHandler` and `serveStdio`.
+  A repository-owned Node HTTP bridge adapts the web-standard handler without
+  `@modelcontextprotocol/node` or its web-framework dependency. The monolithic
+  `@modelcontextprotocol/sdk` v1 package is not an allowed dependency.
 
 ## Package Policy
 

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -84,11 +84,12 @@ Protocol tests cover the SDK v2 serving matrix used in production:
 | HTTP  | GET/DELETE rejection, ignored `Mcp-Session-Id`, no event replay from `Last-Event-ID`.      |
 | stdio | `serveStdio` factory wiring, including degraded capability lookup behavior.                |
 
-The modern HTTP path uses one `createMcpHandler` wrapped once by
-`toNodeHandler` from `@modelcontextprotocol/node`. Tests assert that body-size,
-Host, Origin, credential, rate-limit, in-flight, and shutdown behavior stays
-outside the MCP handler while the SDK owns protocol validation and modern result
-metadata.
+The modern HTTP path uses one `createMcpHandler` wrapped once by the
+repository-owned Node HTTP bridge. Tests assert request abort propagation,
+stream completion, and dependency-graph exclusion of `@modelcontextprotocol/node`
+and `@hono/node-server`, while body-size, Host, Origin, credential, rate-limit,
+in-flight, and shutdown behavior stays outside the MCP handler and the SDK owns
+protocol validation and modern result metadata.
 
 Tool-surface tests inspect the repository-owned registration registry, not SDK
 private fields. The registry is sorted by tool name and mirrors the public

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -37,6 +37,10 @@ registry availability cannot stall `ci-green`.
 The current CI check names are `lint` and `test`. If branch protection is added,
 use those names, not the retired matrix names `test (20)` or `test (22)`.
 
+TypeScript is intentionally constrained to the `6.0.x` line while
+`typescript-eslint` declares a `<6.1.0` peer range. Widen the TypeScript range
+only with a matching lint toolchain upgrade.
+
 ## File Naming Convention
 
 Test files must use these suffixes so scripts do not depend on accidental paths:

--- a/package-lock.json
+++ b/package-lock.json
@@ -38,7 +38,7 @@
         "prettier": "^3.9.6",
         "ts-jest": "^29.4.12",
         "ts-node": "^10.9.0",
-        "typescript": "^6.0.3",
+        "typescript": "~6.0.3",
         "typescript-eslint": "^8.65.0"
       },
       "engines": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,12 +9,11 @@
       "version": "0.1.0",
       "license": "MIT",
       "dependencies": {
-        "@aws-sdk/client-s3": "^3.1096.0",
-        "@aws-sdk/s3-request-presigner": "^3.1096.0",
+        "@aws-sdk/client-s3": "^3.1103.0",
+        "@aws-sdk/s3-request-presigner": "^3.1103.0",
         "@backblaze-labs/b2-sdk": "0.2.0",
-        "@modelcontextprotocol/node": "2.0.0",
         "@modelcontextprotocol/server": "2.0.0",
-        "axios": "^1.18.1",
+        "axios": "^1.19.0",
         "opossum": "^9.0.0",
         "pino": "^10.3.1",
         "zod": "4.4.3"
@@ -39,7 +38,7 @@
         "prettier": "^3.9.6",
         "ts-jest": "^29.4.12",
         "ts-node": "^10.9.0",
-        "typescript": "^5.4.0",
+        "typescript": "^6.0.3",
         "typescript-eslint": "^8.65.0"
       },
       "engines": {
@@ -47,12 +46,12 @@
       }
     },
     "node_modules/@aws-sdk/checksums": {
-      "version": "3.1000.23",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/checksums/-/checksums-3.1000.23.tgz",
-      "integrity": "sha512-Hv4VX5+IdDYmAbOdiwZguz8fLh3WnE4VtyJwVNEHLulA+OYy7Z5L0ETGUlX2T4g8DLO8XxCV8CyWrtVL4uwqkg==",
+      "version": "3.1000.26",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/checksums/-/checksums-3.1000.26.tgz",
+      "integrity": "sha512-CGznePoL+1oWCSzqmkvlYMpWQEZohPR3LntjKXXfVH+oh6Kd8d+yHLkjpiAGwPIHAxFe4OAq3aKfRnv/wqWIyA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.977.3",
+        "@aws-sdk/core": "^3.977.6",
         "@aws-sdk/types": "^3.974.2",
         "@smithy/core": "^3.31.1",
         "@smithy/types": "^4.16.1",
@@ -63,20 +62,20 @@
       }
     },
     "node_modules/@aws-sdk/client-s3": {
-      "version": "3.1096.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-s3/-/client-s3-3.1096.0.tgz",
-      "integrity": "sha512-sEx7KAEtkp1UqOoWQv2baM1rreClZG7o9YE8EfPvYpPBvGad1fQRG3sMHrOPMkIdZ9VjGRl25GiaG1MSeie2Mw==",
+      "version": "3.1103.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-s3/-/client-s3-3.1103.0.tgz",
+      "integrity": "sha512-FO7SB2vLhZRN3lBHVhMhRm3YKSHK8e917qjB8LMEEhU69cQ0Ahd/OMyezu+KqNANqEtyxfSnFVvYt81x6ZKGZA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/checksums": "^3.1000.21",
-        "@aws-sdk/core": "^3.977.1",
-        "@aws-sdk/credential-provider-node": "^3.972.73",
-        "@aws-sdk/middleware-sdk-s3": "^3.972.67",
-        "@aws-sdk/signature-v4-multi-region": "^3.996.42",
+        "@aws-sdk/checksums": "^3.1000.26",
+        "@aws-sdk/core": "^3.977.6",
+        "@aws-sdk/credential-provider-node": "^3.972.78",
+        "@aws-sdk/middleware-sdk-s3": "^3.972.72",
+        "@aws-sdk/signature-v4-multi-region": "^3.996.43",
         "@aws-sdk/types": "^3.974.2",
-        "@smithy/core": "^3.29.8",
-        "@smithy/fetch-http-handler": "^5.6.10",
-        "@smithy/node-http-handler": "^4.9.10",
+        "@smithy/core": "^3.31.1",
+        "@smithy/fetch-http-handler": "^5.6.13",
+        "@smithy/node-http-handler": "^4.9.13",
         "@smithy/types": "^4.16.1",
         "tslib": "^2.6.2"
       },
@@ -85,9 +84,9 @@
       }
     },
     "node_modules/@aws-sdk/core": {
-      "version": "3.977.3",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.977.3.tgz",
-      "integrity": "sha512-6YZTpF5Zzl0KdSrztM0l6ErKdnXrnnodIDYfayHE9SFfZU8Ubxls7H2XnfWT121jgwiG+WP1z5kyfVDsH5V4qA==",
+      "version": "3.977.6",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.977.6.tgz",
+      "integrity": "sha512-QiaJV4/zDrB4ZY2mfeSXSzSTc36W16sZXcGz+SPFk0CJ26gziO0cS+4LjJUMAbdeeBOvS0k0Aq1cZpfGdUXxSw==",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-sdk/types": "^3.974.2",
@@ -104,12 +103,12 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-env": {
-      "version": "3.972.64",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.972.64.tgz",
-      "integrity": "sha512-14kkR5aj1c7D+cYCrEcG2W3xw87wMYAEUeB/tMiQ2j0RVKzzdewd4mJw1+Q0JVLr4IFU1JHGDCyj0WqLrtIixg==",
+      "version": "3.972.67",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.972.67.tgz",
+      "integrity": "sha512-rcIpk5kxUqDaaNa6Xk23pQ6ViY7jlqzmfFWCahQcBT97ddXaXYYwzCen9Tz1Jvo6aJft6wDl5bN44/Jw5B4oLA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.977.3",
+        "@aws-sdk/core": "^3.977.6",
         "@aws-sdk/types": "^3.974.2",
         "@smithy/core": "^3.31.1",
         "@smithy/types": "^4.16.1",
@@ -120,12 +119,12 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-http": {
-      "version": "3.972.66",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-http/-/credential-provider-http-3.972.66.tgz",
-      "integrity": "sha512-BrZxoXScBZ+nTOYy388zHkz1n5cS8C+uGFMozD4w9OKEWMq39Cu/9l/k385Hb54dtv0VIeh12f8h67o3xDNH9g==",
+      "version": "3.972.69",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-http/-/credential-provider-http-3.972.69.tgz",
+      "integrity": "sha512-nggwJtZ4eeNsUw5IeWBMXsi1ryct5idi0K+/SCRF3kybLubOMaNTb3XCihXpWMiVpyzyPeIrl0zTkzhBH9porA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.977.3",
+        "@aws-sdk/core": "^3.977.6",
         "@aws-sdk/types": "^3.974.2",
         "@smithy/core": "^3.31.1",
         "@smithy/fetch-http-handler": "^5.6.13",
@@ -138,19 +137,19 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-ini": {
-      "version": "3.973.9",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.973.9.tgz",
-      "integrity": "sha512-d/mMvS+sQjSWNA6+JCldK1YB/jQmtoWM8Izj10mrOZdRCeWNVb8IYQuuyHHKKKXcpGo5Pd0LIK6onHbLvlhuVQ==",
+      "version": "3.973.12",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.973.12.tgz",
+      "integrity": "sha512-pNEf/OeyN5X3VmLKlgSO6TqaWmW10CvI3TfwL1XhsuhYjSLT2VDaxFnCPHnOeQXSaFisMX4jNhpETriqN8DOmg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.977.3",
-        "@aws-sdk/credential-provider-env": "^3.972.64",
-        "@aws-sdk/credential-provider-http": "^3.972.66",
-        "@aws-sdk/credential-provider-login": "^3.972.71",
-        "@aws-sdk/credential-provider-process": "^3.972.64",
-        "@aws-sdk/credential-provider-sso": "^3.973.8",
-        "@aws-sdk/credential-provider-web-identity": "^3.972.70",
-        "@aws-sdk/nested-clients": "^3.997.38",
+        "@aws-sdk/core": "^3.977.6",
+        "@aws-sdk/credential-provider-env": "^3.972.67",
+        "@aws-sdk/credential-provider-http": "^3.972.69",
+        "@aws-sdk/credential-provider-login": "^3.972.74",
+        "@aws-sdk/credential-provider-process": "^3.972.67",
+        "@aws-sdk/credential-provider-sso": "^3.973.11",
+        "@aws-sdk/credential-provider-web-identity": "^3.972.73",
+        "@aws-sdk/nested-clients": "^3.997.41",
         "@aws-sdk/types": "^3.974.2",
         "@smithy/core": "^3.31.1",
         "@smithy/credential-provider-imds": "^4.4.16",
@@ -162,13 +161,13 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-login": {
-      "version": "3.972.71",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-login/-/credential-provider-login-3.972.71.tgz",
-      "integrity": "sha512-l93922lXnTs5RjM3QrMCXSmXiEgLFLaQ0Lco9F3tJ08o0mzGdAj6m2nAXDuTMHoUuL0u7RKmrhm+Z8/7GCilyg==",
+      "version": "3.972.74",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-login/-/credential-provider-login-3.972.74.tgz",
+      "integrity": "sha512-0AQfDcf99TNmqVKv0owHrw/TQs6i4ZE5t9qmz6NvO53bE/sA/tpXhXL9AAcEP1qHc6Zzjd1UMb69+/9zdhvY3g==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.977.3",
-        "@aws-sdk/nested-clients": "^3.997.38",
+        "@aws-sdk/core": "^3.977.6",
+        "@aws-sdk/nested-clients": "^3.997.41",
         "@aws-sdk/types": "^3.974.2",
         "@smithy/core": "^3.31.1",
         "@smithy/types": "^4.16.1",
@@ -179,17 +178,17 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-node": {
-      "version": "3.972.75",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.972.75.tgz",
-      "integrity": "sha512-sdFhR4E3HWZefGL6OsBhxqXdqtFvxGOh8VLfiu9yttPgVNcpEozEDPmrTYmXA3CIf6npUETVLveQPGQ7GBzVhg==",
+      "version": "3.972.78",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.972.78.tgz",
+      "integrity": "sha512-OgPAnfvbGAMWac6yvxJ1ihslrvDpPVwR68D2csospdNCCyPvHk9JLzYKwz48SNiS1T2znDwHauywRKRFfpyYng==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/credential-provider-env": "^3.972.64",
-        "@aws-sdk/credential-provider-http": "^3.972.66",
-        "@aws-sdk/credential-provider-ini": "^3.973.9",
-        "@aws-sdk/credential-provider-process": "^3.972.64",
-        "@aws-sdk/credential-provider-sso": "^3.973.8",
-        "@aws-sdk/credential-provider-web-identity": "^3.972.70",
+        "@aws-sdk/credential-provider-env": "^3.972.67",
+        "@aws-sdk/credential-provider-http": "^3.972.69",
+        "@aws-sdk/credential-provider-ini": "^3.973.12",
+        "@aws-sdk/credential-provider-process": "^3.972.67",
+        "@aws-sdk/credential-provider-sso": "^3.973.11",
+        "@aws-sdk/credential-provider-web-identity": "^3.972.73",
         "@aws-sdk/types": "^3.974.2",
         "@smithy/core": "^3.31.1",
         "@smithy/credential-provider-imds": "^4.4.16",
@@ -201,12 +200,12 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-process": {
-      "version": "3.972.64",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.972.64.tgz",
-      "integrity": "sha512-Q5noG5vfFo++bUaLGcjj8OHX5tmwa1O/5nDVMeaSSZgjzgvWbW6tgu/gSa+aENwcJXjoXDQh+8TRZR2zHds/aw==",
+      "version": "3.972.67",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.972.67.tgz",
+      "integrity": "sha512-IlUEejorGTWKb4/Dm7K5Yw4QxUmXLThLhrvBmzVBqZFTbW72cv9LTcITmo1dsnYriALE4h68mOq4LB99x6sQ7Q==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.977.3",
+        "@aws-sdk/core": "^3.977.6",
         "@aws-sdk/types": "^3.974.2",
         "@smithy/core": "^3.31.1",
         "@smithy/types": "^4.16.1",
@@ -217,14 +216,14 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-sso": {
-      "version": "3.973.8",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.973.8.tgz",
-      "integrity": "sha512-37okeZyRdVkGrU6nyKBPGqQvyl/7CEiMpUVOb0+BCNCIR0VAuBxNgjMb0mnsR1EXm8dqQFfQZOJ5YW/0sBfa1w==",
+      "version": "3.973.11",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.973.11.tgz",
+      "integrity": "sha512-gAQBkBZxUB84d71+pPcI9L+jh2ujhuAVxc/4FgGiWFDjkPBlMKxzd5XDtkSXTFX8Ro7ansnT88+XadasxMeCRw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.977.3",
-        "@aws-sdk/nested-clients": "^3.997.38",
-        "@aws-sdk/token-providers": "3.1098.0",
+        "@aws-sdk/core": "^3.977.6",
+        "@aws-sdk/nested-clients": "^3.997.41",
+        "@aws-sdk/token-providers": "3.1103.0",
         "@aws-sdk/types": "^3.974.2",
         "@smithy/core": "^3.31.1",
         "@smithy/types": "^4.16.1",
@@ -235,13 +234,13 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-web-identity": {
-      "version": "3.972.70",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.972.70.tgz",
-      "integrity": "sha512-Ps/f9USafScb6CSQTRPNMzdKL5x5XRwDIRgFvnuFWfClGZe7/fI7iCFqXdxKjc9LBxP28E7iUgNloGgfgw406w==",
+      "version": "3.972.73",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.972.73.tgz",
+      "integrity": "sha512-SnlEmQa6SjOgs6iOPLUQl1Eyq4AKiAdPQlkOhFhqNfDtDCwibMGvL6QlkSmf3o6vAUSImzdPCxowT5dfQUZP1A==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.977.3",
-        "@aws-sdk/nested-clients": "^3.997.38",
+        "@aws-sdk/core": "^3.977.6",
+        "@aws-sdk/nested-clients": "^3.997.41",
         "@aws-sdk/types": "^3.974.2",
         "@smithy/core": "^3.31.1",
         "@smithy/types": "^4.16.1",
@@ -252,12 +251,12 @@
       }
     },
     "node_modules/@aws-sdk/middleware-sdk-s3": {
-      "version": "3.972.69",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-s3/-/middleware-sdk-s3-3.972.69.tgz",
-      "integrity": "sha512-ziSQA8AkB+u4K/5t/SStFbeoiNTG04reUeddCLNCAgmdRJGQ3+MJcpZOXXLdD6uyfCqSK1/R6004gRdXvHbYQA==",
+      "version": "3.972.72",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-s3/-/middleware-sdk-s3-3.972.72.tgz",
+      "integrity": "sha512-lSAoVPvQxX1d8TOM6waKDBQrvvZcm4w6pCldFAsRUffEaXq6lYY0pPyew3KlLu6Xqb74DXI42hGvSsbGBLljlw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.977.3",
+        "@aws-sdk/core": "^3.977.6",
         "@aws-sdk/signature-v4-multi-region": "^3.996.43",
         "@aws-sdk/types": "^3.974.2",
         "@smithy/core": "^3.31.1",
@@ -269,12 +268,12 @@
       }
     },
     "node_modules/@aws-sdk/nested-clients": {
-      "version": "3.997.38",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/nested-clients/-/nested-clients-3.997.38.tgz",
-      "integrity": "sha512-jQDs+nxnmgo4+WPOmY373HIC8jx4KyYYMYDI74FWrzX3Ba9fYsV0dSA+7PNYNkhRbbRCRLre83tQ31F1ACCHkA==",
+      "version": "3.997.41",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/nested-clients/-/nested-clients-3.997.41.tgz",
+      "integrity": "sha512-RDHqPGQWlF6tatA/Tp3rg6oIwtgN9IVderxE+9av2Y93Dfyu+mO1hZ5Bu2jpfZg2rwdNbsssnwM+sLafIczMlQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.977.3",
+        "@aws-sdk/core": "^3.977.6",
         "@aws-sdk/signature-v4-multi-region": "^3.996.43",
         "@aws-sdk/types": "^3.974.2",
         "@smithy/core": "^3.31.1",
@@ -288,15 +287,15 @@
       }
     },
     "node_modules/@aws-sdk/s3-request-presigner": {
-      "version": "3.1096.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/s3-request-presigner/-/s3-request-presigner-3.1096.0.tgz",
-      "integrity": "sha512-vyWoSQwoWLAr/rB06vstzOXLWFCrRvyTz5HQC0jwZ51oEe+GKCIvF671AHicUfiwiVjNZ257VponbCWmrzj0Kw==",
+      "version": "3.1103.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/s3-request-presigner/-/s3-request-presigner-3.1103.0.tgz",
+      "integrity": "sha512-937UiasYudfKWsCU/+kAHJ4UMJa90l0UcMDLwPvZ2UBjhJ4Iz5mVxiZNowthsPmJ8wH+tHqTl/O1kOD6dMuIIg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.977.1",
-        "@aws-sdk/signature-v4-multi-region": "^3.996.42",
+        "@aws-sdk/core": "^3.977.6",
+        "@aws-sdk/signature-v4-multi-region": "^3.996.43",
         "@aws-sdk/types": "^3.974.2",
-        "@smithy/core": "^3.29.8",
+        "@smithy/core": "^3.31.1",
         "@smithy/types": "^4.16.1",
         "tslib": "^2.6.2"
       },
@@ -320,13 +319,13 @@
       }
     },
     "node_modules/@aws-sdk/token-providers": {
-      "version": "3.1098.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.1098.0.tgz",
-      "integrity": "sha512-6cFAviffeqYGjrXn4FqGbWcTxB3nbpBpQXUm6MvnrWZThJaVBTHHnespHgSUh4yVLfzhipSh9H/XjzkHQd9P4g==",
+      "version": "3.1103.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.1103.0.tgz",
+      "integrity": "sha512-N4wy26MNn31ItGVHYHPrEuCIFY4MBBjC+C5v1lJKqIUSA7OZBdhleCY53zCCrXn27hsk7YNOaTuhQu807S4AfQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.977.3",
-        "@aws-sdk/nested-clients": "^3.997.38",
+        "@aws-sdk/core": "^3.977.6",
+        "@aws-sdk/nested-clients": "^3.997.41",
         "@aws-sdk/types": "^3.974.2",
         "@smithy/core": "^3.31.1",
         "@smithy/types": "^4.16.1",
@@ -387,9 +386,9 @@
       }
     },
     "node_modules/@babel/compat-data": {
-      "version": "7.29.3",
-      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.29.3.tgz",
-      "integrity": "sha512-LIVqM46zQWZhj17qA8wb4nW/ixr2y1Nw+r1etiAWgRM6U1IqP+LNhL1yg440jYZR72jCWcWbLWzIosH+uP1fqg==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.29.7.tgz",
+      "integrity": "sha512-locTkQyKvwIEgBzVrn8693ebc97F2U8ZHjbXwDXJ5Fn2TCpNwTlKcaKLkdHop5c/icOFE7qt7Q9JC5hnKNa6Gg==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -397,21 +396,21 @@
       }
     },
     "node_modules/@babel/core": {
-      "version": "7.29.0",
-      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.29.0.tgz",
-      "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.29.7.tgz",
+      "integrity": "sha512-RgHBCvtjbOK2gXSNBNIkNoEc9qoVEtau3hj8gEqKQuL3HZAibKarWFEI3Lfm6EYKkLalOh8eSrj9b+ch9H/VBA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/code-frame": "^7.29.0",
-        "@babel/generator": "^7.29.0",
-        "@babel/helper-compilation-targets": "^7.28.6",
-        "@babel/helper-module-transforms": "^7.28.6",
-        "@babel/helpers": "^7.28.6",
-        "@babel/parser": "^7.29.0",
-        "@babel/template": "^7.28.6",
-        "@babel/traverse": "^7.29.0",
-        "@babel/types": "^7.29.0",
+        "@babel/code-frame": "^7.29.7",
+        "@babel/generator": "^7.29.7",
+        "@babel/helper-compilation-targets": "^7.29.7",
+        "@babel/helper-module-transforms": "^7.29.7",
+        "@babel/helpers": "^7.29.7",
+        "@babel/parser": "^7.29.7",
+        "@babel/template": "^7.29.7",
+        "@babel/traverse": "^7.29.7",
+        "@babel/types": "^7.29.7",
         "@jridgewell/remapping": "^2.3.5",
         "convert-source-map": "^2.0.0",
         "debug": "^4.1.0",
@@ -445,14 +444,14 @@
       }
     },
     "node_modules/@babel/helper-compilation-targets": {
-      "version": "7.28.6",
-      "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.28.6.tgz",
-      "integrity": "sha512-JYtls3hqi15fcx5GaSNL7SCTJ2MNmjrkHXg4FSpOA/grxK8KwyZ5bubHsCq8FXCkua6xhuaaBit+3b7+VZRfcA==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.29.7.tgz",
+      "integrity": "sha512-wem6WaBj4NaVYVdNhLPPVacES6ZJ+KBBfSkTMD3YZxbP3rm3Di85tJU5ljaUNhaOynt+Aj0xruhYuzQBt8n71g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/compat-data": "^7.28.6",
-        "@babel/helper-validator-option": "^7.27.1",
+        "@babel/compat-data": "^7.29.7",
+        "@babel/helper-validator-option": "^7.29.7",
         "browserslist": "^4.24.0",
         "lru-cache": "^5.1.1",
         "semver": "^6.3.1"
@@ -534,9 +533,9 @@
       }
     },
     "node_modules/@babel/helper-validator-option": {
-      "version": "7.27.1",
-      "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.27.1.tgz",
-      "integrity": "sha512-YvjJow9FxbhFFKDSuFnVCe2WxXk1zWc22fFePVNEaWJEu8IrZVlda6N0uHwzZrUM1il7NC9Mlp4MaJYbYd9JSg==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.29.7.tgz",
+      "integrity": "sha512-N9ZErrD+yW5geCDtBqnOoxmR8+tNKiGuxKlDpuJxfsqpa2dFcexaziGAE/qoHLiDDreVNMupxGmSoNlyvsA3gw==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -544,14 +543,14 @@
       }
     },
     "node_modules/@babel/helpers": {
-      "version": "7.29.2",
-      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.29.2.tgz",
-      "integrity": "sha512-HoGuUs4sCZNezVEKdVcwqmZN8GoHirLUcLaYVNBK2J0DadGtdcqgr3BCbvH8+XUo4NGjNl3VOtSjEKNzqfFgKw==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.29.7.tgz",
+      "integrity": "sha512-1k2lAGRMfHTcwuNYcCNUmaUffmQv8KWMfh2iJUUeRlwlwH4FdNG7mfPI10NPfLHJFThE4Tyr4mv7kTNZOiPuBg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/template": "^7.28.6",
-        "@babel/types": "^7.29.0"
+        "@babel/template": "^7.29.7",
+        "@babel/types": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -993,16 +992,16 @@
       }
     },
     "node_modules/@eslint/config-array/node_modules/brace-expansion": {
-      "version": "5.0.6",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
-      "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
+      "version": "5.0.9",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.9.tgz",
+      "integrity": "sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^4.0.2"
       },
       "engines": {
-        "node": "18 || 20 || >=22"
+        "node": "20 || >=22"
       }
     },
     "node_modules/@eslint/config-array/node_modules/minimatch": {
@@ -1090,18 +1089,6 @@
       },
       "engines": {
         "node": "^20.19.0 || ^22.13.0 || >=24"
-      }
-    },
-    "node_modules/@hono/node-server": {
-      "version": "1.19.17",
-      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-1.19.17.tgz",
-      "integrity": "sha512-dSneS5qhiauZWGDCeK4o695Xd9nUNjviSZCMQrj10eetr8Uln1ucn6bbphOM6UynAMMtNIzZNSpL9vnASJwrPQ==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=18.14.1"
-      },
-      "peerDependencies": {
-        "hono": "^4"
       }
     },
     "node_modules/@humanfs/core": {
@@ -1568,27 +1555,6 @@
       },
       "engines": {
         "node": ">=20"
-      }
-    },
-    "node_modules/@modelcontextprotocol/node": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/node/-/node-2.0.0.tgz",
-      "integrity": "sha512-Y4hAC2XdGDUdDOCbLDOCA4+aL3NUldjsOWlDL/YwpAxrPhRm1xHd7lZ+mLacvZ9t3PaH28wgNoaLQGrIk1P2pg==",
-      "license": "MIT",
-      "dependencies": {
-        "@hono/node-server": "^1.19.9"
-      },
-      "engines": {
-        "node": ">=20"
-      },
-      "peerDependencies": {
-        "@modelcontextprotocol/server": "^2.0.0",
-        "hono": "^4.11.4"
-      },
-      "peerDependenciesMeta": {
-        "hono": {
-          "optional": true
-        }
       }
     },
     "node_modules/@modelcontextprotocol/server": {
@@ -2330,13 +2296,13 @@
       }
     },
     "node_modules/axios": {
-      "version": "1.18.1",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.18.1.tgz",
-      "integrity": "sha512-3nTvFlvpn9Zu/RkHUqtc7/+al4UpRW5az71ap5zccp6e8RAYEzhMTecX8Dz1wWDYrPpUoB1HAQEGEAEvUr7S9g==",
+      "version": "1.19.0",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.19.0.tgz",
+      "integrity": "sha512-ht/iuYZXEjFxLH/Hkezgd7m6JKlHHXEUSneaDz8uZe1Gj5QZtCnpyDsckvAiEnT89OEbCLmnte4R4sn7P0EKFw==",
       "license": "MIT",
       "dependencies": {
         "follow-redirects": "^1.16.0",
-        "form-data": "^4.0.5",
+        "form-data": "^4.0.6",
         "https-proxy-agent": "^5.0.1",
         "proxy-from-env": "^2.1.0"
       }
@@ -2465,9 +2431,9 @@
       "license": "MIT"
     },
     "node_modules/baseline-browser-mapping": {
-      "version": "2.10.27",
-      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.27.tgz",
-      "integrity": "sha512-zEs/ufmZoUd7WftKpKyXaT6RFxpQ5Qm9xytKRHvJfxFV9DFJkZph9RvJ1LcOUi0Z1ZVijMte65JbILeV+8QQEA==",
+      "version": "2.11.12",
+      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.11.12.tgz",
+      "integrity": "sha512-r7WnVImvVCeFpf2DOXfy41aPWzeNg3H/A2X4dKmy1QL0MSyyk/e7z8ihJ3N6Nn2PsdhkVlqnEfnUE4a05P2aTA==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {
@@ -2484,9 +2450,9 @@
       "license": "MIT"
     },
     "node_modules/brace-expansion": {
-      "version": "1.1.14",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.14.tgz",
-      "integrity": "sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==",
+      "version": "1.1.18",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.18.tgz",
+      "integrity": "sha512-Edep/X9fGqVNmzKBVsDYIOtD+z1tuezV70LBjdCst9Tqu76lsnvRiZ6oTic1n+/BIwX6QDGAO94PN4N2SADvtw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2508,9 +2474,9 @@
       }
     },
     "node_modules/browserslist": {
-      "version": "4.28.2",
-      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.2.tgz",
-      "integrity": "sha512-48xSriZYYg+8qXna9kwqjIVzuQxi+KYWp2+5nCYnYKPTr0LvD89Jqk2Or5ogxz0NUMfIjhh2lIUX/LyX9B4oIg==",
+      "version": "4.28.7",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.7.tgz",
+      "integrity": "sha512-JxV13hNrFxqjOc8alRbq9dK1MM79NEXYpma2B2J4wAtpWS5zIEIKqWPGCl7N4o7Uc7B7itylh7SuDujATRyyTw==",
       "dev": true,
       "funding": [
         {
@@ -2528,10 +2494,10 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "baseline-browser-mapping": "^2.10.12",
-        "caniuse-lite": "^1.0.30001782",
-        "electron-to-chromium": "^1.5.328",
-        "node-releases": "^2.0.36",
+        "baseline-browser-mapping": "^2.10.44",
+        "caniuse-lite": "^1.0.30001806",
+        "electron-to-chromium": "^1.5.393",
+        "node-releases": "^2.0.51",
         "update-browserslist-db": "^1.2.3"
       },
       "bin": {
@@ -2605,9 +2571,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001791",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001791.tgz",
-      "integrity": "sha512-yk0l/YSrOnFZk3UROpDLQD9+kC1l4meK/wed583AXrzoarMGJcbRi2Q4RaUYbKxYAsZ8sWmaSa/DsLmdBeI1vQ==",
+      "version": "1.0.30001806",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001806.tgz",
+      "integrity": "sha512-72Cuvd95zbSYPKq6Fhg8eDJRlzgWDf7/mtoZv6Qe/DYNCEBdNxoA3+rZAU2ZhGCpZlns3EssFavaZomckT5Uuw==",
       "dev": true,
       "funding": [
         {
@@ -2901,9 +2867,9 @@
       }
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.5.349",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.349.tgz",
-      "integrity": "sha512-QsWVGyRuY07Aqb234QytTfwd5d9AJlfNIQ5wIOl1L+PZDzI9d9+Fn0FRale/QYlFxt/bUnB0/nLd1jFPGxGK1A==",
+      "version": "1.5.401",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.401.tgz",
+      "integrity": "sha512-H6ViHN68nGYlChEvlIU67fn8O2/tpbWQPwck98yaJmh+08LSvHiydzDQ6oXNccLU3kNRVIRS9A4mA7CG+i6fLQ==",
       "dev": true,
       "license": "ISC"
     },
@@ -3137,16 +3103,16 @@
       }
     },
     "node_modules/eslint/node_modules/brace-expansion": {
-      "version": "5.0.6",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
-      "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
+      "version": "5.0.9",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.9.tgz",
+      "integrity": "sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^4.0.2"
       },
       "engines": {
-        "node": "18 || 20 || >=22"
+        "node": "20 || >=22"
       }
     },
     "node_modules/eslint/node_modules/escape-string-regexp": {
@@ -3768,16 +3734,6 @@
       },
       "engines": {
         "node": ">= 0.4"
-      }
-    },
-    "node_modules/hono": {
-      "version": "4.13.0",
-      "resolved": "https://registry.npmjs.org/hono/-/hono-4.13.0.tgz",
-      "integrity": "sha512-jhunvfHWxd7J5EFfSgH4xsYJzSe/lfqbUCxiyyeaQasUsXeEHXtzVid+7EOGByc5JnFa23SSFL3Y2RV/z1T+eQ==",
-      "license": "MIT",
-      "peer": true,
-      "engines": {
-        "node": ">=16.9.0"
       }
     },
     "node_modules/html-escaper": {
@@ -4679,9 +4635,9 @@
       "license": "MIT"
     },
     "node_modules/js-yaml": {
-      "version": "3.14.2",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.2.tgz",
-      "integrity": "sha512-PMSmkqxr106Xa156c2M265Z+FTrPl+oxd/rgOQy2tijQeK5TxQ43psO1ZCwhVOSdnn+RzkzlRz/eY4BgJBYVpg==",
+      "version": "3.15.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.15.1.tgz",
+      "integrity": "sha512-S99WuO3HlhO3XN41EtYUNl9zzXjoJx7QvmipxsJVxtCBT0YHEFy+iOJhjSvrmV12nYhWpZaM8lPHkJm0yUMbag==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -4970,11 +4926,14 @@
       "license": "MIT"
     },
     "node_modules/node-releases": {
-      "version": "2.0.38",
-      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.38.tgz",
-      "integrity": "sha512-3qT/88Y3FbH/Kx4szpQQ4HzUbVrHPKTLVpVocKiLfoYvw9XSGOX2FmD2d6DrXbVYyAQTF2HeF6My8jmzx7/CRw==",
+      "version": "2.0.52",
+      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.52.tgz",
+      "integrity": "sha512-MRlTqhAfoMx/4mhEbPo3Hi02g9LJZaJkka69V6h67Cb1gjrAG0jsTE4CZX1eptNx+VCAwJmfpnDIF4P0Nh1A7A==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
     },
     "node_modules/normalize-path": {
       "version": "3.0.0",
@@ -5975,9 +5934,9 @@
       }
     },
     "node_modules/typescript": {
-      "version": "5.9.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
-      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.3.tgz",
+      "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {

--- a/package.json
+++ b/package.json
@@ -80,7 +80,7 @@
     "prettier": "^3.9.6",
     "ts-jest": "^29.4.12",
     "ts-node": "^10.9.0",
-    "typescript": "^6.0.3",
+    "typescript": "~6.0.3",
     "typescript-eslint": "^8.65.0"
   },
   "engines": {
@@ -123,7 +123,6 @@
     }
   },
   "overrides": {
-    "hono": "^4.12.27",
     "form-data": "^4.0.6"
   }
 }

--- a/package.json
+++ b/package.json
@@ -55,12 +55,11 @@
   "author": "Backblaze",
   "license": "MIT",
   "dependencies": {
-    "@aws-sdk/client-s3": "^3.1096.0",
-    "@aws-sdk/s3-request-presigner": "^3.1096.0",
+    "@aws-sdk/client-s3": "^3.1103.0",
+    "@aws-sdk/s3-request-presigner": "^3.1103.0",
     "@backblaze-labs/b2-sdk": "0.2.0",
-    "@modelcontextprotocol/node": "2.0.0",
     "@modelcontextprotocol/server": "2.0.0",
-    "axios": "^1.18.1",
+    "axios": "^1.19.0",
     "opossum": "^9.0.0",
     "pino": "^10.3.1",
     "zod": "4.4.3"
@@ -81,7 +80,7 @@
     "prettier": "^3.9.6",
     "ts-jest": "^29.4.12",
     "ts-node": "^10.9.0",
-    "typescript": "^5.4.0",
+    "typescript": "^6.0.3",
     "typescript-eslint": "^8.65.0"
   },
   "engines": {
@@ -98,7 +97,12 @@
     "preset": "ts-jest",
     "testEnvironment": "node",
     "transform": {
-      "^.+\\.tsx?$": "ts-jest",
+      "^.+\\.tsx?$": [
+        "ts-jest",
+        {
+          "tsconfig": "tsconfig.typecheck.json"
+        }
+      ],
       "^.+\\.mjs$": [
         "babel-jest",
         {

--- a/src/http-server.ts
+++ b/src/http-server.ts
@@ -20,7 +20,7 @@ import {
   type McpHandlerRequestOptions,
   type McpRequestContext,
 } from "@modelcontextprotocol/server";
-import { toNodeHandler } from "@modelcontextprotocol/node";
+import { createNodeHttpHandler } from "./node-http-adapter.js";
 import {
   createServer as createMcpServerDefinition,
   fetchCapabilities as fetchCredentialCapabilities,
@@ -542,7 +542,7 @@ export function buildHttpServer(options: HttpServerOptions = {}): HttpServerHand
     await Promise.all(servers.map((server) => server.close().catch(() => undefined)));
   }
 
-  const nodeMcpHandler = toNodeHandler(
+  const nodeMcpHandler = createNodeHttpHandler(
     {
       fetch: async (request: Request, requestOptions?: McpHandlerRequestOptions) => {
         return mcpHandler.fetch(request, requestOptions);

--- a/src/node-http-adapter.ts
+++ b/src/node-http-adapter.ts
@@ -1,4 +1,4 @@
-import type { IncomingHttpHeaders, ServerResponse } from "http";
+import type { IncomingHttpHeaders, OutgoingHttpHeaders, ServerResponse } from "http";
 import type {
   AuthInfo,
   McpHandlerRequestOptions,
@@ -116,15 +116,31 @@ function waitForDrain(res: ServerResponse, signal: AbortSignal): Promise<void> {
   });
 }
 
+function headersFromWeb(headers: Headers): OutgoingHttpHeaders {
+  const nodeHeaders: OutgoingHttpHeaders = {};
+  for (const [name, value] of headers) {
+    const current = nodeHeaders[name];
+    if (current === undefined) {
+      nodeHeaders[name] = value;
+    } else if (Array.isArray(current)) {
+      current.push(value);
+    } else {
+      nodeHeaders[name] = [String(current), value];
+    }
+  }
+
+  const setCookies = (headers as Headers & { getSetCookie?: () => string[] }).getSetCookie?.();
+  if (setCookies && setCookies.length > 0) nodeHeaders["set-cookie"] = setCookies;
+  return nodeHeaders;
+}
+
 async function writeWebResponse(
   response: Response,
   res: ServerResponse,
   signal: AbortSignal,
   options: NodeHttpAdapterOptions,
 ): Promise<void> {
-  const headers: Record<string, string> = {};
-  for (const [name, value] of response.headers) headers[name] = value;
-  res.writeHead(response.status, headers);
+  res.writeHead(response.status, headersFromWeb(response.headers));
 
   if (response.body !== null) {
     try {

--- a/src/node-http-adapter.ts
+++ b/src/node-http-adapter.ts
@@ -18,6 +18,14 @@ export interface NodeHttpAdapterOptions {
   onerror?: (error: Error) => void;
 }
 
+function reportAdapterError(options: NodeHttpAdapterOptions, error: unknown): void {
+  try {
+    options.onerror?.(error instanceof Error ? error : new Error(String(error)));
+  } catch {
+    // Error observers must not prevent a protocol-safe response.
+  }
+}
+
 function firstHeaderValue(value: string | string[] | undefined): string | undefined {
   return Array.isArray(value) ? value[0] : value;
 }
@@ -112,6 +120,7 @@ async function writeWebResponse(
   response: Response,
   res: ServerResponse,
   signal: AbortSignal,
+  options: NodeHttpAdapterOptions,
 ): Promise<void> {
   const headers: Record<string, string> = {};
   for (const [name, value] of response.headers) headers[name] = value;
@@ -123,8 +132,11 @@ async function writeWebResponse(
         if (signal.aborted) break;
         if (!res.write(chunk)) await waitForDrain(res, signal);
       }
-    } catch {
-      // A response stream can reject after the client has disconnected.
+    } catch (error) {
+      if (signal.aborted || res.destroyed) return;
+      reportAdapterError(options, error);
+      if (!res.destroyed) res.destroy(error instanceof Error ? error : new Error(String(error)));
+      return;
     }
   }
 
@@ -158,15 +170,11 @@ export function createNodeHttpHandler(
       };
       response = await handler.fetch(request, requestOptions);
     } catch (error) {
-      try {
-        options.onerror?.(error instanceof Error ? error : new Error(String(error)));
-      } catch {
-        // Error observers must not prevent a protocol-safe response.
-      }
+      reportAdapterError(options, error);
       response = internalServerError(parsedBody);
     }
 
-    await writeWebResponse(response, res, abortController.signal);
+    await writeWebResponse(response, res, abortController.signal, options);
     finished = true;
   };
 }

--- a/src/node-http-adapter.ts
+++ b/src/node-http-adapter.ts
@@ -1,0 +1,172 @@
+import type { IncomingHttpHeaders, ServerResponse } from "http";
+import type {
+  AuthInfo,
+  McpHandlerRequestOptions,
+  McpHttpHandler,
+} from "@modelcontextprotocol/server";
+
+type RequestBodyChunk = string | Uint8Array;
+
+export interface NodeHttpRequest extends AsyncIterable<RequestBodyChunk> {
+  method?: string;
+  url?: string;
+  headers: IncomingHttpHeaders;
+  auth?: AuthInfo;
+}
+
+export interface NodeHttpAdapterOptions {
+  onerror?: (error: Error) => void;
+}
+
+function firstHeaderValue(value: string | string[] | undefined): string | undefined {
+  return Array.isArray(value) ? value[0] : value;
+}
+
+async function readRequestBody(req: NodeHttpRequest): Promise<string | undefined> {
+  const decoder = new TextDecoder();
+  let body = "";
+  for await (const chunk of req) {
+    body += typeof chunk === "string" ? chunk : decoder.decode(chunk, { stream: true });
+  }
+  body += decoder.decode();
+  return body || undefined;
+}
+
+async function toWebRequest(
+  req: NodeHttpRequest,
+  parsedBody: unknown,
+  signal: AbortSignal,
+): Promise<Request> {
+  const method = (req.method ?? "GET").toUpperCase();
+  const host =
+    firstHeaderValue(req.headers.host) ??
+    firstHeaderValue(req.headers[":authority"]) ??
+    "localhost";
+  const headers = new Headers();
+
+  for (const [name, value] of Object.entries(req.headers)) {
+    if (value === undefined || name.startsWith(":")) continue;
+    if (Array.isArray(value)) {
+      for (const item of value) headers.append(name, item);
+    } else {
+      headers.set(name, value);
+    }
+  }
+
+  let body: string | undefined;
+  if (method !== "GET" && method !== "HEAD") {
+    if (parsedBody === undefined) {
+      body = await readRequestBody(req);
+    } else {
+      body = JSON.stringify(parsedBody);
+      headers.delete("content-encoding");
+      headers.delete("transfer-encoding");
+      if (body === undefined) {
+        headers.delete("content-length");
+      } else {
+        headers.set("content-length", String(new TextEncoder().encode(body).byteLength));
+      }
+    }
+  }
+
+  return new Request(`http://${host}${req.url ?? "/"}`, {
+    method,
+    headers,
+    signal,
+    ...(body !== undefined && { body }),
+  });
+}
+
+function requestIdFromBody(body: unknown): string | number | null {
+  if (body === null || typeof body !== "object" || Array.isArray(body)) return null;
+  const { method, id } = body as { method?: unknown; id?: unknown };
+  if (typeof method !== "string") return null;
+  return typeof id === "string" || typeof id === "number" ? id : null;
+}
+
+function internalServerError(body: unknown): Response {
+  return Response.json(
+    {
+      jsonrpc: "2.0",
+      error: { code: -32603, message: "Internal server error" },
+      id: requestIdFromBody(body),
+    },
+    { status: 500 },
+  );
+}
+
+function waitForDrain(res: ServerResponse, signal: AbortSignal): Promise<void> {
+  if (signal.aborted) return Promise.resolve();
+  return new Promise((resolve) => {
+    const finish = () => {
+      res.off("drain", finish);
+      signal.removeEventListener("abort", finish);
+      resolve();
+    };
+    res.once("drain", finish);
+    signal.addEventListener("abort", finish, { once: true });
+  });
+}
+
+async function writeWebResponse(
+  response: Response,
+  res: ServerResponse,
+  signal: AbortSignal,
+): Promise<void> {
+  const headers: Record<string, string> = {};
+  for (const [name, value] of response.headers) headers[name] = value;
+  res.writeHead(response.status, headers);
+
+  if (response.body !== null) {
+    try {
+      for await (const chunk of response.body) {
+        if (signal.aborted) break;
+        if (!res.write(chunk)) await waitForDrain(res, signal);
+      }
+    } catch {
+      // A response stream can reject after the client has disconnected.
+    }
+  }
+
+  if (!res.destroyed) res.end();
+}
+
+/**
+ * Adapts the MCP SDK's web-standard fetch handler to Node's HTTP server API.
+ * Keeping this narrow bridge local avoids shipping an additional web framework.
+ */
+export function createNodeHttpHandler(
+  handler: Pick<McpHttpHandler, "fetch">,
+  options: NodeHttpAdapterOptions = {},
+): (req: NodeHttpRequest, res: ServerResponse, parsedBody?: unknown) => Promise<void> {
+  return async (req, res, parsedBody) => {
+    if (typeof parsedBody === "function") parsedBody = undefined;
+
+    let finished = false;
+    const abortController = new AbortController();
+    res.on("close", () => {
+      if (!finished) abortController.abort();
+    });
+    if (res.destroyed) abortController.abort();
+
+    let response: Response;
+    try {
+      const request = await toWebRequest(req, parsedBody, abortController.signal);
+      const requestOptions: McpHandlerRequestOptions = {
+        ...(req.auth !== undefined && { authInfo: req.auth }),
+        ...(parsedBody !== undefined && { parsedBody }),
+      };
+      response = await handler.fetch(request, requestOptions);
+    } catch (error) {
+      try {
+        options.onerror?.(error instanceof Error ? error : new Error(String(error)));
+      } catch {
+        // Error observers must not prevent a protocol-safe response.
+      }
+      response = internalServerError(parsedBody);
+    }
+
+    await writeWebResponse(response, res, abortController.signal);
+    finished = true;
+  };
+}

--- a/tests/contract/ci-workflow-policy.contract.test.ts
+++ b/tests/contract/ci-workflow-policy.contract.test.ts
@@ -13,6 +13,10 @@ function workflowJob(text: string, job: string): string {
 describe("CI workflow policy", () => {
   const ci = readFileSync(join(root, ".github/workflows/test.yml"), "utf8");
 
+  it("defaults workflow permissions to read-only contents", () => {
+    expect(ci).toMatch(/^permissions:\s*\n\s+contents:\s*read\s*$/m);
+  });
+
   it("keeps package verification off the ci-green dependency path", () => {
     const markGreen = workflowJob(ci, "mark-green");
     const testJob = workflowJob(ci, "test");

--- a/tests/contract/mcp-sdk.contract.test.ts
+++ b/tests/contract/mcp-sdk.contract.test.ts
@@ -2,22 +2,22 @@ import { join } from "path";
 import { listFiles, readJson, root } from "./support";
 
 describe("MCP SDK and protocol contract", () => {
-  it("uses the reviewed SDK v2 package split and not the monolithic v1 package", () => {
+  it("uses the reviewed SDK v2 packages without vulnerable Node adapter dependencies", () => {
     const pkg = readJson<{
       dependencies: Record<string, string>;
       devDependencies: Record<string, string>;
     }>("package.json");
     const lock = readJson<{ packages: Record<string, { version?: string }> }>("package-lock.json");
     const serverVersion = pkg.dependencies["@modelcontextprotocol/server"];
-    const nodeVersion = pkg.dependencies["@modelcontextprotocol/node"];
     const clientVersion = pkg.devDependencies["@modelcontextprotocol/client"];
 
     expect(serverVersion).toMatch(/^\d+\.\d+\.\d+$/);
-    expect(nodeVersion).toBe(serverVersion);
     expect(clientVersion).toBe(serverVersion);
     expect(lock.packages["node_modules/@modelcontextprotocol/server"]?.version).toBe(serverVersion);
-    expect(lock.packages["node_modules/@modelcontextprotocol/node"]?.version).toBe(nodeVersion);
     expect(lock.packages["node_modules/@modelcontextprotocol/client"]?.version).toBe(clientVersion);
+    expect(pkg.dependencies).not.toHaveProperty("@modelcontextprotocol/node");
+    expect(lock.packages["node_modules/@modelcontextprotocol/node"]).toBeUndefined();
+    expect(lock.packages["node_modules/@hono/node-server"]).toBeUndefined();
     expect(pkg.dependencies).not.toHaveProperty("@modelcontextprotocol/sdk");
     expect(pkg.devDependencies).not.toHaveProperty("@modelcontextprotocol/sdk");
     expect(lock.packages["node_modules/@modelcontextprotocol/sdk"]).toBeUndefined();
@@ -26,11 +26,11 @@ describe("MCP SDK and protocol contract", () => {
   it("exposes the SDK v2 entry points required by the serving adapters", async () => {
     const serverSdk = await import("@modelcontextprotocol/server");
     const stdioSdk = await import("@modelcontextprotocol/server/stdio");
-    const nodeSdk = await import("@modelcontextprotocol/node");
+    const nodeAdapter = await import("../../src/node-http-adapter");
 
     expect(typeof serverSdk.createMcpHandler).toBe("function");
     expect(typeof stdioSdk.serveStdio).toBe("function");
-    expect(typeof nodeSdk.toNodeHandler).toBe("function");
+    expect(typeof nodeAdapter.createNodeHttpHandler).toBe("function");
   });
 
   it("keeps modern and legacy protocol behavior in separately named tests", () => {

--- a/tests/contract/security-remediation.contract.test.ts
+++ b/tests/contract/security-remediation.contract.test.ts
@@ -1,0 +1,63 @@
+import { readFileSync } from "fs";
+import { join } from "path";
+import { root } from "./support";
+
+type PackageLock = {
+  packages: Record<string, { version?: string }>;
+};
+
+function versionAtLeast(actual: string, floor: string): boolean {
+  const left = actual.split(".").map(Number);
+  const right = floor.split(".").map(Number);
+  for (let index = 0; index < Math.max(left.length, right.length); index += 1) {
+    const difference = (left[index] ?? 0) - (right[index] ?? 0);
+    if (difference !== 0) return difference > 0;
+  }
+  return true;
+}
+
+describe("security dependency policy", () => {
+  const pkg = JSON.parse(readFileSync(join(root, "package.json"), "utf8")) as {
+    dependencies: Record<string, string>;
+    devDependencies: Record<string, string>;
+  };
+  const lock = JSON.parse(readFileSync(join(root, "package-lock.json"), "utf8")) as PackageLock;
+
+  const resolvedVersion = (path: string): string => {
+    const version = lock.packages[path]?.version;
+    if (!version) throw new Error(`Missing lockfile version for ${path}`);
+    return version;
+  };
+
+  it("excludes the vulnerable MCP Node adapter from the published graph", () => {
+    expect(pkg.dependencies).not.toHaveProperty("@modelcontextprotocol/node");
+    expect(lock.packages["node_modules/@modelcontextprotocol/node"]).toBeUndefined();
+    expect(lock.packages["node_modules/@hono/node-server"]).toBeUndefined();
+  });
+
+  it("keeps every brace-expansion resolution above its advisory floor", () => {
+    const versions = Object.entries(lock.packages)
+      .filter(([path]) => path.endsWith("node_modules/brace-expansion"))
+      .map(([, entry]) => entry.version)
+      .filter((version): version is string => Boolean(version));
+
+    expect(versions.length).toBeGreaterThan(0);
+    for (const version of versions) {
+      const major = Number(version.split(".")[0]);
+      expect(versionAtLeast(version, major === 1 ? "1.1.18" : "5.0.9")).toBe(true);
+    }
+  });
+
+  it("keeps vulnerable YAML and Babel transitive packages patched", () => {
+    expect(versionAtLeast(resolvedVersion("node_modules/js-yaml"), "3.15.0")).toBe(true);
+    expect(versionAtLeast(resolvedVersion("node_modules/@babel/core"), "7.29.1")).toBe(true);
+  });
+
+  it("includes the consolidated safe direct dependency updates", () => {
+    expect(pkg.dependencies["@aws-sdk/client-s3"]).toBe("^3.1103.0");
+    expect(pkg.dependencies["@aws-sdk/s3-request-presigner"]).toBe("^3.1103.0");
+    expect(pkg.dependencies.axios).toBe("^1.19.0");
+    expect(pkg.devDependencies.typescript).toBe("^6.0.3");
+    expect(pkg.devDependencies["@babel/plugin-transform-modules-commonjs"]).toBe("7.29.7");
+  });
+});

--- a/tests/contract/security-remediation.contract.test.ts
+++ b/tests/contract/security-remediation.contract.test.ts
@@ -3,7 +3,7 @@ import { join } from "path";
 import { root } from "./support";
 
 type PackageLock = {
-  packages: Record<string, { version?: string }>;
+  packages: Record<string, { version?: string; peerDependencies?: Record<string, string> }>;
 };
 
 function versionAtLeast(actual: string, floor: string): boolean {
@@ -16,10 +16,23 @@ function versionAtLeast(actual: string, floor: string): boolean {
   return true;
 }
 
+function versionTuple(version: string): [number, number, number] {
+  const match = /^(\d+)\.(\d+)\.(\d+)/.exec(version);
+  if (!match) throw new Error(`Invalid semver version: ${version}`);
+  return [Number(match[1]), Number(match[2]), Number(match[3])];
+}
+
+function rangeFloor(range: string): string {
+  const match = /(\d+\.\d+\.\d+)/.exec(range);
+  if (!match) throw new Error(`Missing semver floor in range: ${range}`);
+  return match[1];
+}
+
 describe("security dependency policy", () => {
   const pkg = JSON.parse(readFileSync(join(root, "package.json"), "utf8")) as {
     dependencies: Record<string, string>;
     devDependencies: Record<string, string>;
+    overrides?: Record<string, string>;
   };
   const lock = JSON.parse(readFileSync(join(root, "package-lock.json"), "utf8")) as PackageLock;
 
@@ -29,10 +42,26 @@ describe("security dependency policy", () => {
     return version;
   };
 
+  const expectManifestAndLockAtLeast = (
+    manifestRange: string,
+    lockPath: string,
+    floor: string,
+    expectedMajor: number,
+  ): void => {
+    const manifestFloor = rangeFloor(manifestRange);
+    expect(versionAtLeast(manifestFloor, floor)).toBe(true);
+    expect(versionTuple(manifestFloor)[0]).toBe(expectedMajor);
+
+    const lockedVersion = resolvedVersion(lockPath);
+    expect(versionAtLeast(lockedVersion, floor)).toBe(true);
+    expect(versionTuple(lockedVersion)[0]).toBe(expectedMajor);
+  };
+
   it("excludes the vulnerable MCP Node adapter from the published graph", () => {
     expect(pkg.dependencies).not.toHaveProperty("@modelcontextprotocol/node");
     expect(lock.packages["node_modules/@modelcontextprotocol/node"]).toBeUndefined();
     expect(lock.packages["node_modules/@hono/node-server"]).toBeUndefined();
+    expect(pkg.overrides ?? {}).not.toHaveProperty("hono");
   });
 
   it("keeps every brace-expansion resolution above its advisory floor", () => {
@@ -54,10 +83,39 @@ describe("security dependency policy", () => {
   });
 
   it("includes the consolidated safe direct dependency updates", () => {
-    expect(pkg.dependencies["@aws-sdk/client-s3"]).toBe("^3.1103.0");
-    expect(pkg.dependencies["@aws-sdk/s3-request-presigner"]).toBe("^3.1103.0");
-    expect(pkg.dependencies.axios).toBe("^1.19.0");
-    expect(pkg.devDependencies.typescript).toBe("^6.0.3");
-    expect(pkg.devDependencies["@babel/plugin-transform-modules-commonjs"]).toBe("7.29.7");
+    expectManifestAndLockAtLeast(
+      pkg.dependencies["@aws-sdk/client-s3"],
+      "node_modules/@aws-sdk/client-s3",
+      "3.1103.0",
+      3,
+    );
+    expectManifestAndLockAtLeast(
+      pkg.dependencies["@aws-sdk/s3-request-presigner"],
+      "node_modules/@aws-sdk/s3-request-presigner",
+      "3.1103.0",
+      3,
+    );
+    expectManifestAndLockAtLeast(pkg.dependencies.axios, "node_modules/axios", "1.19.0", 1);
+    expectManifestAndLockAtLeast(
+      pkg.devDependencies["@babel/plugin-transform-modules-commonjs"],
+      "node_modules/@babel/plugin-transform-modules-commonjs",
+      "7.29.7",
+      7,
+    );
+  });
+
+  it("keeps TypeScript inside the eslint toolchain peer window", () => {
+    const range = pkg.devDependencies.typescript;
+    const [major, minor] = versionTuple(rangeFloor(range));
+    expect(versionAtLeast(rangeFloor(range), "6.0.3")).toBe(true);
+    expect([major, minor]).toEqual([6, 0]);
+    expect(range).toMatch(/^~?6\.0\.\d+$/);
+
+    const lockedVersion = resolvedVersion("node_modules/typescript");
+    expect(versionAtLeast(lockedVersion, "6.0.3")).toBe(true);
+    expect(versionTuple(lockedVersion).slice(0, 2)).toEqual([6, 0]);
+    expect(
+      lock.packages["node_modules/@typescript-eslint/parser"]?.peerDependencies?.typescript,
+    ).toContain("<6.1.0");
   });
 });

--- a/tests/unit/http-transport.unit.test.ts
+++ b/tests/unit/http-transport.unit.test.ts
@@ -677,6 +677,36 @@ describe("HTTP transport handler", () => {
     expect(capturedAuth).toBe(authInfo);
   });
 
+  it("preserves repeated adapter response headers", async () => {
+    await replaceHandle(undefined, {
+      credentialProvider: credentialProviderFromHeaders(),
+      fetchCapabilities: jest.fn(async () => null),
+      mcpHandler: {
+        fetch: async () =>
+          new Response(JSON.stringify({ jsonrpc: "2.0", id: 1, result: { ok: true } }), {
+            status: 200,
+            headers: [
+              ["Content-Type", "application/json"],
+              ["Set-Cookie", "first=1; Path=/; HttpOnly"],
+              ["Set-Cookie", "second=2; Path=/; HttpOnly"],
+            ],
+          }),
+        close: jest.fn(),
+      },
+    });
+
+    const res = await request(port, "POST", "/mcp", {
+      headers: { ...creds, ...modernHeaders("tools/list") },
+      body: LIST_TOOLS,
+    });
+
+    expect(res.status).toBe(200);
+    expect(res.headers["set-cookie"]).toEqual([
+      "first=1; Path=/; HttpOnly",
+      "second=2; Path=/; HttpOnly",
+    ]);
+  });
+
   it("returns a protocol-safe 500 when the fetch handler throws", async () => {
     await replaceHandle(undefined, {
       credentialProvider: credentialProviderFromHeaders(),

--- a/tests/unit/http-transport.unit.test.ts
+++ b/tests/unit/http-transport.unit.test.ts
@@ -22,6 +22,7 @@ import {
   invalidateCapabilityCache,
 } from "../../src/server";
 import { CredentialProvider, CredentialResolutionError } from "../../src/credentials";
+import { logger } from "../../src/utils/logger";
 import {
   JSON_HEADERS,
   type Resp,
@@ -76,6 +77,46 @@ function postDeclaredLargeBody(port: number, pathname: string): Promise<Resp> {
       "content-length": String(1024 * 1024 + 1),
     },
     body: "{}",
+  });
+}
+
+function requestAndTrackEnd(
+  port: number,
+  method: string,
+  pathname: string,
+  opts: { headers?: Record<string, string>; body?: string } = {},
+): Promise<Resp & { ended: boolean }> {
+  return new Promise((resolve, reject) => {
+    let settled = false;
+    let status = 0;
+    let data = "";
+    let headers: http.IncomingHttpHeaders = {};
+    const finish = (ended: boolean) => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timer);
+      resolve({ status, body: data, headers, ended });
+    };
+    const req = http.request(
+      { host: "127.0.0.1", port, method, path: pathname, headers: opts.headers },
+      (res) => {
+        status = res.statusCode ?? 0;
+        headers = res.headers;
+        res.on("data", (c) => (data += c));
+        res.on("end", () => finish(true));
+        res.on("aborted", () => finish(false));
+        res.on("error", () => finish(false));
+        res.on("close", () => finish(false));
+      },
+    );
+    req.on("error", () => finish(false));
+    const timer = setTimeout(() => {
+      req.destroy();
+      reject(new Error("request timed out"));
+    }, 4000);
+    timer.unref();
+    if (opts.body) req.write(opts.body);
+    req.end();
   });
 }
 
@@ -659,6 +700,38 @@ describe("HTTP transport handler", () => {
       error: { code: -32603, message: "Internal server error" },
       id: null,
     });
+  });
+
+  it("reports response stream failures and fails the connection", async () => {
+    const streamError = new Error("stream failed while client connected");
+    const warnSpy = jest.spyOn(logger, "warn").mockImplementation(() => undefined as never);
+    await replaceHandle(undefined, {
+      credentialProvider: credentialProviderFromHeaders(),
+      fetchCapabilities: jest.fn(async () => null),
+      mcpHandler: {
+        fetch: jest.fn(async () => {
+          const stream = new ReadableStream<Uint8Array>({
+            start(controller) {
+              controller.enqueue(new TextEncoder().encode("data: partial\n\n"));
+              controller.error(streamError);
+            },
+          });
+          return new Response(stream, {
+            status: 200,
+            headers: { "Content-Type": "text/event-stream" },
+          });
+        }),
+        close: jest.fn(),
+      },
+    });
+
+    const res = await requestAndTrackEnd(port, "POST", "/mcp", {
+      headers: { ...creds, ...modernHeaders("tools/list") },
+      body: LIST_TOOLS,
+    });
+
+    expect(res.ended).toBe(false);
+    expect(warnSpy).toHaveBeenCalledWith({ err: streamError.message }, "mcp.http.failed");
   });
 
   it("aborts the adapter Request signal when the client disconnects", async () => {

--- a/tests/unit/http-transport.unit.test.ts
+++ b/tests/unit/http-transport.unit.test.ts
@@ -608,6 +608,59 @@ describe("HTTP transport handler", () => {
     }
   });
 
+  it("forwards verified authInfo outside the sanitized HTTP headers", async () => {
+    const authInfo: AuthInfo = {
+      token: "verified-token",
+      clientId: "test-client",
+      scopes: ["mcp:invoke"],
+    };
+    let capturedAuth: AuthInfo | undefined;
+    await replaceHandle(() => authInfo, {
+      credentialProvider: credentialProviderFromHeaders(),
+      fetchCapabilities: jest.fn(async () => null),
+      mcpHandler: {
+        fetch: async (_req, options) => {
+          capturedAuth = options?.authInfo;
+          return jsonRpcResponse({ ok: true });
+        },
+        close: jest.fn(),
+      },
+    });
+
+    const res = await request(port, "POST", "/mcp", {
+      headers: { ...creds, ...modernHeaders("tools/list") },
+      body: LIST_TOOLS,
+    });
+
+    expect(res.status).toBe(200);
+    expect(capturedAuth).toBe(authInfo);
+  });
+
+  it("returns a protocol-safe 500 when the fetch handler throws", async () => {
+    await replaceHandle(undefined, {
+      credentialProvider: credentialProviderFromHeaders(),
+      fetchCapabilities: jest.fn(async () => null),
+      mcpHandler: {
+        fetch: jest.fn(async () => {
+          throw new Error("adapter test failure");
+        }),
+        close: jest.fn(),
+      },
+    });
+
+    const res = await request(port, "POST", "/mcp", {
+      headers: { ...creds, ...modernHeaders("tools/list") },
+      body: LIST_TOOLS,
+    });
+
+    expect(res.status).toBe(500);
+    expect(JSON.parse(res.body)).toEqual({
+      jsonrpc: "2.0",
+      error: { code: -32603, message: "Internal server error" },
+      id: null,
+    });
+  });
+
   it("aborts the adapter Request signal when the client disconnects", async () => {
     let markFetchStarted!: () => void;
     const fetchStarted = new Promise<void>((resolve) => {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -12,7 +12,8 @@
     "resolveJsonModule": true,
     "declaration": true,
     "declarationMap": true,
-    "sourceMap": true
+    "sourceMap": true,
+    "types": ["node"]
   },
   "include": ["src/**/*"],
   "exclude": ["node_modules", "dist", "tests"]

--- a/tsconfig.typecheck.json
+++ b/tsconfig.typecheck.json
@@ -9,7 +9,8 @@
     "rootDir": ".",
     "declaration": false,
     "declarationMap": false,
-    "sourceMap": false
+    "sourceMap": false,
+    "types": ["node", "jest"]
   },
   "include": ["src/**/*", "tests/**/*"],
   "exclude": ["node_modules", "dist"]


### PR DESCRIPTION
## Summary

- remove `@modelcontextprotocol/node` and its vulnerable `@hono/node-server` dependency from both the development and published package graphs
- add a platform-only Node HTTP bridge that preserves MCP auth metadata, request aborts, response streaming, backpressure, and protocol-safe failures
- update every vulnerable `brace-expansion`, `js-yaml`, and Babel core resolution reported by Dependabot
- consolidate the safe AWS SDK and Axios upgrades from Dependabot PRs #79, #80, and #81
- upgrade to TypeScript 6.0.3 with explicit production/test type environments and `ts-jest` configuration
- set GitHub Actions' default token permissions to read-only contents

## Security alerts covered

Dependabot alerts:

- #14 and #13: `brace-expansion` 1.x, upgraded to 1.1.18
- #12 and #11: `brace-expansion` 5.x, upgraded to 5.0.9
- #9: earlier `brace-expansion` advisory, covered by 1.1.18
- #8: `js-yaml`, upgraded to 3.15.1
- #5: `@hono/node-server`, removed from the package graph

Code scanning alerts #3, #9, #10, and #11 are addressed by explicit top-level workflow permissions:

```yaml
permissions:
  contents: read
```

Secret scanning currently has no open alerts.

## Major-version compatibility decisions

- TypeScript 6 is included. Its new empty default for `compilerOptions.types` is handled explicitly for production and Jest. TypeScript 7 is not included because `ts-jest@29.4.12` declares support for TypeScript `<7`.
- `@babel/plugin-transform-modules-commonjs` remains on the latest compatible 7.x release, 7.29.7, with patched Babel core 7.29.7. Babel 8 requires a higher Node 22 patch floor than this package supports and conflicts with `ts-jest`'s Babel core `<8` peer range.

This PR supersedes Dependabot PRs #46, #79, #80, #81, and #88.

## Verification

- `npm audit --audit-level=low` (`0 vulnerabilities`)
- `npm ls @hono/node-server @modelcontextprotocol/node brace-expansion js-yaml @babel/core`
- `npm run verify`
  - 38 coverage suites, 499 tests
  - compiled-output slow test
  - packed npm artifact install and entry-point test
- focused HTTP adapter tests for auth forwarding, disconnect aborts, streaming lifecycle, and protocol-safe 500 responses
