### PR TITLE
[b2-mcp] Add spell checking with cspell

### DIFF
--- a/.cspell/project-words.txt
+++ b/.cspell/project-words.txt
@@ -43,6 +43,7 @@ sophiecarreras
 behaviour
 creds
 EOPENBREAKER
+exfiltration
 noout
 paginators
 sessionful

--- a/.cspell/project-words.txt
+++ b/.cspell/project-words.txt
@@ -3,8 +3,7 @@
 # One word per line. Comments allowed (lines starting with `#`). Words are
 # case-insensitive by default.
 #
-# Adding a word here is preferred to inline `// cspell:ignore` directives
-# because the list stays auditable and reusable. Sort within each block.
+# See cspell.config.yaml for dictionary policy. Sort within each block.
 
 # Backblaze + B2
 b2sdk
@@ -40,7 +39,6 @@ Gonza
 sophiecarreras
 
 # Cloud, network, storage, and security terms
-behaviour
 creds
 EOPENBREAKER
 exfiltration

--- a/.cspell/project-words.txt
+++ b/.cspell/project-words.txt
@@ -1,0 +1,58 @@
+# Project-specific dictionary for @backblaze-labs/b2-mcp.
+#
+# One word per line. Comments allowed (lines starting with `#`). Words are
+# case-insensitive by default.
+#
+# Adding a word here is preferred to inline `// cspell:ignore` directives
+# because the list stays auditable and reusable. Sort within each block.
+
+# Backblaze + B2
+backblaze
+backblazeb
+Backblaze
+b2sdk
+MGMT
+mgmt
+
+# Tooling, libraries, runtimes
+biome
+biomejs
+cobertura
+corepack
+cspell
+iocs
+junit
+MCP
+NOFILE
+opossum
+pino
+presigner
+SUIDSGID
+thiennq
+toon
+tvzf
+ustar
+xvda
+zod
+
+# People and account names
+goanpeca
+Gonza
+sophiecarreras
+
+# Cloud, network, storage, and security terms
+behaviour
+creds
+EOPENBREAKER
+noout
+paginators
+sessionful
+unallowed
+unparseable
+unreviewed
+
+# Test fixture tokens and identifier fragments
+dontMock
+ghijkl
+klass
+pathb

--- a/.cspell/project-words.txt
+++ b/.cspell/project-words.txt
@@ -7,11 +7,10 @@
 # because the list stays auditable and reusable. Sort within each block.
 
 # Backblaze + B2
-backblaze
-backblazeb
-Backblaze
 b2sdk
-MGMT
+backblaze
+# Host fragment from backblazeb2.com after cspell splits the numeral.
+backblazeb
 mgmt
 
 # Tooling, libraries, runtimes

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -29,7 +29,7 @@ jobs:
       - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803
       - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020
         with:
-          node-version: 22.13.0
+          node-version: 22.23.1
           cache: npm
       - run: npm ci --engine-strict
       - run: npm run build
@@ -68,7 +68,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node-version: [22.13.0]
+        node-version: [22.23.1]
     steps:
       - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803
       - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020
@@ -78,6 +78,7 @@ jobs:
       - run: npm ci --engine-strict
       - run: npm run format:check
       - run: npm run lint
+      - run: npm run spell
       - run: npm run build
       - id: typecheck
         continue-on-error: true
@@ -128,6 +129,7 @@ jobs:
       - run: npm ci --engine-strict
       - run: npm run format:check
       - run: npm run lint
+      - run: npm run spell
       - run: npm run build
       - id: typecheck
         continue-on-error: true

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -36,7 +36,8 @@ jobs:
       - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020
         with:
           node-version: 22.3.0
-      - run: node scripts/packed-consumer-smoke.mjs
+      - name: Run Node 22.3.0 runtime compatibility smoke
+        run: node scripts/packed-consumer-smoke.mjs
 
   package-budget:
     name: package budget

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,7 +43,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Aligned package metadata on the `0.1.0` Phase 1 release line.
 - Aligned the enforced runtime policy with the official B2 SDK floor:
   `engines.node` is `>=22.3.0`, CI verifies production dependencies at Node.js
-  22.3.0 and the full toolchain on Node.js 22.13.0, 24, and 26, local and live
+  22.3.0 and the full toolchain on Node.js 22.23.1, 24, and 26, local and live
   22.x jobs use a patched Node 22 LTS release, and workflow drift is checked
   from `runtime-policy.json`.
 - Migrated linting and Biome-supported formatting from ESLint and Prettier to

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -11,7 +11,7 @@ The package engine floor is `>=22.3.0` because it matches the official B2 SDK.
 For local development and deployed 22.x hosts, use the patched Node 22 LTS
 release pinned in `.nvmrc` (`22.23.1` at the time of writing) or a later patched
 22.x release. CI verifies the production dependency graph at Node 22.3.0 and
-runs the full toolchain on Node.js 22.13.0, 24, and 26.
+runs the full toolchain on Node.js 22.23.1, 24, and 26.
 
 ```bash
 npm ci
@@ -49,7 +49,7 @@ Test files must follow the layer suffix convention documented in
 
 - Branch off `main`; keep changes focused.
 - `npm run verify` must pass before opening a PR. CI runs the bundled
-  deterministic coverage and slow layers on Node.js 22.13.0, 24, and 26, checks
+  deterministic coverage and slow layers on Node.js 22.23.1, 24, and 26, checks
   production-only dependency installation at the Node.js 22.3.0 engine floor,
   and runs a patched Node 22 LTS cross-platform suite. A separate package-install
   job stays off the deploy-gating path.

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Destructive actions are gated, durable B2 secrets never enter the model's contex
 
 ## Quick start
 
-**Prerequisites:** A supported [Node.js](https://nodejs.org) runtime and a Backblaze B2 [application key](https://www.backblaze.com/docs/cloud-storage-application-keys) (a non-master key is all you need). Use Node.js 22.23.1 or a later patched 22 LTS release for local/deployed 22.x hosts; CI verifies production dependencies at the SDK floor (`>=22.3.0`) and runs the full toolchain on Node.js 22.13.0, 24, and 26.
+**Prerequisites:** A supported [Node.js](https://nodejs.org) runtime and a Backblaze B2 [application key](https://www.backblaze.com/docs/cloud-storage-application-keys) (a non-master key is all you need). Use Node.js 22.23.1 or a later patched 22 LTS release for local/deployed 22.x hosts; CI verifies production dependencies at the SDK floor (`>=22.3.0`) and runs the full toolchain on Node.js 22.23.1, 24, and 26.
 
 **1. Build:**
 

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -29,7 +29,7 @@ Before publishing `v0.1.0`:
    tool profiles, and MCP transport contract.
 2. Confirm operators use a patched Node 22 LTS release (`.nvmrc`) or Node.js 24
    or 26. Keep CI production-dependency installation evidence on Node.js 22.3.0
-   and full toolchain evidence on Node.js 22.13.0. Build release artifacts on
+   and full toolchain evidence on Node.js 22.23.1. Build release artifacts on
    the patched Node 22 LTS pin, then run the deterministic local gate: `npm ci`,
    `npm run build`, `npm run typecheck`, `npm run lint`,
    `npm run format:check`, `npm test`, `npm run test:integration`,

--- a/cspell.config.yaml
+++ b/cspell.config.yaml
@@ -1,0 +1,72 @@
+# cspell configuration for @backblaze-labs/b2-mcp.
+#
+# Scope: comments, JSDoc, Markdown docs, GitHub workflows, and string literals
+# across source, tests, and local scripts. Generated output and lockfiles are
+# excluded because they contain minified text, hashes, and registry-encoded
+# names that are not meaningfully spell-checkable.
+#
+# Project-specific terminology lives in `.cspell/project-words.txt`. Adding a
+# new word there is preferred over inlining `// cspell:ignore foo` directives
+# because the central list is auditable and reusable.
+version: '0.2'
+language: en
+
+# Built-in dictionaries. `softwareTerms` + `typescript` + `node` cover most
+# programmer vocabulary; the project list fills the repo-specific terms.
+dictionaries:
+  - typescript
+  - node
+  - npm
+  - bash
+  - softwareTerms
+  - filetypes
+  - misc
+  - en_US
+  - project-words
+
+dictionaryDefinitions:
+  - name: project-words
+    path: ./.cspell/project-words.txt
+    addWords: true
+
+ignorePaths:
+  - node_modules/**
+  - dist/**
+  - coverage/**
+  - reports/**
+  - package-lock.json
+  - pnpm-lock.yaml
+  - .git/**
+  - .cspell/**
+
+files:
+  - 'src/**/*.ts'
+  - 'tests/**/*.ts'
+  - 'scripts/**/*.{mjs,cjs}'
+  - 'docs/**/*.md'
+  - '*.md'
+  - 'CLAUDE.md'
+  - '.github/**/*.yml'
+
+# Patterns we never want to flag, even inside otherwise-scanned files.
+# - SHA-1 / SHA-256 hex strings: long contiguous hex looks like gibberish but is not.
+# - Base64 / base32 blobs: same.
+# - Percent-encoded URL escapes: without this, `%5Btest` can surface as `Btest`.
+patterns:
+  - name: long-hex
+    pattern: /\b[0-9a-f]{16,}\b/gi
+  - name: base64-blob
+    pattern: '/[A-Za-z0-9+/]{20,}={0,2}/g'
+  - name: percent-encoded
+    pattern: /%[0-9A-Fa-f]{2}/g
+
+ignoreRegExpList:
+  - long-hex
+  - base64-blob
+  - percent-encoded
+  - Urls
+  - Email
+
+# Split identifiers on case boundaries so typos inside camelCase, PascalCase,
+# and ALLCAPS_SNAKE names are still checked.
+allowCompoundWords: true

--- a/cspell.config.yaml
+++ b/cspell.config.yaml
@@ -67,6 +67,7 @@ ignoreRegExpList:
   - Urls
   - Email
 
-# Split identifiers on case boundaries so typos inside camelCase, PascalCase,
-# and ALLCAPS_SNAKE names are still checked.
+# Permit established run-together domain and tooling compounds that appear in
+# docs, scripts, and identifiers. This is intentionally permissive for valid
+# word pairs; obvious misspellings are still checked by the dictionaries above.
 allowCompoundWords: true

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -35,7 +35,7 @@ matrix runs the bundled coverage and slow deterministic lifecycle layers, while
 `test:package` runs in a separate non-blocking package job.
 CI verifies the production dependency graph with `npm ci --omit=dev
 --engine-strict` on the Node.js 22.3.0 package floor. The credential-free full
-toolchain gate runs on Linux for Node.js 22.13.0, 24, and 26. It also runs
+toolchain gate runs on Linux for Node.js 22.23.1, 24, and 26. It also runs
 `npm run check:runtime-policy`, which fails if workflow or metadata runtime
 policy drifts. Cross-platform coverage stays lean: the fast stdio, CLI port
 parsing, local-path policy, and request shutdown/signal suite runs on Linux,
