### PR TITLE
[b2-mcp] Add narrow ESLint for TSDoc/JSDoc doc-comment linting

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -80,6 +80,7 @@ jobs:
       - run: npm run format:check
       - run: npm run lint
       - run: npm run spell
+      - run: npm run lint:docs
       - run: npm run build
       - id: typecheck
         continue-on-error: true
@@ -131,6 +132,7 @@ jobs:
       - run: npm run format:check
       - run: npm run lint
       - run: npm run spell
+      - run: npm run lint:docs
       - run: npm run build
       - id: typecheck
         continue-on-error: true

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,6 +15,8 @@ jobs:
     timeout-minutes: 5
     steps:
       - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803
+        with:
+          persist-credentials: false
       - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020
         with:
           node-version: 22.23.1
@@ -27,6 +29,8 @@ jobs:
     timeout-minutes: 10
     steps:
       - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803
+        with:
+          persist-credentials: false
       - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020
         with:
           node-version: 22.23.1
@@ -72,6 +76,8 @@ jobs:
         node-version: [22.23.1]
     steps:
       - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803
+        with:
+          persist-credentials: false
       - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020
         with:
           node-version: ${{ matrix.node-version }}
@@ -124,6 +130,8 @@ jobs:
         node-version: [24, 26]
     steps:
       - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803