@@ -85,7 +85,7 @@ runner exits nonzero and prints the summary path. A skipped-only run is visible
 evidence, not an authoritative pass.
 
 The `ci-green` production deploy marker depends on both the Node.js 22.3.0
-production-dependency install and the Node 22.13.0 deterministic gate. Node.js
+production-dependency install and the Node 22.23.1 deterministic gate. Node.js
 24 and 26 remain required PR checks, but a regression isolated to those
 non-production current lines does not freeze the production deploy ref. The
 production host is pinned to the patched Node 22 LTS line from `.nvmrc`.

--- a/docs/V1_SCOPE.md
+++ b/docs/V1_SCOPE.md
@@ -30,7 +30,7 @@ In scope for Phase 1:
   profiles.
 - A Node.js `>=22.3.0` package engine floor matching the official B2 SDK, with
   production dependency-install evidence at Node.js 22.3.0 and full toolchain
-  coverage on Node.js 22.13.0, 24, and 26.
+  coverage on Node.js 22.23.1, 24, and 26.
 - Release, package, CI, protocol, security, and reference-deployment work needed
   to ship `v0.1.0`.
 
@@ -81,7 +81,7 @@ Node.js `>=22.3.0` is the package engine floor for Phase 1.
 
 CI must continuously verify production dependency installation on Node.js
 22.3.0 and the full implementation, tests, and package toolchain on Node.js
-22.13.0, 24, and 26. Operators should use a patched Node 22 LTS release
+22.23.1, 24, and 26. Operators should use a patched Node 22 LTS release
 (`22.23.1` or newer at the time of writing), Node.js 24, or Node.js 26. Other
 Node.js lines are not part of the `v0.1.0` support contract.
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -30,6 +30,7 @@
         "@types/node": "22.3.0",
         "@types/opossum": "^8.1.9",
         "babel-jest": "^29.7.0",
+        "cspell": "^10.0.1",
         "jest": "^29.5.0",
         "jest-junit": "^17.0.0",
         "ts-jest": "^29.4.12",
@@ -1058,6 +1059,635 @@
         "node": ">=14.21.3"
       }
     },
+    "node_modules/@cspell/cspell-bundled-dicts": {
+      "version": "10.0.1",
+      "resolved": "https://registry.npmjs.org/@cspell/cspell-bundled-dicts/-/cspell-bundled-dicts-10.0.1.tgz",
+      "integrity": "sha512-WvkSDNX4Uyyj/ZgbPO6L38iFNMfK1EqsH1FteRiI2qLz6QZMXRFrIt12OqiWIplzZDDaVpBH9FCJOPJll0fjCQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@cspell/dict-ada": "^4.1.1",
+        "@cspell/dict-al": "^1.1.1",
+        "@cspell/dict-aws": "^4.0.17",
+        "@cspell/dict-bash": "^4.2.2",
+        "@cspell/dict-companies": "^3.2.11",
+        "@cspell/dict-cpp": "^7.0.2",
+        "@cspell/dict-cryptocurrencies": "^5.0.5",
+        "@cspell/dict-csharp": "^4.0.8",
+        "@cspell/dict-css": "^4.1.1",
+        "@cspell/dict-dart": "^2.3.2",
+        "@cspell/dict-data-science": "^2.0.13",
+        "@cspell/dict-django": "^4.1.6",
+        "@cspell/dict-docker": "^1.1.17",
+        "@cspell/dict-dotnet": "^5.0.13",
+        "@cspell/dict-elixir": "^4.0.8",
+        "@cspell/dict-en_us": "^4.4.33",
+        "@cspell/dict-en-common-misspellings": "^2.1.12",
+        "@cspell/dict-en-gb-mit": "^3.1.22",
+        "@cspell/dict-filetypes": "^3.0.18",
+        "@cspell/dict-flutter": "^1.1.1",
+        "@cspell/dict-fonts": "^4.0.6",
+        "@cspell/dict-fsharp": "^1.1.1",
+        "@cspell/dict-fullstack": "^3.2.9",
+        "@cspell/dict-gaming-terms": "^1.1.2",
+        "@cspell/dict-git": "^3.1.0",
+        "@cspell/dict-golang": "^6.0.26",
+        "@cspell/dict-google": "^1.0.9",
+        "@cspell/dict-haskell": "^4.0.6",
+        "@cspell/dict-html": "^4.0.15",
+        "@cspell/dict-html-symbol-entities": "^4.0.5",
+        "@cspell/dict-java": "^5.0.12",
+        "@cspell/dict-julia": "^1.1.1",
+        "@cspell/dict-k8s": "^1.0.12",
+        "@cspell/dict-kotlin": "^1.1.1",
+        "@cspell/dict-latex": "^5.1.0",
+        "@cspell/dict-lorem-ipsum": "^4.0.5",
+        "@cspell/dict-lua": "^4.0.8",
+        "@cspell/dict-makefile": "^1.0.5",
+        "@cspell/dict-markdown": "^2.0.16",
+        "@cspell/dict-monkeyc": "^1.0.12",
+        "@cspell/dict-node": "^5.0.9",
+        "@cspell/dict-npm": "^5.2.38",
+        "@cspell/dict-php": "^4.1.1",
+        "@cspell/dict-powershell": "^5.0.15",
+        "@cspell/dict-public-licenses": "^2.0.16",
+        "@cspell/dict-python": "^4.2.26",
+        "@cspell/dict-r": "^2.1.1",
+        "@cspell/dict-ruby": "^5.1.1",
+        "@cspell/dict-rust": "^4.1.2",
+        "@cspell/dict-scala": "^5.0.9",
+        "@cspell/dict-shell": "^1.1.2",
+        "@cspell/dict-software-terms": "^5.2.2",
+        "@cspell/dict-sql": "^2.2.1",
+        "@cspell/dict-svelte": "^1.0.7",
+        "@cspell/dict-swift": "^2.0.6",
+        "@cspell/dict-terraform": "^1.1.3",
+        "@cspell/dict-typescript": "^3.2.3",
+        "@cspell/dict-vue": "^3.0.5",
+        "@cspell/dict-zig": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=22.18.0"
+      }
+    },
+    "node_modules/@cspell/cspell-json-reporter": {
+      "version": "10.0.1",
+      "resolved": "https://registry.npmjs.org/@cspell/cspell-json-reporter/-/cspell-json-reporter-10.0.1.tgz",
+      "integrity": "sha512-/nes1RGILec3WCBcoMOd0byNTBtnJuPaVz/+ZzqYkLtY7x58VMcBG5kyP6hPyN8cIwjRADE/SR43gwdXuqk/FA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@cspell/cspell-types": "10.0.1"
+      },
+      "engines": {
+        "node": ">=22.18.0"
+      }
+    },
+    "node_modules/@cspell/cspell-performance-monitor": {
+      "version": "10.0.1",
+      "resolved": "https://registry.npmjs.org/@cspell/cspell-performance-monitor/-/cspell-performance-monitor-10.0.1.tgz",
+      "integrity": "sha512-9tVcHXwRnbazUv4WSG0h3MqV4+LgmLNgSALAQUflPPW0EMxTf7C4Dmv9cgxJyCEQrdnVKCr58nPPaahhz9LJUg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=22.18.0"
+      }
+    },
+    "node_modules/@cspell/cspell-pipe": {
+      "version": "10.0.1",
+      "resolved": "https://registry.npmjs.org/@cspell/cspell-pipe/-/cspell-pipe-10.0.1.tgz",
+      "integrity": "sha512-HPeXMD9AZ3V/qPkvQaPcak+C7cJ2z7JTHN8smd6J8L2aThLRky2cHc2OyeaHPSHB7WA47b4z2n5u5nawZhv5VQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=22.18.0"
+      }
+    },
+    "node_modules/@cspell/cspell-resolver": {
+      "version": "10.0.1",
+      "resolved": "https://registry.npmjs.org/@cspell/cspell-resolver/-/cspell-resolver-10.0.1.tgz",
+      "integrity": "sha512-PIzkZHD1fGUQx1XteK2d1iQ0Mzq/maYcoB4jkvAiiR6WqP3MWYNKFdI9z+R5pOq5KgMfW+5Ig1q0oSR6h8irlA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "global-directory": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=22.18.0"
+      }
+    },
+    "node_modules/@cspell/cspell-service-bus": {
+      "version": "10.0.1",
+      "resolved": "https://registry.npmjs.org/@cspell/cspell-service-bus/-/cspell-service-bus-10.0.1.tgz",
+      "integrity": "sha512-y6NcIGP2IdXaBL4PVH8vxsr7K27wzz3Ech87UtUtrDSXAiVEOvXgAIknEOUVp59rTlUE8Rn4IRURC6f/hgMyfw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=22.18.0"
+      }
+    },
+    "node_modules/@cspell/cspell-types": {
+      "version": "10.0.1",
+      "resolved": "https://registry.npmjs.org/@cspell/cspell-types/-/cspell-types-10.0.1.tgz",
+      "integrity": "sha512-kLgLShnWADDVreKC63pBrWkcvxgZzFIfO34Jhx/SWfuOIA3cD8AXT+HjyuLfoGJ7mUb58hv2kUziKzEy4INb1w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=22.18.0"
+      }
+    },
+    "node_modules/@cspell/cspell-worker": {
+      "version": "10.0.1",
+      "resolved": "https://registry.npmjs.org/@cspell/cspell-worker/-/cspell-worker-10.0.1.tgz",
+      "integrity": "sha512-L2bJerfuYOls2wEknm8FmynLtj/G7O4UqX9I/HznRggEW6i2yZIxagDetpVDNowpyavNHJ3SJtUFiyMiZc16Sw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cspell-lib": "10.0.1"
+      },
+      "engines": {
+        "node": ">=22.18.0"
+      }
+    },
+    "node_modules/@cspell/dict-ada": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/@cspell/dict-ada/-/dict-ada-4.1.1.tgz",
+      "integrity": "sha512-E+0YW9RhZod/9Qy2gxfNZiHJjCYFlCdI69br1eviQQWB8yOTJX0JHXLs79kOYhSW0kINPVUdvddEBe6Lu6CjGQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@cspell/dict-al": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@cspell/dict-al/-/dict-al-1.1.1.tgz",
+      "integrity": "sha512-sD8GCaZetgQL4+MaJLXqbzWcRjfKVp8x+px3HuCaaiATAAtvjwUQ5/Iubiqwfd1boIh2Y1/3EgM3TLQ7Q8e0wQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@cspell/dict-aws": {
+      "version": "4.0.17",
+      "resolved": "https://registry.npmjs.org/@cspell/dict-aws/-/dict-aws-4.0.17.tgz",
+      "integrity": "sha512-ORcblTWcdlGjIbWrgKF+8CNEBQiLVKdUOFoTn0KPNkAYnFcdPP0muT4892h7H4Xafh3j72wqB4/loQ6Nti9E/w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@cspell/dict-bash": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/@cspell/dict-bash/-/dict-bash-4.2.3.tgz",
+      "integrity": "sha512-ljUZoKHbDqw5Sx0qpL2qTUlmkmr+vhZH/sCNrNaBZKTbdgiswErSnIF1jRbGmEitJNxHRHWsuZyVgnTGfVO1Yw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@cspell/dict-shell": "1.2.0"
+      }
+    },
+    "node_modules/@cspell/dict-companies": {
+      "version": "3.2.12",
+      "resolved": "https://registry.npmjs.org/@cspell/dict-companies/-/dict-companies-3.2.12.tgz",
+      "integrity": "sha512-mjiz/N3zWOCsz5VfwMUydSl7uW0OU9H2PnbCNc3RV44Vj6Q59CSp6EYGSGZQxrXU1gpsuZUrwr6QCjNjFOOg5A==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@cspell/dict-cpp": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@cspell/dict-cpp/-/dict-cpp-7.0.2.tgz",
+      "integrity": "sha512-dfbeERiVNeqmo/npivdR6rDiBCqZi3QtjH2Z0HFcXwpdj6i97dX1xaKyK2GUsO/p4u1TOv63Dmj5Vm48haDpuA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@cspell/dict-cryptocurrencies": {
+      "version": "5.0.5",
+      "resolved": "https://registry.npmjs.org/@cspell/dict-cryptocurrencies/-/dict-cryptocurrencies-5.0.5.tgz",
+      "integrity": "sha512-R68hYYF/rtlE6T/dsObStzN5QZw+0aQBinAXuWCVqwdS7YZo0X33vGMfChkHaiCo3Z2+bkegqHlqxZF4TD3rUA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@cspell/dict-csharp": {
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/@cspell/dict-csharp/-/dict-csharp-4.0.8.tgz",
+      "integrity": "sha512-qmk45pKFHSxckl5mSlbHxmDitSsGMlk/XzFgt7emeTJWLNSTUK//MbYAkBNRtfzB4uD7pAFiKgpKgtJrTMRnrQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@cspell/dict-css": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/@cspell/dict-css/-/dict-css-4.1.2.tgz",
+      "integrity": "sha512-+ylGoKdwZ2sVOCOnU2Eq5wDZx+RaVX3HoKyNHGGsFvhSw6IidQ6tH/mAPKBDofViHJoWCPNlklE0lTr6MDG3QA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@cspell/dict-dart": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/@cspell/dict-dart/-/dict-dart-2.3.2.tgz",
+      "integrity": "sha512-sUiLW56t9gfZcu8iR/5EUg+KYyRD83Cjl3yjDEA2ApVuJvK1HhX+vn4e4k4YfjpUQMag8XO2AaRhARE09+/rqw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@cspell/dict-data-science": {
+      "version": "2.0.16",
+      "resolved": "https://registry.npmjs.org/@cspell/dict-data-science/-/dict-data-science-2.0.16.tgz",
+      "integrity": "sha512-M72mxv5asuAnORurz4iXRJ+Tw9XBq6eu7D2Ne7biP0Z1RciKGNxXWu9JycA/KlVvK1hAlKj/fANlXhuEWpXKFg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@cspell/dict-django": {
+      "version": "4.1.6",
+      "resolved": "https://registry.npmjs.org/@cspell/dict-django/-/dict-django-4.1.6.tgz",
+      "integrity": "sha512-SdbSFDGy9ulETqNz15oWv2+kpWLlk8DJYd573xhIkeRdcXOjskRuxjSZPKfW7O3NxN/KEf3gm3IevVOiNuFS+w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@cspell/dict-docker": {
+      "version": "1.1.17",
+      "resolved": "https://registry.npmjs.org/@cspell/dict-docker/-/dict-docker-1.1.17.tgz",
+      "integrity": "sha512-OcnVTIpHIYYKhztNTyK8ShAnXTfnqs43hVH6p0py0wlcwRIXe5uj4f12n7zPf2CeBI7JAlPjEsV0Rlf4hbz/xQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@cspell/dict-dotnet": {
+      "version": "5.0.13",
+      "resolved": "https://registry.npmjs.org/@cspell/dict-dotnet/-/dict-dotnet-5.0.13.tgz",
+      "integrity": "sha512-xPp7jMnFpOri7tzmqmm/dXMolXz1t2bhNqxYkOyMqXhvs08oc7BFs+EsbDY0X7hqiISgeFZGNqn0dOCr+ncPYw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@cspell/dict-elixir": {
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/@cspell/dict-elixir/-/dict-elixir-4.0.8.tgz",
+      "integrity": "sha512-CyfphrbMyl4Ms55Vzuj+mNmd693HjBFr9hvU+B2YbFEZprE5AG+EXLYTMRWrXbpds4AuZcvN3deM2XVB80BN/Q==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@cspell/dict-en_us": {
+      "version": "4.4.36",
+      "resolved": "https://registry.npmjs.org/@cspell/dict-en_us/-/dict-en_us-4.4.36.tgz",
+      "integrity": "sha512-2yOhI/+7d1DbfvMljGW4jw8pLqDEsVmnvUXBOCFXtLU2BWgQkrqOJDCNseYjEiEbTp0OtdrWEWWPFSP1TNugQw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@cspell/dict-en-common-misspellings": {
+      "version": "2.1.13",
+      "resolved": "https://registry.npmjs.org/@cspell/dict-en-common-misspellings/-/dict-en-common-misspellings-2.1.13.tgz",
+      "integrity": "sha512-00rpydUxKNWY2xxrSx+h46aNWLvbkJdd57SsnEFt24fbs1fROhXZ6XSQu+gQz/zNuiCvFi4Ro3ej9DLbEdWQmQ==",
+      "dev": true,
+      "license": "CC BY-SA 4.0"
+    },
+    "node_modules/@cspell/dict-en-gb-mit": {
+      "version": "3.1.25",
+      "resolved": "https://registry.npmjs.org/@cspell/dict-en-gb-mit/-/dict-en-gb-mit-3.1.25.tgz",
+      "integrity": "sha512-zGODptk24CMrXi49ieG2SUm94CKxEsVF0dYNF+1ZYH0MSsQDZ/PKDlrrbvtBqSupKdPSj0Z9sjOmMNfHHW9ZSg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@cspell/dict-filetypes": {
+      "version": "3.0.18",
+      "resolved": "https://registry.npmjs.org/@cspell/dict-filetypes/-/dict-filetypes-3.0.18.tgz",
+      "integrity": "sha512-yU7RKD/x1IWmDLzWeiItMwgV+6bUcU/af23uS0+uGiFUbsY1qWV/D4rxlAAO6Z7no3J2z8aZOkYIOvUrJq0Rcw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@cspell/dict-flutter": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@cspell/dict-flutter/-/dict-flutter-1.1.1.tgz",
+      "integrity": "sha512-UlOzRcH2tNbFhZmHJN48Za/2/MEdRHl2BMkCWZBYs+30b91mWvBfzaN4IJQU7dUZtowKayVIF9FzvLZtZokc5A==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@cspell/dict-fonts": {
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/@cspell/dict-fonts/-/dict-fonts-4.0.6.tgz",
+      "integrity": "sha512-aR/0csY01dNb0A1tw/UmN9rKgHruUxsYsvXu6YlSBJFu60s26SKr/k1o4LavpHTQ+lznlYMqAvuxGkE4Flliqw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@cspell/dict-fsharp": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@cspell/dict-fsharp/-/dict-fsharp-1.1.1.tgz",
+      "integrity": "sha512-imhs0u87wEA4/cYjgzS0tAyaJpwG7vwtC8UyMFbwpmtw+/bgss+osNfyqhYRyS/ehVCWL17Ewx2UPkexjKyaBA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@cspell/dict-fullstack": {
+      "version": "3.2.9",
+      "resolved": "https://registry.npmjs.org/@cspell/dict-fullstack/-/dict-fullstack-3.2.9.tgz",
+      "integrity": "sha512-diZX+usW5aZ4/b2T0QM/H/Wl9aNMbdODa1Jq0ReBr/jazmNeWjd+PyqeVgzd1joEaHY+SAnjrf/i9CwKd2ZtWQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@cspell/dict-gaming-terms": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@cspell/dict-gaming-terms/-/dict-gaming-terms-1.1.2.tgz",
+      "integrity": "sha512-9XnOvaoTBscq0xuD6KTEIkk9hhdfBkkvJAIsvw3JMcnp1214OCGW8+kako5RqQ2vTZR3Tnf3pc57o7VgkM0q1Q==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@cspell/dict-git": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@cspell/dict-git/-/dict-git-3.1.0.tgz",
+      "integrity": "sha512-KEt9zGkxqGy2q1nwH4CbyqTSv5nadpn8BAlDnzlRcnL0Xb3LX9xTgSGShKvzb0bw35lHoYyLWN2ZKAqbC4pgGQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@cspell/dict-golang": {
+      "version": "6.0.26",
+      "resolved": "https://registry.npmjs.org/@cspell/dict-golang/-/dict-golang-6.0.26.tgz",
+      "integrity": "sha512-YKA7Xm5KeOd14v5SQ4ll6afe9VSy3a2DWM7L9uBq4u3lXToRBQ1W5PRa+/Q9udd+DTURyVVnQ+7b9cnOlNxaRg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@cspell/dict-google": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/@cspell/dict-google/-/dict-google-1.0.9.tgz",
+      "integrity": "sha512-biL65POqialY0i4g6crj7pR6JnBkbsPovB2WDYkj3H4TuC/QXv7Pu5pdPxeUJA6TSCHI7T5twsO4VSVyRxD9CA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@cspell/dict-haskell": {
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/@cspell/dict-haskell/-/dict-haskell-4.0.6.tgz",
+      "integrity": "sha512-ib8SA5qgftExpYNjWhpYIgvDsZ/0wvKKxSP+kuSkkak520iPvTJumEpIE+qPcmJQo4NzdKMN8nEfaeci4OcFAQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@cspell/dict-html": {
+      "version": "4.0.15",
+      "resolved": "https://registry.npmjs.org/@cspell/dict-html/-/dict-html-4.0.15.tgz",
+      "integrity": "sha512-GJYnYKoD9fmo2OI0aySEGZOjThnx3upSUvV7mmqUu8oG+mGgzqm82P/f7OqsuvTaInZZwZbo+PwJQd/yHcyFIw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@cspell/dict-html-symbol-entities": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/@cspell/dict-html-symbol-entities/-/dict-html-symbol-entities-4.0.5.tgz",
+      "integrity": "sha512-429alTD4cE0FIwpMucvSN35Ld87HCyuM8mF731KU5Rm4Je2SG6hmVx7nkBsLyrmH3sQukTcr1GaiZsiEg8svPA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@cspell/dict-java": {
+      "version": "5.0.12",
+      "resolved": "https://registry.npmjs.org/@cspell/dict-java/-/dict-java-5.0.12.tgz",
+      "integrity": "sha512-qPSNhTcl7LGJ5Qp6VN71H8zqvRQK04S08T67knMq9hTA8U7G1sTKzLmBaDOFhq17vNX/+rT+rbRYp+B5Nwza1A==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@cspell/dict-julia": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@cspell/dict-julia/-/dict-julia-1.1.1.tgz",
+      "integrity": "sha512-WylJR9TQ2cgwd5BWEOfdO3zvDB+L7kYFm0I9u0s9jKHWQ6yKmfKeMjU9oXxTBxIufhCXm92SKwwVNAC7gjv+yA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@cspell/dict-k8s": {
+      "version": "1.0.13",
+      "resolved": "https://registry.npmjs.org/@cspell/dict-k8s/-/dict-k8s-1.0.13.tgz",
+      "integrity": "sha512-ELGkS13k7K/NEfVimBSrxVTfqXvOF/Kvxj4I62YxRm8bvHbfoXgrGaOx28lPiNRz+dmu+yYtvuXbnURKtYbC6g==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@cspell/dict-kotlin": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@cspell/dict-kotlin/-/dict-kotlin-1.1.1.tgz",
+      "integrity": "sha512-J3NzzfgmxRvEeOe3qUXnSJQCd38i/dpF9/t3quuWh6gXM+krsAXP75dY1CzDmS8mrJAlBdVBeAW5eAZTD8g86Q==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@cspell/dict-latex": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/@cspell/dict-latex/-/dict-latex-5.1.0.tgz",
+      "integrity": "sha512-qxT4guhysyBt0gzoliXYEBYinkAdEtR2M7goRaUH0a7ltCsoqqAeEV8aXYRIdZGcV77gYSobvu3jJL038tlPAw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@cspell/dict-lorem-ipsum": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/@cspell/dict-lorem-ipsum/-/dict-lorem-ipsum-4.0.5.tgz",
+      "integrity": "sha512-9a4TJYRcPWPBKkQAJ/whCu4uCAEgv/O2xAaZEI0n4y1/l18Yyx8pBKoIX5QuVXjjmKEkK7hi5SxyIsH7pFEK9Q==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@cspell/dict-lua": {
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/@cspell/dict-lua/-/dict-lua-4.0.8.tgz",
+      "integrity": "sha512-N4PkgNDMu9JVsRu7JBS/3E/dvfItRgk9w5ga2dKq+JupP2Y3lojNaAVFhXISh4Y0a6qXDn2clA6nvnavQ/jjLA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@cspell/dict-makefile": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/@cspell/dict-makefile/-/dict-makefile-1.0.5.tgz",
+      "integrity": "sha512-4vrVt7bGiK8Rx98tfRbYo42Xo2IstJkAF4tLLDMNQLkQ86msDlYSKG1ZCk8Abg+EdNcFAjNhXIiNO+w4KflGAQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@cspell/dict-markdown": {
+      "version": "2.0.17",
+      "resolved": "https://registry.npmjs.org/@cspell/dict-markdown/-/dict-markdown-2.0.17.tgz",
+      "integrity": "sha512-H8bAxih6U8NOnSPL7R8My+tqjaB4tmnJTjERuz4zYqmf+cH+5xshX3UVgKlwWFcyjsYfv/zEDuRdMctQv1q6HQ==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "@cspell/dict-css": "^4.1.2",
+        "@cspell/dict-html": "^4.0.15",
+        "@cspell/dict-html-symbol-entities": "^4.0.5",
+        "@cspell/dict-typescript": "^3.2.3"
+      }
+    },
+    "node_modules/@cspell/dict-monkeyc": {
+      "version": "1.0.12",
+      "resolved": "https://registry.npmjs.org/@cspell/dict-monkeyc/-/dict-monkeyc-1.0.12.tgz",
+      "integrity": "sha512-MN7Vs11TdP5mbdNFQP5x2Ac8zOBm97ARg6zM5Sb53YQt/eMvXOMvrep7+/+8NJXs0jkp70bBzjqU4APcqBFNAw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@cspell/dict-node": {
+      "version": "5.0.9",
+      "resolved": "https://registry.npmjs.org/@cspell/dict-node/-/dict-node-5.0.9.tgz",
+      "integrity": "sha512-hO+ga+uYZ/WA4OtiMEyKt5rDUlUyu3nXMf8KVEeqq2msYvAPdldKBGH7lGONg6R/rPhv53Rb+0Y1SLdoK1+7wQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@cspell/dict-npm": {
+      "version": "5.2.43",
+      "resolved": "https://registry.npmjs.org/@cspell/dict-npm/-/dict-npm-5.2.43.tgz",
+      "integrity": "sha512-H2gYwtu59dNO9662Uq0usfuhyNd7lZJE1C61a/UXcpRyWWSrTo2Bz+vwGYp1bXZ1LmjXadqvwJ8ArFlGdiadNQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@cspell/dict-php": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/@cspell/dict-php/-/dict-php-4.1.1.tgz",
+      "integrity": "sha512-EXelI+4AftmdIGtA8HL8kr4WlUE11OqCSVlnIgZekmTkEGSZdYnkFdiJ5IANSALtlQ1mghKjz+OFqVs6yowgWA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@cspell/dict-powershell": {
+      "version": "5.0.15",
+      "resolved": "https://registry.npmjs.org/@cspell/dict-powershell/-/dict-powershell-5.0.15.tgz",
+      "integrity": "sha512-l4S5PAcvCFcVDMJShrYD0X6Huv9dcsQPlsVsBGbH38wvuN7gS7+GxZFAjTNxDmTY1wrNi1cCatSg6Pu2BW4rgg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@cspell/dict-public-licenses": {
+      "version": "2.0.16",
+      "resolved": "https://registry.npmjs.org/@cspell/dict-public-licenses/-/dict-public-licenses-2.0.16.tgz",
+      "integrity": "sha512-EQRrPvEOmwhwWezV+W7LjXbIBjiy6y/shrET6Qcpnk3XANTzfvWflf9PnJ5kId/oKWvihFy0za0AV1JHd03pSQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@cspell/dict-python": {
+      "version": "4.2.29",
+      "resolved": "https://registry.npmjs.org/@cspell/dict-python/-/dict-python-4.2.29.tgz",
+      "integrity": "sha512-OnEt1a35iuQzc2Ize1qU/43ZyF10urRKAm+mlTz++vnAgDLBHpKfWakpSK50nyL5/1WvyQ8BaMjb52MBLEpTeA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@cspell/dict-data-science": "^2.0.16"
+      }
+    },
+    "node_modules/@cspell/dict-r": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@cspell/dict-r/-/dict-r-2.1.1.tgz",
+      "integrity": "sha512-71Ka+yKfG4ZHEMEmDxc6+blFkeTTvgKbKAbwiwQAuKl3zpqs1Y0vUtwW2N4b3LgmSPhV3ODVY0y4m5ofqDuKMw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@cspell/dict-ruby": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/@cspell/dict-ruby/-/dict-ruby-5.1.1.tgz",
+      "integrity": "sha512-LHrp84oEV6q1ZxPPyj4z+FdKyq1XAKYPtmGptrd+uwHbrF/Ns5+fy6gtSi7pS+uc0zk3JdO9w/tPK+8N1/7WUA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@cspell/dict-rust": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/@cspell/dict-rust/-/dict-rust-4.1.2.tgz",
+      "integrity": "sha512-O1FHrumYcO+HZti3dHfBPUdnDFkI+nbYK3pxYmiM1sr+G0ebOd6qchmswS0Wsc6ZdEVNiPYJY/gZQR6jfW3uOg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@cspell/dict-scala": {
+      "version": "5.0.9",
+      "resolved": "https://registry.npmjs.org/@cspell/dict-scala/-/dict-scala-5.0.9.tgz",
+      "integrity": "sha512-AjVcVAELgllybr1zk93CJ5wSUNu/Zb5kIubymR/GAYkMyBdYFCZ3Zbwn4Zz8GJlFFAbazABGOu0JPVbeY59vGg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@cspell/dict-shell": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@cspell/dict-shell/-/dict-shell-1.2.0.tgz",
+      "integrity": "sha512-PVctvT22lJ49niMiakO8xieY7ELCAzjSqhejWR7bAMb5AZ9F4WDEs+XdGMnoVHWeXq7K5rcepLPmEJb+37zzIw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@cspell/dict-software-terms": {
+      "version": "5.2.4",
+      "resolved": "https://registry.npmjs.org/@cspell/dict-software-terms/-/dict-software-terms-5.2.4.tgz",
+      "integrity": "sha512-z6y/TGH3QNf5wB4pVvN/P3GfFEW/Whf6QAekNsIn06VKl95dnamfpkPWqV8rEtCixQFaKalb5+y9hRQXH3XQ1g==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@cspell/dict-sql": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/@cspell/dict-sql/-/dict-sql-2.2.1.tgz",
+      "integrity": "sha512-qDHF8MpAYCf4pWU8NKbnVGzkoxMNrFqBHyG/dgrlic5EQiKANCLELYtGlX5auIMDLmTf1inA0eNtv74tyRJ/vg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@cspell/dict-svelte": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/@cspell/dict-svelte/-/dict-svelte-1.0.7.tgz",
+      "integrity": "sha512-hGZsGqP0WdzKkdpeVLBivRuSNzOTvN036EBmpOwxH+FTY2DuUH7ecW+cSaMwOgmq5JFSdTcbTNFlNC8HN8lhaQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@cspell/dict-swift": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/@cspell/dict-swift/-/dict-swift-2.0.6.tgz",
+      "integrity": "sha512-PnpNbrIbex2aqU1kMgwEKvCzgbkHtj3dlFLPMqW1vSniop7YxaDTtvTUO4zA++ugYAEL+UK8vYrBwDPTjjvSnA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@cspell/dict-terraform": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@cspell/dict-terraform/-/dict-terraform-1.1.4.tgz",
+      "integrity": "sha512-Ere42ilvMFvQA4GlcN0OKlruMPR6EsvaB+iTHzj2xc+NJGRK64V7yApUcWrOrSgTiM/vhWXPIsK3OMfiAiNdmA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@cspell/dict-typescript": {
+      "version": "3.2.3",
+      "resolved": "https://registry.npmjs.org/@cspell/dict-typescript/-/dict-typescript-3.2.3.tgz",
+      "integrity": "sha512-zXh1wYsNljQZfWWdSPYwQhpwiuW0KPW1dSd8idjMRvSD0aSvWWHoWlrMsmZeRl4qM4QCEAjua8+cjflm41cQBg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@cspell/dict-vue": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/@cspell/dict-vue/-/dict-vue-3.0.5.tgz",
+      "integrity": "sha512-Mqutb8jbM+kIcywuPQCCaK5qQHTdaByoEO2J9LKFy3sqAdiBogNkrplqUK0HyyRFgCfbJUgjz3N85iCMcWH0JA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@cspell/dict-zig": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@cspell/dict-zig/-/dict-zig-1.0.0.tgz",
+      "integrity": "sha512-XibBIxBlVosU06+M6uHWkFeT0/pW5WajDRYdXG2CgHnq85b0TI/Ks0FuBJykmsgi2CAD3Qtx8UHFEtl/DSFnAQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@cspell/dynamic-import": {
+      "version": "10.0.1",
+      "resolved": "https://registry.npmjs.org/@cspell/dynamic-import/-/dynamic-import-10.0.1.tgz",
+      "integrity": "sha512-mP1gdq00aIcH8HxNMqnH11X6BKxLcneDtFgl/ecjIKnaGKwi44m8AndP5Kr4ODaYdl8UUw9O3dJh7KaQXnLHZQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@cspell/url": "10.0.1",
+        "import-meta-resolve": "^4.2.0"
+      },
+      "engines": {
+        "node": ">=22.18.0"
+      }
+    },
+    "node_modules/@cspell/filetypes": {
+      "version": "10.0.1",
+      "resolved": "https://registry.npmjs.org/@cspell/filetypes/-/filetypes-10.0.1.tgz",
+      "integrity": "sha512-Z5S35giU5IW49fBBq6BksUbE8PC4IYPfaKuwl5Nl9jkf/OkAKiBmCowKX45NzRUQInwK/GSqqIUifrNeI6LdLw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=22.18.0"
+      }
+    },
+    "node_modules/@cspell/rpc": {
+      "version": "10.0.1",
+      "resolved": "https://registry.npmjs.org/@cspell/rpc/-/rpc-10.0.1.tgz",
+      "integrity": "sha512-axSRKv3zEAmBm66iD/FV/MPmE4/Yf7c3PZiwTW894Yd3iEhtn3KPKeTrqQ2/tDrhB1Z2qTsap/Hue0MK4o5WXg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=22.18.0"
+      }
+    },
+    "node_modules/@cspell/strong-weak-map": {
+      "version": "10.0.1",
+      "resolved": "https://registry.npmjs.org/@cspell/strong-weak-map/-/strong-weak-map-10.0.1.tgz",
+      "integrity": "sha512-lenN1DVyPi8nJLSMSJJ670ddTjyiruLueuSZO1qLcxBqUhgxDt/mALu9N/1m6WdOVcg6m/5cLiZVg2KOo2UzRw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=22.18.0"
+      }
+    },
+    "node_modules/@cspell/url": {
+      "version": "10.0.1",
+      "resolved": "https://registry.npmjs.org/@cspell/url/-/url-10.0.1.tgz",
+      "integrity": "sha512-abYYgI29wJhWIfWTYrYuzRYDcHQUQ1N5ylnhxYn1NJnIQMqUWGLbDmt12JABtZ+R6h6UNatQrS7rhP86etvJyQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=22.18.0"
+      }
+    },
     "node_modules/@cspotcode/source-map-support": {
       "version": "0.8.1",
       "resolved": "https://registry.npmjs.org/@cspotcode/source-map-support/-/source-map-support-0.8.1.tgz",
@@ -1880,6 +2510,13 @@
         "sprintf-js": "~1.0.2"
       }
     },
+    "node_modules/array-timsort": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/array-timsort/-/array-timsort-1.0.3.tgz",
+      "integrity": "sha512-/+3GRL7dDAGEfM6TseQk/U+mi18TU2Ms9I3UlLdUMhz2hbvGNTKdj9xniwXfUqgYhHxRx0+8UnKkvlNwVU+cWQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/atomic-sleep": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/atomic-sleep/-/atomic-sleep-1.0.0.tgz",
@@ -2177,6 +2814,35 @@
         "url": "https://github.com/chalk/chalk?sponsor=1"
       }
     },
+    "node_modules/chalk-template": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/chalk-template/-/chalk-template-1.1.2.tgz",
+      "integrity": "sha512-2bxTP2yUH7AJj/VAXfcA+4IcWGdQ87HwBANLt5XxGTeomo8yG0y95N1um9i5StvhT/Bl0/2cARA5v1PpPXUxUA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "chalk": "^5.2.0"
+      },
+      "engines": {
+        "node": ">=14.16"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk-template?sponsor=1"
+      }
+    },
+    "node_modules/chalk-template/node_modules/chalk": {
+      "version": "5.6.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.6.2.tgz",
+      "integrity": "sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^12.17.0 || ^14.13 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
     "node_modules/char-regex": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/char-regex/-/char-regex-1.0.2.tgz",
@@ -2263,6 +2929,30 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/commander": {
+      "version": "14.0.3",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-14.0.3.tgz",
+      "integrity": "sha512-H+y0Jo/T1RZ9qPP4Eh1pkcQcLRglraJaSLoyOtHxu6AapkjWVCy2Sit1QQ4x3Dng8qDlSsZEet7g5Pq06MvTgw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/comment-json": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/comment-json/-/comment-json-5.0.0.tgz",
+      "integrity": "sha512-uiqLcOiVDJtBP8WGkZHEP+FZIhTzP1dxvn59EfoYUi9gqupjrBWVQkO2atDrbnKPwLeotFYDsuNb26uBMqB+hw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "array-timsort": "^1.0.3",
+        "esprima": "^4.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
     "node_modules/concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
@@ -2319,6 +3009,242 @@
       },
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/cspell": {
+      "version": "10.0.1",
+      "resolved": "https://registry.npmjs.org/cspell/-/cspell-10.0.1.tgz",
+      "integrity": "sha512-Gg6w/flT3fKfl3la62hfTnhtNnDQ+9mU7kUhVqw/axl/Ms4oENw0oJMkWFIoj4f6nL/SDPz7KcPXd2XbkKFNmQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@cspell/cspell-json-reporter": "10.0.1",
+        "@cspell/cspell-performance-monitor": "10.0.1",
+        "@cspell/cspell-pipe": "10.0.1",
+        "@cspell/cspell-types": "10.0.1",
+        "@cspell/cspell-worker": "10.0.1",
+        "@cspell/dynamic-import": "10.0.1",
+        "@cspell/url": "10.0.1",
+        "ansi-regex": "^6.2.2",
+        "chalk": "^5.6.2",
+        "chalk-template": "^1.1.2",
+        "commander": "^14.0.3",
+        "cspell-config-lib": "10.0.1",
+        "cspell-dictionary": "10.0.1",
+        "cspell-gitignore": "10.0.1",
+        "cspell-glob": "10.0.1",
+        "cspell-io": "10.0.1",
+        "cspell-lib": "10.0.1",
+        "fast-json-stable-stringify": "^2.1.0",
+        "flatted": "^3.4.2",
+        "semver": "^7.8.1",
+        "tinyglobby": "^0.2.16"
+      },
+      "bin": {
+        "cspell": "bin.mjs",
+        "cspell-esm": "bin.mjs"
+      },
+      "engines": {
+        "node": ">=22.18.0"
+      },
+      "funding": {
+        "url": "https://github.com/streetsidesoftware/cspell?sponsor=1"
+      }
+    },
+    "node_modules/cspell-config-lib": {
+      "version": "10.0.1",
+      "resolved": "https://registry.npmjs.org/cspell-config-lib/-/cspell-config-lib-10.0.1.tgz",
+      "integrity": "sha512-hMpo/0j6k7pbiqrLDOLJKD2IGP9XwhjKf2miiM6p84Xeo4nyuFZaxxDCQ68R851HSYFrrdltgpoipMbj1h2Tnw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@cspell/cspell-types": "10.0.1",
+        "comment-json": "^5.0.0",
+        "smol-toml": "^1.6.1",
+        "yaml": "^2.9.0"
+      },
+      "engines": {
+        "node": ">=22.18.0"
+      }
+    },
+    "node_modules/cspell-dictionary": {
+      "version": "10.0.1",
+      "resolved": "https://registry.npmjs.org/cspell-dictionary/-/cspell-dictionary-10.0.1.tgz",
+      "integrity": "sha512-3cZ659vgsZWkzGQJR/sNqGDVt/OnvTSieLKI76V++4t1bHJfochb9ZrrwsuMsb1VPGiyqClUP1/O6WrefF/FVg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@cspell/cspell-performance-monitor": "10.0.1",
+        "@cspell/cspell-pipe": "10.0.1",
+        "@cspell/cspell-types": "10.0.1",
+        "cspell-trie-lib": "10.0.1",
+        "fast-equals": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=22.18.0"
+      }
+    },
+    "node_modules/cspell-gitignore": {
+      "version": "10.0.1",
+      "resolved": "https://registry.npmjs.org/cspell-gitignore/-/cspell-gitignore-10.0.1.tgz",
+      "integrity": "sha512-wN23U61Mx6qPJN3CesOmBU9vnbJ0jQm/ylK0iaVui3CcnO7Zzl5qLu5mPHUzGQGm8yso6qjyxqo16Ho7LpZGOQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@cspell/url": "10.0.1",
+        "cspell-glob": "10.0.1",
+        "cspell-io": "10.0.1"
+      },
+      "bin": {
+        "cspell-gitignore": "bin.mjs"
+      },
+      "engines": {
+        "node": ">=22.18.0"
+      }
+    },
+    "node_modules/cspell-glob": {
+      "version": "10.0.1",
+      "resolved": "https://registry.npmjs.org/cspell-glob/-/cspell-glob-10.0.1.tgz",
+      "integrity": "sha512-7bII9J3aSSpZDwhx7w+zfQXbMxHZQ3be0ilUp5bHrsjz6o07v/NqOHMGcwKdPn1sw2dxDz9sv057xE5pqXnSdw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@cspell/url": "10.0.1",
+        "picomatch": "^4.0.4"
+      },
+      "engines": {
+        "node": ">=22.18.0"
+      }
+    },
+    "node_modules/cspell-glob/node_modules/picomatch": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.5.tgz",
+      "integrity": "sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/cspell-grammar": {
+      "version": "10.0.1",
+      "resolved": "https://registry.npmjs.org/cspell-grammar/-/cspell-grammar-10.0.1.tgz",
+      "integrity": "sha512-xC9AFYmaI9wsO//a7S5tdDGKGJVD5UEEsTg+Up2fi7lPfXIryisYmV6tePNL1SEg0idYss4ja8LUZ3Mib09BjQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@cspell/cspell-pipe": "10.0.1",
+        "@cspell/cspell-types": "10.0.1"
+      },
+      "bin": {
+        "cspell-grammar": "bin.mjs"
+      },
+      "engines": {
+        "node": ">=22.18.0"
+      }
+    },
+    "node_modules/cspell-io": {
+      "version": "10.0.1",
+      "resolved": "https://registry.npmjs.org/cspell-io/-/cspell-io-10.0.1.tgz",
+      "integrity": "sha512-8C2ka07faxflnaqEBO3pektS21XViE/SEHT7F5ZD1ou7FyMR5u3xawTBJSczClfsxLt/WYeztBYrpmGAjmjksw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@cspell/cspell-service-bus": "10.0.1",
+        "@cspell/url": "10.0.1"
+      },
+      "engines": {
+        "node": ">=22.18.0"
+      }
+    },
+    "node_modules/cspell-lib": {
+      "version": "10.0.1",
+      "resolved": "https://registry.npmjs.org/cspell-lib/-/cspell-lib-10.0.1.tgz",
+      "integrity": "sha512-RpsIPiLzc4/YMW8BMRKpyJ81x439qjYWcqgdKeXnMkbKM88J9PexzutfFf/4v97v96KzfNitEzMpbI0uj8OeUg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@cspell/cspell-bundled-dicts": "10.0.1",
+        "@cspell/cspell-performance-monitor": "10.0.1",
+        "@cspell/cspell-pipe": "10.0.1",
+        "@cspell/cspell-resolver": "10.0.1",
+        "@cspell/cspell-types": "10.0.1",
+        "@cspell/dynamic-import": "10.0.1",
+        "@cspell/filetypes": "10.0.1",
+        "@cspell/rpc": "10.0.1",
+        "@cspell/strong-weak-map": "10.0.1",
+        "@cspell/url": "10.0.1",
+        "cspell-config-lib": "10.0.1",
+        "cspell-dictionary": "10.0.1",
+        "cspell-glob": "10.0.1",
+        "cspell-grammar": "10.0.1",
+        "cspell-io": "10.0.1",
+        "cspell-trie-lib": "10.0.1",
+        "env-paths": "^4.0.0",
+        "gensequence": "^8.0.8",
+        "import-fresh": "^4.0.0",
+        "resolve-from": "^5.0.0",
+        "vscode-languageserver-textdocument": "^1.0.12",
+        "vscode-uri": "^3.1.0",
+        "xdg-basedir": "^5.1.0"
+      },
+      "engines": {
+        "node": ">=22.18.0"
+      }
+    },
+    "node_modules/cspell-trie-lib": {
+      "version": "10.0.1",
+      "resolved": "https://registry.npmjs.org/cspell-trie-lib/-/cspell-trie-lib-10.0.1.tgz",
+      "integrity": "sha512-BFvhalSkRQFjKrZ//FKK7fRGrZFpifnxB5AwCkzsIsBZqicsfafcQ1xP21qpb0QqyV/IomjNgviG+tRJs+0rMw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=22.18.0"
+      },
+      "peerDependencies": {
+        "@cspell/cspell-types": "10.0.1"
+      }
+    },
+    "node_modules/cspell/node_modules/ansi-regex": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.2.tgz",
+      "integrity": "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-regex?sponsor=1"
+      }
+    },
+    "node_modules/cspell/node_modules/chalk": {
+      "version": "5.6.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.6.2.tgz",
+      "integrity": "sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^12.17.0 || ^14.13 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/cspell/node_modules/semver": {
+      "version": "7.8.5",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
+      "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/debug": {
@@ -2420,6 +3346,22 @@
       "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/env-paths": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/env-paths/-/env-paths-4.0.0.tgz",
+      "integrity": "sha512-pxP8eL2SwwaTRi/KHYwLYXinDs7gL3jxFcBYmEdYfZmZXbaVDvdppd0XBU8qVz03rDfKZMXg1omHCbsJjZrMsw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-safe-filename": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
     },
     "node_modules/error-ex": {
       "version": "1.3.4",
@@ -2548,6 +3490,16 @@
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
       }
     },
+    "node_modules/fast-equals": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/fast-equals/-/fast-equals-6.0.2.tgz",
+      "integrity": "sha512-sAjhj9ZhOxYCGiNMnZLaucOqf5ZeFnHNoKoAZiD9thhJ0N8RP85qJK759/97C/3L7NzzmGVB5uiX9AUpySZmUQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
     "node_modules/fast-json-stable-stringify": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
@@ -2592,6 +3544,13 @@
         "node": ">=8"
       }
     },
+    "node_modules/flatted": {
+      "version": "3.4.4",
+      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.4.4.tgz",
+      "integrity": "sha512-5+ybhBZANEJxaH3X5evAFatUxLfEHSr7n6kYJ+1Qd0mUqr4eu9gIf6GDbWHf8RJijHrjjO8G+la14SlL2SeS1Q==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/fs.realpath": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
@@ -2622,6 +3581,16 @@
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/gensequence": {
+      "version": "8.0.8",
+      "resolved": "https://registry.npmjs.org/gensequence/-/gensequence-8.0.8.tgz",
+      "integrity": "sha512-omMVniXEXpdx/vKxGnPRoO2394Otlze28TyxECbFVyoSpZ9H3EO7lemjcB12OpQJzRW4e5tt/dL1rOxry6aMHg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
       }
     },
     "node_modules/gensync": {
@@ -2687,6 +3656,22 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/global-directory": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/global-directory/-/global-directory-5.0.0.tgz",
+      "integrity": "sha512-1pgFdhK3J2LeM+dVf2Pd424yHx2ou338lC0ErNP2hPx4j8eW1Sp0XqSjNxtk6Tc4Kr5wlWtSvz8cn2yb7/SG/w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ini": "6.0.0"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/graceful-fs": {
@@ -2758,6 +3743,19 @@
         "node": ">=10.17.0"
       }
     },