+        with:
+          persist-credentials: false
       - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020
         with:
           node-version: ${{ matrix.node-version }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,8 +15,6 @@ jobs:
     timeout-minutes: 5
     steps:
       - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803
-        with:
-          persist-credentials: false
       - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020
         with:
           node-version: 22.23.1
@@ -29,8 +27,6 @@ jobs:
     timeout-minutes: 10
     steps:
       - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803
-        with:
-          persist-credentials: false
       - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020
         with:
           node-version: 22.23.1

--- a/docs/SUPPLY_CHAIN_SECURITY.md
+++ b/docs/SUPPLY_CHAIN_SECURITY.md
@@ -38,9 +38,12 @@ npm run audit:supply-chain:denylist -- --packlist
 [`../scripts/run-doc-lint.mjs`](../scripts/run-doc-lint.mjs) wrapper rather than
 executing the ESLint binary directly. The wrapper strips secret-like environment
 variables, refuses local checkout credentials such as persisted GitHub
-`extraheader` values, and preloads a lockdown module that blocks Node network,
-DNS, child-process, and worker APIs before ESLint plugins are loaded. CI jobs
-that run `lint:docs` also check out with `persist-credentials: false`.
+`extraheader` values, and preloads a best-effort lockdown module that denies the
+tracked Node network, DNS, listener, child-process, and worker APIs before
+ESLint plugins are loaded. This in-process denylist is not a complete sandbox;
+review it when the Node runtime is upgraded and add newly exposed egress or code
+execution APIs to the lockdown tests. CI jobs that run `lint:docs` also check
+out with `persist-credentials: false`.
 
 ## Normal Install Policy
 

--- a/docs/SUPPLY_CHAIN_SECURITY.md
+++ b/docs/SUPPLY_CHAIN_SECURITY.md
@@ -9,11 +9,21 @@ controls that remain in force after the incident.
 ## Current Exposure Snapshot
 
 As of 2026-08-05, this repository's `package-lock.json` includes these related
-transitive packages through the ESLint toolchain:
+transitive packages through the narrowly reintroduced ESLint doc-comment
+toolchain:
 
 - `file-entry-cache@8.0.0`
 - `flat-cache@4.0.1`
 - `keyv@4.5.4`
+
+Biome remains the owner for code linting and formatting. ESLint is present only
+for `npm run lint:docs`, where it validates TSDoc syntax and JSDoc hygiene for
+the exported TypeScript tool/handler surface that Biome cannot validate. The
+direct doc-lint packages are exact-pinned in `package.json`; the lockfile
+snapshot above remains unchanged after reintroducing that narrow ESLint path.
+The `@typescript-eslint/visitor-keys` override keeps its `eslint-visitor-keys`
+resolution on a Node.js 22.3-compatible release so the full lockfile still
+installs under the advertised package engine floor with `npm ci --engine-strict`.
 
 Those are not the denied malicious versions recorded in the checked-in Wiz IOC
 snapshot at [`../security/iocs/keyv-packages.csv`](../security/iocs/keyv-packages.csv)
@@ -23,6 +33,14 @@ The current lockfile and publish packlist are checked by:
 ```bash
 npm run audit:supply-chain:denylist -- --packlist
 ```
+
+`npm run lint:docs` uses the repository-owned
+[`../scripts/run-doc-lint.mjs`](../scripts/run-doc-lint.mjs) wrapper rather than
+executing the ESLint binary directly. The wrapper strips secret-like environment
+variables, refuses local checkout credentials such as persisted GitHub
+`extraheader` values, and preloads a lockdown module that blocks Node network,
+DNS, child-process, and worker APIs before ESLint plugins are loaded. CI jobs
+that run `lint:docs` also check out with `persist-credentials: false`.
 
 ## Normal Install Policy
 

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -16,13 +16,15 @@ npm ci
 npm run verify
 ```
 
-`npm run verify` runs typecheck, build, lint, the Biome-supported format check,
-deterministic coverage, deterministic slow tests, and packed-package
-installation tests. The individual deterministic layers are:
+`npm run verify` runs typecheck, build, Biome lint, doc-comment lint, the
+Biome-supported format check, deterministic coverage, deterministic slow tests,
+and packed-package installation tests. The individual deterministic layers are:
 
 | Command                 | Layer                                                                                |
 | ----------------------- | ------------------------------------------------------------------------------------ |
 | `npm test`              | Typecheck, then `npm run test:unit`.                                                 |
+| `npm run lint`          | Biome lint for source, test, and script code.                                        |
+| `npm run lint:docs`     | TSDoc/JSDoc doc-comment syntax and hygiene gate for non-test `src/**/*.ts` files.    |
 | `npm run test:unit`     | Fast source unit tests.                                                              |
 | `npm run test:contract` | Deterministic MCP/package/schema/document/workflow contracts.                        |
 | `npm run test:protocol` | Aggregate protocol gate (`test:protocol:modern` + `test:protocol:legacy`).           |
@@ -35,7 +37,8 @@ matrix runs the bundled coverage and slow deterministic lifecycle layers, while
 `test:package` runs in a separate non-blocking package job.
 CI verifies the production dependency graph with `npm ci --omit=dev
 --engine-strict` on the Node.js 22.3.0 package floor. The credential-free full
-toolchain gate runs on Linux for Node.js 22.23.1, 24, and 26. It also runs
+toolchain gate, including `npm run lint:docs`, runs on Linux for Node.js
+22.23.1, 24, and 26. It also runs
 `npm run check:runtime-policy`, which fails if workflow or metadata runtime
 policy drifts. Cross-platform coverage stays lean: the fast stdio, CLI port
 parsing, local-path policy, and request shutdown/signal suite runs on Linux,

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -2,16 +2,14 @@ const jsdoc = require("eslint-plugin-jsdoc");
 const tsdoc = require("eslint-plugin-tsdoc");
 const tseslint = require("typescript-eslint");
 
-const disabledTypeScriptRules = Object.fromEntries(
-  Object.keys(tseslint.plugin.rules).map((ruleName) => [`@typescript-eslint/${ruleName}`, "off"]),
-);
-
+// ESLint is parser-only for TypeScript here; Biome owns code linting.
+// Do not register @typescript-eslint as a plugin unless doc lint starts using
+// one of its rules explicitly.
 module.exports = [
   {
     files: ["src/**/*.ts"],
     ignores: ["src/**/*.test.ts"],
     plugins: {
-      "@typescript-eslint": tseslint.plugin,
       jsdoc,
       tsdoc: { rules: tsdoc.rules },
     },
@@ -31,7 +29,6 @@ module.exports = [
       },
     },
     rules: {
-      ...disabledTypeScriptRules,
       "tsdoc/syntax": "error",
       "jsdoc/no-bad-blocks": "error",
       "jsdoc/no-blank-blocks": "error",

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -1,0 +1,70 @@
+const jsdoc = require("eslint-plugin-jsdoc");
+const tsdoc = require("eslint-plugin-tsdoc");
+const tseslint = require("typescript-eslint");
+
+const disabledTypeScriptRules = Object.fromEntries(
+  Object.keys(tseslint.plugin.rules).map((ruleName) => [`@typescript-eslint/${ruleName}`, "off"]),
+);
+
+module.exports = [
+  {
+    files: ["src/**/*.ts"],
+    ignores: ["src/**/*.test.ts"],
+    plugins: {
+      "@typescript-eslint": tseslint.plugin,
+      jsdoc,
+      tsdoc: { rules: tsdoc.rules },
+    },
+    languageOptions: {
+      parser: tseslint.parser,
+      parserOptions: {
+        projectService: true,
+        tsconfigRootDir: __dirname,
+      },
+    },
+    settings: {
+      jsdoc: {
+        mode: "typescript",
+        tagNamePreference: {
+          template: "typeParam",
+        },
+      },
+    },
+    rules: {
+      ...disabledTypeScriptRules,
+      "tsdoc/syntax": "error",
+      "jsdoc/no-bad-blocks": "error",
+      "jsdoc/no-blank-blocks": "error",
+      "jsdoc/multiline-blocks": "error",
+      "jsdoc/empty-tags": "error",
+      "jsdoc/check-tag-names": [
+        "error",
+        {
+          definedTags: ["internal", "inheritDoc", "typeParam", "packageDocumentation"],
+        },
+      ],
+      "jsdoc/require-param-description": "error",
+      "jsdoc/require-hyphen-before-param-description": ["error", "always"],
+      "jsdoc/require-returns": ["error", { publicOnly: true }],
+      "jsdoc/require-returns-check": "error",
+      "jsdoc/require-throws": "error",
+      "jsdoc/no-types": "error",
+      "jsdoc/sort-tags": [
+        "error",
+        {
+          tagSequence: [
+            { tags: ["module", "packageDocumentation"] },
+            { tags: ["typeParam", "template"] },
+            { tags: ["param"] },
+            { tags: ["returns"] },
+            { tags: ["throws"] },
+            { tags: ["example"] },
+            { tags: ["see"] },
+            { tags: ["deprecated"] },
+            { tags: ["internal"] },
+          ],
+        },
+      ],
+    },
+  },
+];

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -42,6 +42,8 @@ module.exports = [
       ],
       "jsdoc/require-param-description": "error",
       "jsdoc/require-hyphen-before-param-description": ["error", "always"],
+      // Keep public return docs intentional even when small wrappers need a
+      // short @returns line; the docs gate covers exported API surfaces.
       "jsdoc/require-returns": ["error", { publicOnly: true }],
       "jsdoc/require-returns-check": "error",
       "jsdoc/require-throws": "error",

--- a/package-lock.json
+++ b/package-lock.json
@@ -24,7 +24,6 @@
       "devDependencies": {
         "@babel/plugin-transform-modules-commonjs": "7.29.7",
         "@biomejs/biome": "2.5.7",
-        "@microsoft/tsdoc-config": "0.18.1",
         "@modelcontextprotocol/client": "2.0.0",
         "@toon-format/toon": "4.1.0",
         "@types/jest": "^29.5.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -24,6 +24,7 @@
       "devDependencies": {
         "@babel/plugin-transform-modules-commonjs": "7.29.7",
         "@biomejs/biome": "2.5.7",
+        "@microsoft/tsdoc-config": "^0.18.1",
         "@modelcontextprotocol/client": "2.0.0",
         "@toon-format/toon": "4.1.0",
         "@types/jest": "^29.5.0",
@@ -31,11 +32,15 @@
         "@types/opossum": "^8.1.9",
         "babel-jest": "^29.7.0",
         "cspell": "^10.0.1",
+        "eslint": "^10.8.0",
+        "eslint-plugin-jsdoc": "^63.3.3",
+        "eslint-plugin-tsdoc": "^0.5.2",
         "jest": "^29.5.0",
         "jest-junit": "^17.0.0",
         "ts-jest": "^29.4.12",
         "ts-node": "^10.9.0",
-        "typescript": "~6.0.3"
+        "typescript": "~6.0.3",
+        "typescript-eslint": "^8.66.0"
       },
       "engines": {
         "node": ">=22.3.0"
@@ -1712,6 +1717,245 @@
         "@jridgewell/sourcemap-codec": "^1.4.10"
       }
     },
+    "node_modules/@es-joy/jsdoccomment": {
+      "version": "0.91.0",
+      "resolved": "https://registry.npmjs.org/@es-joy/jsdoccomment/-/jsdoccomment-0.91.0.tgz",
+      "integrity": "sha512-vgqlMGNNhZxwDYbUNIHj3Hskb4R28iqdXx90ufHyt/NeuTQkeqjTDslAs9I0/GCAfbxP5BpH5WsL1R1fht5Lxg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.9",
+        "@typescript-eslint/types": "^8.65.0",
+        "comment-parser": "1.4.7",
+        "esquery": "^1.7.0",
+        "jsdoc-type-pratt-parser": "~8.0.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      }
+    },
+    "node_modules/@es-joy/resolve.exports": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@es-joy/resolve.exports/-/resolve.exports-1.2.0.tgz",
+      "integrity": "sha512-Q9hjxWI5xBM+qW2enxfe8wDKdFWMfd0Z29k5ZJnuBqD/CasY5Zryj09aCA6owbGATWz+39p5uIdaHXpopOcG8g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@eslint-community/eslint-utils": {
+      "version": "4.10.1",
+      "resolved": "https://registry.npmjs.org/@eslint-community/eslint-utils/-/eslint-utils-4.10.1.tgz",
+      "integrity": "sha512-cuadcxVFE8sDK6iWJbs8Sn0av2Nrh2QSGQhVlBW9AaAHqHwjWsZHT8LJ4hFGPh7ASBV2deFdM7H/DPjulmh8rg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "eslint-visitor-keys": "^3.4.3"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^6.0.0 || ^7.0.0 || >=8.0.0"
+      }
+    },
+    "node_modules/@eslint-community/eslint-utils/node_modules/eslint-visitor-keys": {
+      "version": "3.4.3",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.4.3.tgz",
+      "integrity": "sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/@eslint-community/regexpp": {
+      "version": "4.12.2",
+      "resolved": "https://registry.npmjs.org/@eslint-community/regexpp/-/regexpp-4.12.2.tgz",
+      "integrity": "sha512-EriSTlt5OC9/7SXkRSCAhfSxxoSUgBm33OH+IkwbdpgoqsSsUg7y3uh+IICI/Qg4BBWr3U2i39RpmycbxMq4ew==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^12.0.0 || ^14.0.0 || >=16.0.0"
+      }
+    },
+    "node_modules/@eslint/config-array": {
+      "version": "0.23.5",
+      "resolved": "https://registry.npmjs.org/@eslint/config-array/-/config-array-0.23.5.tgz",
+      "integrity": "sha512-Y3kKLvC1dvTOT+oGlqNQ1XLqK6D1HU2YXPc52NmAlJZbMMWDzGYXMiPRJ8TYD39muD/OTjlZmNJ4ib7dvSrMBA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@eslint/object-schema": "^3.0.5",
+        "debug": "^4.3.1",
+        "minimatch": "^10.2.4"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      }
+    },
+    "node_modules/@eslint/config-array/node_modules/balanced-match": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
+      "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/@eslint/config-array/node_modules/brace-expansion": {
+      "version": "5.0.9",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.9.tgz",
+      "integrity": "sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^4.0.2"
+      },
+      "engines": {
+        "node": "20 || >=22"
+      }
+    },
+    "node_modules/@eslint/config-array/node_modules/minimatch": {
+      "version": "10.2.6",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.6.tgz",
+      "integrity": "sha512-vpLQEs+VLCr1nU0BXS07maYoFwlDAH0gngQuuttxIwutDFEMHq2blX+8vpgxDdK3J1PwjCJiep77OitTZ4Ll1A==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "brace-expansion": "^5.0.8"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/@eslint/config-helpers": {
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/@eslint/config-helpers/-/config-helpers-0.7.0.tgz",
+      "integrity": "sha512-DObd/KKUsU+FaFv4PLxSRenpXfQWmPXXP3pPZ6/K1PCrMu2vQpMDMuQe/BqYeoLcz8ro0bVDF1RxOJgfVEdhUw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@eslint/core": "^1.2.1"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      }
+    },
+    "node_modules/@eslint/core": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@eslint/core/-/core-1.2.1.tgz",
+      "integrity": "sha512-MwcE1P+AZ4C6DWlpin/OmOA54mmIZ/+xZuJiQd4SyB29oAJjN30UW9wkKNptW2ctp4cEsvhlLY/CsQ1uoHDloQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@types/json-schema": "^7.0.15"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      }
+    },
+    "node_modules/@eslint/object-schema": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/@eslint/object-schema/-/object-schema-3.0.5.tgz",
+      "integrity": "sha512-vqTaUEgxzm+YDSdElad6PiRoX4t8VGDjCtt05zn4nU810UIx/uNEV7/lZJ6KwFThKZOzOxzXy48da+No7HZaMw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      }
+    },
+    "node_modules/@eslint/plugin-kit": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/@eslint/plugin-kit/-/plugin-kit-0.7.2.tgz",
+      "integrity": "sha512-+CNAzxglkrpNf/kKywqQfk74QjtceuOE7Qm+AF8miRvPF/wmmK5+OJOgVh3AVTT3RP2mH3+FOaxlE5v72owk0A==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@eslint/core": "^1.2.1",
+        "levn": "^0.4.1"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      }
+    },
+    "node_modules/@humanfs/core": {
+      "version": "0.19.2",
+      "resolved": "https://registry.npmjs.org/@humanfs/core/-/core-0.19.2.tgz",
+      "integrity": "sha512-UhXNm+CFMWcbChXywFwkmhqjs3PRCmcSa/hfBgLIb7oQ5HNb1wS0icWsGtSAUNgefHeI+eBrA8I1fxmbHsGdvA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@humanfs/types": "^0.15.0"
+      },
+      "engines": {
+        "node": ">=18.18.0"
+      }
+    },
+    "node_modules/@humanfs/node": {
+      "version": "0.16.8",
+      "resolved": "https://registry.npmjs.org/@humanfs/node/-/node-0.16.8.tgz",
+      "integrity": "sha512-gE1eQNZ3R++kTzFUpdGlpmy8kDZD/MLyHqDwqjkVQI0JMdI1D51sy1H958PNXYkM2rAac7e5/CnIKZrHtPh3BQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@humanfs/core": "^0.19.2",
+        "@humanfs/types": "^0.15.0",
+        "@humanwhocodes/retry": "^0.4.0"
+      },
+      "engines": {
+        "node": ">=18.18.0"
+      }
+    },
+    "node_modules/@humanfs/types": {
+      "version": "0.15.0",
+      "resolved": "https://registry.npmjs.org/@humanfs/types/-/types-0.15.0.tgz",
+      "integrity": "sha512-ZZ1w0aoQkwuUuC7Yf+7sdeaNfqQiiLcSRbfI08oAxqLtpXQr9AIVX7Ay7HLDuiLYAaFPu8oBYNq/QIi9URHJ3Q==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18.18.0"
+      }
+    },
+    "node_modules/@humanwhocodes/module-importer": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@humanwhocodes/module-importer/-/module-importer-1.0.1.tgz",
+      "integrity": "sha512-bxveV4V8v5Yb4ncFTT3rPSgZBOpCkjfK0y4oVVVJwIuDVBRMDXrPyXRL988i5ap9m9bnyEEjWfm5WkBmtffLfA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.22"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/nzakas"
+      }
+    },
+    "node_modules/@humanwhocodes/retry": {
+      "version": "0.4.3",
+      "resolved": "https://registry.npmjs.org/@humanwhocodes/retry/-/retry-0.4.3.tgz",
+      "integrity": "sha512-bV0Tgo9K4hfPCek+aMAn81RppFKv2ySDQeMoSZuvTASywNTnVJCArCZE2FWqpvIatKu7VMRLWlR1EazvVhDyhQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18.18"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/nzakas"
+      }
+    },
     "node_modules/@istanbuljs/load-nyc-config": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@istanbuljs/load-nyc-config/-/load-nyc-config-1.1.0.tgz",
@@ -2081,6 +2325,26 @@
         "@jridgewell/sourcemap-codec": "^1.4.14"
       }
     },
+    "node_modules/@microsoft/tsdoc": {
+      "version": "0.16.0",
+      "resolved": "https://registry.npmjs.org/@microsoft/tsdoc/-/tsdoc-0.16.0.tgz",
+      "integrity": "sha512-xgAyonlVVS+q7Vc7qLW0UrJU7rSFcETRWsqdXZtjzRU8dF+6CkozTK4V4y1LwOX7j8r/vHphjDeMeGI4tNGeGA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@microsoft/tsdoc-config": {
+      "version": "0.18.1",
+      "resolved": "https://registry.npmjs.org/@microsoft/tsdoc-config/-/tsdoc-config-0.18.1.tgz",
+      "integrity": "sha512-9brPoVdfN9k9g0dcWkFeA7IH9bbcttzDJlXvkf8b2OBzd5MueR1V2wkKBL0abn0otvmkHJC6aapBOTJDDeMCZg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@microsoft/tsdoc": "0.16.0",
+        "ajv": "~8.18.0",
+        "jju": "~1.4.0",
+        "resolve": "~1.22.2"
+      }
+    },
     "node_modules/@modelcontextprotocol/client": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/@modelcontextprotocol/client/-/client-2.0.0.tgz",
@@ -2137,6 +2401,19 @@
       "integrity": "sha512-MTBk/3jGLNB2tVxv6uLlFh1iu64iYOQ2PbdOSK3NW8JZsmlaOh2q6sdtKowBhfw8QFLmYNzTW4/oK4uATIi6ZA==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@sindresorhus/base62": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@sindresorhus/base62/-/base62-1.0.0.tgz",
+      "integrity": "sha512-TeheYy0ILzBEI/CO55CP6zJCSdSWeRtGnHy8U8dWSUH4I68iqTsy7HkMktR4xakThc9jotkPQUXT4ITdbV7cHA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
     },
     "node_modules/@sinonjs/commons": {
       "version": "3.0.1",
@@ -2319,6 +2596,20 @@
         "@babel/types": "^7.28.2"
       }
     },
+    "node_modules/@types/esrecurse": {
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/@types/esrecurse/-/esrecurse-4.3.1.tgz",
+      "integrity": "sha512-xJBAbDifo5hpffDBuHl0Y8ywswbiAp/Wi7Y/GtAgSlZyIABppyurxVueOPE8LUQOxdlgi6Zqce7uoEpqNTeiUw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/estree": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.9.tgz",
+      "integrity": "sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/graceful-fs": {
       "version": "4.1.9",
       "resolved": "https://registry.npmjs.org/@types/graceful-fs/-/graceful-fs-4.1.9.tgz",
@@ -2367,6 +2658,13 @@
         "pretty-format": "^29.0.0"
       }
     },
+    "node_modules/@types/json-schema": {
+      "version": "7.0.15",
+      "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz",
+      "integrity": "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/node": {
       "version": "22.3.0",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-22.3.0.tgz",
@@ -2411,6 +2709,288 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@typescript-eslint/eslint-plugin": {
+      "version": "8.66.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.66.0.tgz",
+      "integrity": "sha512-p088eaGrzYz1s+7cov0aMOCkNGTJlVxF4jgubf28c8L0Cv9Rloj8YBHnv4hXLq6IIEE1AsjNWavO+k+8kP2Y0A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@eslint-community/regexpp": "^4.12.2",
+        "@typescript-eslint/scope-manager": "8.66.0",
+        "@typescript-eslint/type-utils": "8.66.0",
+        "@typescript-eslint/utils": "8.66.0",
+        "@typescript-eslint/visitor-keys": "8.66.0",
+        "ignore": "^7.0.5",
+        "natural-compare": "^1.4.0",
+        "ts-api-utils": "^2.5.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "@typescript-eslint/parser": "^8.66.0",
+        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+        "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "node_modules/@typescript-eslint/eslint-plugin/node_modules/ignore": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-7.0.6.tgz",
+      "integrity": "sha512-BAg6QkE8W+TuQLrrw0Ugr7HegXduRuuj8/ti2kSOc+jz1dmx8/WNcjr6XGnq5YpDWxFwwaavqD0+jIUOKelTsw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4"
+      }
+    },
+    "node_modules/@typescript-eslint/parser": {
+      "version": "8.66.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.66.0.tgz",
+      "integrity": "sha512-X6ypGChaWYk6PBtUg2BwuTZEFFcHJAtGTVJ9/lCTOufhZ4i9fNolQNnktq+kkMCwMj7V8Svsq7+TxSDslmhE0g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/scope-manager": "8.66.0",
+        "@typescript-eslint/types": "8.66.0",
+        "@typescript-eslint/typescript-estree": "8.66.0",
+        "@typescript-eslint/visitor-keys": "8.66.0",
+        "debug": "^4.4.3"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+        "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "node_modules/@typescript-eslint/project-service": {
+      "version": "8.66.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.66.0.tgz",
+      "integrity": "sha512-7MthGPTt4BP69lSryqpqq8HQqxuzynssckL/jyDyk3+TNMQ3y2jFWkptCrktWvBrP+EH787Nl5N5Qpw7WZg+5g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/tsconfig-utils": "^8.66.0",
+        "@typescript-eslint/types": "^8.66.0",
+        "debug": "^4.4.3"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "node_modules/@typescript-eslint/scope-manager": {
+      "version": "8.66.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.66.0.tgz",
+      "integrity": "sha512-8TGcH25j9zqJ/IULB/ppyhRvxA8QYfFEZ7nfbg6/BN9spDgb8fPWQXlE5l8TWBL50EtUx007uZ1o9VOwrq2/9g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/types": "8.66.0",
+        "@typescript-eslint/visitor-keys": "8.66.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@typescript-eslint/tsconfig-utils": {
+      "version": "8.66.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.66.0.tgz",
+      "integrity": "sha512-9D5gLYZG4rOjcoag8MQ/fWI8WqA9wcPDyOGyWtWFhvM1lHRbliqUSPIY5J3zqCU1tvSwzXxnnjhQhz5Ne7mJ4g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "node_modules/@typescript-eslint/type-utils": {
+      "version": "8.66.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.66.0.tgz",
+      "integrity": "sha512-LG2dWfjZQQp0ADtAu/EWJVayefGL2UEZ3CDeI44D9v3rXB/WYUqE/jpO28KrEKul5AySrmI+Zh1v6v+xW2U9+g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/types": "8.66.0",
+        "@typescript-eslint/typescript-estree": "8.66.0",
+        "@typescript-eslint/utils": "8.66.0",
+        "debug": "^4.4.3",
+        "ts-api-utils": "^2.5.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+        "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "node_modules/@typescript-eslint/types": {
+      "version": "8.66.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.66.0.tgz",
+      "integrity": "sha512-H6gcYaSDOyvL3AD/jHUtUFo2jqGgn/F6nuyuZSu0QTesxL+cP4dQoIMrODRofuJC09g64+WgZ6tE19Y1N2YIFQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@typescript-eslint/typescript-estree": {
+      "version": "8.66.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.66.0.tgz",
+      "integrity": "sha512-8/x4INiiQb10jGgXYD7116/zQ+OL84ZIFn0za68wwFHCanT/VLbBEroWht8RV8fn0/ZCAoazHLQgwUC0UQcDfg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/project-service": "8.66.0",
+        "@typescript-eslint/tsconfig-utils": "8.66.0",
+        "@typescript-eslint/types": "8.66.0",
+        "@typescript-eslint/visitor-keys": "8.66.0",
+        "debug": "^4.4.3",
+        "minimatch": "^10.2.2",
+        "semver": "^7.7.3",
+        "tinyglobby": "^0.2.15",
+        "ts-api-utils": "^2.5.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "node_modules/@typescript-eslint/typescript-estree/node_modules/balanced-match": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
+      "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/@typescript-eslint/typescript-estree/node_modules/brace-expansion": {
+      "version": "5.0.9",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.9.tgz",
+      "integrity": "sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^4.0.2"
+      },
+      "engines": {
+        "node": "20 || >=22"
+      }
+    },
+    "node_modules/@typescript-eslint/typescript-estree/node_modules/minimatch": {
+      "version": "10.2.6",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.6.tgz",
+      "integrity": "sha512-vpLQEs+VLCr1nU0BXS07maYoFwlDAH0gngQuuttxIwutDFEMHq2blX+8vpgxDdK3J1PwjCJiep77OitTZ4Ll1A==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "brace-expansion": "^5.0.8"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/@typescript-eslint/typescript-estree/node_modules/semver": {
+      "version": "7.8.5",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
+      "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@typescript-eslint/utils": {
+      "version": "8.66.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.66.0.tgz",
+      "integrity": "sha512-jasearZPolBw5NJNYGMwxzHMF83niVWmMU1VdHzG1CyfI2VS7f7nZltnKtHcg20hW+7Uo5GfK4MeDPoU3qI8EA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@eslint-community/eslint-utils": "^4.9.1",
+        "@typescript-eslint/scope-manager": "8.66.0",
+        "@typescript-eslint/types": "8.66.0",
+        "@typescript-eslint/typescript-estree": "8.66.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+        "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "node_modules/@typescript-eslint/visitor-keys": {
+      "version": "8.66.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.66.0.tgz",
+      "integrity": "sha512-dkKR8q+lKciskj1Y3vthHktl+3cMLWGyVUP23bRiPZ5O9BRT++4EqDDV+TVeIKBL1VXVEqrJlz8MYbcnvJcAlg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/types": "8.66.0",
+        "eslint-visitor-keys": "^5.0.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
     "node_modules/acorn": {
       "version": "8.16.0",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.16.0.tgz",
@@ -2424,6 +3004,16 @@
         "node": ">=0.4.0"
       }
     },
+    "node_modules/acorn-jsx": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.2.tgz",
+      "integrity": "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      }
+    },
     "node_modules/acorn-walk": {
       "version": "8.3.5",
       "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.3.5.tgz",
@@ -2435,6 +3025,23 @@
       },
       "engines": {
         "node": ">=0.4.0"
+      }
+    },
+    "node_modules/ajv": {
+      "version": "8.18.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.18.0.tgz",
+      "integrity": "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3",
+        "fast-uri": "^3.0.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
       }
     },
     "node_modules/ansi-escapes": {
@@ -2491,6 +3098,16 @@
       },
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/are-docs-informative": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/are-docs-informative/-/are-docs-informative-0.0.2.tgz",
+      "integrity": "sha512-ixiS0nLNNG5jNQzgZJNoUpBKdo9yTYZMGJ+QgT2jmjR7G7+QHRCc4v6LQ3NgE7EBJq+o0ams3waJwkrlBom8Ig==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14"
       }
     },
     "node_modules/arg": {
@@ -2953,6 +3570,16 @@
         "node": ">= 6"
       }
     },
+    "node_modules/comment-parser": {
+      "version": "1.4.7",
+      "resolved": "https://registry.npmjs.org/comment-parser/-/comment-parser-1.4.7.tgz",
+      "integrity": "sha512-0h+uSNtQGW3D98eQt3jJ8L06Fves8hncB4V/PKdw/Qb8Hnk19VaKuTr55UNRYiSoVa7WwrFls+rh3ux9agmkeQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12.0.0"
+      }
+    },
     "node_modules/concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
@@ -3280,6 +3907,13 @@
         }
       }
     },
+    "node_modules/deep-is": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz",
+      "integrity": "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/deepmerge": {
       "version": "4.3.1",
       "resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-4.3.1.tgz",
@@ -3403,6 +4037,515 @@
         "node": ">=8"
       }
     },
+    "node_modules/eslint": {
+      "version": "10.8.0",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-10.8.0.tgz",
+      "integrity": "sha512-nuKKvN+oIBO0koN7Tm7dlkmnkc21mtt0QJLwAKzjLq14y6lRTdVG36MZHJ8eQHwdJMwZbQNMlPOYedMq/oVJvQ==",
+      "dev": true,
+      "license": "MIT",
+      "workspaces": [
+        "packages/*"
+      ],
+      "dependencies": {
+        "@eslint-community/eslint-utils": "^4.8.0",
+        "@eslint-community/regexpp": "^4.12.2",
+        "@eslint/config-array": "^0.23.5",
+        "@eslint/config-helpers": "^0.7.0",
+        "@eslint/core": "^1.2.1",
+        "@eslint/plugin-kit": "^0.7.2",
+        "@humanfs/node": "^0.16.6",
+        "@humanwhocodes/module-importer": "^1.0.1",
+        "@humanwhocodes/retry": "^0.4.2",
+        "@types/estree": "^1.0.6",
+        "ajv": "^6.14.0",
+        "cross-spawn": "^7.0.6",
+        "debug": "^4.3.2",
+        "escape-string-regexp": "^4.0.0",
+        "eslint-scope": "^9.1.2",
+        "eslint-visitor-keys": "^5.0.1",
+        "espree": "^11.2.0",
+        "esquery": "^1.7.0",
+        "esutils": "^2.0.2",
+        "fast-deep-equal": "^3.1.3",
+        "file-entry-cache": "^8.0.0",
+        "find-up": "^5.0.0",
+        "glob-parent": "^6.0.2",
+        "ignore": "^5.2.0",
+        "imurmurhash": "^0.1.4",
+        "is-glob": "^4.0.0",
+        "json-stable-stringify-without-jsonify": "^1.0.1",
+        "minimatch": "^10.2.5",
+        "natural-compare": "^1.4.0",
+        "optionator": "^0.9.3"
+      },
+      "bin": {
+        "eslint": "bin/eslint.js"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      },
+      "funding": {
+        "url": "https://eslint.org/donate"
+      },
+      "peerDependencies": {
+        "jiti": "*"
+      },
+      "peerDependenciesMeta": {
+        "jiti": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/eslint-plugin-jsdoc": {
+      "version": "63.3.3",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-jsdoc/-/eslint-plugin-jsdoc-63.3.3.tgz",
+      "integrity": "sha512-xI4IeVRzRFA2DGHrPLIxF3U+oJHU3FE+P9Zb27fVs5dPHgfcpoAs0PyCbznVhK7pwR+9BPUztFeXSgpw/CL4Yg==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@es-joy/jsdoccomment": "~0.91.0",
+        "@es-joy/resolve.exports": "1.2.0",
+        "are-docs-informative": "^0.0.2",
+        "comment-parser": "1.4.7",
+        "debug": "^4.4.3",
+        "escape-string-regexp": "^4.0.0",
+        "espree": "^11.2.0",
+        "esquery": "^1.7.0",
+        "html-entities": "^2.6.0",
+        "object-deep-merge": "^2.0.1",
+        "parse-imports-exports": "^0.2.4",
+        "semver": "^7.8.5",
+        "spdx-expression-parse": "^5.0.0",
+        "to-valid-identifier": "^1.0.0"
+      },
+      "engines": {
+        "node": "^22.13.0 || >=24"
+      },
+      "peerDependencies": {
+        "eslint": "^7.0.0 || ^8.0.0 || ^9.0.0 || ^10.0.0"
+      }
+    },
+    "node_modules/eslint-plugin-jsdoc/node_modules/escape-string-regexp": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
+      "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/eslint-plugin-jsdoc/node_modules/semver": {
+      "version": "7.8.5",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
+      "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/eslint-plugin-tsdoc": {
+      "version": "0.5.2",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-tsdoc/-/eslint-plugin-tsdoc-0.5.2.tgz",
+      "integrity": "sha512-BlvqjWZdBJDIPO/YU3zcPCF23CvjYT3gyu63yo6b609NNV3D1b6zceAREy2xnweuBoDpZcLNuPyAUq9cvx6bbQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@microsoft/tsdoc": "0.16.0",
+        "@microsoft/tsdoc-config": "0.18.1",
+        "@typescript-eslint/utils": "~8.56.0"
+      }
+    },
+    "node_modules/eslint-plugin-tsdoc/node_modules/@typescript-eslint/project-service": {
+      "version": "8.56.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.56.1.tgz",
+      "integrity": "sha512-TAdqQTzHNNvlVFfR+hu2PDJrURiwKsUvxFn1M0h95BB8ah5jejas08jUWG4dBA68jDMI988IvtfdAI53JzEHOQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/tsconfig-utils": "^8.56.1",
+        "@typescript-eslint/types": "^8.56.1",
+        "debug": "^4.4.3"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.8.4 <6.0.0"
+      }
+    },
+    "node_modules/eslint-plugin-tsdoc/node_modules/@typescript-eslint/scope-manager": {
+      "version": "8.56.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.56.1.tgz",
+      "integrity": "sha512-YAi4VDKcIZp0O4tz/haYKhmIDZFEUPOreKbfdAN3SzUDMcPhJ8QI99xQXqX+HoUVq8cs85eRKnD+rne2UAnj2w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/types": "8.56.1",
+        "@typescript-eslint/visitor-keys": "8.56.1"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/eslint-plugin-tsdoc/node_modules/@typescript-eslint/tsconfig-utils": {
+      "version": "8.56.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.56.1.tgz",
+      "integrity": "sha512-qOtCYzKEeyr3aR9f28mPJqBty7+DBqsdd63eO0yyDwc6vgThj2UjWfJIcsFeSucYydqcuudMOprZ+x1SpF3ZuQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.8.4 <6.0.0"
+      }
+    },
+    "node_modules/eslint-plugin-tsdoc/node_modules/@typescript-eslint/types": {
+      "version": "8.56.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.56.1.tgz",
+      "integrity": "sha512-dbMkdIUkIkchgGDIv7KLUpa0Mda4IYjo4IAMJUZ+3xNoUXxMsk9YtKpTHSChRS85o+H9ftm51gsK1dZReY9CVw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/eslint-plugin-tsdoc/node_modules/@typescript-eslint/typescript-estree": {
+      "version": "8.56.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.56.1.tgz",
+      "integrity": "sha512-qzUL1qgalIvKWAf9C1HpvBjif+Vm6rcT5wZd4VoMb9+Km3iS3Cv9DY6dMRMDtPnwRAFyAi7YXJpTIEXLvdfPxg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/project-service": "8.56.1",
+        "@typescript-eslint/tsconfig-utils": "8.56.1",
+        "@typescript-eslint/types": "8.56.1",
+        "@typescript-eslint/visitor-keys": "8.56.1",
+        "debug": "^4.4.3",
+        "minimatch": "^10.2.2",
+        "semver": "^7.7.3",
+        "tinyglobby": "^0.2.15",
+        "ts-api-utils": "^2.4.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.8.4 <6.0.0"
+      }
+    },
+    "node_modules/eslint-plugin-tsdoc/node_modules/@typescript-eslint/utils": {
+      "version": "8.56.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.56.1.tgz",
+      "integrity": "sha512-HPAVNIME3tABJ61siYlHzSWCGtOoeP2RTIaHXFMPqjrQKCGB9OgUVdiNgH7TJS2JNIQ5qQ4RsAUDuGaGme/KOA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@eslint-community/eslint-utils": "^4.9.1",
+        "@typescript-eslint/scope-manager": "8.56.1",
+        "@typescript-eslint/types": "8.56.1",
+        "@typescript-eslint/typescript-estree": "8.56.1"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+        "typescript": ">=4.8.4 <6.0.0"
+      }
+    },
+    "node_modules/eslint-plugin-tsdoc/node_modules/@typescript-eslint/visitor-keys": {
+      "version": "8.56.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.56.1.tgz",
+      "integrity": "sha512-KiROIzYdEV85YygXw6BI/Dx4fnBlFQu6Mq4QE4MOH9fFnhohw6wX/OAvDY2/C+ut0I3RSPKenvZJIVYqJNkhEw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/types": "8.56.1",
+        "eslint-visitor-keys": "^5.0.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/eslint-plugin-tsdoc/node_modules/balanced-match": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
+      "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/eslint-plugin-tsdoc/node_modules/brace-expansion": {
+      "version": "5.0.9",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.9.tgz",
+      "integrity": "sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^4.0.2"
+      },
+      "engines": {
+        "node": "20 || >=22"
+      }
+    },
+    "node_modules/eslint-plugin-tsdoc/node_modules/minimatch": {
+      "version": "10.2.6",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.6.tgz",
+      "integrity": "sha512-vpLQEs+VLCr1nU0BXS07maYoFwlDAH0gngQuuttxIwutDFEMHq2blX+8vpgxDdK3J1PwjCJiep77OitTZ4Ll1A==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "brace-expansion": "^5.0.8"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/eslint-plugin-tsdoc/node_modules/semver": {
+      "version": "7.8.5",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
+      "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/eslint-plugin-tsdoc/node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "peer": true,
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/eslint-scope": {
+      "version": "9.1.2",
+      "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-9.1.2.tgz",
+      "integrity": "sha512-xS90H51cKw0jltxmvmHy2Iai1LIqrfbw57b79w/J7MfvDfkIkFZ+kj6zC3BjtUwh150HsSSdxXZcsuv72miDFQ==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "@types/esrecurse": "^4.3.1",
+        "@types/estree": "^1.0.8",
+        "esrecurse": "^4.3.0",
+        "estraverse": "^5.2.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/eslint-visitor-keys": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-5.0.1.tgz",
+      "integrity": "sha512-tD40eHxA35h0PEIZNeIjkHoDR4YjjJp34biM0mDvplBe//mB+IHCqHDGV7pxF+7MklTvighcCPPZC7ynWyjdTA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/eslint/node_modules/ajv": {
+      "version": "6.15.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.15.0.tgz",
+      "integrity": "sha512-fgFx7Hfoq60ytK2c7DhnF8jIvzYgOMxfugjLOSMHjLIPgenqa7S7oaagATUq99mV6IYvN2tRmC0wnTYX6iPbMw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.1",
+        "fast-json-stable-stringify": "^2.0.0",
+        "json-schema-traverse": "^0.4.1",
+        "uri-js": "^4.2.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/eslint/node_modules/balanced-match": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
+      "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/eslint/node_modules/brace-expansion": {
+      "version": "5.0.9",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.9.tgz",
+      "integrity": "sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^4.0.2"
+      },
+      "engines": {
+        "node": "20 || >=22"
+      }
+    },
+    "node_modules/eslint/node_modules/escape-string-regexp": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
+      "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/eslint/node_modules/find-up": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/find-up/-/find-up-5.0.0.tgz",
+      "integrity": "sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "locate-path": "^6.0.0",
+        "path-exists": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/eslint/node_modules/json-schema-traverse": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/eslint/node_modules/locate-path": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz",
+      "integrity": "sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "p-locate": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/eslint/node_modules/minimatch": {
+      "version": "10.2.6",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.6.tgz",
+      "integrity": "sha512-vpLQEs+VLCr1nU0BXS07maYoFwlDAH0gngQuuttxIwutDFEMHq2blX+8vpgxDdK3J1PwjCJiep77OitTZ4Ll1A==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "brace-expansion": "^5.0.8"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/eslint/node_modules/p-locate": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-5.0.0.tgz",
+      "integrity": "sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "p-limit": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/espree": {
+      "version": "11.2.0",
+      "resolved": "https://registry.npmjs.org/espree/-/espree-11.2.0.tgz",
+      "integrity": "sha512-7p3DrVEIopW1B1avAGLuCSh1jubc01H2JHc8B4qqGblmg5gI9yumBgACjWo4JlIc04ufug4xJ3SQI8HkS/Rgzw==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "acorn": "^8.16.0",
+        "acorn-jsx": "^5.3.2",
+        "eslint-visitor-keys": "^5.0.1"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
     "node_modules/esprima": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
@@ -3415,6 +4558,52 @@
       },
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/esquery": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/esquery/-/esquery-1.7.0.tgz",
+      "integrity": "sha512-Ap6G0WQwcU/LHsvLwON1fAQX9Zp0A2Y6Y/cJBl9r/JbW90Zyg4/zbG6zzKa2OTALELarYHmKu0GhpM5EO+7T0g==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "estraverse": "^5.1.0"
+      },
+      "engines": {
+        "node": ">=0.10"
+      }
+    },
+    "node_modules/esrecurse": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/esrecurse/-/esrecurse-4.3.0.tgz",
+      "integrity": "sha512-KmfKL3b6G+RXvP8N1vr3Tq1kL/oCFgn2NYXEtqP8/L3pKapUA4G8cFVaoF3SU323CD4XypR/ffioHmkti6/Tag==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "estraverse": "^5.2.0"
+      },
+      "engines": {
+        "node": ">=4.0"
+      }
+    },
+    "node_modules/estraverse": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
+      "integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=4.0"
+      }
+    },
+    "node_modules/esutils": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
+      "integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/eventsource": {
@@ -3490,6 +4679,13 @@
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
       }
     },
+    "node_modules/fast-deep-equal": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/fast-equals": {
       "version": "6.0.2",
       "resolved": "https://registry.npmjs.org/fast-equals/-/fast-equals-6.0.2.tgz",
@@ -3507,6 +4703,30 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/fast-levenshtein": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
+      "integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/fast-uri": {
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.5.tgz",
+      "integrity": "sha512-gHwA1O9LDIcKunMKhObS/HimwtehO1nPUECKAu5TpKgaO19fcWEl4bliWe1jWxVFvIXztJjjQ4L8XQ1EU9f7Jw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "BSD-3-Clause"
+    },
     "node_modules/fb-watchman": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/fb-watchman/-/fb-watchman-2.0.2.tgz",
@@ -3515,6 +4735,19 @@
       "license": "Apache-2.0",
       "dependencies": {
         "bser": "2.1.1"
+      }
+    },
+    "node_modules/file-entry-cache": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-8.0.0.tgz",
+      "integrity": "sha512-XXTUwCvisa5oacNGRP9SfNtYBNAMi+RPwBFmblZEF7N7swHYQS6/Zfk7SRwx4D5j3CH211YNRco1DEMNVfZCnQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "flat-cache": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=16.0.0"
       }
     },
     "node_modules/fill-range": {
@@ -3542,6 +4775,20 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/flat-cache": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-4.0.1.tgz",
+      "integrity": "sha512-f7ccFPK3SXFHpx15UIGyRJ/FJQctuKZ0zVuN3frBo4HnK3cay9VEW0R6yPYFHC0AgqhukPzKjq22t5DmAyqGyw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "flatted": "^3.2.9",
+        "keyv": "^4.5.4"
+      },
+      "engines": {
+        "node": ">=16"
       }
     },
     "node_modules/flatted": {
@@ -3658,6 +4905,19 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
+    "node_modules/glob-parent": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-6.0.2.tgz",
+      "integrity": "sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "is-glob": "^4.0.3"
+      },
+      "engines": {
+        "node": ">=10.13.0"
+      }
+    },
     "node_modules/global-directory": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/global-directory/-/global-directory-5.0.0.tgz",
@@ -3726,6 +4986,23 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/html-entities": {
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/html-entities/-/html-entities-2.6.0.tgz",
+      "integrity": "sha512-kig+rMn/QOVRvr7c86gQ8lWXq+Hkv6CbAH1hLu+RG338StTpE8Z0b44SDVaqVu7HGKf27frdmUYEs9hTUX/cLQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/mdevils"
+        },
+        {
+          "type": "patreon",
+          "url": "https://patreon.com/mdevils"
+        }
+      ],
+      "license": "MIT"
+    },
     "node_modules/html-escaper": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-2.0.2.tgz",
@@ -3741,6 +5018,16 @@
       "license": "Apache-2.0",
       "engines": {
         "node": ">=10.17.0"
+      }
+    },
+    "node_modules/ignore": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.2.tgz",
+      "integrity": "sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4"
       }
     },
     "node_modules/import-fresh": {
@@ -3849,6 +5136,16 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/is-extglob": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
+      "integrity": "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/is-fullwidth-code-point": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
@@ -3867,6 +5164,19 @@
       "license": "MIT",
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/is-glob": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
+      "integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-extglob": "^2.1.1"
+      },
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/is-number": {
@@ -4608,6 +5918,13 @@
         "url": "https://github.com/chalk/supports-color?sponsor=1"
       }
     },
+    "node_modules/jju": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/jju/-/jju-1.4.0.tgz",
+      "integrity": "sha512-8wb9Yw966OSxApiCt0K3yNJL8pnNeIv+OEq2YMidz4FKP6nonSRoOXc80iXY4JaN2FC11B9qsNmDsm+ZOfMROA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/jose": {
       "version": "6.2.8",
       "resolved": "https://registry.npmjs.org/jose/-/jose-6.2.8.tgz",
@@ -4639,6 +5956,16 @@
         "js-yaml": "bin/js-yaml.js"
       }
     },
+    "node_modules/jsdoc-type-pratt-parser": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/jsdoc-type-pratt-parser/-/jsdoc-type-pratt-parser-8.0.0.tgz",
+      "integrity": "sha512-uQu/fXVqVaMg6gM8/E5G5+eygVcZ1NV0Z51CvqhNa2bDWxvHMl484ETr6vph4oPyC+KUcbP/w2W2pewfCiR9aQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
     "node_modules/jsesc": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-3.1.0.tgz",
@@ -4652,10 +5979,31 @@
         "node": ">=6"
       }
     },
+    "node_modules/json-buffer": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/json-buffer/-/json-buffer-3.0.1.tgz",
+      "integrity": "sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/json-parse-even-better-errors": {
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/json-parse-even-better-errors/-/json-parse-even-better-errors-2.3.1.tgz",
       "integrity": "sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/json-schema-traverse": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/json-stable-stringify-without-jsonify": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
+      "integrity": "sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==",
       "dev": true,
       "license": "MIT"
     },
@@ -4670,6 +6018,16 @@
       },
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/keyv": {
+      "version": "4.5.4",
+      "resolved": "https://registry.npmjs.org/keyv/-/keyv-4.5.4.tgz",
+      "integrity": "sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "json-buffer": "3.0.1"
       }
     },
     "node_modules/kleur": {
@@ -4690,6 +6048,20 @@
       "license": "MIT",
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/levn": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/levn/-/levn-0.4.1.tgz",
+      "integrity": "sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "prelude-ls": "^1.2.1",
+        "type-check": "~0.4.0"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
       }
     },
     "node_modules/lines-and-columns": {
@@ -4903,6 +6275,13 @@
         "node": ">=8"
       }
     },
+    "node_modules/object-deep-merge": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/object-deep-merge/-/object-deep-merge-2.0.1.tgz",
+      "integrity": "sha512-aKttDKcU3pyZqKcCkDhsMn70WmZFG2JGDQLP9EcLyTSIFQRCPWLAmBZRLJnrVUrhPG1jETEEbfdgbNtJf1LyMg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/on-exit-leak-free": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/on-exit-leak-free/-/on-exit-leak-free-2.1.2.tgz",
@@ -4945,6 +6324,24 @@
       "license": "Apache-2.0",
       "engines": {
         "node": "^26 || ^24 || ^22"
+      }
+    },
+    "node_modules/optionator": {
+      "version": "0.9.4",
+      "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.9.4.tgz",
+      "integrity": "sha512-6IpQ7mKUxRcZNLIObR0hz7lxsapSSIYNZJwXPGeF0mTVqGKFIXj1DQcMoT22S3ROcLyY/rz0PWaWZ9ayWmad9g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "deep-is": "^0.1.3",
+        "fast-levenshtein": "^2.0.6",
+        "levn": "^0.4.1",
+        "prelude-ls": "^1.2.1",
+        "type-check": "^0.4.0",
+        "word-wrap": "^1.2.5"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
       }
     },
     "node_modules/p-limit": {
@@ -5002,6 +6399,16 @@
         "node": ">=6"
       }
     },
+    "node_modules/parse-imports-exports": {
+      "version": "0.2.4",
+      "resolved": "https://registry.npmjs.org/parse-imports-exports/-/parse-imports-exports-0.2.4.tgz",
+      "integrity": "sha512-4s6vd6dx1AotCx/RCI2m7t7GCh5bDRUtGNvRfHSP2wbBQdMi67pPe7mtzmgwcaQ8VKK/6IB7Glfyu3qdZJPybQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "parse-statements": "1.0.11"
+      }
+    },
     "node_modules/parse-json": {
       "version": "5.2.0",
       "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-5.2.0.tgz",
@@ -5020,6 +6427,13 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/parse-statements": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/parse-statements/-/parse-statements-1.0.11.tgz",
+      "integrity": "sha512-HlsyYdMBnbPQ9Jr/VgJ1YF4scnldvJpJxCVx6KgqPL4dxppsWrJHCIIxQXMJrqGnsRkNPATbeMJ8Yxu7JMsYcA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/path-exists": {
       "version": "4.0.0",
@@ -5148,6 +6562,16 @@
         "node": ">=8"
       }
     },
+    "node_modules/prelude-ls": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
+      "integrity": "sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
     "node_modules/pretty-format": {
       "version": "29.7.0",
       "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-29.7.0.tgz",
@@ -5206,6 +6630,16 @@
         "node": ">= 6"
       }
     },
+    "node_modules/punycode": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
+      "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/pure-rand": {
       "version": "6.1.0",
       "resolved": "https://registry.npmjs.org/pure-rand/-/pure-rand-6.1.0.tgz",
@@ -5253,6 +6687,29 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/require-from-string": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/reserved-identifiers": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/reserved-identifiers/-/reserved-identifiers-1.2.0.tgz",
+      "integrity": "sha512-yE7KUfFvaBFzGPs5H3Ops1RevfUEsDc5Iz65rOwWg4lE8HJSYtle77uul3+573457oHvBKuHYDl/xqUkKpEEdw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/resolve": {
@@ -5418,6 +6875,31 @@
         "buffer-from": "^1.0.0",
         "source-map": "^0.6.0"
       }
+    },
+    "node_modules/spdx-exceptions": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/spdx-exceptions/-/spdx-exceptions-2.5.0.tgz",
+      "integrity": "sha512-PiU42r+xO4UbUS1buo3LPJkjlO7430Xn5SVAhdpzzsPHsjbYVflnnFdATgabnLude+Cqu25p6N+g2lw/PFsa4w==",
+      "dev": true,
+      "license": "CC-BY-3.0"
+    },
+    "node_modules/spdx-expression-parse": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-5.0.0.tgz",
+      "integrity": "sha512-vngmw3Rgn+o2arXNbnZaj5UtOEBuWBfvaI+Wc8GFfykIhA5/vdK9/Sp/XkLv63dykz2rxKDvKEHupF5P0FORcQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "spdx-exceptions": "^2.1.0",
+        "spdx-license-ids": "^3.0.0"
+      }
+    },
+    "node_modules/spdx-license-ids": {
+      "version": "3.0.23",
+      "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.23.tgz",
+      "integrity": "sha512-CWLcCCH7VLu13TgOH+r8p1O/Znwhqv/dbb6lqWy67G+pT1kHmeD/+V36AVb/vq8QMIQwVShJ6Ssl5FPh0fuSdw==",
+      "dev": true,
+      "license": "CC0-1.0"
     },
     "node_modules/split2": {
       "version": "4.2.0",
@@ -5650,6 +7132,36 @@
         "node": ">=8.0"
       }
     },
+    "node_modules/to-valid-identifier": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/to-valid-identifier/-/to-valid-identifier-1.0.0.tgz",
+      "integrity": "sha512-41wJyvKep3yT2tyPqX/4blcfybknGB4D+oETKLs7Q76UiPqRpUJK3hr1nxelyYO0PHKVzJwlu0aCeEAsGI6rpw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@sindresorhus/base62": "^1.0.0",
+        "reserved-identifiers": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/ts-api-utils": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-2.5.0.tgz",
+      "integrity": "sha512-OJ/ibxhPlqrMM0UiNHJ/0CKQkoKF243/AEmplt3qpRgkW8VG7IfOS41h7V8TjITqdByHzrjcS/2si+y4lIh8NA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.12"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.8.4"
+      }
+    },
     "node_modules/ts-jest": {
       "version": "29.4.12",
       "resolved": "https://registry.npmjs.org/ts-jest/-/ts-jest-29.4.12.tgz",
@@ -5779,6 +7291,19 @@
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
       "license": "0BSD"
     },
+    "node_modules/type-check": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.4.0.tgz",
+      "integrity": "sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "prelude-ls": "^1.2.1"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
     "node_modules/type-detect": {
       "version": "4.0.8",
       "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.0.8.tgz",
@@ -5814,6 +7339,30 @@
       },
       "engines": {
         "node": ">=14.17"
+      }
+    },
+    "node_modules/typescript-eslint": {
+      "version": "8.66.0",
+      "resolved": "https://registry.npmjs.org/typescript-eslint/-/typescript-eslint-8.66.0.tgz",
+      "integrity": "sha512-QlEbBPz/RuJ1XUHj29nm3t0F/O/cSlEnntozqPOYHnnTGAXFamnMBu5i9Vn6vhUPHGAjR+Vl+5J8vPN/BMUrJw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/eslint-plugin": "8.66.0",
+        "@typescript-eslint/parser": "8.66.0",
+        "@typescript-eslint/typescript-estree": "8.66.0",
+        "@typescript-eslint/utils": "8.66.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+        "typescript": ">=4.8.4 <6.1.0"
       }
     },
     "node_modules/uglify-js": {
@@ -5866,6 +7415,16 @@
       },
       "peerDependencies": {
         "browserslist": ">= 4.21.0"
+      }
+    },
+    "node_modules/uri-js": {
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
+      "integrity": "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "punycode": "^2.1.0"
       }
     },
     "node_modules/uuid": {
@@ -5942,6 +7501,16 @@
       },
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/word-wrap": {
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.5.tgz",
+      "integrity": "sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/wordwrap": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -24,7 +24,7 @@
       "devDependencies": {
         "@babel/plugin-transform-modules-commonjs": "7.29.7",
         "@biomejs/biome": "2.5.7",
-        "@microsoft/tsdoc-config": "^0.18.1",
+        "@microsoft/tsdoc-config": "0.18.1",
         "@modelcontextprotocol/client": "2.0.0",
         "@toon-format/toon": "4.1.0",
         "@types/jest": "^29.5.0",
@@ -32,15 +32,15 @@
         "@types/opossum": "^8.1.9",
         "babel-jest": "^29.7.0",
         "cspell": "^10.0.1",
-        "eslint": "^10.8.0",
-        "eslint-plugin-jsdoc": "^63.3.3",
-        "eslint-plugin-tsdoc": "^0.5.2",
+        "eslint": "9.39.1",
+        "eslint-plugin-jsdoc": "50.8.0",
+        "eslint-plugin-tsdoc": "0.5.2",
         "jest": "^29.5.0",
         "jest-junit": "^17.0.0",
         "ts-jest": "^29.4.12",
         "ts-node": "^10.9.0",
         "typescript": "~6.0.3",
-        "typescript-eslint": "^8.66.0"
+        "typescript-eslint": "8.66.0"
       },
       "engines": {
         "node": ">=22.3.0"
@@ -1718,30 +1718,20 @@
       }
     },
     "node_modules/@es-joy/jsdoccomment": {
-      "version": "0.91.0",
-      "resolved": "https://registry.npmjs.org/@es-joy/jsdoccomment/-/jsdoccomment-0.91.0.tgz",
-      "integrity": "sha512-vgqlMGNNhZxwDYbUNIHj3Hskb4R28iqdXx90ufHyt/NeuTQkeqjTDslAs9I0/GCAfbxP5BpH5WsL1R1fht5Lxg==",
+      "version": "0.50.2",
+      "resolved": "https://registry.npmjs.org/@es-joy/jsdoccomment/-/jsdoccomment-0.50.2.tgz",
+      "integrity": "sha512-YAdE/IJSpwbOTiaURNCKECdAwqrJuFiZhylmesBcIRawtYKnBR2wxPhoIewMg+Yu+QuYvHfJNReWpoxGBKOChA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@types/estree": "^1.0.9",
-        "@typescript-eslint/types": "^8.65.0",
-        "comment-parser": "1.4.7",
-        "esquery": "^1.7.0",
-        "jsdoc-type-pratt-parser": "~8.0.0"
+        "@types/estree": "^1.0.6",
+        "@typescript-eslint/types": "^8.11.0",
+        "comment-parser": "1.4.1",
+        "esquery": "^1.6.0",
+        "jsdoc-type-pratt-parser": "~4.1.0"
       },
       "engines": {
-        "node": "^20.19.0 || ^22.13.0 || >=24"
-      }
-    },
-    "node_modules/@es-joy/resolve.exports": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/@es-joy/resolve.exports/-/resolve.exports-1.2.0.tgz",
-      "integrity": "sha512-Q9hjxWI5xBM+qW2enxfe8wDKdFWMfd0Z29k5ZJnuBqD/CasY5Zryj09aCA6owbGATWz+39p5uIdaHXpopOcG8g==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=10"
+        "node": ">=18"
       }
     },
     "node_modules/@eslint-community/eslint-utils": {
@@ -1787,107 +1777,186 @@
       }
     },
     "node_modules/@eslint/config-array": {
-      "version": "0.23.5",
-      "resolved": "https://registry.npmjs.org/@eslint/config-array/-/config-array-0.23.5.tgz",
-      "integrity": "sha512-Y3kKLvC1dvTOT+oGlqNQ1XLqK6D1HU2YXPc52NmAlJZbMMWDzGYXMiPRJ8TYD39muD/OTjlZmNJ4ib7dvSrMBA==",
+      "version": "0.21.2",
+      "resolved": "https://registry.npmjs.org/@eslint/config-array/-/config-array-0.21.2.tgz",
+      "integrity": "sha512-nJl2KGTlrf9GjLimgIru+V/mzgSK0ABCDQRvxw5BjURL7WfH5uoWmizbH7QB6MmnMBd8cIC9uceWnezL1VZWWw==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@eslint/object-schema": "^3.0.5",
+        "@eslint/object-schema": "^2.1.7",
         "debug": "^4.3.1",
-        "minimatch": "^10.2.4"
+        "minimatch": "^3.1.5"
       },
       "engines": {
-        "node": "^20.19.0 || ^22.13.0 || >=24"
-      }
-    },
-    "node_modules/@eslint/config-array/node_modules/balanced-match": {
-      "version": "4.0.4",
-      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
-      "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": "18 || 20 || >=22"
-      }
-    },
-    "node_modules/@eslint/config-array/node_modules/brace-expansion": {
-      "version": "5.0.9",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.9.tgz",
-      "integrity": "sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "balanced-match": "^4.0.2"
-      },
-      "engines": {
-        "node": "20 || >=22"
-      }
-    },
-    "node_modules/@eslint/config-array/node_modules/minimatch": {
-      "version": "10.2.6",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.6.tgz",
-      "integrity": "sha512-vpLQEs+VLCr1nU0BXS07maYoFwlDAH0gngQuuttxIwutDFEMHq2blX+8vpgxDdK3J1PwjCJiep77OitTZ4Ll1A==",
-      "dev": true,
-      "license": "BlueOak-1.0.0",
-      "dependencies": {
-        "brace-expansion": "^5.0.8"
-      },
-      "engines": {
-        "node": "18 || 20 || >=22"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       }
     },
     "node_modules/@eslint/config-helpers": {
-      "version": "0.7.0",
-      "resolved": "https://registry.npmjs.org/@eslint/config-helpers/-/config-helpers-0.7.0.tgz",
-      "integrity": "sha512-DObd/KKUsU+FaFv4PLxSRenpXfQWmPXXP3pPZ6/K1PCrMu2vQpMDMuQe/BqYeoLcz8ro0bVDF1RxOJgfVEdhUw==",
+      "version": "0.4.2",
+      "resolved": "https://registry.npmjs.org/@eslint/config-helpers/-/config-helpers-0.4.2.tgz",
+      "integrity": "sha512-gBrxN88gOIf3R7ja5K9slwNayVcZgK6SOUORm2uBzTeIEfeVaIhOpCtTox3P6R7o2jLFwLFTLnC7kU/RGcYEgw==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@eslint/core": "^1.2.1"
+        "@eslint/core": "^0.17.0"
       },
       "engines": {
-        "node": "^20.19.0 || ^22.13.0 || >=24"
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       }
     },
     "node_modules/@eslint/core": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/@eslint/core/-/core-1.2.1.tgz",
-      "integrity": "sha512-MwcE1P+AZ4C6DWlpin/OmOA54mmIZ/+xZuJiQd4SyB29oAJjN30UW9wkKNptW2ctp4cEsvhlLY/CsQ1uoHDloQ==",
+      "version": "0.17.0",
+      "resolved": "https://registry.npmjs.org/@eslint/core/-/core-0.17.0.tgz",
+      "integrity": "sha512-yL/sLrpmtDaFEiUj1osRP4TI2MDz1AddJL+jZ7KSqvBuliN4xqYY54IfdN8qD8Toa6g1iloph1fxQNkjOxrrpQ==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@types/json-schema": "^7.0.15"
       },
       "engines": {
-        "node": "^20.19.0 || ^22.13.0 || >=24"
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
+    "node_modules/@eslint/eslintrc": {
+      "version": "3.3.6",
+      "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-3.3.6.tgz",
+      "integrity": "sha512-l2Ul9PrHsPCKcEY/ac7VgFj9D80C7S68sOKc618SyHDPK36s1XcFebXY0iTzUVn4Yq+YbwvSnDmCz9yxjX+QrA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ajv": "^6.14.0",
+        "debug": "^4.3.2",
+        "espree": "^10.0.1",
+        "globals": "^14.0.0",
+        "ignore": "^5.2.0",
+        "import-fresh": "^3.2.1",
+        "js-yaml": "^4.3.0",
+        "minimatch": "^3.1.5",
+        "strip-json-comments": "^3.1.1"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/@eslint/eslintrc/node_modules/ajv": {
+      "version": "6.15.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.15.0.tgz",
+      "integrity": "sha512-fgFx7Hfoq60ytK2c7DhnF8jIvzYgOMxfugjLOSMHjLIPgenqa7S7oaagATUq99mV6IYvN2tRmC0wnTYX6iPbMw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.1",
+        "fast-json-stable-stringify": "^2.0.0",
+        "json-schema-traverse": "^0.4.1",
+        "uri-js": "^4.2.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/@eslint/eslintrc/node_modules/argparse": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
+      "dev": true,
+      "license": "Python-2.0"
+    },
+    "node_modules/@eslint/eslintrc/node_modules/import-fresh": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.1.tgz",
+      "integrity": "sha512-TR3KfrTZTYLPB6jUjfx6MF9WcWrHL9su5TObK4ZkYgBdWKPOFoSoQIdEuTuR82pmtxH2spWG9h6etwfr1pLBqQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "parent-module": "^1.0.0",
+        "resolve-from": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@eslint/eslintrc/node_modules/js-yaml": {
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.1.tgz",
+      "integrity": "sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/puzrin"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/nodeca"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "argparse": "^2.0.1"
+      },
+      "bin": {
+        "js-yaml": "bin/js-yaml.js"
+      }
+    },
+    "node_modules/@eslint/eslintrc/node_modules/json-schema-traverse": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@eslint/eslintrc/node_modules/resolve-from": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
+      "integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/@eslint/js": {
+      "version": "9.39.1",
+      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-9.39.1.tgz",
+      "integrity": "sha512-S26Stp4zCy88tH94QbBv3XCuzRQiZ9yXofEILmglYTh/Ug/a9/umqvgFtYBAo3Lp0nsI/5/qH1CCrbdK3AP1Tw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://eslint.org/donate"
       }
     },
     "node_modules/@eslint/object-schema": {
-      "version": "3.0.5",
-      "resolved": "https://registry.npmjs.org/@eslint/object-schema/-/object-schema-3.0.5.tgz",
-      "integrity": "sha512-vqTaUEgxzm+YDSdElad6PiRoX4t8VGDjCtt05zn4nU810UIx/uNEV7/lZJ6KwFThKZOzOxzXy48da+No7HZaMw==",
+      "version": "2.1.7",
+      "resolved": "https://registry.npmjs.org/@eslint/object-schema/-/object-schema-2.1.7.tgz",
+      "integrity": "sha512-VtAOaymWVfZcmZbp6E2mympDIHvyjXs/12LqWYjVw6qjrfF+VK+fyG33kChz3nnK+SU5/NeHOqrTEHS8sXO3OA==",
       "dev": true,
       "license": "Apache-2.0",
       "engines": {
-        "node": "^20.19.0 || ^22.13.0 || >=24"
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       }
     },
     "node_modules/@eslint/plugin-kit": {
-      "version": "0.7.2",
-      "resolved": "https://registry.npmjs.org/@eslint/plugin-kit/-/plugin-kit-0.7.2.tgz",
-      "integrity": "sha512-+CNAzxglkrpNf/kKywqQfk74QjtceuOE7Qm+AF8miRvPF/wmmK5+OJOgVh3AVTT3RP2mH3+FOaxlE5v72owk0A==",
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/@eslint/plugin-kit/-/plugin-kit-0.4.1.tgz",
+      "integrity": "sha512-43/qtrDUokr7LJqoF2c3+RInu/t4zfrpYdoSDfYyhg52rwLV6TnOvdG4fXm7IkSB3wErkcmJS9iEhjVtOSEjjA==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@eslint/core": "^1.2.1",
+        "@eslint/core": "^0.17.0",
         "levn": "^0.4.1"
       },
       "engines": {
-        "node": "^20.19.0 || ^22.13.0 || >=24"
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       }
     },
     "node_modules/@humanfs/core": {
@@ -2402,19 +2471,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/@sindresorhus/base62": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@sindresorhus/base62/-/base62-1.0.0.tgz",
-      "integrity": "sha512-TeheYy0ILzBEI/CO55CP6zJCSdSWeRtGnHy8U8dWSUH4I68iqTsy7HkMktR4xakThc9jotkPQUXT4ITdbV7cHA==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/@sinonjs/commons": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-3.0.1.tgz",
@@ -2595,13 +2651,6 @@
       "dependencies": {
         "@babel/types": "^7.28.2"
       }
-    },
-    "node_modules/@types/esrecurse": {
-      "version": "4.3.1",
-      "resolved": "https://registry.npmjs.org/@types/esrecurse/-/esrecurse-4.3.1.tgz",
-      "integrity": "sha512-xJBAbDifo5hpffDBuHl0Y8ywswbiAp/Wi7Y/GtAgSlZyIABppyurxVueOPE8LUQOxdlgi6Zqce7uoEpqNTeiUw==",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/@types/estree": {
       "version": "1.0.9",
@@ -3571,9 +3620,9 @@
       }
     },
     "node_modules/comment-parser": {
-      "version": "1.4.7",
-      "resolved": "https://registry.npmjs.org/comment-parser/-/comment-parser-1.4.7.tgz",
-      "integrity": "sha512-0h+uSNtQGW3D98eQt3jJ8L06Fves8hncB4V/PKdw/Qb8Hnk19VaKuTr55UNRYiSoVa7WwrFls+rh3ux9agmkeQ==",
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/comment-parser/-/comment-parser-1.4.1.tgz",
+      "integrity": "sha512-buhp5kePrmda3vhc5B9t7pUQXAb2Tnd0qgpkIhPhkHXxJpiPJ11H0ZEU0oBpJ2QztSbzG/ZxMj/CHsYJqRHmyg==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -4038,33 +4087,33 @@
       }
     },
     "node_modules/eslint": {
-      "version": "10.8.0",
-      "resolved": "https://registry.npmjs.org/eslint/-/eslint-10.8.0.tgz",
-      "integrity": "sha512-nuKKvN+oIBO0koN7Tm7dlkmnkc21mtt0QJLwAKzjLq14y6lRTdVG36MZHJ8eQHwdJMwZbQNMlPOYedMq/oVJvQ==",
+      "version": "9.39.1",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-9.39.1.tgz",
+      "integrity": "sha512-BhHmn2yNOFA9H9JmmIVKJmd288g9hrVRDkdoIgRCRuSySRUHH7r/DI6aAXW9T1WwUuY3DFgrcaqB+deURBLR5g==",
       "dev": true,
       "license": "MIT",
-      "workspaces": [
-        "packages/*"
-      ],
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
-        "@eslint-community/regexpp": "^4.12.2",
-        "@eslint/config-array": "^0.23.5",
-        "@eslint/config-helpers": "^0.7.0",
-        "@eslint/core": "^1.2.1",
-        "@eslint/plugin-kit": "^0.7.2",
+        "@eslint-community/regexpp": "^4.12.1",
+        "@eslint/config-array": "^0.21.1",
+        "@eslint/config-helpers": "^0.4.2",
+        "@eslint/core": "^0.17.0",
+        "@eslint/eslintrc": "^3.3.1",
+        "@eslint/js": "9.39.1",
+        "@eslint/plugin-kit": "^0.4.1",
         "@humanfs/node": "^0.16.6",
         "@humanwhocodes/module-importer": "^1.0.1",
         "@humanwhocodes/retry": "^0.4.2",
         "@types/estree": "^1.0.6",
-        "ajv": "^6.14.0",
+        "ajv": "^6.12.4",
+        "chalk": "^4.0.0",
         "cross-spawn": "^7.0.6",
         "debug": "^4.3.2",
         "escape-string-regexp": "^4.0.0",
-        "eslint-scope": "^9.1.2",
-        "eslint-visitor-keys": "^5.0.1",
-        "espree": "^11.2.0",
-        "esquery": "^1.7.0",
+        "eslint-scope": "^8.4.0",
+        "eslint-visitor-keys": "^4.2.1",
+        "espree": "^10.4.0",
+        "esquery": "^1.5.0",
         "esutils": "^2.0.2",
         "fast-deep-equal": "^3.1.3",
         "file-entry-cache": "^8.0.0",
@@ -4074,7 +4123,8 @@
         "imurmurhash": "^0.1.4",
         "is-glob": "^4.0.0",
         "json-stable-stringify-without-jsonify": "^1.0.1",
-        "minimatch": "^10.2.5",
+        "lodash.merge": "^4.6.2",
+        "minimatch": "^3.1.2",
         "natural-compare": "^1.4.0",
         "optionator": "^0.9.3"
       },
@@ -4082,7 +4132,7 @@
         "eslint": "bin/eslint.js"
       },
       "engines": {
-        "node": "^20.19.0 || ^22.13.0 || >=24"
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       },
       "funding": {
         "url": "https://eslint.org/donate"
@@ -4097,32 +4147,28 @@
       }
     },
     "node_modules/eslint-plugin-jsdoc": {
-      "version": "63.3.3",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-jsdoc/-/eslint-plugin-jsdoc-63.3.3.tgz",
-      "integrity": "sha512-xI4IeVRzRFA2DGHrPLIxF3U+oJHU3FE+P9Zb27fVs5dPHgfcpoAs0PyCbznVhK7pwR+9BPUztFeXSgpw/CL4Yg==",
+      "version": "50.8.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-jsdoc/-/eslint-plugin-jsdoc-50.8.0.tgz",
+      "integrity": "sha512-UyGb5755LMFWPrZTEqqvTJ3urLz1iqj+bYOHFNag+sw3NvaMWP9K2z+uIn37XfNALmQLQyrBlJ5mkiVPL7ADEg==",
       "dev": true,
       "license": "BSD-3-Clause",
       "dependencies": {
-        "@es-joy/jsdoccomment": "~0.91.0",
-        "@es-joy/resolve.exports": "1.2.0",
+        "@es-joy/jsdoccomment": "~0.50.2",
         "are-docs-informative": "^0.0.2",
-        "comment-parser": "1.4.7",
-        "debug": "^4.4.3",
+        "comment-parser": "1.4.1",
+        "debug": "^4.4.1",
         "escape-string-regexp": "^4.0.0",
-        "espree": "^11.2.0",
-        "esquery": "^1.7.0",
-        "html-entities": "^2.6.0",
-        "object-deep-merge": "^2.0.1",
+        "espree": "^10.3.0",
+        "esquery": "^1.6.0",
         "parse-imports-exports": "^0.2.4",
-        "semver": "^7.8.5",
-        "spdx-expression-parse": "^5.0.0",
-        "to-valid-identifier": "^1.0.0"
+        "semver": "^7.7.2",
+        "spdx-expression-parse": "^4.0.0"
       },
       "engines": {
-        "node": "^22.13.0 || >=24"
+        "node": ">=18"
       },
       "peerDependencies": {
-        "eslint": "^7.0.0 || ^8.0.0 || ^9.0.0 || ^10.0.0"
+        "eslint": "^7.0.0 || ^8.0.0 || ^9.0.0"
       }
     },
     "node_modules/eslint-plugin-jsdoc/node_modules/escape-string-regexp": {
@@ -4372,32 +4418,30 @@
       }
     },
     "node_modules/eslint-scope": {
-      "version": "9.1.2",
-      "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-9.1.2.tgz",
-      "integrity": "sha512-xS90H51cKw0jltxmvmHy2Iai1LIqrfbw57b79w/J7MfvDfkIkFZ+kj6zC3BjtUwh150HsSSdxXZcsuv72miDFQ==",
+      "version": "8.4.0",
+      "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-8.4.0.tgz",
+      "integrity": "sha512-sNXOfKCn74rt8RICKMvJS7XKV/Xk9kA7DyJr8mJik3S7Cwgy3qlkkmyS2uQB3jiJg6VNdZd/pDBJu0nvG2NlTg==",
       "dev": true,
       "license": "BSD-2-Clause",
       "dependencies": {
-        "@types/esrecurse": "^4.3.1",
-        "@types/estree": "^1.0.8",
         "esrecurse": "^4.3.0",
         "estraverse": "^5.2.0"
       },
       "engines": {
-        "node": "^20.19.0 || ^22.13.0 || >=24"
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       },
       "funding": {
         "url": "https://opencollective.com/eslint"
       }
     },
     "node_modules/eslint-visitor-keys": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-5.0.1.tgz",
-      "integrity": "sha512-tD40eHxA35h0PEIZNeIjkHoDR4YjjJp34biM0mDvplBe//mB+IHCqHDGV7pxF+7MklTvighcCPPZC7ynWyjdTA==",
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-4.2.1.tgz",
+      "integrity": "sha512-Uhdk5sfqcee/9H/rCOJikYz67o0a2Tw2hGRPOG2Y1R2dg7brRe1uG0yaNQDHu+TO/uQPF/5eCapvYSmHUjt7JQ==",
       "dev": true,
       "license": "Apache-2.0",
       "engines": {
-        "node": "^20.19.0 || ^22.13.0 || >=24"
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       },
       "funding": {
         "url": "https://opencollective.com/eslint"
@@ -4418,29 +4462,6 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/epoberezkin"
-      }
-    },
-    "node_modules/eslint/node_modules/balanced-match": {
-      "version": "4.0.4",
-      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
-      "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": "18 || 20 || >=22"
-      }
-    },
-    "node_modules/eslint/node_modules/brace-expansion": {
-      "version": "5.0.9",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.9.tgz",
-      "integrity": "sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "balanced-match": "^4.0.2"
-      },
-      "engines": {
-        "node": "20 || >=22"
       }
     },
     "node_modules/eslint/node_modules/escape-string-regexp": {
@@ -4496,22 +4517,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/eslint/node_modules/minimatch": {
-      "version": "10.2.6",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.6.tgz",
-      "integrity": "sha512-vpLQEs+VLCr1nU0BXS07maYoFwlDAH0gngQuuttxIwutDFEMHq2blX+8vpgxDdK3J1PwjCJiep77OitTZ4Ll1A==",
-      "dev": true,
-      "license": "BlueOak-1.0.0",
-      "dependencies": {
-        "brace-expansion": "^5.0.8"
-      },
-      "engines": {
-        "node": "18 || 20 || >=22"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
     "node_modules/eslint/node_modules/p-locate": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-5.0.0.tgz",
@@ -4529,18 +4534,18 @@
       }
     },
     "node_modules/espree": {
-      "version": "11.2.0",
-      "resolved": "https://registry.npmjs.org/espree/-/espree-11.2.0.tgz",
-      "integrity": "sha512-7p3DrVEIopW1B1avAGLuCSh1jubc01H2JHc8B4qqGblmg5gI9yumBgACjWo4JlIc04ufug4xJ3SQI8HkS/Rgzw==",
+      "version": "10.4.0",
+      "resolved": "https://registry.npmjs.org/espree/-/espree-10.4.0.tgz",
+      "integrity": "sha512-j6PAQ2uUr79PZhBjP5C5fhl8e39FmRnOjsD5lGnWrFU8i2G776tBK7+nP8KuQUTTyAZUwfQqXAgrVH5MbH9CYQ==",
       "dev": true,
       "license": "BSD-2-Clause",
       "dependencies": {
-        "acorn": "^8.16.0",
+        "acorn": "^8.15.0",
         "acorn-jsx": "^5.3.2",
-        "eslint-visitor-keys": "^5.0.1"
+        "eslint-visitor-keys": "^4.2.1"
       },
       "engines": {
-        "node": "^20.19.0 || ^22.13.0 || >=24"
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       },
       "funding": {
         "url": "https://opencollective.com/eslint"
@@ -4934,6 +4939,19 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/globals": {
+      "version": "14.0.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-14.0.0.tgz",
+      "integrity": "sha512-oahGvuMGQlPw/ivIYBjVSrWAfWLBeku5tpPE2fOPLi+WHffIWbuh2tCjhyQhTBPMf5E9jDEH4FOmTYgYwbKwtQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/graceful-fs": {
       "version": "4.2.11",
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
@@ -4985,23 +5003,6 @@
       "engines": {
         "node": ">= 0.4"
       }
-    },
-    "node_modules/html-entities": {
-      "version": "2.6.0",
-      "resolved": "https://registry.npmjs.org/html-entities/-/html-entities-2.6.0.tgz",
-      "integrity": "sha512-kig+rMn/QOVRvr7c86gQ8lWXq+Hkv6CbAH1hLu+RG338StTpE8Z0b44SDVaqVu7HGKf27frdmUYEs9hTUX/cLQ==",
-      "dev": true,
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/mdevils"
-        },
-        {
-          "type": "patreon",
-          "url": "https://patreon.com/mdevils"
-        }
-      ],
-      "license": "MIT"
     },
     "node_modules/html-escaper": {
       "version": "2.0.2",
@@ -5957,13 +5958,13 @@
       }
     },
     "node_modules/jsdoc-type-pratt-parser": {
-      "version": "8.0.0",
-      "resolved": "https://registry.npmjs.org/jsdoc-type-pratt-parser/-/jsdoc-type-pratt-parser-8.0.0.tgz",
-      "integrity": "sha512-uQu/fXVqVaMg6gM8/E5G5+eygVcZ1NV0Z51CvqhNa2bDWxvHMl484ETr6vph4oPyC+KUcbP/w2W2pewfCiR9aQ==",
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/jsdoc-type-pratt-parser/-/jsdoc-type-pratt-parser-4.1.0.tgz",
+      "integrity": "sha512-Hicd6JK5Njt2QB6XYFS7ok9e37O8AYk3jTcppG4YVQnYjOemymvTcmc7OWsmq/Qqj5TdRFO5/x/tIPmBeRtGHg==",
       "dev": true,
       "license": "MIT",
       "engines": {
-        "node": ">=20.0.0"
+        "node": ">=12.0.0"
       }
     },
     "node_modules/jsesc": {
@@ -6088,6 +6089,13 @@
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/lodash.memoize/-/lodash.memoize-4.1.2.tgz",
       "integrity": "sha512-t7j+NzmgnQzTAYXcsHYLgimltOV1MXHtlOWf6GjL9Kj8GK5FInw5JotxvbOs+IvV1/Dzo04/fCGfLVs7aXb4Ag==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/lodash.merge": {
+      "version": "4.6.2",
+      "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
+      "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
       "dev": true,
       "license": "MIT"
     },
@@ -6275,13 +6283,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/object-deep-merge": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/object-deep-merge/-/object-deep-merge-2.0.1.tgz",
-      "integrity": "sha512-aKttDKcU3pyZqKcCkDhsMn70WmZFG2JGDQLP9EcLyTSIFQRCPWLAmBZRLJnrVUrhPG1jETEEbfdgbNtJf1LyMg==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/on-exit-leak-free": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/on-exit-leak-free/-/on-exit-leak-free-2.1.2.tgz",
@@ -6395,6 +6396,19 @@
       "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
       "dev": true,
       "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/parent-module": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
+      "integrity": "sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "callsites": "^3.0.0"
+      },
       "engines": {
         "node": ">=6"
       }
@@ -6699,19 +6713,6 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/reserved-identifiers": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/reserved-identifiers/-/reserved-identifiers-1.2.0.tgz",
-      "integrity": "sha512-yE7KUfFvaBFzGPs5H3Ops1RevfUEsDc5Iz65rOwWg4lE8HJSYtle77uul3+573457oHvBKuHYDl/xqUkKpEEdw==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/resolve": {
       "version": "1.22.12",
       "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.12.tgz",
@@ -6884,9 +6885,9 @@
       "license": "CC-BY-3.0"
     },
     "node_modules/spdx-expression-parse": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-5.0.0.tgz",
-      "integrity": "sha512-vngmw3Rgn+o2arXNbnZaj5UtOEBuWBfvaI+Wc8GFfykIhA5/vdK9/Sp/XkLv63dykz2rxKDvKEHupF5P0FORcQ==",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-4.0.0.tgz",
+      "integrity": "sha512-Clya5JIij/7C6bRR22+tnGXbc4VKlibKSVj2iHvVeX5iMW7s1SIQlqu699JkODJJIhh/pUu8L0/VLh8xflD+LQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -7130,23 +7131,6 @@
       },
       "engines": {
         "node": ">=8.0"
-      }
-    },
-    "node_modules/to-valid-identifier": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/to-valid-identifier/-/to-valid-identifier-1.0.0.tgz",
-      "integrity": "sha512-41wJyvKep3yT2tyPqX/4blcfybknGB4D+oETKLs7Q76UiPqRpUJK3hr1nxelyYO0PHKVzJwlu0aCeEAsGI6rpw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@sindresorhus/base62": "^1.0.0",
-        "reserved-identifiers": "^1.0.0"
-      },
-      "engines": {
-        "node": ">=20"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/ts-api-utils": {

--- a/package.json
+++ b/package.json
@@ -83,7 +83,6 @@
   "devDependencies": {
     "@babel/plugin-transform-modules-commonjs": "7.29.7",
     "@biomejs/biome": "2.5.7",
-    "@microsoft/tsdoc-config": "0.18.1",
     "@modelcontextprotocol/client": "2.0.0",
     "@toon-format/toon": "4.1.0",
     "@types/jest": "^29.5.0",

--- a/package.json
+++ b/package.json
@@ -55,8 +55,8 @@
     "probe:500": "npm run build && node scripts/probe-b2-500s.mjs",
     "lint": "node scripts/run-biome.mjs lint src tests scripts",
     "lint:fix": "node scripts/run-biome.mjs lint src tests scripts --write",
-    "lint:docs": "eslint src --no-warn-ignored",
-    "lint:docs:fix": "eslint src --fix --no-warn-ignored",
+    "lint:docs": "node scripts/run-doc-lint.mjs",
+    "lint:docs:fix": "node scripts/run-doc-lint.mjs --fix",
     "format": "node scripts/run-biome.mjs format . --write",
     "format:check": "node scripts/run-biome.mjs format .",
     "spell": "cspell lint --no-progress --gitignore"
@@ -83,7 +83,7 @@
   "devDependencies": {
     "@babel/plugin-transform-modules-commonjs": "7.29.7",
     "@biomejs/biome": "2.5.7",
-    "@microsoft/tsdoc-config": "^0.18.1",
+    "@microsoft/tsdoc-config": "0.18.1",
     "@modelcontextprotocol/client": "2.0.0",
     "@toon-format/toon": "4.1.0",
     "@types/jest": "^29.5.0",
@@ -91,15 +91,15 @@
     "@types/opossum": "^8.1.9",
     "babel-jest": "^29.7.0",
     "cspell": "^10.0.1",
-    "eslint": "^10.8.0",
-    "eslint-plugin-jsdoc": "^63.3.3",
-    "eslint-plugin-tsdoc": "^0.5.2",
+    "eslint": "9.39.1",
+    "eslint-plugin-jsdoc": "50.8.0",
+    "eslint-plugin-tsdoc": "0.5.2",
     "jest": "^29.5.0",
     "jest-junit": "^17.0.0",
     "ts-jest": "^29.4.12",
     "ts-node": "^10.9.0",
     "typescript": "~6.0.3",
-    "typescript-eslint": "^8.66.0"
+    "typescript-eslint": "8.66.0"
   },
   "engines": {
     "node": ">=22.3.0"
@@ -146,6 +146,9 @@
   "overrides": {
     "@istanbuljs/load-nyc-config": {
       "js-yaml": "3.15.1"
+    },
+    "@typescript-eslint/visitor-keys": {
+      "eslint-visitor-keys": "4.2.1"
     },
     "minimatch@3.1.5": {
       "brace-expansion": "1.1.18"

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "test:integration:live": "node scripts/require-live-env.mjs integration && node scripts/run-jest-layer.mjs integration-live",
     "test:contract:live": "node scripts/require-live-env.mjs contract && node scripts/run-jest-layer.mjs contract-live",
     "test:package": "npm run build && node scripts/run-jest-layer.mjs package",
-    "verify": "npm run typecheck && npm run build && npm run lint && npm run format:check && npm run spell && npm run test:coverage && npm run test:slow && npm run test:package",
+    "verify": "npm run typecheck && npm run build && npm run lint && npm run lint:docs && npm run format:check && npm run spell && npm run test:coverage && npm run test:slow && npm run test:package",
     "test:cross-platform": "node scripts/run-cross-platform-tests.mjs",
     "smoke": "node scripts/smoke-test.mjs",
     "generate:tool-contract": "npm run build && node scripts/generate-tool-contract.mjs",
@@ -55,6 +55,8 @@
     "probe:500": "npm run build && node scripts/probe-b2-500s.mjs",
     "lint": "node scripts/run-biome.mjs lint src tests scripts",
     "lint:fix": "node scripts/run-biome.mjs lint src tests scripts --write",
+    "lint:docs": "eslint src --no-warn-ignored",
+    "lint:docs:fix": "eslint src --fix --no-warn-ignored",
     "format": "node scripts/run-biome.mjs format . --write",
     "format:check": "node scripts/run-biome.mjs format .",
     "spell": "cspell lint --no-progress --gitignore"
@@ -81,6 +83,7 @@
   "devDependencies": {
     "@babel/plugin-transform-modules-commonjs": "7.29.7",
     "@biomejs/biome": "2.5.7",
+    "@microsoft/tsdoc-config": "^0.18.1",
     "@modelcontextprotocol/client": "2.0.0",
     "@toon-format/toon": "4.1.0",
     "@types/jest": "^29.5.0",
@@ -88,11 +91,15 @@
     "@types/opossum": "^8.1.9",
     "babel-jest": "^29.7.0",
     "cspell": "^10.0.1",
+    "eslint": "^10.8.0",
+    "eslint-plugin-jsdoc": "^63.3.3",
+    "eslint-plugin-tsdoc": "^0.5.2",
     "jest": "^29.5.0",
     "jest-junit": "^17.0.0",
     "ts-jest": "^29.4.12",
     "ts-node": "^10.9.0",
-    "typescript": "~6.0.3"
+    "typescript": "~6.0.3",
+    "typescript-eslint": "^8.66.0"
   },
   "engines": {
     "node": ">=22.3.0"

--- a/scripts/doc-lint-lockdown.mjs
+++ b/scripts/doc-lint-lockdown.mjs
@@ -11,31 +11,50 @@ if (leakedEnv.length) {
 }
 
 function blocked(name) {
-  return () => {
+  return function blockedDocLintApi() {
     throw new Error(`doc-lint lockdown blocked ${name}`);
   };
 }
 
+function blockMethods(target, names, label) {
+  for (const name of names) {
+    if (typeof target?.[name] === "function") {
+      target[name] = blocked(`${label}.${name}`);
+    }
+  }
+}
+
+// This is a best-effort denylist for Node API surfaces that can perform
+// network egress, open listeners, or execute code while ESLint plugins load.
+// Keep this list in sync with Node runtime upgrades and extend it whenever a
+// new built-in API exposes those capabilities. OS-level network policy remains
+// the only complete sandbox boundary.
 globalThis.fetch = blocked("fetch network egress");
 
 const net = require("node:net");
 net.connect = blocked("net.connect network egress");
 net.createConnection = blocked("net.createConnection network egress");
 net.createServer = blocked("net.createServer listener");
+net.Socket.prototype.connect = blocked("net.Socket.connect network egress");
 
 const tls = require("node:tls");
 tls.connect = blocked("tls.connect network egress");
 tls.createServer = blocked("tls.createServer listener");
+tls.TLSSocket.prototype.connect = blocked("tls.TLSSocket.connect network egress");
+tls.TLSSocket = blocked("tls.TLSSocket network egress");
 
 const http = require("node:http");
 http.get = blocked("http.get network egress");
 http.request = blocked("http.request network egress");
 http.createServer = blocked("http.createServer listener");
+http.ClientRequest = blocked("http.ClientRequest network egress");
+http.Agent.prototype.createConnection = blocked("http.Agent.createConnection network egress");
 
 const https = require("node:https");
 https.get = blocked("https.get network egress");
 https.request = blocked("https.request network egress");
 https.createServer = blocked("https.createServer listener");
+https.Agent.prototype.createConnection = blocked("https.Agent.createConnection network egress");
 
 const http2 = require("node:http2");
 http2.connect = blocked("http2.connect network egress");
@@ -46,9 +65,29 @@ const dgram = require("node:dgram");
 dgram.createSocket = blocked("dgram.createSocket network egress");
 
 const dns = require("node:dns");
-for (const name of ["lookup", "resolve", "resolve4", "resolve6", "resolveAny", "reverse"]) {
-  dns[name] = blocked(`dns.${name} network lookup`);
-}
+const dnsLookupMethods = [
+  "lookup",
+  "lookupService",
+  "resolve",
+  "resolve4",
+  "resolve6",
+  "resolveAny",
+  "resolveCaa",
+  "resolveCname",
+  "resolveMx",
+  "resolveNaptr",
+  "resolveNs",
+  "resolvePtr",
+  "resolveSoa",
+  "resolveSrv",
+  "resolveTxt",
+  "reverse",
+];
+blockMethods(dns, dnsLookupMethods, "dns");
+blockMethods(dns.promises, dnsLookupMethods, "dns.promises");
+
+const dnsPromises = require("node:dns/promises");
+blockMethods(dnsPromises, dnsLookupMethods, "dns/promises");
 
 const childProcess = require("node:child_process");
 for (const name of ["exec", "execFile", "fork", "spawn", "execSync", "execFileSync", "spawnSync"]) {
@@ -57,5 +96,8 @@ for (const name of ["exec", "execFile", "fork", "spawn", "execSync", "execFileSy
 
 const workerThreads = require("node:worker_threads");
 workerThreads.Worker = blocked("worker_threads.Worker");
+
+const inspector = require("node:inspector");
+inspector.open = blocked("inspector.open listener");
 
 syncBuiltinESMExports();

--- a/scripts/doc-lint-lockdown.mjs
+++ b/scripts/doc-lint-lockdown.mjs
@@ -1,0 +1,61 @@
+import { createRequire, syncBuiltinESMExports } from "node:module";
+
+const require = createRequire(import.meta.url);
+const { secretLikeEnvNames } = require("./lib/doc-lint-policy.cjs");
+
+const leakedEnv = secretLikeEnvNames(process.env);
+if (leakedEnv.length) {
+  throw new Error(
+    `Refusing to run doc lint with secret-like environment variables: ${leakedEnv.join(", ")}`,
+  );
+}
+
+function blocked(name) {
+  return () => {
+    throw new Error(`doc-lint lockdown blocked ${name}`);
+  };
+}
+
+globalThis.fetch = blocked("fetch network egress");
+
+const net = require("node:net");
+net.connect = blocked("net.connect network egress");
+net.createConnection = blocked("net.createConnection network egress");
+net.createServer = blocked("net.createServer listener");
+
+const tls = require("node:tls");
+tls.connect = blocked("tls.connect network egress");
+tls.createServer = blocked("tls.createServer listener");
+
+const http = require("node:http");
+http.get = blocked("http.get network egress");
+http.request = blocked("http.request network egress");
+http.createServer = blocked("http.createServer listener");
+
+const https = require("node:https");
+https.get = blocked("https.get network egress");
+https.request = blocked("https.request network egress");
+https.createServer = blocked("https.createServer listener");
+
+const http2 = require("node:http2");
+http2.connect = blocked("http2.connect network egress");
+http2.createServer = blocked("http2.createServer listener");
+http2.createSecureServer = blocked("http2.createSecureServer listener");
+
+const dgram = require("node:dgram");
+dgram.createSocket = blocked("dgram.createSocket network egress");
+
+const dns = require("node:dns");
+for (const name of ["lookup", "resolve", "resolve4", "resolve6", "resolveAny", "reverse"]) {
+  dns[name] = blocked(`dns.${name} network lookup`);
+}
+
+const childProcess = require("node:child_process");
+for (const name of ["exec", "execFile", "fork", "spawn", "execSync", "execFileSync", "spawnSync"]) {
+  childProcess[name] = blocked(`child_process.${name}`);
+}
+
+const workerThreads = require("node:worker_threads");
+workerThreads.Worker = blocked("worker_threads.Worker");
+
+syncBuiltinESMExports();

--- a/scripts/lib/doc-lint-policy.cjs
+++ b/scripts/lib/doc-lint-policy.cjs
@@ -1,0 +1,77 @@
+const { spawnSync } = require("node:child_process");
+const { pathToFileURL } = require("node:url");
+const { sanitizedEnv, secretNamePattern } = require("./sanitized-env.cjs");
+
+const docLintAllowedSecretLikeEnvNames = new Set(["B2_MCP_DOC_LINT_LOCKDOWN"]);
+
+function isSecretLikeEnvName(name) {
+  return secretNamePattern.test(name) && !docLintAllowedSecretLikeEnvNames.has(name);
+}
+
+function secretLikeEnvNames(env) {
+  return Object.keys(env).filter(isSecretLikeEnvName).sort();
+}
+
+function docLintNodeOptions(lockdownPath) {
+  return `--import=${pathToFileURL(lockdownPath).href}`;
+}
+
+function buildDocLintEnv({ lockdownPath, sourceEnv = process.env }) {
+  const env = sanitizedEnv(
+    {
+      B2_MCP_DOC_LINT_LOCKDOWN: "1",
+      CI: sourceEnv.CI,
+      NODE_OPTIONS: docLintNodeOptions(lockdownPath),
+      NO_COLOR: "1",
+    },
+    {
+      nonSecretEnvNames: ["B2_MCP_DOC_LINT_LOCKDOWN"],
+      sourceEnv,
+    },
+  );
+
+  for (const [name, value] of Object.entries(env)) {
+    if (value === undefined || value === "") delete env[name];
+  }
+
+  return env;
+}
+
+function credentialFindingsFromGitConfigText(text) {
+  const findings = [];
+  for (const line of text.split(/\r?\n/)) {
+    if (!line.trim()) continue;
+    const lower = line.toLowerCase();
+    if (lower.includes(".extraheader=") && lower.includes("authorization:")) {
+      findings.push("local git config contains an authorization extraheader");
+    }
+    if (/https?:\/\/[^/\s]+@/i.test(line)) {
+      findings.push("local git config contains a credentialed remote URL");
+    }
+    if (/(github_pat_|ghp_|x-access-token)/i.test(line)) {
+      findings.push("local git config contains a GitHub token-like value");
+    }
+  }
+  return [...new Set(findings)].sort();
+}
+
+function checkoutCredentialFindings(root) {
+  const result = spawnSync("git", ["config", "--local", "--list", "--show-origin"], {
+    cwd: root,
+    encoding: "utf8",
+    env: sanitizedEnv({}, { sourceEnv: process.env }),
+  });
+
+  if (result.error || result.status !== 0) return [];
+  return credentialFindingsFromGitConfigText(String(result.stdout ?? ""));
+}
+
+module.exports = {
+  buildDocLintEnv,
+  checkoutCredentialFindings,
+  credentialFindingsFromGitConfigText,
+  docLintAllowedSecretLikeEnvNames,
+  docLintNodeOptions,
+  isSecretLikeEnvName,
+  secretLikeEnvNames,
+};

--- a/scripts/run-doc-lint.mjs
+++ b/scripts/run-doc-lint.mjs
@@ -1,0 +1,42 @@
+#!/usr/bin/env node
+import { existsSync } from "node:fs";
+import { spawnSync } from "node:child_process";
+import { createRequire } from "node:module";
+import { dirname, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const require = createRequire(import.meta.url);
+const { buildDocLintEnv, checkoutCredentialFindings } = require("./lib/doc-lint-policy.cjs");
+
+const root = resolve(dirname(fileURLToPath(import.meta.url)), "..");
+const eslintEntrypoint = join(root, "node_modules", "eslint", "bin", "eslint.js");
+const lockdownEntrypoint = join(root, "scripts", "doc-lint-lockdown.mjs");
+
+if (!existsSync(eslintEntrypoint)) {
+  console.error("Local ESLint is not installed. Run npm ci before npm run lint:docs.");
+  process.exit(1);
+}
+
+const checkoutFindings = checkoutCredentialFindings(root);
+if (checkoutFindings.length) {
+  console.error("Refusing to run doc lint while checkout credentials are persisted:");
+  for (const finding of checkoutFindings) console.error(`- ${finding}`);
+  process.exit(1);
+}
+
+const result = spawnSync(
+  process.execPath,
+  [eslintEntrypoint, "src", "--no-warn-ignored", ...process.argv.slice(2)],
+  {
+    cwd: root,
+    stdio: "inherit",
+    env: buildDocLintEnv({ lockdownPath: lockdownEntrypoint }),
+  },
+);
+
+if (result.error) {
+  console.error(result.error.message);
+  process.exit(1);
+}
+
+process.exit(result.status ?? 1);

--- a/src/auth.ts
+++ b/src/auth.ts
@@ -279,6 +279,8 @@ export class B2AuthManager {
   /**
    * Return cached auth or re-authorize. Thread-safe: multiple concurrent
    * callers share a single in-flight SDK authorize call.
+   *
+   * @returns The cached or freshly authorized B2 auth response.
    */
   async getAuth(): Promise<B2AuthResponse> {
     this.syncCachedAuthFromSdk();
@@ -333,6 +335,8 @@ export class B2AuthManager {
   /**
    * Force a fresh authorization and return the result.
    * Useful for testing credentials or initial setup.
+   *
+   * @returns The freshly authorized B2 auth response.
    */
   async forceRefresh(): Promise<B2AuthResponse> {
     this.invalidate();

--- a/src/b2/insights.ts
+++ b/src/b2/insights.ts
@@ -38,7 +38,11 @@ const GB = 1e9; // report columns are GB = 1e9 bytes
 
 // ── CSV parsing ─────────────────────────────────────────────────────────────
 
-/** Minimal RFC-4180 parser: handles quoted fields, embedded commas, and "" escapes. */
+/**
+ * Minimal RFC-4180 parser: handles quoted fields, embedded commas, and "" escapes.
+ *
+ * @returns Parsed data rows keyed by CSV header names.
+ */
 export function parseCsv(text: string): Array<Record<string, string>> {
   const rows: string[][] = [];
   let field = "";
@@ -87,7 +91,11 @@ export function parseCsv(text: string): Array<Record<string, string>> {
   });
 }
 
-/** Normalize a report date to YYYY-MM-DD (the partner CSV sometimes uses M/D/YY). */
+/**
+ * Normalize a report date to YYYY-MM-DD (the partner CSV sometimes uses M/D/YY).
+ *
+ * @returns The normalized date, or null when the value cannot be parsed.
+ */
 export function normalizeDate(raw: string): string | null {
   const s = (raw || "").trim();
   if (/^\d{4}-\d{2}-\d{2}$/.test(s)) return s;
@@ -304,6 +312,8 @@ function reportScanMetadata(...loads: ReportRowsResult[]): Record<string, unknow
  * full-capability, account-wide keys — so we construct the name directly rather
  * than try to discover it by listing. Existence is then probed by the S3 read in
  * loadReportRows (a 404 on the bucket → Usage Reports not enabled).
+ *
+ * @returns The reserved usage-report bucket name for the authorized account.
  */
 async function reportsBucketName(auth: B2AuthManager): Promise<string> {
   const { accountId } = await auth.getAuth();
@@ -317,6 +327,8 @@ async function reportsBucketName(auth: B2AuthManager): Promise<string> {
  * file would double-count every metric. Falls back to all non-audit CSVs if a
  * different account type names its files differently (Groups/Locations rows lack
  * account_id/date and are dropped by mapRow anyway).
+ *
+ * @returns The report object keys that should be treated as usage data.
  */
 export function selectUsageKeys(keys: string[]): string[] {
   // Data files: usage.account-<acct>.csv and usage.group-<id>.<region>.csv.
@@ -333,6 +345,8 @@ export function selectUsageKeys(keys: string[]): string[] {
 /**
  * List + download the Usage CSVs within the window and return mapped rows.
  * Returns null when the bucket does not exist (reports not enabled).
+ *
+ * @returns The mapped report rows, or null when reports are not enabled.
  */
 async function loadReportRows(
   reportClient: ReportObjectClient,
@@ -469,8 +483,12 @@ const gb = (bytes: number | null) =>
 
 type Period = "month" | "quarter" | "year";
 
-/** Date one period before `from` (UTC), day-clamped for short months
- *  (e.g. Mar 31 minus one month → Feb 28/29, not Mar 3). */
+/**
+ * Date one period before `from` (UTC), day-clamped for short months
+ *  (e.g. Mar 31 minus one month → Feb 28/29, not Mar 3).
+ *
+ * @returns The period start date in YYYY-MM-DD format.
+ */
 export function periodStartDate(period: Period, from: Date): string {
   const y = from.getUTCFullYear();
   const m = from.getUTCMonth();
@@ -498,8 +516,12 @@ function is404(e: unknown): boolean {
   return err.name === "NoSuchBucket" || err.$metadata?.httpStatusCode === 404;
 }
 
-/** Date of the nearest available daily snapshot at or after `target`.
- *  `{ bucketMissing: true }` ⇒ reports bucket absent (not enabled). */
+/**
+ * Date of the nearest available daily snapshot at or after `target`.
+ *  `{ bucketMissing: true }` ⇒ reports bucket absent (not enabled).
+ *
+ * @returns The matching snapshot date and whether the reports bucket is missing.
+ */
 async function nearestSnapshotDate(
   reportClient: ReportObjectClient,
   bucketName: string,
@@ -522,8 +544,12 @@ async function nearestSnapshotDate(
   }
 }
 
-/** Date of the latest available snapshot (most recent day on or before today).
- *  Lists only recent days via StartAfter, widening if reporting is stale. */
+/**
+ * Date of the latest available snapshot (most recent day on or before today).
+ *  Lists only recent days via StartAfter, widening if reporting is stale.
+ *
+ * @returns The latest snapshot date and whether the reports bucket is missing.
+ */
 export async function latestSnapshotDate(
   reportClient: ReportObjectClient,
   bucketName: string,
@@ -562,7 +588,11 @@ export async function latestSnapshotDate(
   return { date: null, bucketMissing: false };
 }
 
-/** All usage rows for a single day folder (summed across that day's region files). */
+/**
+ * All usage rows for a single day folder (summed across that day's region files).
+ *
+ * @returns The mapped usage rows for that day.
+ */
 export async function loadDayRows(
   reportClient: ReportObjectClient,
   bucketName: string,
@@ -624,8 +654,12 @@ export interface SnapshotGrowth {
   isNew: boolean;
 }
 
-/** Per-account stored-data growth between two snapshots. Accounts present only
- *  in `now` are new (no % baseline); present only in `then` shrank toward zero. */
+/**
+ * Per-account stored-data growth between two snapshots. Accounts present only
+ *  in `now` are new (no % baseline); present only in `then` shrank toward zero.
+ *
+ * @returns Growth rows sorted by descending stored-byte growth.
+ */
 export function computeSnapshotGrowth(
   thenRows: ReportRow[],
   nowRows: ReportRow[],

--- a/src/credentials.ts
+++ b/src/credentials.ts
@@ -497,6 +497,10 @@ export function validateHttpCredentialConfiguration(
  * Header-compatibility parser. Returns null only when the required primary
  * header pair is absent/incomplete. Malformed optional pairs or conflicting
  * duplicate headers throw CredentialResolutionError with a stable code.
+ *
+ * @returns A B2 configuration, or null when the primary header pair is absent.
+ *
+ * @throws CredentialResolutionError when supplied HTTP credentials are malformed.
  */
 export function configFromHttpHeaders(req: { headers: http.IncomingHttpHeaders }): B2Config | null {
   try {

--- a/src/http-server.ts
+++ b/src/http-server.ts
@@ -1,5 +1,5 @@
 #!/usr/bin/env node
-/**
+/*
  * Backblaze B2 MCP Server — HTTP transport entry point.
  *
  * Production serving uses the MCP SDK v2 per-request HTTP handler for the

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,5 @@
 #!/usr/bin/env node
-/**
+/*
  * Backblaze B2 MCP Server — stdio transport entry point.
  *
  * Usage:

--- a/src/node-http-adapter.ts
+++ b/src/node-http-adapter.ts
@@ -162,6 +162,8 @@ async function writeWebResponse(
 /**
  * Adapts the MCP SDK's web-standard fetch handler to Node's HTTP server API.
  * Keeping this narrow bridge local avoids shipping an additional web framework.
+ *
+ * @returns A Node HTTP request handler that delegates to the MCP fetch handler.
  */
 export function createNodeHttpHandler(
   handler: Pick<McpHttpHandler, "fetch">,

--- a/src/s3/client.ts
+++ b/src/s3/client.ts
@@ -136,6 +136,8 @@ function customUserAgent(
 
 /**
  * Create an AWS SDK S3Client configured through the B2 SDK S3 helper.
+ *
+ * @returns The AWS SDK S3 client configuration for B2 S3 endpoints.
  */
 export function buildB2S3ClientConfig(
   config: B2Config,

--- a/src/server.ts
+++ b/src/server.ts
@@ -57,6 +57,10 @@ const COMPATIBILITY_STUB_CONFIRM_DESC =
 
 /**
  * Load and validate configuration from environment variables.
+ *
+ * @returns The validated B2 server configuration.
+ *
+ * @throws CredentialResolutionError when an unexpected credential resolution error occurs.
  */
 export function loadConfig(): B2Config {
   try {
@@ -122,6 +126,8 @@ function registerDurableSecretCompatibilityStubs(registrar: ToolRegistrar): void
  * When `capabilities` is null/undefined, the full surface is registered; this is
  * reserved for explicit operator override and legacy unit tests. An empty array
  * is a fail-closed capability set, not "unknown".
+ *
+ * @returns The configured MCP server instance.
  */
 export function createServer(config: B2Config, capabilities?: string[] | null): McpServer {
   const outputFormat = config.outputFormat ?? DEFAULT_MCP_OUTPUT_FORMAT;
@@ -523,6 +529,8 @@ export async function fetchCapabilities(
  * non-secret credential fingerprint, top-level arg keys, duration, and
  * success/error. Argument values are not logged to avoid leaking file content,
  * bucket data, or credentials.
+ *
+ * @returns The wrapped tool callback.
  */
 export function createAuditedToolCallback(
   name: string,

--- a/src/utils/circuit-breaker.ts
+++ b/src/utils/circuit-breaker.ts
@@ -17,6 +17,8 @@ function isAbortLikeError(err: unknown): boolean {
  * Caller cancellations are also filtered so client disconnects cannot open a
  * shared B2 circuit breaker.
  * Exported for direct testing.
+ *
+ * @returns True when the error should be filtered out of breaker failures.
  */
 export function isClientError(err: unknown): boolean {
   if (isAbortLikeError(err)) return true;
@@ -144,6 +146,8 @@ async function withDeadlineSignal<T>(timeoutMs: number, fn: () => Promise<T>): P
 /**
  * Run `fn` through the circuit breaker. When the breaker is open, this
  * throws an `EOPENBREAKER` error immediately without invoking `fn`.
+ *
+ * @returns The result produced by `fn`.
  */
 export async function withCircuit<T>(fn: () => Promise<T>): Promise<T> {
   return breaker.fire(() => withDeadlineSignal(CIRCUIT_TIMEOUT_MS, fn)) as Promise<T>;
@@ -152,6 +156,8 @@ export async function withCircuit<T>(fn: () => Promise<T>): Promise<T> {
 /**
  * Like withCircuit, but for long-running transfers — no per-call timeout.
  * Use for uploads and large file downloads, never for quick metadata calls.
+ *
+ * @returns The result produced by `fn`.
  */
 export async function withLongCircuit<T>(fn: () => Promise<T>): Promise<T> {
   return longBreaker.fire(fn as () => Promise<unknown>) as Promise<T>;
@@ -159,6 +165,8 @@ export async function withLongCircuit<T>(fn: () => Promise<T>): Promise<T> {
 
 /**
  * Run Usage Report S3 calls through their own breaker.
+ *
+ * @returns The result produced by `fn`.
  */
 export async function withReportCircuit<T>(fn: () => Promise<T>): Promise<T> {
   return reportBreaker.fire(() => withDeadlineSignal(CIRCUIT_TIMEOUT_MS, fn)) as Promise<T>;

--- a/src/utils/circuit-breaker.ts
+++ b/src/utils/circuit-breaker.ts
@@ -147,7 +147,7 @@ async function withDeadlineSignal<T>(timeoutMs: number, fn: () => Promise<T>): P
  * Run `fn` through the circuit breaker. When the breaker is open, this
  * throws an `EOPENBREAKER` error immediately without invoking `fn`.
  *
- * @returns The result produced by `fn`.
+ * @returns The callback result after the default circuit breaker allows execution.
  */
 export async function withCircuit<T>(fn: () => Promise<T>): Promise<T> {
   return breaker.fire(() => withDeadlineSignal(CIRCUIT_TIMEOUT_MS, fn)) as Promise<T>;
@@ -157,7 +157,7 @@ export async function withCircuit<T>(fn: () => Promise<T>): Promise<T> {
  * Like withCircuit, but for long-running transfers — no per-call timeout.
  * Use for uploads and large file downloads, never for quick metadata calls.
  *
- * @returns The result produced by `fn`.
+ * @returns The callback result after the transfer circuit breaker allows execution.
  */
 export async function withLongCircuit<T>(fn: () => Promise<T>): Promise<T> {
   return longBreaker.fire(fn as () => Promise<unknown>) as Promise<T>;
@@ -166,7 +166,7 @@ export async function withLongCircuit<T>(fn: () => Promise<T>): Promise<T> {
 /**
  * Run Usage Report S3 calls through their own breaker.
  *
- * @returns The result produced by `fn`.
+ * @returns The callback result after the usage-report circuit breaker allows execution.
  */
 export async function withReportCircuit<T>(fn: () => Promise<T>): Promise<T> {
   return reportBreaker.fire(() => withDeadlineSignal(CIRCUIT_TIMEOUT_MS, fn)) as Promise<T>;

--- a/src/utils/config.ts
+++ b/src/utils/config.ts
@@ -2,6 +2,8 @@
  * Parse an integer from an environment variable, falling back to a default
  * when the value is absent or not a finite number. Shared by loadConfig
  * (stdio entry) and configFromHeaders (HTTP entry) so both guard identically.
+ *
+ * @returns The parsed integer, or `fallback` when parsing fails.
  */
 export function parseIntEnv(raw: string | undefined, fallback: number): number {
   if (raw === undefined) return fallback;

--- a/src/utils/destructive-gate.ts
+++ b/src/utils/destructive-gate.ts
@@ -103,6 +103,8 @@ export interface GateResult {
 /**
  * Evaluate whether a tool call may proceed. Call at the top of a destructive
  * tool's handler; if `ok` is false, return `toolError(new Error(message))`.
+ *
+ * @returns The gate decision for the requested tool call.
  */
 export function checkDestructive(
   toolName: string,

--- a/src/utils/errors.ts
+++ b/src/utils/errors.ts
@@ -58,6 +58,8 @@ function numberOrFallback(value: unknown, fallback: number): number {
  *
  * Reading the AWS SDK shape is what lets us tell a genuine Backblaze 5xx apart
  * from a 4xx (e.g. NoSuchKey) and surface the requestId support needs.
+ *
+ * @returns The normalized B2 API error object.
  */
 export function parseB2Error(err: unknown): B2ApiError {
   if (typeof err === "object" && err !== null) {
@@ -128,6 +130,8 @@ export function parseB2Error(err: unknown): B2ApiError {
  * to record error code/status/requestId from a tool's error response (the tool
  * surface only carries the formatted text). Returns null if the text isn't a
  * formatted B2 error.
+ *
+ * @returns Parsed error metadata, or null when the text is not a formatted B2 error.
  */
 export function parseErrorText(
   text: string | undefined,
@@ -142,6 +146,8 @@ export function parseErrorText(
  * Format a B2 error into a human-readable string for MCP tool responses.
  * Includes the provider requestId when available — the field a Backblaze
  * support ticket needs to trace a server-side failure.
+ *
+ * @returns The formatted, sanitized B2 error message.
  */
 export function formatB2Error(err: unknown): string {
   const parsed = parseB2Error(err);
@@ -191,6 +197,8 @@ function errorHint(parsed: B2ApiError): string {
 
 /**
  * Return a structured MCP error content block for tool error responses.
+ *
+ * @returns The structured MCP error response.
  */
 export function toolError(err: unknown): {
   isError: true;
@@ -204,6 +212,8 @@ export function toolError(err: unknown): {
 
 /**
  * Return a successful tool response with text content.
+ *
+ * @returns The structured MCP success response.
  */
 export function toolSuccess(text: string): { content: Array<{ type: "text"; text: string }> } {
   return markSanitizedMcpResponse({
@@ -213,6 +223,8 @@ export function toolSuccess(text: string): { content: Array<{ type: "text"; text
 
 /**
  * Return a successful tool response with a JSON object.
+ *
+ * @returns The structured MCP JSON response.
  */
 export function toolJson(data: unknown): StructuredToolResult {
   return markSanitizedMcpResponse(serializeStructuredToolResult(data, currentSanitizerOptions()));

--- a/src/utils/fs-guard.ts
+++ b/src/utils/fs-guard.ts
@@ -53,6 +53,10 @@ function realTargetForWrite(resolved: string): string {
  * - `write`: the file need not exist yet, but its resolved path and nearest
  *   existing ancestor must both be inside the root, so symlinked ancestors
  *   can't redirect the write outside.
+ *
+ * @returns The safe absolute path to use for the requested access.
+ *
+ * @throws FileAccessError when local file access is disabled or outside policy.
  */
 export function resolveLocalPath(
   config: B2Config,

--- a/src/utils/payload.ts
+++ b/src/utils/payload.ts
@@ -5,6 +5,8 @@
  * used across the B2-native tool handlers — the one obvious way to do it,
  * instead of hand-rolling an `if (args.x !== undefined) payload.x = args.x`
  * chain (or an inline loop) in each handler.
+ *
+ * @returns The target object after copying defined values.
  */
 export function assignDefined<T extends Record<string, unknown>>(
   target: Record<string, unknown>,

--- a/src/utils/rate-limiter.ts
+++ b/src/utils/rate-limiter.ts
@@ -40,6 +40,8 @@ const buckets = new Map<string, Bucket>();
 /**
  * Try to consume one token for `key`. Returns true if allowed, false if
  * the bucket is empty (caller should respond with 429).
+ *
+ * @returns True when a token was consumed and the request may proceed.
  */
 export function allowRequest(key: string): boolean {
   const now = Date.now();
@@ -61,7 +63,7 @@ export function allowRequest(key: string): boolean {
 }
 
 /**
- * Drop idle buckets (full and untouched for > IDLE_TTL_MS).
+ * Drop idle buckets (full and untouched for more than IDLE_TTL_MS).
  * Called periodically from the HTTP server; safe to call any time.
  */
 export function sweepIdleBuckets(now: number = Date.now()): void {
@@ -77,7 +79,11 @@ export function _resetRateLimiter(): void {
   buckets.clear();
 }
 
-/** Test-only: read current bucket state. */
+/**
+ * Test-only: read current bucket state.
+ *
+ * @returns The bucket state for `key`, if present.
+ */
 export function _getBucket(key: string): Readonly<Bucket> | undefined {
   return buckets.get(key);
 }

--- a/src/utils/retry.ts
+++ b/src/utils/retry.ts
@@ -51,7 +51,11 @@ export function _resetRetryBudget(): void {
   budget.lastRefill = Date.now();
 }
 
-/** Test-only: synchronously try to consume a retry token. */
+/**
+ * Test-only: synchronously try to consume a retry token.
+ *
+ * @returns True when a retry-budget token was consumed.
+ */
 export function _consumeRetryToken(): boolean {
   return consumeRetryBudgetToken();
 }

--- a/src/utils/tool-capabilities.ts
+++ b/src/utils/tool-capabilities.ts
@@ -63,9 +63,11 @@ export const DURABLE_SECRET_PRODUCING_TOOLS = new Set<string>([
   "b2_reserve_trial_create_account",
 ]);
 
-/** Partner/Groups tools — registered only when a distinct master key is
+/**
+ * Partner/Groups tools — registered only when a distinct master key is
  *  configured (they need Partner-API entitlement, not a standard capability),
- *  so they are exempt from capability filtering and gated in createServer. */
+ *  so they are exempt from capability filtering and gated in createServer.
+ */
 export const PARTNER_TOOLS = new Set<string>([
   "b2_list_groups",
   "b2_eject_group_member",
@@ -79,6 +81,8 @@ export const PARTNER_TOOLS = new Set<string>([
  * never hide a tool we did not explicitly classify). Mapped tools register when
  * the key holds any of the required capabilities. A null capability set is the
  * explicit full-surface mode and still honors durable-secret handler exclusion.
+ *
+ * @returns True when the tool should be registered for the capability set.
  */
 export function isToolEnabled(name: string, caps: ReadonlySet<string> | null): boolean {
   if (DURABLE_SECRET_PRODUCING_TOOLS.has(name)) return false;

--- a/src/utils/types.ts
+++ b/src/utils/types.ts
@@ -6,20 +6,26 @@ export type DestructivePolicy = "allow" | "confirm" | "block";
 export type { McpOutputFormat };
 
 export interface B2Config {
-  /** The application key — the workhorse credential. Used for the B2 native API,
+  /**
+   * The application key — the workhorse credential. Used for the B2 native API,
    *  the S3-compatible API, and key management. A non-master key is all most
-   *  users need; it works for everything except the Partner API. */
+   *  users need; it works for everything except the Partner API.
+   */
   applicationKeyId: string;
   applicationKey: string;
-  /** Credential the S3-compatible client signs with. Defaults to the application
+  /**
+   * Credential the S3-compatible client signs with. Defaults to the application
    *  key (which is what should be used). The deprecated B2_APP_KEY_ID override
    *  remains only for legacy setups whose application key is a master key (B2's
-   *  S3 endpoint rejects master keys). */
+   *  S3 endpoint rejects master keys).
+   */
   appKeyId: string;
   appKey: string;
-  /** Optional master application key, used ONLY by the Partner API
+  /**
+   * Optional master application key, used ONLY by the Partner API
    *  tools. Falls back to the application key when unset, so a
-   *  single non-master key remains a complete config for everything else. */
+   *  single non-master key remains a complete config for everything else.
+   */
   masterKeyId: string;
   masterKey: string;
   region: string;
@@ -36,11 +42,13 @@ export interface B2Config {
    * single-user stdio process. Set via B2_FILE_ROOT.
    */
   fileRoot: string | null;
-  /** Gate policy for destructive/irreversible tools (delete bucket/file-version/
+  /**
+   * Gate policy for destructive/irreversible tools (delete bucket/file-version/
    *  key, cancel large file, eject group member, make-public / weaken-lock /
    *  replication via b2_update_bucket, outbound notification rules).
    *  "confirm" (default) requires confirm:true; "block" refuses;
-   *  "allow" disables the gate. Set via B2_DESTRUCTIVE_POLICY. */
+   *  "allow" disables the gate. Set via B2_DESTRUCTIVE_POLICY.
+   */
   destructivePolicy?: DestructivePolicy;
   /**
    * LLM-facing TextContent serialization for structured successful tool results.
@@ -61,8 +69,10 @@ export interface B2AuthResponse {
   recommendedPartSize: number;
   absoluteMinimumPartSize: number;
   s3ApiUrl: string;
-  /** Capabilities granted to this key (from the v4 authorize `allowed` object).
-   *  Drives capability-aware tool registration. Empty array if unknown. */
+  /**
+   * Capabilities granted to this key (from the v4 authorize `allowed` object).
+   *  Drives capability-aware tool registration. Empty array if unknown.
+   */
   capabilities: string[];
 }
 

--- a/src/utils/user-agent.ts
+++ b/src/utils/user-agent.ts
@@ -5,6 +5,8 @@ import { B2Config } from "./types.js";
  * Build the product token passed to the official B2 SDK. The SDK owns its
  * transport stack identity; this prefix keeps MCP traffic attributable without
  * rebuilding or depending on the SDK's underlying User-Agent details.
+ *
+ * @returns The product token for SDK User-Agent metadata.
  */
 export function buildUserAgent(config: B2Config): string {
   const transport = config.transport ?? "stdio";

--- a/tests/unit/doc-lint-runner.unit.test.ts
+++ b/tests/unit/doc-lint-runner.unit.test.ts
@@ -48,7 +48,7 @@ describe("doc lint runner", () => {
     expect(env).not.toHaveProperty("GITHUB_ACTIONS");
   });
 
-  it("blocks network and child-process APIs in the lint process", () => {
+  it("blocks egress, listener, and child-process APIs in the lint process", () => {
     const env = buildDocLintEnv({
       lockdownPath,
       sourceEnv: { PATH: process.env.PATH },
@@ -58,21 +58,81 @@ describe("doc lint runner", () => {
       [
         "-e",
         [
+          "(async () => {",
           'const https = require("node:https");',
+          'const http = require("node:http");',
+          'const net = require("node:net");',
+          'const tls = require("node:tls");',
+          'const dns = require("node:dns");',
+          'const dnsPromises = require("node:dns/promises");',
+          'const inspector = require("node:inspector");',
           'const child = require("node:child_process");',
-          "let blocked = 0;",
-          'for (const fn of [() => https.request("https://example.invalid"), () => child.spawnSync("node", ["-v"])]) {',
-          "  try { fn(); } catch (err) { blocked++; console.error(err.message); }",
+          "const blocked = [];",
+          "async function expectBlocked(label, fn) {",
+          "  try {",
+          "    const value = fn();",
+          '    if (value && typeof value.then === "function") await value;',
+          "    console.error(`${label} was not blocked`);",
+          "  } catch (err) {",
+          "    const message = err && err.message ? err.message : String(err);",
+          '    if (message.includes("doc-lint lockdown blocked")) {',
+          "      blocked.push(label);",
+          "      console.error(`${label}: ${message}`);",
+          "      return;",
+          "    }",
+          "    console.error(`${label} failed without lockdown: ${message}`);",
+          "  }",
           "}",
-          "process.exit(blocked === 2 ? 0 : 1);",
+          'await expectBlocked("https.request", () => https.request("https://example.invalid"));',
+          'await expectBlocked("net.Socket.connect", () => {',
+          "  const socket = new net.Socket();",
+          '  socket.on("error", () => {});',
+          "  try {",
+          '    return socket.connect({ host: "127.0.0.1", port: 9 });',
+          "  } finally {",
+          "    socket.destroy();",
+          "  }",
+          "});",
+          'await expectBlocked("tls.TLSSocket", () => new tls.TLSSocket());',
+          'await expectBlocked("http.ClientRequest", () => new http.ClientRequest("http://127.0.0.1:9"));',
+          'await expectBlocked("http.Agent.createConnection", () =>',
+          '  new http.Agent().createConnection({ host: "127.0.0.1", port: 9 }),',
+          ");",
+          'await expectBlocked("dns.promises.resolve4", () => dns.promises.resolve4("example.invalid"));',
+          'await expectBlocked("dns/promises.resolve4", () => dnsPromises.resolve4("example.invalid"));',
+          'await expectBlocked("inspector.open", () => inspector.open(0, "0.0.0.0"));',
+          'await expectBlocked("child_process.spawnSync", () => child.spawnSync("node", ["-v"]));',
+          "process.exit(blocked.length === 9 ? 0 : 1);",
+          "})().catch((err) => { console.error(err); process.exit(1); });",
         ].join("\n"),
       ],
-      { cwd: root, encoding: "utf8", env },
+      { cwd: root, encoding: "utf8", env, timeout: 5000 },
     );
 
     expect(result.status).toBe(0);
-    expect(outputOf(result)).toContain("doc-lint lockdown blocked https.request network egress");
-    expect(outputOf(result)).toContain("doc-lint lockdown blocked child_process.spawnSync");
+    expect(outputOf(result)).toContain(
+      "https.request: doc-lint lockdown blocked https.request network egress",
+    );
+    expect(outputOf(result)).toContain(
+      "net.Socket.connect: doc-lint lockdown blocked net.Socket.connect network egress",
+    );
+    expect(outputOf(result)).toContain(
+      "tls.TLSSocket: doc-lint lockdown blocked tls.TLSSocket network egress",
+    );
+    expect(outputOf(result)).toContain(
+      "http.ClientRequest: doc-lint lockdown blocked http.ClientRequest network egress",
+    );
+    expect(outputOf(result)).toContain(
+      "http.Agent.createConnection: doc-lint lockdown blocked http.Agent.createConnection network egress",
+    );
+    expect(outputOf(result)).toContain("dns.promises.resolve4: doc-lint lockdown blocked");
+    expect(outputOf(result)).toContain("dns/promises.resolve4: doc-lint lockdown blocked");
+    expect(outputOf(result)).toContain(
+      "inspector.open: doc-lint lockdown blocked inspector.open listener",
+    );
+    expect(outputOf(result)).toContain(
+      "child_process.spawnSync: doc-lint lockdown blocked child_process.spawnSync",
+    );
   });
 
   it("detects checkout credentials that actions/checkout can persist", () => {
@@ -107,12 +167,23 @@ describe("doc lint runner", () => {
   });
 
   it("keeps eslint.config.js limited to parser plus doc-comment plugins", () => {
-    const config = readFileSync(join(root, "eslint.config.js"), "utf8");
+    type FlatConfig = {
+      files?: string[];
+      plugins?: Record<string, unknown>;
+      languageOptions?: { parser?: unknown };
+      rules?: Record<string, unknown>;
+    };
+    const config = nodeRequire(join(root, "eslint.config.js")) as FlatConfig[];
+    const tseslint = nodeRequire("typescript-eslint") as { parser: unknown };
+    const docConfig = config.find((entry) => entry.files?.includes("src/**/*.ts"));
 
-    expect(config).toContain("parser: tseslint.parser");
-    expect(config).toContain("eslint-plugin-jsdoc");
-    expect(config).toContain("eslint-plugin-tsdoc");
-    expect(config).not.toContain("disabledTypeScriptRules");
-    expect(config).not.toContain('"@typescript-eslint": tseslint.plugin');
+    expect(docConfig).toBeDefined();
+    expect(docConfig?.languageOptions?.parser).toBe(tseslint.parser);
+    expect(Object.keys(docConfig?.plugins ?? {}).sort()).toEqual(["jsdoc", "tsdoc"]);
+    expect(
+      Object.keys(docConfig?.rules ?? {}).some((ruleName) =>
+        ruleName.startsWith("@typescript-eslint/"),
+      ),
+    ).toBe(false);
   });
 });

--- a/tests/unit/doc-lint-runner.unit.test.ts
+++ b/tests/unit/doc-lint-runner.unit.test.ts
@@ -1,0 +1,118 @@
+import { readFileSync } from "fs";
+import { join } from "path";
+import { spawnSync } from "child_process";
+import { createRequire } from "module";
+
+const root = join(__dirname, "../..");
+const nodeRequire = createRequire(__filename);
+const { buildDocLintEnv, credentialFindingsFromGitConfigText, secretLikeEnvNames } = nodeRequire(
+  "../../scripts/lib/doc-lint-policy.cjs",
+) as {
+  buildDocLintEnv: (options: {
+    lockdownPath: string;
+    sourceEnv?: Record<string, string | undefined>;
+  }) => Record<string, string>;
+  credentialFindingsFromGitConfigText: (text: string) => string[];
+  secretLikeEnvNames: (env: Record<string, string | undefined>) => string[];
+};
+
+const lockdownPath = join(root, "scripts", "doc-lint-lockdown.mjs");
+const sentinel = "B2_MCP_DOC_LINT_SENTINEL";
+
+function outputOf(result: ReturnType<typeof spawnSync>): string {
+  return `${String(result.stdout ?? "")}\n${String(result.stderr ?? "")}`;
+}
+
+describe("doc lint runner", () => {
+  it("strips secret-like environment variables before loading ESLint plugins", () => {
+    const env = buildDocLintEnv({
+      lockdownPath,
+      sourceEnv: {
+        AWS_SECRET_ACCESS_KEY: sentinel,
+        B2_APPLICATION_KEY: sentinel,
+        GH_TOKEN: sentinel,
+        GITHUB_ACTIONS: "true",
+        GITHUB_TOKEN: sentinel,
+        NODE_AUTH_TOKEN: sentinel,
+        NODE_OPTIONS: "--require ./leak.js",
+        NPM_TOKEN: sentinel,
+        PATH: process.env.PATH,
+      },
+    });
+
+    expect(secretLikeEnvNames(env)).toEqual([]);
+    expect(env.B2_MCP_DOC_LINT_LOCKDOWN).toBe("1");
+    expect(env.NODE_OPTIONS).toContain("doc-lint-lockdown.mjs");
+    expect(JSON.stringify(env)).not.toContain(sentinel);
+    expect(env.NODE_OPTIONS).not.toContain("leak.js");
+    expect(env).not.toHaveProperty("GITHUB_ACTIONS");
+  });
+
+  it("blocks network and child-process APIs in the lint process", () => {
+    const env = buildDocLintEnv({
+      lockdownPath,
+      sourceEnv: { PATH: process.env.PATH },
+    });
+    const result = spawnSync(
+      process.execPath,
+      [
+        "-e",
+        [
+          'const https = require("node:https");',
+          'const child = require("node:child_process");',
+          "let blocked = 0;",
+          'for (const fn of [() => https.request("https://example.invalid"), () => child.spawnSync("node", ["-v"])]) {',
+          "  try { fn(); } catch (err) { blocked++; console.error(err.message); }",
+          "}",
+          "process.exit(blocked === 2 ? 0 : 1);",
+        ].join("\n"),
+      ],
+      { cwd: root, encoding: "utf8", env },
+    );
+
+    expect(result.status).toBe(0);
+    expect(outputOf(result)).toContain("doc-lint lockdown blocked https.request network egress");
+    expect(outputOf(result)).toContain("doc-lint lockdown blocked child_process.spawnSync");
+  });
+
+  it("detects checkout credentials that actions/checkout can persist", () => {
+    expect(
+      credentialFindingsFromGitConfigText(
+        [
+          "file:.git/config\tremote.origin.url=https://github.com/backblaze-labs/b2-mcp.git",
+          "file:.git/config\thttp.https://github.com/.extraheader=AUTHORIZATION: basic abc",
+          "file:.git/config\tremote.bad.url=https://x-access-token:ghp_example@github.com/o/r.git",
+        ].join("\n"),
+      ),
+    ).toEqual([
+      "local git config contains a GitHub token-like value",
+      "local git config contains a credentialed remote URL",
+      "local git config contains an authorization extraheader",
+    ]);
+
+    expect(
+      credentialFindingsFromGitConfigText(
+        "file:.git/config\tremote.origin.url=https://github.com/backblaze-labs/b2-mcp.git",
+      ),
+    ).toEqual([]);
+  });
+
+  it("keeps package scripts on the locked-down docs lint wrapper", () => {
+    const pkg = JSON.parse(readFileSync(join(root, "package.json"), "utf8")) as {
+      scripts: Record<string, string>;
+    };
+
+    expect(pkg.scripts["lint:docs"]).toBe("node scripts/run-doc-lint.mjs");
+    expect(pkg.scripts["lint:docs:fix"]).toBe("node scripts/run-doc-lint.mjs --fix");
+  });
+
+  it("keeps eslint.config.js limited to parser plus doc-comment plugins", () => {
+    const config = readFileSync(join(root, "eslint.config.js"), "utf8");
+
+    expect(config).toContain("parser: tseslint.parser");
+    expect(config).toContain("eslint-plugin-jsdoc");
+    expect(config).toContain("eslint-plugin-tsdoc");
+    expect(config).not.toContain("disabledTypeScriptRules");
+    expect(config).not.toContain('"@typescript-eslint": tseslint.plugin');
+  });
+});

--- a/tests/unit/supply-chain-policy.unit.test.ts
+++ b/tests/unit/supply-chain-policy.unit.test.ts
@@ -9,12 +9,16 @@ const nodeRequire = createRequire(__filename);
 const { workflowJobBlock } = nodeRequire("../../scripts/lib/workflow-yaml.cjs") as {
   workflowJobBlock: (text: string, jobName: string) => string | null;
 };
+const semver = nodeRequire("semver") as {
+  satisfies: (version: string, range: string, options?: { includePrerelease?: boolean }) => boolean;
+};
 
 describe("supply-chain audit policy", () => {
   const workflow = readFileSync(join(root, ".github/workflows/test.yml"), "utf8");
   const publishWorkflow = readFileSync(join(root, ".github/workflows/publish.yml"), "utf8");
   const npmrc = readFileSync(join(root, ".npmrc"), "utf8");
   const packageJson = JSON.parse(readFileSync(join(root, "package.json"), "utf8")) as {
+    devDependencies: Record<string, string>;
     scripts: Record<string, string>;
   };
   const auditPolicy = JSON.parse(readFileSync(join(root, "audit-policy.json"), "utf8")) as {
@@ -33,7 +37,12 @@ describe("supply-chain audit policy", () => {
   const lock = JSON.parse(readFileSync(join(root, "package-lock.json"), "utf8")) as {
     packages: Record<
       string,
-      { version?: string; integrity?: string; dependencies?: Record<string, string> }
+      {
+        dependencies?: Record<string, string>;
+        engines?: { node?: string };
+        integrity?: string;
+        version?: string;
+      }
     >;
   };
   const braceExpansion = lock.packages["node_modules/brace-expansion"];
@@ -252,6 +261,37 @@ describe("supply-chain audit policy", () => {
     expect(publishWorkflow).toContain("--provenance --access public --ignore-scripts");
     expect(publishWorkflow).not.toContain("--ignore-scripts=false");
     expect(publishWorkflow).not.toContain("tar -xzf");
+  });
+
+  it("exact-pins executable doc lint tooling", () => {
+    for (const name of [
+      "@microsoft/tsdoc-config",
+      "eslint",
+      "eslint-plugin-jsdoc",
+      "eslint-plugin-tsdoc",
+      "typescript-eslint",
+    ]) {
+      expect(packageJson.devDependencies[name]).toBeDefined();
+      expect(packageJson.devDependencies[name]).not.toMatch(/^[~^]/);
+    }
+  });
+
+  it("keeps the full lockfile installable on the advertised Node floor", () => {
+    const unsupported = Object.entries(lock.packages)
+      .filter(([_path, pkg]) => {
+        return pkg.engines?.node && !semver.satisfies("22.3.0", pkg.engines.node);
+      })
+      .map(([path, pkg]) => `${path || "<root>"}@${pkg.version}: ${pkg.engines?.node}`);
+
+    expect(unsupported).toEqual([]);
+  });
+
+  it("runs doc lint without persisted checkout credentials", () => {
+    for (const name of ["deterministic-linux-production", "deterministic-linux-current"]) {
+      const job = jobBlock(name);
+      expect(job).toContain("persist-credentials: false");
+      expect(job).toContain("npm run lint:docs");
+    }
   });
 
   it("keeps npm trusted-publishing OIDC away from repo and dependency code", () => {

--- a/tests/unit/supply-chain-policy.unit.test.ts
+++ b/tests/unit/supply-chain-policy.unit.test.ts
@@ -39,6 +39,7 @@ describe("supply-chain audit policy", () => {
       string,
       {
         dependencies?: Record<string, string>;
+        optionalDependencies?: Record<string, string>;
         engines?: { node?: string };
         integrity?: string;
         version?: string;
@@ -275,12 +276,56 @@ describe("supply-chain audit policy", () => {
     }
   });
 
-  it("keeps the full lockfile installable on the advertised Node floor", () => {
-    const unsupported = Object.entries(lock.packages)
-      .filter(([_path, pkg]) => {
-        return pkg.engines?.node && !semver.satisfies("22.3.0", pkg.engines.node);
+  it("keeps the doc lint dependency closure installable on the Node runtime floor", () => {
+    const pending = [
+      "eslint",
+      "eslint-plugin-jsdoc",
+      "eslint-plugin-tsdoc",
+      "typescript",
+      "typescript-eslint",
+    ].map((name) => `node_modules/${name}`);
+    const docLintPackages = new Set<string>();
+
+    while (pending.length > 0) {
+      const packagePath = pending.pop() as string;
+      if (docLintPackages.has(packagePath)) continue;
+      const pkg = lock.packages[packagePath];
+      if (!pkg) throw new Error(`Missing doc lint lockfile package: ${packagePath}`);
+      docLintPackages.add(packagePath);
+
+      const dependencies = {
+        ...(pkg.dependencies ?? {}),
+        ...(pkg.optionalDependencies ?? {}),
+      };
+      for (const name of Object.keys(dependencies)) {
+        let scope = packagePath;
+        let resolvedPath: string | undefined;
+        while (scope) {
+          const candidate = `${scope}/node_modules/${name}`;
+          if (lock.packages[candidate]) {
+            resolvedPath = candidate;
+            break;
+          }
+          const parentIndex = scope.lastIndexOf("/node_modules/");
+          scope = parentIndex === -1 ? "" : scope.slice(0, parentIndex);
+        }
+        resolvedPath ??= lock.packages[`node_modules/${name}`] ? `node_modules/${name}` : undefined;
+        if (!resolvedPath) {
+          throw new Error(`Missing ${name} required by ${packagePath}`);
+        }
+        pending.push(resolvedPath);
+      }
+    }
+
+    const unsupported = [...docLintPackages]
+      .filter((path) => {
+        const range = lock.packages[path].engines?.node;
+        return range && !semver.satisfies("22.3.0", range);
       })
-      .map(([path, pkg]) => `${path || "<root>"}@${pkg.version}: ${pkg.engines?.node}`);
+      .map((path) => {
+        const pkg = lock.packages[path];
+        return `${path}@${pkg.version}: ${pkg.engines?.node}`;
+      });
 
     expect(unsupported).toEqual([]);
   });

--- a/tests/unit/supply-chain-policy.unit.test.ts
+++ b/tests/unit/supply-chain-policy.unit.test.ts
@@ -265,7 +265,6 @@ describe("supply-chain audit policy", () => {
 
   it("exact-pins executable doc lint tooling", () => {
     for (const name of [
-      "@microsoft/tsdoc-config",
       "eslint",
       "eslint-plugin-jsdoc",
       "eslint-plugin-tsdoc",

--- a/tsdoc.json
+++ b/tsdoc.json
@@ -1,0 +1,27 @@
+{
+  "$schema": "https://developer.microsoft.com/json-schemas/tsdoc/v0/tsdoc.schema.json",
+  "supportForTags": {
+    "@alpha": false,
+    "@beta": false,
+    "@defaultValue": true,
+    "@deprecated": true,
+    "@example": true,
+    "@experimental": false,
+    "@inheritDoc": true,
+    "@internal": true,
+    "@link": true,
+    "@override": true,
+    "@packageDocumentation": true,
+    "@param": true,
+    "@privateRemarks": false,
+    "@public": true,
+    "@readonly": true,
+    "@remarks": true,
+    "@returns": true,
+    "@sealed": false,
+    "@see": true,
+    "@throws": true,
+    "@typeParam": true,
+    "@virtual": false
+  }
+}


### PR DESCRIPTION
## Summary
- Added a docs-only ESLint flat config and tsdoc.json for TSDoc/JSDoc validation on src TypeScript files.
- Added lint:docs and lint:docs:fix scripts, wired lint:docs into verify and CI, and adjusted existing exported-surface doc comments so the new gate passes.
- Hardened the docs-lint runner with exact-pinned Node 22.3.0-compatible tooling, secret and checkout-credential filtering, and a best-effort Node API lockdown for common egress, listener, child-process, worker, DNS, and inspector paths.
- Removed the unused direct @microsoft/tsdoc-config devDependency while keeping it transitively through eslint-plugin-tsdoc.
- Documented the narrow ESLint reintroduction and lockdown limits in TESTING and SUPPLY_CHAIN_SECURITY, including the supply-chain trade-off relative to Biome.
- Added regression coverage for the docs-lint lockdown bypass paths, config shape, dependency engine floor, and CI credential policy.

## Linked issue
Closes #101

## Tests run
- npm ci --engine-strict (Node 22.3.0 via conda env b2-mcp-issue-101-node223)
- npm run test:unit -- --runTestsByPath tests/unit/doc-lint-runner.unit.test.ts tests/unit/supply-chain-policy.unit.test.ts --runInBand
- npm run verify
- npm run check:runtime-policy
- npm run audit:supply-chain

## Follow-up notes
- None.