+    "node_modules/import-fresh": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-4.0.0.tgz",
+      "integrity": "sha512-Fpi660c7VPDM3fPKYovStd9IP1CPOikf6v/dGxJJMmHPcwYQIMJ4W7kO1avBYEpMqkCh+Dx3Ln6H7VYqgztLjw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=22.15"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/import-local": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/import-local/-/import-local-3.2.0.tgz",
@@ -2776,6 +3774,17 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/import-meta-resolve": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/import-meta-resolve/-/import-meta-resolve-4.2.0.tgz",
+      "integrity": "sha512-Iqv2fzaTQN28s/FwZAoFq0ZSs/7hMAHJVX+w8PZl3cY19Pxk6jFFalxQoIfW2826i/fDLXv8IiEZRIT0lDuWcg==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
       }
     },
     "node_modules/imurmurhash": {
@@ -2806,6 +3815,16 @@
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/ini": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/ini/-/ini-6.0.0.tgz",
+      "integrity": "sha512-IBTdIkzZNOpqm7q3dRqJvMaldXjDHWkEDfrwGEQTs5eaQMWV+djAhR+wahyNNMAa+qpbDUhBMVt4ZKNwpPm7xQ==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": "^20.17.0 || >=22.9.0"
+      }
     },
     "node_modules/is-arrayish": {
       "version": "0.2.1",
@@ -2858,6 +3877,19 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.12.0"
+      }
+    },
+    "node_modules/is-safe-filename": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/is-safe-filename/-/is-safe-filename-0.1.1.tgz",
+      "integrity": "sha512-4SrR7AdnY11LHfDKTZY1u6Ga3RuxZdl3YKWWShO5iyuG5h8QS4GD2tOb04peBJ5I7pXbR+CGBNEhTcwK+FzN3g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/is-stream": {
@@ -4344,6 +5376,19 @@
         "node": ">=8"
       }
     },
+    "node_modules/smol-toml": {
+      "version": "1.7.1",
+      "resolved": "https://registry.npmjs.org/smol-toml/-/smol-toml-1.7.1.tgz",
+      "integrity": "sha512-PPlsspAZ4jbMBu5DMFhfUGDQLu/vrL4SyBROVS37x8ynnVmFIs1VPBz1Co8Xks3TvpIaZXmU85y4DrQ+UyVFoQ==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/cyyynthia"
+      }
+    },
     "node_modules/sonic-boom": {
       "version": "4.2.1",
       "resolved": "https://registry.npmjs.org/sonic-boom/-/sonic-boom-4.2.1.tgz",
@@ -4536,6 +5581,54 @@
       "resolved": "https://registry.npmjs.org/real-require/-/real-require-1.0.0.tgz",
       "integrity": "sha512-P4nbQYQfePJxRSmY+v/KINxVucm4NF3p3s7pJveMTtom52FR4YGltUQLB8idDXwDDWW+eYrWDFbuzUnjoWHF7g==",
       "license": "MIT"
+    },
+    "node_modules/tinyglobby": {
+      "version": "0.2.17",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.17.tgz",
+      "integrity": "sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fdir": "^6.5.0",
+        "picomatch": "^4.0.4"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/tinyglobby/node_modules/fdir": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
+      "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "peerDependencies": {
+        "picomatch": "^3 || ^4"
+      },
+      "peerDependenciesMeta": {
+        "picomatch": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/tinyglobby/node_modules/picomatch": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.5.tgz",
+      "integrity": "sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
     },
     "node_modules/tmpl": {
       "version": "1.0.5",
@@ -4811,6 +5904,20 @@
         "node": ">=10.12.0"
       }
     },
+    "node_modules/vscode-languageserver-textdocument": {
+      "version": "1.0.12",
+      "resolved": "https://registry.npmjs.org/vscode-languageserver-textdocument/-/vscode-languageserver-textdocument-1.0.12.tgz",
+      "integrity": "sha512-cxWNPesCnQCcMPeenjKKsOCKQZ/L6Tv19DTRIGuLWe32lyzWhihGVJ/rcckZXJxfdKCFvRLS3fpBIsV/ZGX4zA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/vscode-uri": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/vscode-uri/-/vscode-uri-3.1.0.tgz",
+      "integrity": "sha512-/BpdSx+yCQGnCvecbyXdxHDkuk55/G3xwnC0GqY4gmQ3j+A+g8kzzgB4Nk/SINjqn6+waqw3EgbVF2QKExkRxQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/walker": {
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/walker/-/walker-1.0.8.tgz",
@@ -4883,6 +5990,19 @@
         "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
       }
     },
+    "node_modules/xdg-basedir": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/xdg-basedir/-/xdg-basedir-5.1.0.tgz",
+      "integrity": "sha512-GCPAHLvrIH13+c0SuacwvRYj2SxJXQ4kaVTT5xgL3kPrz56XxkF21IGhjSE1+W0aw7gpBWRGXLCPnPby6lSpmQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/xml": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/xml/-/xml-1.0.1.tgz",
@@ -4906,6 +6026,22 @@
       "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/yaml": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.9.0.tgz",
+      "integrity": "sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "yaml": "bin.mjs"
+      },
+      "engines": {
+        "node": ">= 14.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/eemeli"
+      }
     },
     "node_modules/yargs": {
       "version": "17.7.2",

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "test:integration:live": "node scripts/require-live-env.mjs integration && node scripts/run-jest-layer.mjs integration-live",
     "test:contract:live": "node scripts/require-live-env.mjs contract && node scripts/run-jest-layer.mjs contract-live",
     "test:package": "npm run build && node scripts/run-jest-layer.mjs package",
-    "verify": "npm run typecheck && npm run build && npm run lint && npm run format:check && npm run test:coverage && npm run test:slow && npm run test:package",
+    "verify": "npm run typecheck && npm run build && npm run lint && npm run format:check && npm run spell && npm run test:coverage && npm run test:slow && npm run test:package",
     "test:cross-platform": "node scripts/run-cross-platform-tests.mjs",
     "smoke": "node scripts/smoke-test.mjs",
     "smoke:package": "npm run build && node scripts/packed-consumer-smoke.mjs",
@@ -55,7 +55,8 @@
     "lint": "node scripts/run-biome.mjs lint src tests scripts",
     "lint:fix": "node scripts/run-biome.mjs lint src tests scripts --write",
     "format": "node scripts/run-biome.mjs format . --write",
-    "format:check": "node scripts/run-biome.mjs format ."
+    "format:check": "node scripts/run-biome.mjs format .",
+    "spell": "cspell --no-progress --gitignore \"src/**/*.ts\" \"tests/**/*.ts\" \"scripts/**/*.{mjs,cjs}\" \"docs/**/*.md\" \"*.md\" \"CLAUDE.md\" \".github/**/*.yml\""
   },
   "keywords": [
     "mcp",
@@ -85,6 +86,7 @@
     "@types/node": "22.3.0",
     "@types/opossum": "^8.1.9",
     "babel-jest": "^29.7.0",
+    "cspell": "^10.0.1",
     "jest": "^29.5.0",
     "jest-junit": "^17.0.0",
     "ts-jest": "^29.4.12",

--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
     "lint:fix": "node scripts/run-biome.mjs lint src tests scripts --write",
     "format": "node scripts/run-biome.mjs format . --write",
     "format:check": "node scripts/run-biome.mjs format .",
-    "spell": "cspell --no-progress --gitignore \"src/**/*.ts\" \"tests/**/*.ts\" \"scripts/**/*.{mjs,cjs}\" \"docs/**/*.md\" \"*.md\" \"CLAUDE.md\" \".github/**/*.yml\""
+    "spell": "cspell lint --no-progress --gitignore"
   },
   "keywords": [
     "mcp",

--- a/runtime-policy.json
+++ b/runtime-policy.json
@@ -1,10 +1,10 @@
 {
   "engineFloor": ">=22.3.0",
   "runtimeInstallNode": "22.3.0",
-  "minimumEvidenceNode": "22.13.0",
+  "minimumEvidenceNode": "22.23.1",
   "node22LtsMinimum": "22.11.0",
   "node22Pinned": "22.23.1",
-  "deterministicLinuxMatrix": ["22.13.0", "24", "26"],
+  "deterministicLinuxMatrix": ["22.23.1", "24", "26"],
   "crossPlatformNode": "22.23.1",
   "liveNodeMatrix": ["22.23.1", "24", "26"],
   "unsupportedMajors": [18, 20],

--- a/scripts/packed-consumer-smoke.mjs
+++ b/scripts/packed-consumer-smoke.mjs
@@ -143,6 +143,33 @@ try {
         'for (const repoOnlyFile of ["runtime-policy.json", "audit-policy.json", "package-budget.json"]) {',
         "  if (fs.existsSync(path.join(packageRoot, repoOnlyFile))) throw new Error(`${repoOnlyFile} should not be published`);",
         "}",
+        "(async () => {",
+        '  const { createServer, getRegisteredTools } = require(path.join(packageRoot, "dist", "server.js"));',
+        "  const runtimeConfig = {",
+        '    applicationKeyId: "key-id",',
+        '    applicationKey: "key-secret",',
+        '    appKeyId: "key-id",',
+        '    appKey: "key-secret",',
+        '    masterKeyId: "key-id",',
+        '    masterKey: "key-secret",',
+        '    region: "us-west-004",',
+        "    allowLocalFiles: false,",
+        "    fileRoot: null,",
+        "  };",
+        "  const server = createServer(runtimeConfig);",
+        "  const tools = getRegisteredTools(server) || {};",
+        "  const toolNames = Object.keys(tools);",
+        "  if (toolNames.length !== 40) throw new Error(`expected 40 registered tools, got ${toolNames.length}`);",
+        '  if (!tools.s3_get_object.inputSchema.safeParse({ bucket: "bucket", key: "object" }).success) throw new Error("s3_get_object schema rejected required bucket/key");',
+        '  const readOnlyServer = createServer(runtimeConfig, ["listBuckets", "listFiles", "readFiles", "listKeys"]);',
+        "  const readOnlyTools = getRegisteredTools(readOnlyServer) || {};",
+        '  if (readOnlyTools.s3_delete_object) throw new Error("read-only capability filter exposed delete object");',
+        '  if (!readOnlyTools.s3_get_object) throw new Error("read-only capability filter hid get object");',
+        "  const stubResult = await tools.b2_create_key.execute({}, {});",
+        '  const stubText = stubResult?.content?.[0]?.text ?? "";',
+        '  if (!stubText.includes("tool_unavailable")) throw new Error("durable secret stub did not return unavailable response");',
+        "  await Promise.all([server.close(), readOnlyServer.close()]);",
+        "})().catch((err) => { console.error(err); process.exit(1); });",
       ].join("\n"),
     ],
     { env: sanitizerBlockedEnv },
@@ -171,7 +198,9 @@ try {
     throw new Error(`expected missing-credential startup to exit 1, got ${withoutCreds.status}`);
   }
 
-  console.log(`packed-consumer-smoke: installed and executed ${filename}`);
+  console.log(
+    `packed-consumer-smoke: installed and exercised runtime compatibility for ${filename}`,
+  );
 } finally {
   rmSync(workspace, { recursive: true, force: true });
 }

--- a/src/utils/circuit-breaker.ts
+++ b/src/utils/circuit-breaker.ts
@@ -67,7 +67,7 @@ breaker.on("close", () => logger.info("circuit.close"));
 /**
  * Circuit breaker for long-running data transfers (uploads / large downloads).
  *
- * Identical failure-tripping behaviour to the default breaker, but with the
+ * Identical failure-tripping behavior to the default breaker, but with the
  * per-call timeout DISABLED. A 100 MB part on a slow uplink legitimately takes
  * far longer than the default 150s; timing it out would abort a healthy upload,
  * surface a non-retryable error, and unfairly push the breaker toward open.

--- a/tests/contract/spelling-policy.contract.test.ts
+++ b/tests/contract/spelling-policy.contract.test.ts
@@ -63,6 +63,9 @@ describe("spelling policy", () => {
       const spellStep = job.indexOf("npm run spell");
       const buildStep = job.indexOf("npm run build");
 
+      expect(lintStep).toBeGreaterThan(-1);
+      expect(spellStep).toBeGreaterThan(-1);
+      expect(buildStep).toBeGreaterThan(-1);
       expect(spellStep).toBeGreaterThan(lintStep);
       expect(spellStep).toBeLessThan(buildStep);
     }

--- a/tests/contract/spelling-policy.contract.test.ts
+++ b/tests/contract/spelling-policy.contract.test.ts
@@ -30,6 +30,10 @@ describe("spelling policy", () => {
     return job;
   }
 
+  function stripAnsi(text: string): string {
+    return text.replace(/\u001b\[[0-9;]*m/g, "");
+  }
+
   it("wires cspell into package scripts and verify", () => {
     expect(pkg.devDependencies.cspell).toBeDefined();
     expect(pkg.scripts.spell).toEqual(expect.stringMatching(/\bcspell\b/));
@@ -54,6 +58,22 @@ describe("spelling policy", () => {
       throw new Error(`cspell config check failed\n${result.stdout}\n${result.stderr}`);
     }
     expect(result.status).toBe(0);
+  });
+
+  it("scans repo files from the cspell config", () => {
+    const result = spawnSync(cspellBin, ["lint", "--config", cspellConfigPath, "--no-progress"], {
+      cwd: root,
+      encoding: "utf8",
+      timeout: 60_000,
+    });
+    const output = stripAnsi(`${result.stdout}\n${result.stderr}`);
+
+    if (result.status !== 0) {
+      throw new Error(`cspell repo scan failed\n${output}`);
+    }
+    const filesChecked = output.match(/Files checked:\s*([0-9]+)/);
+    expect(filesChecked).not.toBeNull();
+    expect(Number(filesChecked?.[1])).toBeGreaterThan(0);
   });
 
   it("gates the deterministic CI jobs on spelling", () => {

--- a/tests/contract/spelling-policy.contract.test.ts
+++ b/tests/contract/spelling-policy.contract.test.ts
@@ -1,3 +1,4 @@
+import { spawnSync } from "child_process";
 import { existsSync, readFileSync } from "fs";
 import { createRequire } from "module";
 import { join } from "path";
@@ -14,9 +15,14 @@ describe("spelling policy", () => {
     scripts: Record<string, string>;
   };
   const ci = readFileSync(join(root, ".github/workflows/test.yml"), "utf8");
-  const cspellConfig = readFileSync(join(root, "cspell.config.yaml"), "utf8");
+  const cspellConfigPath = join(root, "cspell.config.yaml");
   const projectWordsPath = join(root, ".cspell/project-words.txt");
-  const projectWords = readFileSync(projectWordsPath, "utf8");
+  const cspellBin = join(
+    root,
+    "node_modules",
+    ".bin",
+    process.platform === "win32" ? "cspell.cmd" : "cspell",
+  );
 
   function workflowJob(name: string): string {
     const job = workflowJobBlock(ci, name);
@@ -24,30 +30,30 @@ describe("spelling policy", () => {
     return job;
   }
 
-  it("wires cspell into package scripts", () => {
-    expect(pkg.devDependencies.cspell).toMatch(/^\^10\./);
-    expect(pkg.scripts.spell).toContain("cspell --no-progress --gitignore");
-    expect(pkg.scripts.spell).toContain('"src/**/*.ts"');
-    expect(pkg.scripts.spell).toContain('"tests/**/*.ts"');
-    expect(pkg.scripts.spell).toContain('"scripts/**/*.{mjs,cjs}"');
-    expect(pkg.scripts.spell).toContain('"docs/**/*.md"');
-    expect(pkg.scripts.spell).toContain('".github/**/*.yml"');
+  it("wires cspell into package scripts and verify", () => {
+    expect(pkg.devDependencies.cspell).toBeDefined();
+    expect(pkg.scripts.spell).toEqual(expect.stringMatching(/\bcspell\b/));
     expect(pkg.scripts.verify).toContain("npm run spell");
   });
 
-  it("keeps a central project dictionary and noise filters", () => {
+  it("loads the cspell config and central project dictionary", () => {
+    const result = spawnSync(
+      cspellBin,
+      ["lint", "--config", cspellConfigPath, "--no-progress", "--no-summary", "stdin://README.md"],
+      {
+        cwd: root,
+        encoding: "utf8",
+        input: "b2sdk\n",
+        timeout: 30_000,
+      },
+    );
+
+    expect(existsSync(cspellConfigPath)).toBe(true);
     expect(existsSync(projectWordsPath)).toBe(true);
-    expect(projectWords).toContain("Backblaze");
-    expect(projectWords).toContain("MCP");
-    expect(cspellConfig).toContain("allowCompoundWords: true");
-    expect(cspellConfig).toContain("project-words");
-    expect(cspellConfig).toContain("package-lock.json");
-    expect(cspellConfig).toContain("pnpm-lock.yaml");
-    expect(cspellConfig).toContain("long-hex");
-    expect(cspellConfig).toContain("base64-blob");
-    expect(cspellConfig).toContain("percent-encoded");
-    expect(cspellConfig).toContain("Urls");
-    expect(cspellConfig).toContain("Email");
+    if (result.status !== 0) {
+      throw new Error(`cspell config check failed\n${result.stdout}\n${result.stderr}`);
+    }
+    expect(result.status).toBe(0);
   });
 
   it("gates the deterministic CI jobs on spelling", () => {

--- a/tests/contract/spelling-policy.contract.test.ts
+++ b/tests/contract/spelling-policy.contract.test.ts
@@ -1,0 +1,64 @@
+import { existsSync, readFileSync } from "fs";
+import { createRequire } from "module";
+import { join } from "path";
+import { root } from "./support";
+
+const nodeRequire = createRequire(__filename);
+const { workflowJobBlock } = nodeRequire("../../scripts/lib/workflow-yaml.cjs") as {
+  workflowJobBlock: (text: string, jobName: string) => string | null;
+};
+
+describe("spelling policy", () => {
+  const pkg = JSON.parse(readFileSync(join(root, "package.json"), "utf8")) as {
+    devDependencies: Record<string, string>;
+    scripts: Record<string, string>;
+  };
+  const ci = readFileSync(join(root, ".github/workflows/test.yml"), "utf8");
+  const cspellConfig = readFileSync(join(root, "cspell.config.yaml"), "utf8");
+  const projectWordsPath = join(root, ".cspell/project-words.txt");
+  const projectWords = readFileSync(projectWordsPath, "utf8");
+
+  function workflowJob(name: string): string {
+    const job = workflowJobBlock(ci, name);
+    if (!job) throw new Error(`Workflow job not found: ${name}`);
+    return job;
+  }
+
+  it("wires cspell into package scripts", () => {
+    expect(pkg.devDependencies.cspell).toMatch(/^\^10\./);
+    expect(pkg.scripts.spell).toContain("cspell --no-progress --gitignore");
+    expect(pkg.scripts.spell).toContain('"src/**/*.ts"');
+    expect(pkg.scripts.spell).toContain('"tests/**/*.ts"');
+    expect(pkg.scripts.spell).toContain('"scripts/**/*.{mjs,cjs}"');
+    expect(pkg.scripts.spell).toContain('"docs/**/*.md"');
+    expect(pkg.scripts.spell).toContain('".github/**/*.yml"');
+    expect(pkg.scripts.verify).toContain("npm run spell");
+  });
+
+  it("keeps a central project dictionary and noise filters", () => {
+    expect(existsSync(projectWordsPath)).toBe(true);
+    expect(projectWords).toContain("Backblaze");
+    expect(projectWords).toContain("MCP");
+    expect(cspellConfig).toContain("allowCompoundWords: true");
+    expect(cspellConfig).toContain("project-words");
+    expect(cspellConfig).toContain("package-lock.json");
+    expect(cspellConfig).toContain("pnpm-lock.yaml");
+    expect(cspellConfig).toContain("long-hex");
+    expect(cspellConfig).toContain("base64-blob");
+    expect(cspellConfig).toContain("percent-encoded");
+    expect(cspellConfig).toContain("Urls");
+    expect(cspellConfig).toContain("Email");
+  });
+
+  it("gates the deterministic CI jobs on spelling", () => {
+    for (const jobName of ["deterministic-linux-production", "deterministic-linux-current"]) {
+      const job = workflowJob(jobName);
+      const lintStep = job.indexOf("npm run lint");
+      const spellStep = job.indexOf("npm run spell");
+      const buildStep = job.indexOf("npm run build");
+
+      expect(spellStep).toBeGreaterThan(lintStep);
+      expect(spellStep).toBeLessThan(buildStep);
+    }
+  });
+});

--- a/tests/contract/spelling-policy.contract.test.ts
+++ b/tests/contract/spelling-policy.contract.test.ts
@@ -2,6 +2,7 @@ import { spawnSync } from "child_process";
 import { existsSync, readFileSync } from "fs";
 import { createRequire } from "module";
 import { join } from "path";
+import { stripVTControlCharacters } from "util";
 import { root } from "./support";
 
 const nodeRequire = createRequire(__filename);
@@ -28,10 +29,6 @@ describe("spelling policy", () => {
     const job = workflowJobBlock(ci, name);
     if (!job) throw new Error(`Workflow job not found: ${name}`);
     return job;
-  }
-
-  function stripAnsi(text: string): string {
-    return text.replace(/\u001b\[[0-9;]*m/g, "");
   }
 
   it("wires cspell into package scripts and verify", () => {
@@ -66,7 +63,7 @@ describe("spelling policy", () => {
       encoding: "utf8",
       timeout: 60_000,
     });
-    const output = stripAnsi(`${result.stdout}\n${result.stderr}`);
+    const output = stripVTControlCharacters(`${result.stdout}\n${result.stderr}`);
 
     if (result.status !== 0) {
       throw new Error(`cspell repo scan failed\n${output}`);

--- a/tests/unit/package-surface-policy.unit.test.ts
+++ b/tests/unit/package-surface-policy.unit.test.ts
@@ -104,6 +104,24 @@ describe("package surface policy", () => {
         '    path.join(packageRoot, "dist", "http-server.js"),',
         '    "module.exports = { buildHttpServer() {} };\\n",',
         "  );",
+        "  fs.writeFileSync(",
+        '    path.join(packageRoot, "dist", "server.js"),',
+        "    [",
+        '      "const allTools = {};\\n",',
+        '      "for (let i = 0; i < 37; i += 1) allTools[`b2_fixture_${i}`] = {};\\n",',
+        '      "allTools.b2_create_key = { execute: async () => ({ content: [{ text: \\"tool_unavailable\\" }] }) };\\n",',
+        '      "allTools.s3_get_object = { inputSchema: { safeParse: () => ({ success: true }) } };\\n",',
+        '      "allTools.s3_delete_object = {};\\n",',
+        '      "function createServer(_config, capabilities) { return { capabilities, close: async () => {} }; }\\n",',
+        '      "function getRegisteredTools(server) {\\n",',
+        '      "  if (Array.isArray(server.capabilities)) {\\n",',
+        '      "    return { b2_create_key: allTools.b2_create_key, s3_get_object: allTools.s3_get_object };\\n",',
+        '      "  }\\n",',
+        '      "  return allTools;\\n",',
+        '      "}\\n",',
+        '      "module.exports = { createServer, getRegisteredTools };\\n",',
+        '    ].join(""),',
+        "  );",
         "  process.exit(0);",
         "}",
         'console.error(`unexpected npm command: ${args.join(" ")}`);',
@@ -124,7 +142,9 @@ describe("package surface policy", () => {
 
       expect(result.status).toBe(0);
       expect(result.stderr).toContain("packed-consumer-smoke: retrying npm install");
-      expect(result.stdout).toContain("packed-consumer-smoke: installed and executed");
+      expect(result.stdout).toContain(
+        "packed-consumer-smoke: installed and exercised runtime compatibility",
+      );
       expect(readFileSync(state, "utf8")).toBe("2");
     } finally {
       rmSync(dir, { recursive: true, force: true });


### PR DESCRIPTION
## Summary

- Add cspell v10, a `spell` npm script, `cspell.config.yaml`, and a curated `.cspell/project-words.txt`.
- Keep spell-checked file scope in `cspell.config.yaml` and have the npm script delegate to cspell without duplicating globs.
- Run spelling from `npm run verify` and the deterministic Linux CI jobs.
- Add contract coverage for durable spell-policy wiring, including a no-argument cspell scan that proves the config globs check real repo files.
- Move the Node 22 full dev-toolchain CI evidence to the existing 22.23.1 pin because cspell v10 requires Node >=22.18, while strengthening the Node 22.3.0 packed runtime compatibility smoke required by `ci-green`.
- Address review and CI feedback by hardening spell-policy assertions, normalizing the project dictionary, removing overbroad spelling allow-list entries, and adding the project dictionary term needed by the main-branch tool-profile contract tests.

## Node 22.3.0 runtime compatibility

cspell v10 cannot run on the advertised engine floor, so this PR moves full dev-toolchain evidence from the older Node 22 pin to Node 22.23.1. The packed runtime consumer smoke intentionally remains on Node 22.3.0 with production dependencies only, and its tool-registration, capability-filtering, and durable-secret-stub checks are the in-scope replacement evidence that the published package still works at the runtime floor.

## Linked issue

Closes #100

## Tests run

- `conda run -n b2-mcp-issue-100 npm ci --engine-strict`
- `conda run -n b2-mcp-issue-100 npm run spell`
- `git show origin/main:tests/contract/tool-profile-contract.contract.test.ts | conda run -n b2-mcp-issue-100 npx --no-install cspell lint --config cspell.config.yaml --no-progress --no-summary stdin://tests/contract/tool-profile-contract.contract.test.ts`
- `conda run -n b2-mcp-issue-100 npm run lint`
- `conda run -n b2-mcp-issue-100 npm run check:runtime-policy`
- `conda run -n b2-mcp-issue-100 npm run check:package-budget`
- `conda run -n b2-mcp-issue-100 npm run audit:supply-chain`
- `conda run -n b2-mcp-issue-100 npm run smoke:package`
- `conda run -n b2-mcp-issue-100 npm run test:unit -- --runTestsByPath tests/unit/package-surface-policy.unit.test.ts`
- `conda run -n b2-mcp-issue-100 npm run test:contract -- --runTestsByPath tests/contract/spelling-policy.contract.test.ts tests/contract/ci-workflow-policy.contract.test.ts`
- `conda run -n b2-mcp-issue-100 npm run test:contract -- --runTestsByPath tests/contract/spelling-policy.contract.test.ts`
- `conda run -n b2-mcp-issue-100 npm run format:check`
- GitHub Actions CI: https://github.com/backblaze-labs/b2-mcp/actions/runs/31052570616
- `conda run -n b2-mcp-issue-100 npm run verify`

## Follow-up notes

- No follow-up required.