### PR TITLE
feat: add MCP protocol transport coverage

### DIFF
--- a/package-budget.json
+++ b/package-budget.json
@@ -11,10 +11,10 @@
     "directProductionDependencyCount": 8,
     "totalProductionPackageCount": 47,
     "transitiveProductionPackageCount": 38,
-    "packedTarballBytes": 228193,
-    "unpackedPackageBytes": 1123560,
-    "packedEntryCount": 177,
-    "cleanConsumerInstallFootprintBytes": 27972172
+    "packedTarballBytes": 231252,
+    "unpackedPackageBytes": 1136830,
+    "packedEntryCount": 181,
+    "cleanConsumerInstallFootprintBytes": 27996586
   },
   "limits": {
     "directProductionDependencyCount": 8,

--- a/package-budget.json
+++ b/package-budget.json
@@ -91,8 +91,7 @@
     "allowedBackblazeSdkSpecifiers": [
       "@backblaze-labs/b2-sdk",
       "@backblaze-labs/b2-sdk/raw",
-      "@backblaze-labs/b2-sdk/s3",
-      "@backblaze-labs/b2-sdk/simulator"
+      "@backblaze-labs/b2-sdk/s3"
     ],
     "allowedAwsRuntimeImports": [
       {

--- a/package-budget.json
+++ b/package-budget.json
@@ -60,7 +60,7 @@
     },
     "@modelcontextprotocol/server": {
       "purpose": "Stable MCP server v2 runtime for stdio and Streamable HTTP handling.",
-      "policy": "Use public v2 server exports only; do not add the monolithic v1 SDK or Node adapter packages.",
+      "policy": "Use public v2 server exports only; do not add the monolithic v1 SDK.",
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/@modelcontextprotocol/server/-/server-2.0.0.tgz",
       "integrity": "sha512-YhHWdHfpFMQfd0prsEnxKeS3Qz3ytIGmsS0sth4KDjnacIT7hxk6hXHkJ9KysxlkvTM+WZAtQbbcUhdoP4Hvtw=="
@@ -91,7 +91,8 @@
     "allowedBackblazeSdkSpecifiers": [
       "@backblaze-labs/b2-sdk",
       "@backblaze-labs/b2-sdk/raw",
-      "@backblaze-labs/b2-sdk/s3"
+      "@backblaze-labs/b2-sdk/s3",
+      "@backblaze-labs/b2-sdk/simulator"
     ],
     "allowedAwsRuntimeImports": [
       {
@@ -106,7 +107,6 @@
     "forbiddenRuntimeDependencies": [
       "axios",
       "@aws-sdk/s3-presigned-post",
-      "@modelcontextprotocol/node",
       "@modelcontextprotocol/sdk"
     ]
   },

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "test:contract": "node scripts/run-vitest-layer.mjs contract",
     "test:protocol:modern": "node scripts/run-vitest-layer.mjs protocol-modern",
     "test:protocol:legacy": "node scripts/run-vitest-layer.mjs protocol-legacy",
-    "test:protocol": "pnpm run test:protocol:modern && pnpm run test:protocol:legacy",
+    "test:protocol": "pnpm run build && pnpm run test:protocol:modern && pnpm run test:protocol:legacy",
     "test:slow": "node scripts/run-vitest-layer.mjs slow",
     "test:coverage": "pnpm run build && node scripts/run-vitest-layer.mjs coverage",
     "test:integration": "node scripts/reject-live-alias.mjs integration",
@@ -85,6 +85,7 @@
   "devDependencies": {
     "@biomejs/biome": "2.5.7",
     "@modelcontextprotocol/client": "2.0.0",
+    "@modelcontextprotocol/node": "2.0.0",
     "@toon-format/toon": "4.1.0",
     "@types/node": "22.3.0",
     "@types/opossum": "^8.1.9",
@@ -121,6 +122,7 @@
     },
     "minimatch@3.1.5": {
       "brace-expansion": "1.1.18"
-    }
+    },
+    "@hono/node-server": "2.0.10"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4,6 +4,9 @@ settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
+overrides:
+  '@hono/node-server': 2.0.10
+
 importers:
 
   .:
@@ -39,6 +42,9 @@ importers:
       '@modelcontextprotocol/client':
         specifier: 2.0.0
         version: 2.0.0
+      '@modelcontextprotocol/node':
+        specifier: 2.0.0
+        version: 2.0.0(@modelcontextprotocol/server@2.0.0)(hono@4.13.0)
       '@toon-format/toon':
         specifier: 4.1.0
         version: 4.1.0
@@ -524,6 +530,12 @@ packages:
     resolution: {integrity: sha512-43/qtrDUokr7LJqoF2c3+RInu/t4zfrpYdoSDfYyhg52rwLV6TnOvdG4fXm7IkSB3wErkcmJS9iEhjVtOSEjjA==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
+  '@hono/node-server@2.0.10':
+    resolution: {integrity: sha512-ZcnNVhKTmyDJeg0UlnZjvM73JBsTAuhrH/J4fjwGOw59PwOW51r4J+p6CsKZWXdKSme4MFqU62CZMOsdDrU4CA==}
+    engines: {node: '>=20'}
+    peerDependencies:
+      hono: ^4
+
   '@humanfs/core@0.19.2':
     resolution: {integrity: sha512-UhXNm+CFMWcbChXywFwkmhqjs3PRCmcSa/hfBgLIb7oQ5HNb1wS0icWsGtSAUNgefHeI+eBrA8I1fxmbHsGdvA==}
     engines: {node: '>=18.18.0'}
@@ -570,6 +582,16 @@ packages:
   '@modelcontextprotocol/core@2.0.0':
     resolution: {integrity: sha512-pJCEwGG7Lfr/+PQp9ZTwKXNeO5wzbfKL7H3MYpCorM4oFBoQrdjnBgEoqG+RjhsvS1FKrDbKux+M1HhlnGWqcA==}
     engines: {node: '>=20'}
+
+  '@modelcontextprotocol/node@2.0.0':
+    resolution: {integrity: sha512-Y4hAC2XdGDUdDOCbLDOCA4+aL3NUldjsOWlDL/YwpAxrPhRm1xHd7lZ+mLacvZ9t3PaH28wgNoaLQGrIk1P2pg==}
+    engines: {node: '>=20'}
+    peerDependencies:
+      '@modelcontextprotocol/server': ^2.0.0
+      hono: ^4.11.4
+    peerDependenciesMeta:
+      hono:
+        optional: true
 
   '@modelcontextprotocol/server@2.0.0':
     resolution: {integrity: sha512-YhHWdHfpFMQfd0prsEnxKeS3Qz3ytIGmsS0sth4KDjnacIT7hxk6hXHkJ9KysxlkvTM+WZAtQbbcUhdoP4Hvtw==}
@@ -1211,6 +1233,10 @@ packages:
   hasown@2.0.4:
     resolution: {integrity: sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==}
     engines: {node: '>= 0.4'}
+
+  hono@4.13.0:
+    resolution: {integrity: sha512-jhunvfHWxd7J5EFfSgH4xsYJzSe/lfqbUCxiyyeaQasUsXeEHXtzVid+7EOGByc5JnFa23SSFL3Y2RV/z1T+eQ==}
+    engines: {node: '>=16.9.0'}
 
   html-escaper@2.0.2:
     resolution: {integrity: sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==}
@@ -2304,6 +2330,10 @@ snapshots:
       '@eslint/core': 0.17.0
       levn: 0.4.1
 
+  '@hono/node-server@2.0.10(hono@4.13.0)':
+    dependencies:
+      hono: 4.13.0
+
   '@humanfs/core@0.19.2':
     dependencies:
       '@humanfs/types': 0.15.0
@@ -2356,6 +2386,13 @@ snapshots:
   '@modelcontextprotocol/core@2.0.0':
     dependencies:
       zod: 4.4.3
+
+  '@modelcontextprotocol/node@2.0.0(@modelcontextprotocol/server@2.0.0)(hono@4.13.0)':
+    dependencies:
+      '@hono/node-server': 2.0.10(hono@4.13.0)
+      '@modelcontextprotocol/server': 2.0.0
+    optionalDependencies:
+      hono: 4.13.0
 
   '@modelcontextprotocol/server@2.0.0':
     dependencies:
@@ -3048,6 +3085,8 @@ snapshots:
   hasown@2.0.4:
     dependencies:
       function-bind: 1.1.2
+
+  hono@4.13.0: {}
 
   html-escaper@2.0.2: {}
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,0 +1,2 @@
+overrides:
+  '@hono/node-server': 2.0.10

--- a/src/auth.ts
+++ b/src/auth.ts
@@ -10,14 +10,12 @@ import {
   type HttpTransport,
   type RetryOptions,
 } from "@backblaze-labs/b2-sdk";
-import { B2Simulator } from "@backblaze-labs/b2-sdk/simulator";
 import { B2AuthResponse, B2Config } from "./utils/types.js";
 import { buildUserAgent } from "./utils/user-agent.js";
 import { currentMcpRequestSignal, runWithMcpRequestSignal } from "./request-context.js";
 import { consumeRetryBudgetToken } from "./utils/retry.js";
 import { abortError, isAbortError } from "./utils/named-error.js";
 import { isTestRuntime } from "./utils/runtime.js";
-import { verificationFingerprintConfig } from "./credentials.js";
 
 /** Per-attempt timeout for ordinary SDK JSON requests, including authorization. */
 const API_TIMEOUT_MS = 30_000;
@@ -61,7 +59,6 @@ interface ManagedSdkClient {
 
 type SdkClientFactory = (config: B2Config) => ManagedSdkClient;
 let sdkClientFactoryForTests: SdkClientFactory | null = null;
-const sdkSimulatorClientsForTests = new Map<string, ManagedSdkClient>();
 
 type DomExceptionConstructor = new (message?: string, name?: string) => Error;
 
@@ -75,35 +72,12 @@ export function setB2SdkClientFactoryForTests(factory: SdkClientFactory | null):
   if (!isTestRuntime()) {
     throw new Error("SDK client factory override is only available in tests.");
   }
-  sdkSimulatorClientsForTests.clear();
   sdkClientFactoryForTests = factory;
 }
 
 function configuredSdkClientFactoryForTests(): SdkClientFactory | null {
   if (!isTestRuntime()) return null;
-  if (sdkClientFactoryForTests) return sdkClientFactoryForTests;
-  if (process.env.B2_MCP_TEST_SDK_SIMULATOR !== "true") return null;
-  return (config) => {
-    const cacheKey = verificationFingerprintConfig(config);
-    const existing = sdkSimulatorClientsForTests.get(cacheKey);
-    if (existing) return existing;
-    const simulator = new B2Simulator({ minimumPartSize: 1024, recommendedPartSize: 1024 });
-    const client = {
-      client: new SdkB2Client({
-        applicationKeyId: config.applicationKeyId,
-        applicationKey: config.applicationKey,
-        transport: createMcpHttpTransport(simulator.transport(), {
-          maxRetries: 0,
-          initialRetryDelayMs: 1,
-          maxRetryDelayMs: 1,
-          requestTimeoutMs: API_TIMEOUT_MS,
-        }),
-        retry: { maxRetries: 0, requestTimeoutMs: API_TIMEOUT_MS },
-      }),
-    };
-    sdkSimulatorClientsForTests.set(cacheKey, client);
-    return client;
-  };
+  return sdkClientFactoryForTests;
 }
 
 class RequestSignalTransport implements HttpTransport {

--- a/src/auth.ts
+++ b/src/auth.ts
@@ -10,12 +10,14 @@ import {
   type HttpTransport,
   type RetryOptions,
 } from "@backblaze-labs/b2-sdk";
+import { B2Simulator } from "@backblaze-labs/b2-sdk/simulator";
 import { B2AuthResponse, B2Config } from "./utils/types.js";
 import { buildUserAgent } from "./utils/user-agent.js";
 import { currentMcpRequestSignal, runWithMcpRequestSignal } from "./request-context.js";
 import { consumeRetryBudgetToken } from "./utils/retry.js";
 import { abortError, isAbortError } from "./utils/named-error.js";
 import { isTestRuntime } from "./utils/runtime.js";
+import { verificationFingerprintConfig } from "./credentials.js";
 
 /** Per-attempt timeout for ordinary SDK JSON requests, including authorization. */
 const API_TIMEOUT_MS = 30_000;
@@ -59,6 +61,7 @@ interface ManagedSdkClient {
 
 type SdkClientFactory = (config: B2Config) => ManagedSdkClient;
 let sdkClientFactoryForTests: SdkClientFactory | null = null;
+const sdkSimulatorClientsForTests = new Map<string, ManagedSdkClient>();
 
 type DomExceptionConstructor = new (message?: string, name?: string) => Error;
 
@@ -72,11 +75,35 @@ export function setB2SdkClientFactoryForTests(factory: SdkClientFactory | null):
   if (!isTestRuntime()) {
     throw new Error("SDK client factory override is only available in tests.");
   }
+  sdkSimulatorClientsForTests.clear();
   sdkClientFactoryForTests = factory;
 }
 
 function configuredSdkClientFactoryForTests(): SdkClientFactory | null {
-  return isTestRuntime() ? sdkClientFactoryForTests : null;
+  if (!isTestRuntime()) return null;
+  if (sdkClientFactoryForTests) return sdkClientFactoryForTests;
+  if (process.env.B2_MCP_TEST_SDK_SIMULATOR !== "true") return null;
+  return (config) => {
+    const cacheKey = verificationFingerprintConfig(config);
+    const existing = sdkSimulatorClientsForTests.get(cacheKey);
+    if (existing) return existing;
+    const simulator = new B2Simulator({ minimumPartSize: 1024, recommendedPartSize: 1024 });
+    const client = {
+      client: new SdkB2Client({
+        applicationKeyId: config.applicationKeyId,
+        applicationKey: config.applicationKey,
+        transport: createMcpHttpTransport(simulator.transport(), {
+          maxRetries: 0,
+          initialRetryDelayMs: 1,
+          maxRetryDelayMs: 1,
+          requestTimeoutMs: API_TIMEOUT_MS,
+        }),
+        retry: { maxRetries: 0, requestTimeoutMs: API_TIMEOUT_MS },
+      }),
+    };
+    sdkSimulatorClientsForTests.set(cacheKey, client);
+    return client;
+  };
 }
 
 class RequestSignalTransport implements HttpTransport {

--- a/src/http-server.ts
+++ b/src/http-server.ts
@@ -210,6 +210,7 @@ const SDK_HEADER_ALLOWLIST = new Set([
   "last-event-id",
   "traceparent",
   "tracestate",
+  "baggage",
 ]);
 
 function sdkHeaderAllowed(name: string): boolean {
@@ -377,6 +378,103 @@ function parsedJsonBody(rawBody: string | undefined): { ok: true; body?: unknown
   } catch {
     return { ok: false };
   }
+}
+
+function requestIdFromParsedBody(body: unknown): string | number | null {
+  if (!body || typeof body !== "object" || Array.isArray(body)) return null;
+  const id = (body as { id?: unknown }).id;
+  return typeof id === "string" || typeof id === "number" ? id : null;
+}
+
+function jsonRpcErrorBody(code: number, message: string, id: string | number | null): unknown {
+  return {
+    jsonrpc: "2.0",
+    error: { code, message },
+    id,
+  };
+}
+
+function modernMetaVersion(body: unknown): string | undefined {
+  if (!body || typeof body !== "object" || Array.isArray(body)) return undefined;
+  const params = (body as { params?: unknown }).params;
+  if (!params || typeof params !== "object" || Array.isArray(params)) return undefined;
+  const meta = (params as { _meta?: unknown })._meta;
+  if (!meta || typeof meta !== "object" || Array.isArray(meta)) return undefined;
+  const version = (meta as Record<string, unknown>)["io.modelcontextprotocol/protocolVersion"];
+  return typeof version === "string" ? version : undefined;
+}
+
+function requestMethodFromParsedBody(body: unknown): string | undefined {
+  if (!body || typeof body !== "object" || Array.isArray(body)) return undefined;
+  const method = (body as { method?: unknown }).method;
+  return typeof method === "string" ? method : undefined;
+}
+
+function toolNameFromParsedBody(body: unknown): string | undefined {
+  if (!body || typeof body !== "object" || Array.isArray(body)) return undefined;
+  const params = (body as { params?: unknown }).params;
+  if (!params || typeof params !== "object" || Array.isArray(params)) return undefined;
+  const name = (params as { name?: unknown }).name;
+  return typeof name === "string" ? name : undefined;
+}
+
+function modernHeaderRejection(
+  req: http.IncomingMessage,
+  sanitizedHeaders: Record<string, string | string[] | undefined>,
+  rawBody: string | undefined,
+): { status: number; body: unknown } | null {
+  if ((req.method ?? "GET").toUpperCase() !== "POST") return null;
+  if (!isJsonContentType(firstHeaderValue(sanitizedHeaders["content-type"]) ?? null)) return null;
+  const parsed = parsedJsonBody(rawBody);
+  if (!parsed.ok) return null;
+
+  const body = parsed.body;
+  const bodyVersion = modernMetaVersion(body);
+  if (!bodyVersion) return null;
+
+  const id = requestIdFromParsedBody(body);
+  const headerVersion = firstHeaderValue(sanitizedHeaders["mcp-protocol-version"]);
+  const headerMethod = firstHeaderValue(sanitizedHeaders["mcp-method"]);
+  const headerName = firstHeaderValue(sanitizedHeaders["mcp-name"]);
+  const bodyMethod = requestMethodFromParsedBody(body);
+  const bodyName = toolNameFromParsedBody(body);
+
+  if (headerVersion && headerVersion !== bodyVersion) {
+    return {
+      status: 400,
+      body: jsonRpcErrorBody(
+        -32020,
+        "Bad Request: MCP-Protocol-Version header does not match request metadata",
+        id,
+      ),
+    };
+  }
+  if (bodyVersion !== MODERN_MCP_PROTOCOL_VERSION) {
+    return {
+      status: 400,
+      body: jsonRpcErrorBody(-32022, "Unsupported protocol version", id),
+    };
+  }
+  if (!headerVersion) {
+    return {
+      status: 400,
+      body: jsonRpcErrorBody(-32020, "Bad Request: MCP-Protocol-Version header is required", id),
+    };
+  }
+  if (!headerMethod || headerMethod !== bodyMethod) {
+    return {
+      status: 400,
+      body: jsonRpcErrorBody(-32020, "Bad Request: Mcp-Method header does not match request", id),
+    };
+  }
+  if (bodyMethod === "tools/call" && (!headerName || headerName !== bodyName)) {
+    return {
+      status: 400,
+      body: jsonRpcErrorBody(-32020, "Bad Request: Mcp-Name header does not match tool name", id),
+    };
+  }
+
+  return null;
 }
 
 function isProtocolOnlyRejection(
@@ -624,6 +722,11 @@ export function buildHttpServer(options: HttpServerOptions = {}): HttpServerHand
       if (rawBody === null) return;
 
       const sanitizedHeaders = sanitizedHeadersFromNode(req.headers);
+      const headerRejection = modernHeaderRejection(req, sanitizedHeaders, rawBody);
+      if (headerRejection) {
+        writeJson(res, headerRejection.status, headerRejection.body);
+        return;
+      }
       if (isProtocolOnlyRejection(req, sanitizedHeaders, rawBody)) {
         await nodeMcpHandler(nodeRequestWithBody(req, rawBody, authInfo), res);
         return;

--- a/src/http-server.ts
+++ b/src/http-server.ts
@@ -208,6 +208,7 @@ const SDK_HEADER_ALLOWLIST = new Set([
   "content-type",
   "content-length",
   "last-event-id",
+  // W3C trace context propagation: baggage is caller-supplied and forwarded only to the SDK boundary.
   "traceparent",
   "tracestate",
   "baggage",
@@ -366,12 +367,16 @@ export function createPreparedMcpServerFactory(
 }
 
 const MODERN_MCP_PROTOCOL_VERSION = "2026-07-28";
+// SDK v2 uses -32020 for mirrored header/body disagreement.
+const JSON_RPC_HEADER_BODY_MISMATCH = -32020;
 
 function firstHeaderValue(value: string | string[] | undefined): string | undefined {
   return Array.isArray(value) ? value[0] : value;
 }
 
-function parsedJsonBody(rawBody: string | undefined): { ok: true; body?: unknown } | { ok: false } {
+type ParsedJsonBody = { ok: true; body?: unknown } | { ok: false };
+
+function parsedJsonBody(rawBody: string | undefined): ParsedJsonBody {
   if (rawBody === undefined || rawBody.length === 0) return { ok: true };
   try {
     return { ok: true, body: JSON.parse(rawBody) };
@@ -380,115 +385,68 @@ function parsedJsonBody(rawBody: string | undefined): { ok: true; body?: unknown
   }
 }
 
+function asRecord(value: unknown): Record<string, unknown> | null {
+  return value && typeof value === "object" && !Array.isArray(value)
+    ? (value as Record<string, unknown>)
+    : null;
+}
+
 function requestIdFromParsedBody(body: unknown): string | number | null {
-  if (!body || typeof body !== "object" || Array.isArray(body)) return null;
-  const id = (body as { id?: unknown }).id;
+  const id = asRecord(body)?.id;
   return typeof id === "string" || typeof id === "number" ? id : null;
 }
 
-function jsonRpcErrorBody(code: number, message: string, id: string | number | null): unknown {
+function jsonRpcErrorBody(
+  code: number,
+  message: string,
+  id: string | number | null,
+  data?: unknown,
+): unknown {
   return {
     jsonrpc: "2.0",
-    error: { code, message },
+    error: { code, message, ...(data !== undefined && { data }) },
     id,
   };
 }
 
-function modernMetaVersion(body: unknown): string | undefined {
-  if (!body || typeof body !== "object" || Array.isArray(body)) return undefined;
-  const params = (body as { params?: unknown }).params;
-  if (!params || typeof params !== "object" || Array.isArray(params)) return undefined;
-  const meta = (params as { _meta?: unknown })._meta;
-  if (!meta || typeof meta !== "object" || Array.isArray(meta)) return undefined;
-  const version = (meta as Record<string, unknown>)["io.modelcontextprotocol/protocolVersion"];
-  return typeof version === "string" ? version : undefined;
-}
-
 function requestMethodFromParsedBody(body: unknown): string | undefined {
-  if (!body || typeof body !== "object" || Array.isArray(body)) return undefined;
-  const method = (body as { method?: unknown }).method;
+  const method = asRecord(body)?.method;
   return typeof method === "string" ? method : undefined;
 }
 
 function toolNameFromParsedBody(body: unknown): string | undefined {
-  if (!body || typeof body !== "object" || Array.isArray(body)) return undefined;
-  const params = (body as { params?: unknown }).params;
-  if (!params || typeof params !== "object" || Array.isArray(params)) return undefined;
-  const name = (params as { name?: unknown }).name;
+  const params = asRecord(asRecord(body)?.params);
+  const name = params?.name;
   return typeof name === "string" ? name : undefined;
 }
 
-function modernHeaderRejection(
-  req: http.IncomingMessage,
-  sanitizedHeaders: Record<string, string | string[] | undefined>,
-  rawBody: string | undefined,
-): { status: number; body: unknown } | null {
-  if ((req.method ?? "GET").toUpperCase() !== "POST") return null;
-  if (!isJsonContentType(firstHeaderValue(sanitizedHeaders["content-type"]) ?? null)) return null;
-  const parsed = parsedJsonBody(rawBody);
-  if (!parsed.ok) return null;
-
-  const body = parsed.body;
-  const bodyVersion = modernMetaVersion(body);
-  if (!bodyVersion) return null;
-
-  const id = requestIdFromParsedBody(body);
-  const headerVersion = firstHeaderValue(sanitizedHeaders["mcp-protocol-version"]);
-  const headerMethod = firstHeaderValue(sanitizedHeaders["mcp-method"]);
-  const headerName = firstHeaderValue(sanitizedHeaders["mcp-name"]);
-  const bodyMethod = requestMethodFromParsedBody(body);
-  const bodyName = toolNameFromParsedBody(body);
-
-  if (headerVersion && headerVersion !== bodyVersion) {
-    return {
-      status: 400,
-      body: jsonRpcErrorBody(
-        -32020,
-        "Bad Request: MCP-Protocol-Version header does not match request metadata",
-        id,
-      ),
-    };
-  }
-  if (bodyVersion !== MODERN_MCP_PROTOCOL_VERSION) {
-    return {
-      status: 400,
-      body: jsonRpcErrorBody(-32022, "Unsupported protocol version", id),
-    };
-  }
-  if (!headerVersion) {
-    return {
-      status: 400,
-      body: jsonRpcErrorBody(-32020, "Bad Request: MCP-Protocol-Version header is required", id),
-    };
-  }
-  if (!headerMethod || headerMethod !== bodyMethod) {
-    return {
-      status: 400,
-      body: jsonRpcErrorBody(-32020, "Bad Request: Mcp-Method header does not match request", id),
-    };
-  }
-  if (bodyMethod === "tools/call" && (!headerName || headerName !== bodyName)) {
-    return {
-      status: 400,
-      body: jsonRpcErrorBody(-32020, "Bad Request: Mcp-Name header does not match tool name", id),
-    };
-  }
-
-  return null;
+interface ProtocolRejection {
+  status: number;
+  body: unknown;
+  code: number;
+  reason: string;
+  requestId: string | number | null;
 }
 
-function isProtocolOnlyRejection(
+interface ProtocolPreflight {
+  protocolOnly: boolean;
+  rejection?: ProtocolRejection;
+  sdkHeaders?: Record<string, string | string[] | undefined>;
+}
+
+function classifyProtocolPreflight(
   req: http.IncomingMessage,
   sanitizedHeaders: Record<string, string | string[] | undefined>,
-  rawBody: string | undefined,
-): boolean {
+  parsed: ParsedJsonBody,
+): ProtocolPreflight {
   const httpMethod = (req.method ?? "GET").toUpperCase();
-  if (httpMethod === "GET" || httpMethod === "DELETE") return true;
-  if (httpMethod !== "POST") return false;
-  if (!isJsonContentType(firstHeaderValue(sanitizedHeaders["content-type"]) ?? null)) return true;
+  if (httpMethod === "GET" || httpMethod === "DELETE") return { protocolOnly: true };
+  if (httpMethod !== "POST") return { protocolOnly: false };
+  if (!isJsonContentType(firstHeaderValue(sanitizedHeaders["content-type"]) ?? null)) {
+    return { protocolOnly: true };
+  }
 
-  const parsed = parsedJsonBody(rawBody);
-  if (!parsed.ok) return false;
+  if (!parsed.ok) return { protocolOnly: false };
   const outcome = classifyInboundRequest({
     httpMethod,
     protocolVersionHeader: firstHeaderValue(sanitizedHeaders["mcp-protocol-version"]),
@@ -497,9 +455,66 @@ function isProtocolOnlyRejection(
     body: parsed.body,
   });
 
-  if (outcome.kind === "reject") return true;
-  return (
-    outcome.kind === "modern" && outcome.classification.revision !== MODERN_MCP_PROTOCOL_VERSION
+  if (outcome.kind === "reject") return { protocolOnly: true };
+  if (outcome.kind !== "modern") return { protocolOnly: false };
+  if (outcome.classification.revision !== MODERN_MCP_PROTOCOL_VERSION) {
+    return { protocolOnly: true };
+  }
+
+  const sdkHeaders = inferredModernHeaders(
+    sanitizedHeaders,
+    outcome.classification.revision,
+    parsed.body,
+  );
+  const headerName = firstHeaderValue(sanitizedHeaders["mcp-name"]);
+  const bodyMethod = requestMethodFromParsedBody(parsed.body);
+  if (bodyMethod !== "tools/call" || !headerName) return { protocolOnly: false, sdkHeaders };
+
+  const bodyName = toolNameFromParsedBody(parsed.body);
+  if (headerName === bodyName) return { protocolOnly: false, sdkHeaders };
+
+  const requestId = requestIdFromParsedBody(parsed.body);
+  return {
+    protocolOnly: false,
+    rejection: {
+      status: 400,
+      code: JSON_RPC_HEADER_BODY_MISMATCH,
+      reason: "mcp-name-mismatch",
+      requestId,
+      body: jsonRpcErrorBody(
+        JSON_RPC_HEADER_BODY_MISMATCH,
+        "Bad Request: Mcp-Name header does not match tool name",
+        requestId,
+        { mismatch: { header: headerName, body: bodyName ?? null } },
+      ),
+    },
+  };
+}
+
+function inferredModernHeaders(
+  sanitizedHeaders: Record<string, string | string[] | undefined>,
+  revision: string,
+  body: unknown,
+): Record<string, string | string[] | undefined> {
+  const headers = { ...sanitizedHeaders };
+  const bodyMethod = requestMethodFromParsedBody(body);
+  const bodyName = toolNameFromParsedBody(body);
+  headers["mcp-protocol-version"] ??= revision;
+  if (bodyMethod) headers["mcp-method"] ??= bodyMethod;
+  if (bodyMethod === "tools/call" && bodyName) headers["mcp-name"] ??= bodyName;
+  return headers;
+}
+
+function logProtocolRejection(req: http.IncomingMessage, rejection: ProtocolRejection): void {
+  logger.warn(
+    {
+      code: rejection.code,
+      reason: rejection.reason,
+      method: req.method,
+      path: req.url,
+      requestId: rejection.requestId,
+    },
+    "mcp.http.protocol_rejected",
   );
 }
 
@@ -507,11 +522,12 @@ function nodeRequestWithBody(
   req: http.IncomingMessage,
   body: string | undefined,
   authInfo: AuthInfo | null | undefined,
+  headers: Record<string, string | string[] | undefined> = sanitizedHeadersFromNode(req.headers),
 ) {
   return {
     method: req.method,
     url: req.url,
-    headers: sanitizedHeadersFromNode(req.headers),
+    headers,
     ...(authInfo && { auth: authInfo }),
     async *[Symbol.asyncIterator]() {
       if (body !== undefined) yield body;
@@ -722,13 +738,18 @@ export function buildHttpServer(options: HttpServerOptions = {}): HttpServerHand
       if (rawBody === null) return;
 
       const sanitizedHeaders = sanitizedHeadersFromNode(req.headers);
-      const headerRejection = modernHeaderRejection(req, sanitizedHeaders, rawBody);
-      if (headerRejection) {
-        writeJson(res, headerRejection.status, headerRejection.body);
+      const parsedBody = req.method === "POST" ? parsedJsonBody(rawBody) : ({ ok: true } as const);
+      const protocolPreflight = classifyProtocolPreflight(req, sanitizedHeaders, parsedBody);
+      if (protocolPreflight.rejection) {
+        logProtocolRejection(req, protocolPreflight.rejection);
+        writeJson(res, protocolPreflight.rejection.status, protocolPreflight.rejection.body);
         return;
       }
-      if (isProtocolOnlyRejection(req, sanitizedHeaders, rawBody)) {
-        await nodeMcpHandler(nodeRequestWithBody(req, rawBody, authInfo), res);
+      if (protocolPreflight.protocolOnly) {
+        await nodeMcpHandler(
+          nodeRequestWithBody(req, rawBody, authInfo, protocolPreflight.sdkHeaders),
+          res,
+        );
         return;
       }
 
@@ -776,7 +797,10 @@ export function buildHttpServer(options: HttpServerOptions = {}): HttpServerHand
       const prepared: PreparedMcpRequest = { resolved, capabilities, servers: new Set() };
       try {
         await preparedRequestScope.run(prepared, () =>
-          nodeMcpHandler(nodeRequestWithBody(req, rawBody, authInfo), res),
+          nodeMcpHandler(
+            nodeRequestWithBody(req, rawBody, authInfo, protocolPreflight.sdkHeaders),
+            res,
+          ),
         );
       } finally {
         await closePreparedServers(prepared);

--- a/tests/contract/mcp-sdk.contract.test.ts
+++ b/tests/contract/mcp-sdk.contract.test.ts
@@ -1,23 +1,35 @@
+import { readFileSync } from "fs";
 import { join } from "path";
 import { listFiles, readJson, readLock, root } from "./support";
 
 describe("MCP SDK and protocol contract", () => {
-  it("uses the reviewed SDK v2 packages without vulnerable Node adapter dependencies", () => {
+  it("uses the reviewed SDK v2 package split without publishing the Node adapter", () => {
     const pkg = readJson<{
       dependencies: Record<string, string>;
       devDependencies: Record<string, string>;
+      overrides?: Record<string, string | Record<string, string>>;
     }>("package.json");
-    const lock = readLock<{ packages: Record<string, { version?: string }> }>();
+    const lock = readLock<{
+      packages: Record<string, { dev?: boolean; version?: string }>;
+    }>();
     const serverVersion = pkg.dependencies["@modelcontextprotocol/server"];
+    const nodeVersion = pkg.devDependencies["@modelcontextprotocol/node"];
     const clientVersion = pkg.devDependencies["@modelcontextprotocol/client"];
 
     expect(serverVersion).toMatch(/^\d+\.\d+\.\d+$/);
+    expect(nodeVersion).toBe(serverVersion);
     expect(clientVersion).toBe(serverVersion);
-    expect(lock.packages["node_modules/@modelcontextprotocol/server"]?.version).toBe(serverVersion);
-    expect(lock.packages["node_modules/@modelcontextprotocol/client"]?.version).toBe(clientVersion);
     expect(pkg.dependencies).not.toHaveProperty("@modelcontextprotocol/node");
-    expect(lock.packages["node_modules/@modelcontextprotocol/node"]).toBeUndefined();
-    expect(lock.packages["node_modules/@hono/node-server"]).toBeUndefined();
+    expect(lock.packages["node_modules/@modelcontextprotocol/server"]?.version).toBe(serverVersion);
+    expect(lock.packages["node_modules/@modelcontextprotocol/node"]?.version).toBe(nodeVersion);
+    expect(lock.packages["node_modules/@modelcontextprotocol/node"]?.dev).toBe(true);
+    expect(lock.packages["node_modules/@modelcontextprotocol/client"]?.version).toBe(clientVersion);
+    expect(pkg.overrides?.["@hono/node-server"]).toBe("2.0.10");
+    expect(readFileSync(join(root, "pnpm-workspace.yaml"), "utf8")).toContain(
+      "'@hono/node-server': 2.0.10",
+    );
+    expect(lock.packages["node_modules/@hono/node-server"]?.version).toBe("2.0.10");
+    expect(lock.packages["node_modules/@hono/node-server"]?.dev).toBe(true);
     expect(pkg.dependencies).not.toHaveProperty("@modelcontextprotocol/sdk");
     expect(pkg.devDependencies).not.toHaveProperty("@modelcontextprotocol/sdk");
     expect(lock.packages["node_modules/@modelcontextprotocol/sdk"]).toBeUndefined();
@@ -26,10 +38,12 @@ describe("MCP SDK and protocol contract", () => {
   it("exposes the SDK v2 entry points required by the serving adapters", async () => {
     const serverSdk = await import("@modelcontextprotocol/server");
     const stdioSdk = await import("@modelcontextprotocol/server/stdio");
+    const nodeSdk = await import("@modelcontextprotocol/node");
     const nodeAdapter = await import("../../src/node-http-adapter");
 
     expect(typeof serverSdk.createMcpHandler).toBe("function");
     expect(typeof stdioSdk.serveStdio).toBe("function");
+    expect(typeof nodeSdk.toWebRequest).toBe("function");
     expect(typeof nodeAdapter.createNodeHttpHandler).toBe("function");
   });
 

--- a/tests/contract/mcp-sdk.contract.test.ts
+++ b/tests/contract/mcp-sdk.contract.test.ts
@@ -47,6 +47,18 @@ describe("MCP SDK and protocol contract", () => {
     expect(typeof nodeAdapter.createNodeHttpHandler).toBe("function");
   });
 
+  it("keeps the MCP Node adapter out of runtime source imports", () => {
+    const runtimeSource = listFiles(join(root, "src"))
+      .filter((path) => /\.(?:c|m)?tsx?$/.test(path))
+      .map((path) => [path, readJsonOrText(path)] as const);
+
+    for (const [path, text] of runtimeSource) {
+      expect(text, path).not.toMatch(
+        /(?:from\s+|import\s*\(|require\s*\()\s*["']@modelcontextprotocol\/node(?:["'/])/,
+      );
+    }
+  });
+
   it("keeps modern and legacy protocol behavior in separately named tests", () => {
     const protocolTests = listFiles(join(root, "tests/protocol")).map((path) =>
       path.slice(root.length + 1),
@@ -56,3 +68,7 @@ describe("MCP SDK and protocol contract", () => {
     expect(protocolTests.some((path) => path.endsWith(".legacy-protocol.test.ts"))).toBe(true);
   });
 });
+
+function readJsonOrText(path: string): string {
+  return readFileSync(path, "utf8");
+}

--- a/tests/contract/security-remediation.contract.test.ts
+++ b/tests/contract/security-remediation.contract.test.ts
@@ -3,7 +3,10 @@ import { join } from "path";
 import { root, readLock } from "./support";
 
 type PackageLock = {
-  packages: Record<string, { version?: string; peerDependencies?: Record<string, string> }>;
+  packages: Record<
+    string,
+    { dev?: boolean; version?: string; peerDependencies?: Record<string, string> }
+  >;
 };
 
 function versionAtLeast(actual: string, floor: string): boolean {
@@ -57,10 +60,21 @@ describe("security dependency policy", () => {
     expect(versionTuple(lockedVersion)[0]).toBe(expectedMajor);
   };
 
-  it("excludes the vulnerable MCP Node adapter from the published graph", () => {
+  it("keeps the MCP Node adapter out of the published graph while pinning the dev SDK split", () => {
     expect(pkg.dependencies).not.toHaveProperty("@modelcontextprotocol/node");
-    expect(lock.packages["node_modules/@modelcontextprotocol/node"]).toBeUndefined();
-    expect(lock.packages["node_modules/@hono/node-server"]).toBeUndefined();
+    expect(pkg.devDependencies["@modelcontextprotocol/node"]).toBe(
+      pkg.dependencies["@modelcontextprotocol/server"],
+    );
+    expect(lock.packages["node_modules/@modelcontextprotocol/node"]?.version).toBe(
+      pkg.devDependencies["@modelcontextprotocol/node"],
+    );
+    expect(lock.packages["node_modules/@modelcontextprotocol/node"]?.dev).toBe(true);
+    expect(pkg.overrides?.["@hono/node-server"]).toBe("2.0.10");
+    expect(readFileSync(join(root, "pnpm-workspace.yaml"), "utf8")).toContain(
+      "'@hono/node-server': 2.0.10",
+    );
+    expect(lock.packages["node_modules/@hono/node-server"]?.version).toBe("2.0.10");
+    expect(lock.packages["node_modules/@hono/node-server"]?.dev).toBe(true);
     expect(pkg.overrides ?? {}).not.toHaveProperty("hono");
   });
 

--- a/tests/contract/security-remediation.contract.test.ts
+++ b/tests/contract/security-remediation.contract.test.ts
@@ -1,6 +1,6 @@
-import { readFileSync } from "fs";
+import { existsSync, readFileSync } from "fs";
 import { join } from "path";
-import { root, readLock } from "./support";
+import { listFiles, readLock, root } from "./support";
 
 type PackageLock = {
   packages: Record<
@@ -76,6 +76,22 @@ describe("security dependency policy", () => {
     expect(lock.packages["node_modules/@hono/node-server"]?.version).toBe("2.0.10");
     expect(lock.packages["node_modules/@hono/node-server"]?.dev).toBe(true);
     expect(pkg.overrides ?? {}).not.toHaveProperty("hono");
+  });
+
+  it("keeps the B2 SDK simulator out of production source and built output", () => {
+    const dist = join(root, "dist");
+    const productionFiles = [
+      ...listFiles(join(root, "src")),
+      ...(existsSync(dist) ? listFiles(dist) : []),
+    ].filter((path) => /\.(?:c|m)?[jt]s$/.test(path) && !path.endsWith(".d.ts"));
+
+    for (const path of productionFiles) {
+      const text = readFileSync(path, "utf8");
+      expect(text, path).not.toMatch(
+        /(?:from\s+|import\s*\(|require\s*\()\s*["']@backblaze-labs\/b2-sdk\/simulator["']/,
+      );
+      expect(text, path).not.toContain("B2_MCP_TEST_SDK_SIMULATOR");
+    }
   });
 
   it("keeps every brace-expansion resolution above its advisory floor", () => {

--- a/tests/protocol/http.guards.modern-protocol.test.ts
+++ b/tests/protocol/http.guards.modern-protocol.test.ts
@@ -1,0 +1,193 @@
+/**
+ * Transport-guard coverage for the modern HTTP entry point (#52 items 12, 14, 15):
+ * capacity/abuse guards (unsafe Origin, oversized body, in-flight caps),
+ * modern request cancellation reaching the handler abort signal, and
+ * `subscriptions/listen` unavailability when no list-change capability is advertised.
+ * Deterministic, no live B2 calls (SDK simulator transport only).
+ */
+
+import { buildHttpServer, type HttpServerHandle } from "../../src/http-server";
+import { invalidateAuthManagerCache } from "../../src/server";
+import { B2Simulator } from "@backblaze-labs/b2-sdk/simulator";
+import {
+  JSON_HEADERS,
+  closeHttpServer,
+  creds,
+  listenOnLocalhost,
+  request,
+  restoreEnv,
+  saveEnv,
+  setDefaultHttpTestEnv,
+} from "../support/http";
+import { modernBody, modernHeaders } from "./support/clients";
+import { setB2SdkClientFactoryForTests } from "../support/sdk-factory-hook";
+import { installSdkTransport } from "../support/sdk-test-helpers";
+
+let handle: HttpServerHandle;
+let port: number;
+
+const savedEnv = saveEnv([
+  "B2_REGISTER_ALL_TOOLS",
+  "B2_HTTP_CREDENTIAL_MODE",
+  "B2_MAX_SESSIONS",
+  "B2_MAX_SESSIONS_PER_KEY",
+]);
+
+interface Deferred<T> {
+  readonly promise: Promise<T>;
+  resolve(value: T): void;
+}
+
+function deferred<T>(): Deferred<T> {
+  let resolve!: (value: T) => void;
+  const promise = new Promise<T>((res) => (resolve = res));
+  return { promise, resolve };
+}
+
+async function waitFor(condition: () => boolean, timeoutMs = 2000): Promise<void> {
+  const start = Date.now();
+  while (!condition()) {
+    if (Date.now() - start > timeoutMs) return;
+    await new Promise((resolve) => setTimeout(resolve, 10));
+  }
+}
+
+const LIST_TOOLS = modernBody("tools/list");
+
+beforeAll(() => {
+  setDefaultHttpTestEnv();
+});
+
+afterAll(() => {
+  restoreEnv(savedEnv);
+});
+
+beforeEach(() => {
+  const simulator = new B2Simulator({ minimumPartSize: 1024, recommendedPartSize: 1024 });
+  installSdkTransport(simulator.transport());
+  process.env.B2_HTTP_CREDENTIAL_MODE = "headers";
+  delete process.env.B2_APPLICATION_KEY_ID;
+  delete process.env.B2_APPLICATION_KEY;
+  delete process.env.B2_MAX_SESSIONS;
+  delete process.env.B2_MAX_SESSIONS_PER_KEY;
+});
+
+afterEach(async () => {
+  setB2SdkClientFactoryForTests(null);
+  invalidateAuthManagerCache();
+  if (handle) await closeHttpServer(handle);
+});
+
+async function startHandle(overrides = {}): Promise<void> {
+  handle = buildHttpServer(overrides);
+  port = await listenOnLocalhost(handle);
+}
+
+describe("HTTP transport guards (MCP 2026-07-28)", () => {
+  it("rejects a request with a non-localhost Origin (DNS-rebinding guard)", async () => {
+    await startHandle();
+    const res = await request(port, "POST", "/mcp", {
+      headers: { ...creds, ...JSON_HEADERS, origin: "https://evil.example.com" },
+      body: LIST_TOOLS,
+    });
+    expect(res.status).toBe(403);
+    expect(JSON.parse(res.body).error).toMatch(/host\/origin/i);
+  });
+
+  it("rejects a request body over the size cap with 413", async () => {
+    await startHandle();
+    const res = await request(port, "POST", "/mcp", {
+      headers: { ...creds, ...JSON_HEADERS },
+      body: "x".repeat(1024 * 1024 + 1),
+    });
+    expect(res.status).toBe(413);
+  });
+
+  it("returns 503 when the global in-flight cap is exhausted", async () => {
+    process.env.B2_MAX_SESSIONS = "1";
+    const entered = deferred<void>();
+    const gate = deferred<void>();
+    await startHandle({
+      mcpHandler: {
+        fetch: async () => {
+          entered.resolve();
+          await gate.promise;
+          return Response.json({ jsonrpc: "2.0", id: 1, result: { tools: [] } });
+        },
+        close: () => undefined,
+      },
+    });
+
+    const first = request(port, "POST", "/mcp", {
+      headers: { ...creds, ...modernHeaders("tools/list") },
+      body: LIST_TOOLS,
+    });
+    await entered.promise; // first request now occupies the only in-flight slot
+
+    const second = await request(port, "POST", "/mcp", {
+      headers: { ...creds, ...modernHeaders("tools/list") },
+      body: LIST_TOOLS,
+    });
+    expect(second.status).toBe(503);
+    expect(JSON.parse(second.body).error).toMatch(/in-flight/i);
+
+    gate.resolve();
+    await first;
+  });
+
+  it("makes subscriptions/listen unavailable (no list-change capability advertised)", async () => {
+    await startHandle();
+    const res = await request(port, "POST", "/mcp", {
+      headers: { ...creds, ...modernHeaders("subscriptions/listen") },
+      body: modernBody("subscriptions/listen", {}),
+    });
+    const parsed = JSON.parse(res.body);
+    expect(parsed.result).toBeUndefined();
+    expect(parsed.error).toBeDefined();
+    // Method not found (-32601) or invalid params (-32602): either way the
+    // server does not establish a subscription without a list-change capability.
+    expect([-32601, -32602]).toContain(parsed.error.code);
+  });
+
+  it("observes client cancellation on the handler abort signal without a late response", async () => {
+    let sawAbort = false;
+    const entered = deferred<void>();
+    await startHandle({
+      mcpHandler: {
+        fetch: async (req: Request) => {
+          entered.resolve();
+          await new Promise<void>((resolve) => {
+            if (req.signal.aborted) {
+              sawAbort = true;
+              resolve();
+              return;
+            }
+            req.signal.addEventListener("abort", () => {
+              sawAbort = true;
+              resolve();
+            });
+          });
+          // Client is gone; do not emit a late response frame.
+          return Response.json({ jsonrpc: "2.0", id: 1, result: { tools: [] } });
+        },
+        close: () => undefined,
+      },
+    });
+
+    const controller = new AbortController();
+    const inflight = fetch(`http://127.0.0.1:${port}/mcp`, {
+      method: "POST",
+      headers: { ...creds, ...modernHeaders("tools/list") },
+      body: LIST_TOOLS,
+      signal: controller.signal,
+    }).catch((err) => err);
+
+    await entered.promise; // handler is now blocked awaiting the request signal
+    controller.abort();
+
+    const settled = await inflight;
+    expect(settled).toBeInstanceOf(Error);
+    await waitFor(() => sawAbort);
+    expect(sawAbort).toBe(true);
+  });
+});

--- a/tests/protocol/http.guards.modern-protocol.test.ts
+++ b/tests/protocol/http.guards.modern-protocol.test.ts
@@ -54,6 +54,10 @@ async function waitFor(condition: () => boolean, timeoutMs = 2000): Promise<void
 
 const LIST_TOOLS = modernBody("tools/list");
 
+function callToolBody(name: string, args: Record<string, unknown> = {}, id = 1): string {
+  return modernBody("tools/call", { name, arguments: args }, id);
+}
+
 beforeAll(() => {
   setDefaultHttpTestEnv();
 });
@@ -189,5 +193,73 @@ describe("HTTP transport guards (MCP 2026-07-28)", () => {
     expect(settled).toBeInstanceOf(Error);
     await waitFor(() => sawAbort);
     expect(sawAbort).toBe(true);
+  });
+
+  it("returns 429 when the per-credential in-flight cap is exhausted", async () => {
+    process.env.B2_MAX_SESSIONS_PER_KEY = "1";
+    const entered = deferred<void>();
+    const gate = deferred<void>();
+    await startHandle({
+      mcpHandler: {
+        fetch: async () => {
+          entered.resolve();
+          await gate.promise;
+          return Response.json({ jsonrpc: "2.0", id: 1, result: { content: [] } });
+        },
+        close: () => undefined,
+      },
+    });
+
+    const first = request(port, "POST", "/mcp", {
+      headers: { ...creds, ...modernHeaders("tools/call", "b2_list_buckets") },
+      body: callToolBody("b2_list_buckets"),
+    });
+    await entered.promise; // first request holds the only per-credential slot
+
+    const second = await request(port, "POST", "/mcp", {
+      headers: { ...creds, ...modernHeaders("tools/call", "b2_list_buckets") },
+      body: callToolBody("b2_list_buckets"),
+    });
+    expect(second.status).toBe(429);
+    expect(JSON.parse(second.body).error).toMatch(/credential/i);
+
+    gate.resolve();
+    await first;
+  });
+
+  it("rejects a JSON-RPC batch body", async () => {
+    await startHandle();
+    const res = await request(port, "POST", "/mcp", {
+      headers: { ...creds, ...modernHeaders("tools/list") },
+      body: JSON.stringify([JSON.parse(LIST_TOOLS), JSON.parse(LIST_TOOLS)]),
+    });
+    const parsed = JSON.parse(res.body);
+    expect(res.status === 400 || parsed.error !== undefined).toBe(true);
+    expect(parsed.result).toBeUndefined();
+  });
+
+  it("ignores malformed W3C trace context without rejecting the request", async () => {
+    const captured: { traceparent?: string | null } = {};
+    await startHandle({
+      mcpHandler: {
+        fetch: async (req: Request) => {
+          captured.traceparent = req.headers.get("traceparent");
+          return Response.json({ jsonrpc: "2.0", id: 1, result: { tools: [] } });
+        },
+        close: () => undefined,
+      },
+    });
+
+    const res = await request(port, "POST", "/mcp", {
+      headers: {
+        ...creds,
+        ...modernHeaders("tools/list"),
+        traceparent: "not-a-valid-traceparent",
+      },
+      body: LIST_TOOLS,
+    });
+
+    expect(res.status).toBe(200);
+    expect(captured.traceparent).toBe("not-a-valid-traceparent");
   });
 });

--- a/tests/protocol/http.legacy-protocol.test.ts
+++ b/tests/protocol/http.legacy-protocol.test.ts
@@ -8,6 +8,7 @@
 
 import { buildHttpServer, type HttpServerHandle } from "../../src/http-server";
 import { invalidateAuthManagerCache, invalidateCapabilityCache } from "../../src/server";
+import { B2Simulator } from "@backblaze-labs/b2-sdk/simulator";
 import {
   JSON_HEADERS,
   closeHttpServer,
@@ -19,6 +20,8 @@ import {
   setDefaultHttpTestEnv,
 } from "../support/http";
 import { closeClient, connectHttpClient } from "./support/clients";
+import { setB2SdkClientFactoryForTests } from "../support/sdk-factory-hook";
+import { installSdkTransport } from "../support/sdk-test-helpers";
 
 let handle: HttpServerHandle;
 let port: number;
@@ -30,12 +33,12 @@ beforeAll(() => {
 });
 
 afterAll(() => {
-  delete process.env.B2_MCP_TEST_SDK_SIMULATOR;
   restoreEnv(savedHttpEnv);
 });
 
 beforeEach(async () => {
-  process.env.B2_MCP_TEST_SDK_SIMULATOR = "true";
+  const simulator = new B2Simulator({ minimumPartSize: 1024, recommendedPartSize: 1024 });
+  installSdkTransport(simulator.transport());
   process.env.B2_HTTP_CREDENTIAL_MODE = "headers";
   delete process.env.B2_APPLICATION_KEY_ID;
   delete process.env.B2_APPLICATION_KEY;
@@ -45,6 +48,7 @@ beforeEach(async () => {
 });
 
 afterEach(async () => {
+  setB2SdkClientFactoryForTests(null);
   invalidateAuthManagerCache();
   await closeHttpServer(handle);
 });

--- a/tests/protocol/http.legacy-protocol.test.ts
+++ b/tests/protocol/http.legacy-protocol.test.ts
@@ -18,6 +18,7 @@ import {
   saveEnv,
   setDefaultHttpTestEnv,
 } from "../support/http";
+import { closeClient, connectHttpClient } from "./support/clients";
 
 let handle: HttpServerHandle;
 let port: number;
@@ -29,10 +30,12 @@ beforeAll(() => {
 });
 
 afterAll(() => {
+  delete process.env.B2_MCP_TEST_SDK_SIMULATOR;
   restoreEnv(savedHttpEnv);
 });
 
 beforeEach(async () => {
+  process.env.B2_MCP_TEST_SDK_SIMULATOR = "true";
   process.env.B2_HTTP_CREDENTIAL_MODE = "headers";
   delete process.env.B2_APPLICATION_KEY_ID;
   delete process.env.B2_APPLICATION_KEY;
@@ -59,7 +62,71 @@ function legacyInit(protocolVersion: string): string {
   });
 }
 
+function legacyRequest(method: string, params: Record<string, unknown> = {}, id = 1): string {
+  return JSON.stringify({ jsonrpc: "2.0", id, method, params });
+}
+
+function legacyCallTool(name: string, args: Record<string, unknown> = {}, id = 1): string {
+  return legacyRequest("tools/call", { name, arguments: args }, id);
+}
+
+function parseMcpBody(body: string): any {
+  if (body.trimStart().startsWith("{")) return JSON.parse(body);
+  const data = body
+    .split("\n")
+    .filter((line) => line.startsWith("data:"))
+    .map((line) => line.slice("data:".length).trim())
+    .join("\n");
+  return JSON.parse(data);
+}
+
 describe("HTTP legacy protocol fallback (2025 era)", () => {
+  it("serves initialize, list, and representative calls through the SDK HTTP client", async () => {
+    const { client, requests } = await connectHttpClient(port, {
+      era: "legacy",
+      headers: creds,
+      cachePartition: "legacy-tenant",
+    });
+    try {
+      expect(client.getProtocolEra()).toBe("legacy");
+      expect(client.getServerVersion()?.name).toBe("backblaze-b2");
+
+      const listed = await client.listTools(undefined, { cacheMode: "refresh" });
+      const toolNames = listed.tools.map((tool) => tool.name);
+      expect(toolNames).toContain("b2_list_buckets");
+      expect(toolNames).toContain("s3_list_objects_v2");
+
+      const bucketName = "protocol-http-legacy";
+      expect(
+        (
+          await client.callTool({
+            name: "b2_create_bucket",
+            arguments: { bucketName, bucketType: "allPrivate" },
+          })
+        ).isError,
+      ).not.toBe(true);
+      expect((await client.callTool({ name: "b2_list_buckets", arguments: {} })).isError).not.toBe(
+        true,
+      );
+      expect(
+        (
+          await client.callTool({
+            name: "s3_list_objects_v2",
+            arguments: { bucket: bucketName },
+          })
+        ).isError,
+      ).not.toBe(true);
+
+      const posts = requests.filter((record) => record.method === "POST");
+      expect(posts.length).toBeGreaterThan(0);
+      expect(requests.every((record) => record.method !== "DELETE")).toBe(true);
+      expect(posts.every((record) => record.headers["mcp-session-id"] === undefined)).toBe(true);
+      expect(posts.every((record) => record.headers["mcp-method"] === undefined)).toBe(true);
+    } finally {
+      await closeClient(client);
+    }
+  });
+
   it.each(["2025-03-26", "2025-06-18"])(
     "serves %s initialize through the stateless transition fallback",
     async (protocolVersion) => {
@@ -83,6 +150,40 @@ describe("HTTP legacy protocol fallback (2025 era)", () => {
 
     expect(res.status).toBe(200);
     expect(res.headers["mcp-session-id"]).toBeUndefined();
+    expect(handle.sessions.size).toBe(0);
+  });
+
+  it("serves raw stateless legacy list and calls without session affinity", async () => {
+    const bucketName = "protocol-http-raw";
+    const init = await request(port, "POST", "/mcp", {
+      headers: { ...creds, ...JSON_HEADERS },
+      body: legacyInit("2025-06-18"),
+    });
+    const listed = await request(port, "POST", "/mcp", {
+      headers: { ...creds, ...JSON_HEADERS },
+      body: legacyRequest("tools/list", {}, 2),
+    });
+    const created = await request(port, "POST", "/mcp", {
+      headers: { ...creds, ...JSON_HEADERS },
+      body: legacyCallTool("b2_create_bucket", { bucketName, bucketType: "allPrivate" }, 3),
+    });
+    const b2Call = await request(port, "POST", "/mcp", {
+      headers: { ...creds, ...JSON_HEADERS },
+      body: legacyCallTool("b2_list_buckets", {}, 4),
+    });
+    const s3Call = await request(port, "POST", "/mcp", {
+      headers: { ...creds, ...JSON_HEADERS },
+      body: legacyCallTool("s3_list_objects_v2", { bucket: bucketName }, 5),
+    });
+
+    for (const res of [init, listed, created, b2Call, s3Call]) {
+      expect(res.status).toBe(200);
+      expect(res.headers["mcp-session-id"]).toBeUndefined();
+      expect(parseMcpBody(res.body).error).toBeUndefined();
+    }
+    expect(parseMcpBody(listed.body).result.tools.length).toBeGreaterThan(0);
+    expect(JSON.stringify(parseMcpBody(b2Call.body).result)).toContain(bucketName);
+    expect(JSON.stringify(parseMcpBody(s3Call.body).result)).toContain("objects");
     expect(handle.sessions.size).toBe(0);
   });
 });

--- a/tests/protocol/http.modern-protocol.test.ts
+++ b/tests/protocol/http.modern-protocol.test.ts
@@ -9,6 +9,8 @@ import {
   type HttpServerHandle,
   type HttpServerOptions,
 } from "../../src/http-server";
+import { invalidateAuthManagerCache } from "../../src/server";
+import { B2Simulator } from "@backblaze-labs/b2-sdk/simulator";
 import {
   JSON_HEADERS,
   closeHttpServer,
@@ -26,6 +28,8 @@ import {
   modernBody,
   modernHeaders,
 } from "./support/clients";
+import { setB2SdkClientFactoryForTests } from "../support/sdk-factory-hook";
+import { installSdkTransport } from "../support/sdk-test-helpers";
 
 let handle: HttpServerHandle;
 let port: number;
@@ -37,12 +41,12 @@ beforeAll(() => {
 });
 
 afterAll(() => {
-  delete process.env.B2_MCP_TEST_SDK_SIMULATOR;
   restoreEnv(savedHttpEnv);
 });
 
 beforeEach(async () => {
-  process.env.B2_MCP_TEST_SDK_SIMULATOR = "true";
+  const simulator = new B2Simulator({ minimumPartSize: 1024, recommendedPartSize: 1024 });
+  installSdkTransport(simulator.transport());
   process.env.B2_HTTP_CREDENTIAL_MODE = "headers";
   delete process.env.B2_APPLICATION_KEY_ID;
   delete process.env.B2_APPLICATION_KEY;
@@ -51,6 +55,8 @@ beforeEach(async () => {
 });
 
 afterEach(async () => {
+  setB2SdkClientFactoryForTests(null);
+  invalidateAuthManagerCache();
   await closeHttpServer(handle);
 });
 
@@ -195,7 +201,21 @@ describe("HTTP handler (MCP 2026-07-28)", () => {
     expect(resolve).not.toHaveBeenCalled();
   });
 
-  it("requires method and name mirror headers before credential resolution", async () => {
+  it("accepts headerless modern envelopes during the compatibility window", async () => {
+    const list = await request(port, "POST", "/mcp", {
+      headers: { ...creds, ...JSON_HEADERS },
+      body: LIST_TOOLS,
+    });
+    const call = await request(port, "POST", "/mcp", {
+      headers: { ...creds, ...JSON_HEADERS },
+      body: callToolBody("b2_list_buckets"),
+    });
+
+    expect(list.status).toBe(200);
+    expect(call.status).toBe(200);
+  });
+
+  it("rejects mismatched tool-name mirror headers before credential resolution", async () => {
     const resolve = vi.fn(() => {
       throw new Error("credential resolution should not run");
     });
@@ -207,19 +227,16 @@ describe("HTTP handler (MCP 2026-07-28)", () => {
       },
     });
 
-    const missingMethod = await request(port, "POST", "/mcp", {
-      headers: { ...JSON_HEADERS, "mcp-protocol-version": MODERN_PROTOCOL_VERSION },
-      body: LIST_TOOLS,
-    });
-    const missingName = await request(port, "POST", "/mcp", {
-      headers: modernHeaders("tools/call"),
+    const mismatch = await request(port, "POST", "/mcp", {
+      headers: modernHeaders("tools/call", "s3_list_objects_v2"),
       body: callToolBody("b2_list_buckets"),
     });
 
-    expect(missingMethod.status).toBe(400);
-    expect(parsedJson(missingMethod.body).error.code).toBe(-32020);
-    expect(missingName.status).toBe(400);
-    expect(parsedJson(missingName.body).error.code).toBe(-32020);
+    expect(mismatch.status).toBe(400);
+    expect(parsedJson(mismatch.body).error).toMatchObject({
+      code: -32020,
+      data: { mismatch: { header: "s3_list_objects_v2", body: "b2_list_buckets" } },
+    });
     expect(resolve).not.toHaveBeenCalled();
   });
 

--- a/tests/protocol/http.modern-protocol.test.ts
+++ b/tests/protocol/http.modern-protocol.test.ts
@@ -215,6 +215,15 @@ describe("HTTP handler (MCP 2026-07-28)", () => {
     expect(call.status).toBe(200);
   });
 
+  it("accepts modern envelopes with Mcp-Method and no protocol-version header", async () => {
+    const list = await request(port, "POST", "/mcp", {
+      headers: { ...creds, ...JSON_HEADERS, "mcp-method": "tools/list" },
+      body: LIST_TOOLS,
+    });
+
+    expect(list.status).toBe(200);
+  });
+
   it("rejects mismatched tool-name mirror headers before credential resolution", async () => {
     const resolve = vi.fn(() => {
       throw new Error("credential resolution should not run");

--- a/tests/protocol/http.modern-protocol.test.ts
+++ b/tests/protocol/http.modern-protocol.test.ts
@@ -19,6 +19,13 @@ import {
   saveEnv,
   setDefaultHttpTestEnv,
 } from "../support/http";
+import {
+  MODERN_PROTOCOL_VERSION,
+  closeClient,
+  connectHttpClient,
+  modernBody,
+  modernHeaders,
+} from "./support/clients";
 
 let handle: HttpServerHandle;
 let port: number;
@@ -30,10 +37,12 @@ beforeAll(() => {
 });
 
 afterAll(() => {
+  delete process.env.B2_MCP_TEST_SDK_SIMULATOR;
   restoreEnv(savedHttpEnv);
 });
 
 beforeEach(async () => {
+  process.env.B2_MCP_TEST_SDK_SIMULATOR = "true";
   process.env.B2_HTTP_CREDENTIAL_MODE = "headers";
   delete process.env.B2_APPLICATION_KEY_ID;
   delete process.env.B2_APPLICATION_KEY;
@@ -45,29 +54,7 @@ afterEach(async () => {
   await closeHttpServer(handle);
 });
 
-const META = {
-  "io.modelcontextprotocol/protocolVersion": "2026-07-28",
-  "io.modelcontextprotocol/clientCapabilities": {},
-};
-
 const LIST_TOOLS = modernBody("tools/list");
-
-function modernBody(method: string, params: Record<string, unknown> = {}, id = 1): string {
-  return JSON.stringify({
-    jsonrpc: "2.0",
-    id,
-    method,
-    params: { ...params, _meta: META },
-  });
-}
-
-function modernHeaders(method: string, name?: string): Record<string, string> {
-  return {
-    ...JSON_HEADERS,
-    "mcp-method": method,
-    ...(name && { "mcp-name": name }),
-  };
-}
 
 async function replaceHandle(overrides: HttpServerOptions = {}): Promise<void> {
   await closeHttpServer(handle);
@@ -75,7 +62,73 @@ async function replaceHandle(overrides: HttpServerOptions = {}): Promise<void> {
   port = await listenOnLocalhost(handle);
 }
 
+function parsedJson(body: string): any {
+  return JSON.parse(body);
+}
+
+function callToolBody(name: string, args: Record<string, unknown> = {}, id = 1): string {
+  return modernBody("tools/call", { name, arguments: args }, id);
+}
+
 describe("HTTP handler (MCP 2026-07-28)", () => {
+  it("serves discover, list, and representative calls through the SDK HTTP client", async () => {
+    const { client, requests } = await connectHttpClient(port, {
+      era: "modern",
+      headers: creds,
+      cachePartition: "tenant-a",
+    });
+    try {
+      expect(client.getProtocolEra()).toBe("modern");
+      expect(client.getNegotiatedProtocolVersion()).toBe(MODERN_PROTOCOL_VERSION);
+
+      const discover = client.getDiscoverResult() ?? (await client.discover());
+      expect(discover.supportedVersions).toContain(MODERN_PROTOCOL_VERSION);
+      expect(discover.cacheScope).toBe("private");
+
+      const listed = await client.listTools(undefined, { cacheMode: "refresh" });
+      const toolNames = listed.tools.map((tool) => tool.name);
+      expect(toolNames).toContain("b2_list_buckets");
+      expect(toolNames).toContain("s3_list_objects_v2");
+
+      const bucketName = "protocol-http-modern";
+      expect(
+        (
+          await client.callTool({
+            name: "b2_create_bucket",
+            arguments: { bucketName, bucketType: "allPrivate" },
+          })
+        ).isError,
+      ).not.toBe(true);
+      expect((await client.callTool({ name: "b2_list_buckets", arguments: {} })).isError).not.toBe(
+        true,
+      );
+      expect(
+        (
+          await client.callTool({
+            name: "s3_list_objects_v2",
+            arguments: { bucket: bucketName },
+          })
+        ).isError,
+      ).not.toBe(true);
+
+      expect(requests.every((record) => record.method === "POST")).toBe(true);
+      expect(requests.some((record) => record.headers["mcp-method"] === "server/discover")).toBe(
+        true,
+      );
+      expect(requests.some((record) => record.headers["mcp-method"] === "tools/list")).toBe(true);
+      expect(
+        requests.some(
+          (record) =>
+            record.headers["mcp-method"] === "tools/call" &&
+            record.headers["mcp-name"] === "s3_list_objects_v2",
+        ),
+      ).toBe(true);
+      expect(requests.every((record) => record.headers["mcp-session-id"] === undefined)).toBe(true);
+    } finally {
+      await closeClient(client);
+    }
+  });
+
   it("returns SDK 405 for GET and DELETE before credential resolution", async () => {
     const resolve = vi.fn(() => {
       throw new Error("credential resolution should not run");
@@ -114,14 +167,17 @@ describe("HTTP handler (MCP 2026-07-28)", () => {
     });
 
     const unsupported = await request(port, "POST", "/mcp", {
-      headers: modernHeaders("tools/list"),
+      headers: {
+        ...modernHeaders("tools/list"),
+        "mcp-protocol-version": "2099-01-01",
+      },
       body: JSON.stringify({
         jsonrpc: "2.0",
         id: 1,
         method: "tools/list",
         params: {
           _meta: {
-            ...META,
+            "io.modelcontextprotocol/clientCapabilities": {},
             "io.modelcontextprotocol/protocolVersion": "2099-01-01",
           },
         },
@@ -133,9 +189,37 @@ describe("HTTP handler (MCP 2026-07-28)", () => {
     });
 
     expect(unsupported.status).toBe(400);
-    expect(unsupported.body).toMatch(/Unsupported protocol version/i);
+    expect(parsedJson(unsupported.body).error.code).toBe(-32022);
     expect(mismatch.status).toBe(400);
-    expect(JSON.parse(mismatch.body).error.code).toBe(-32020);
+    expect(parsedJson(mismatch.body).error.code).toBe(-32020);
+    expect(resolve).not.toHaveBeenCalled();
+  });
+
+  it("requires method and name mirror headers before credential resolution", async () => {
+    const resolve = vi.fn(() => {
+      throw new Error("credential resolution should not run");
+    });
+    await replaceHandle({
+      credentialProvider: {
+        name: "unused",
+        resolve,
+        validateConfiguration: () => undefined,
+      },
+    });
+
+    const missingMethod = await request(port, "POST", "/mcp", {
+      headers: { ...JSON_HEADERS, "mcp-protocol-version": MODERN_PROTOCOL_VERSION },
+      body: LIST_TOOLS,
+    });
+    const missingName = await request(port, "POST", "/mcp", {
+      headers: modernHeaders("tools/call"),
+      body: callToolBody("b2_list_buckets"),
+    });
+
+    expect(missingMethod.status).toBe(400);
+    expect(parsedJson(missingMethod.body).error.code).toBe(-32020);
+    expect(missingName.status).toBe(400);
+    expect(parsedJson(missingName.body).error.code).toBe(-32020);
     expect(resolve).not.toHaveBeenCalled();
   });
 
@@ -148,5 +232,73 @@ describe("HTTP handler (MCP 2026-07-28)", () => {
     expect(res.headers["mcp-session-id"]).toBeUndefined();
     expect(handle.sessions.size).toBe(0);
     expect(JSON.parse(res.body).result.tools.length).toBeGreaterThan(0);
+  });
+
+  it("ignores Last-Event-ID on stateless POST requests and does not replay", async () => {
+    const res = await request(port, "POST", "/mcp", {
+      headers: { ...creds, ...modernHeaders("tools/list"), "last-event-id": "stale-event" },
+      body: LIST_TOOLS,
+    });
+
+    expect(res.status).toBe(200);
+    expect(res.headers["mcp-session-id"]).toBeUndefined();
+    expect(parsedJson(res.body).result.tools.length).toBeGreaterThan(0);
+  });
+
+  it("returns controlled JSON-RPC errors for invalid tool names and schemas", async () => {
+    const invalidName = await request(port, "POST", "/mcp", {
+      headers: { ...creds, ...modernHeaders("tools/call", "missing_tool") },
+      body: callToolBody("missing_tool"),
+    });
+    const malformedArguments = await request(port, "POST", "/mcp", {
+      headers: { ...creds, ...modernHeaders("tools/call", "b2_list_buckets") },
+      body: modernBody("tools/call", {
+        name: "b2_list_buckets",
+        arguments: "not-an-object",
+      }),
+    });
+    const schemaFailure = await request(port, "POST", "/mcp", {
+      headers: { ...creds, ...modernHeaders("tools/call", "b2_create_bucket") },
+      body: callToolBody("b2_create_bucket", { bucketType: "allPrivate" }),
+    });
+
+    expect(invalidName.status).toBe(200);
+    expect(parsedJson(invalidName.body).error.code).toBe(-32602);
+    expect(malformedArguments.status).toBe(200);
+    expect(parsedJson(malformedArguments.body).error.code).toBe(-32602);
+    expect(schemaFailure.status).toBe(200);
+    expect(parsedJson(schemaFailure.body).result.isError).toBe(true);
+    expect(JSON.stringify(parsedJson(schemaFailure.body).result)).toMatch(/validation/i);
+  });
+
+  it("forwards valid W3C trace context headers to the MCP handler", async () => {
+    const captured: { headers?: Headers } = {};
+    await replaceHandle({
+      mcpHandler: {
+        fetch: async (req) => {
+          captured.headers = req.headers;
+          return Response.json({ jsonrpc: "2.0", id: 1, result: { ok: true } });
+        },
+        close: vi.fn(),
+      },
+    });
+
+    const res = await request(port, "POST", "/mcp", {
+      headers: {
+        ...creds,
+        ...modernHeaders("tools/list"),
+        traceparent: "00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01",
+        tracestate: "tracevendor=00f067aa0ba902b7",
+        baggage: "tenant=protocol",
+      },
+      body: LIST_TOOLS,
+    });
+
+    expect(res.status).toBe(200);
+    expect(captured.headers?.get("traceparent")).toBe(
+      "00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01",
+    );
+    expect(captured.headers?.get("tracestate")).toBe("tracevendor=00f067aa0ba902b7");
+    expect(captured.headers?.get("baggage")).toBe("tenant=protocol");
   });
 });

--- a/tests/protocol/http.round-robin.modern-protocol.test.ts
+++ b/tests/protocol/http.round-robin.modern-protocol.test.ts
@@ -1,0 +1,232 @@
+import * as http from "http";
+import type { AddressInfo } from "net";
+import { spawn, type ChildProcess } from "child_process";
+import { join } from "path";
+import {
+  HTTP_CREDS,
+  modernBody,
+  modernHeaders,
+  protocolEnv,
+  requireBuiltEntrypoints,
+} from "./support/clients";
+import { request } from "../support/http";
+
+interface Replica {
+  name: string;
+  port: number;
+  child: ChildProcess;
+  stderr: string;
+}
+
+interface ProxyHandle {
+  server: http.Server;
+  port: number;
+  seen: string[];
+  setTargets(targets: Replica[]): void;
+}
+
+async function freePort(): Promise<number> {
+  const server = http.createServer();
+  await new Promise<void>((resolve) => server.listen(0, "127.0.0.1", resolve));
+  const port = (server.address() as AddressInfo).port;
+  await new Promise<void>((resolve) => server.close(() => resolve()));
+  return port;
+}
+
+async function waitForHealth(port: number): Promise<void> {
+  const deadline = Date.now() + 5_000;
+  let lastError: unknown;
+  while (Date.now() < deadline) {
+    try {
+      const res = await request(port, "GET", "/health");
+      if (res.status === 200) return;
+    } catch (err) {
+      lastError = err;
+    }
+    await new Promise((resolve) => setTimeout(resolve, 50));
+  }
+  throw new Error(`replica on ${port} did not become healthy: ${String(lastError)}`);
+}
+
+async function startReplica(name: string): Promise<Replica> {
+  requireBuiltEntrypoints();
+  const port = await freePort();
+  const child = spawn(
+    process.execPath,
+    [join(__dirname, "../../dist/http-server.js"), "--port", String(port)],
+    {
+      cwd: join(__dirname, "../.."),
+      env: protocolEnv({
+        LOG_LEVEL: "silent",
+        B2_ALLOWED_HOSTS: "127.0.0.1,localhost",
+        B2_HTTP_CREDENTIAL_MODE: "headers",
+      }),
+      stdio: ["ignore", "pipe", "pipe"],
+    },
+  );
+  const replica: Replica = { name, port, child, stderr: "" };
+  child.stderr?.on("data", (chunk) => {
+    replica.stderr += chunk.toString();
+  });
+  await waitForHealth(port);
+  return replica;
+}
+
+async function stopReplica(replica: Replica): Promise<void> {
+  if (replica.child.exitCode !== null || replica.child.signalCode !== null) return;
+  replica.child.kill("SIGTERM");
+  await new Promise<void>((resolve) => {
+    const timer = setTimeout(() => {
+      replica.child.kill("SIGKILL");
+      resolve();
+    }, 2_000);
+    timer.unref();
+    replica.child.once("exit", () => {
+      clearTimeout(timer);
+      resolve();
+    });
+  });
+}
+
+async function readNodeBody(req: http.IncomingMessage): Promise<Buffer> {
+  const chunks: Buffer[] = [];
+  for await (const chunk of req) {
+    chunks.push(Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk));
+  }
+  return Buffer.concat(chunks as unknown as readonly Uint8Array[]);
+}
+
+async function startRoundRobinProxy(initialTargets: Replica[]): Promise<ProxyHandle> {
+  let targets = [...initialTargets];
+  let next = 0;
+  const seen: string[] = [];
+  const server = http.createServer(async (clientReq, clientRes) => {
+    if (targets.length === 0) {
+      clientRes.writeHead(503);
+      clientRes.end();
+      return;
+    }
+    const target = targets[next % targets.length];
+    next++;
+    seen.push(target.name);
+    const body = await readNodeBody(clientReq);
+    const upstream = http.request(
+      {
+        host: "127.0.0.1",
+        port: target.port,
+        method: clientReq.method,
+        path: clientReq.url,
+        headers: { ...clientReq.headers, host: `127.0.0.1:${target.port}` },
+      },
+      (upstreamRes) => {
+        clientRes.writeHead(upstreamRes.statusCode ?? 502, {
+          ...upstreamRes.headers,
+          "x-b2-mcp-replica": target.name,
+        });
+        upstreamRes.pipe(clientRes);
+      },
+    );
+    upstream.on("error", () => {
+      clientRes.writeHead(502, { "x-b2-mcp-replica": target.name });
+      clientRes.end();
+    });
+    upstream.end(body);
+  });
+  await new Promise<void>((resolve) => server.listen(0, "127.0.0.1", resolve));
+  return {
+    server,
+    port: (server.address() as AddressInfo).port,
+    seen,
+    setTargets(nextTargets: Replica[]) {
+      targets = [...nextTargets];
+      next = 0;
+    },
+  };
+}
+
+function parseBody(body: string): any {
+  return JSON.parse(body);
+}
+
+describe("HTTP round-robin replica smoke (MCP 2026-07-28)", () => {
+  const replicas: Replica[] = [];
+  let proxy: ProxyHandle | null = null;
+
+  afterEach(async () => {
+    if (proxy) {
+      await new Promise<void>((resolve) => proxy?.server.close(() => resolve()));
+      proxy = null;
+    }
+    await Promise.all(replicas.splice(0).map(stopReplica));
+  });
+
+  it("routes idempotent modern requests across replicas without session affinity", async () => {
+    replicas.push(await startReplica("replica-a"));
+    replicas.push(await startReplica("replica-b"));
+    proxy = await startRoundRobinProxy(replicas);
+
+    const discover = await request(proxy.port, "POST", "/mcp", {
+      headers: { ...HTTP_CREDS, ...modernHeaders("server/discover") },
+      body: modernBody("server/discover", {}, 1),
+    });
+    const listA = await request(proxy.port, "POST", "/mcp", {
+      headers: { ...HTTP_CREDS, ...modernHeaders("tools/list") },
+      body: modernBody("tools/list", {}, 2),
+    });
+    const callA = await request(proxy.port, "POST", "/mcp", {
+      headers: { ...HTTP_CREDS, ...modernHeaders("tools/call", "b2_list_buckets") },
+      body: modernBody("tools/call", { name: "b2_list_buckets", arguments: {} }, 3),
+    });
+    const listASecondReplica = await request(proxy.port, "POST", "/mcp", {
+      headers: { ...HTTP_CREDS, ...modernHeaders("tools/list") },
+      body: modernBody("tools/list", {}, 4),
+    });
+    const listBPrincipal = await request(proxy.port, "POST", "/mcp", {
+      headers: {
+        "x-b2-key-id": "protocol-other-key-id",
+        "x-b2-key": "protocol-other-key-secret",
+        ...modernHeaders("tools/list"),
+      },
+      body: modernBody("tools/list", {}, 5),
+    });
+
+    expect(discover.status).toBe(200);
+    expect(listA.status).toBe(200);
+    expect(callA.status).toBe(200);
+    expect(listASecondReplica.status).toBe(200);
+    expect(listBPrincipal.status).toBe(200);
+    expect(proxy.seen.slice(0, 5)).toEqual([
+      "replica-a",
+      "replica-b",
+      "replica-a",
+      "replica-b",
+      "replica-a",
+    ]);
+    for (const res of [discover, listA, callA, listASecondReplica, listBPrincipal]) {
+      expect(res.headers["mcp-session-id"]).toBeUndefined();
+    }
+
+    const firstNames = parseBody(listA.body).result.tools.map(
+      (tool: { name: string }) => tool.name,
+    );
+    const secondNames = parseBody(listASecondReplica.body).result.tools.map(
+      (tool: { name: string }) => tool.name,
+    );
+    const otherPrincipalNames = parseBody(listBPrincipal.body).result.tools.map(
+      (tool: { name: string }) => tool.name,
+    );
+    expect(secondNames).toEqual(firstNames);
+    expect(otherPrincipalNames).toEqual(firstNames);
+    expect(parseBody(callA.body).result.isError).not.toBe(true);
+
+    await stopReplica(replicas[0]);
+    proxy.setTargets([replicas[1]]);
+    const survivor = await request(proxy.port, "POST", "/mcp", {
+      headers: { ...HTTP_CREDS, ...modernHeaders("tools/call", "b2_list_buckets") },
+      body: modernBody("tools/call", { name: "b2_list_buckets", arguments: {} }, 6),
+    });
+    expect(survivor.status).toBe(200);
+    expect(survivor.headers["x-b2-mcp-replica"]).toBe("replica-b");
+    expect(parseBody(survivor.body).result.isError).not.toBe(true);
+  });
+});

--- a/tests/protocol/http.round-robin.modern-protocol.test.ts
+++ b/tests/protocol/http.round-robin.modern-protocol.test.ts
@@ -4,6 +4,7 @@ import { spawn, type ChildProcess } from "child_process";
 import { join } from "path";
 import {
   HTTP_CREDS,
+  SIMULATOR_ENTRYPOINT,
   modernBody,
   modernHeaders,
   protocolEnv,
@@ -51,19 +52,16 @@ async function waitForHealth(port: number): Promise<void> {
 async function startReplica(name: string): Promise<Replica> {
   requireBuiltEntrypoints();
   const port = await freePort();
-  const child = spawn(
-    process.execPath,
-    [join(__dirname, "../../dist/http-server.js"), "--port", String(port)],
-    {
-      cwd: join(__dirname, "../.."),
-      env: protocolEnv({
-        LOG_LEVEL: "silent",
-        B2_ALLOWED_HOSTS: "127.0.0.1,localhost",
-        B2_HTTP_CREDENTIAL_MODE: "headers",
-      }),
-      stdio: ["ignore", "pipe", "pipe"],
-    },
-  );
+  const child = spawn(process.execPath, [SIMULATOR_ENTRYPOINT, "http", "--port", String(port)], {
+    cwd: join(__dirname, "../.."),
+    env: protocolEnv({
+      LOG_LEVEL: "silent",
+      B2_ALLOWED_HOSTS: "127.0.0.1,localhost",
+      B2_HTTP_CREDENTIAL_MODE: "headers",
+      B2_REGISTER_ALL_TOOLS: "false",
+    }),
+    stdio: ["ignore", "pipe", "pipe"],
+  });
   const replica: Replica = { name, port, child, stderr: "" };
   child.stderr?.on("data", (chunk) => {
     replica.stderr += chunk.toString();
@@ -169,17 +167,17 @@ describe("HTTP round-robin replica smoke (MCP 2026-07-28)", () => {
       headers: { ...HTTP_CREDS, ...modernHeaders("server/discover") },
       body: modernBody("server/discover", {}, 1),
     });
-    const listA = await request(proxy.port, "POST", "/mcp", {
+    const listAReplicaB = await request(proxy.port, "POST", "/mcp", {
       headers: { ...HTTP_CREDS, ...modernHeaders("tools/list") },
       body: modernBody("tools/list", {}, 2),
     });
+    const listAReplicaA = await request(proxy.port, "POST", "/mcp", {
+      headers: { ...HTTP_CREDS, ...modernHeaders("tools/list") },
+      body: modernBody("tools/list", {}, 3),
+    });
     const callA = await request(proxy.port, "POST", "/mcp", {
       headers: { ...HTTP_CREDS, ...modernHeaders("tools/call", "b2_list_buckets") },
-      body: modernBody("tools/call", { name: "b2_list_buckets", arguments: {} }, 3),
-    });
-    const listASecondReplica = await request(proxy.port, "POST", "/mcp", {
-      headers: { ...HTTP_CREDS, ...modernHeaders("tools/list") },
-      body: modernBody("tools/list", {}, 4),
+      body: modernBody("tools/call", { name: "b2_list_buckets", arguments: {} }, 4),
     });
     const listBPrincipal = await request(proxy.port, "POST", "/mcp", {
       headers: {
@@ -191,9 +189,9 @@ describe("HTTP round-robin replica smoke (MCP 2026-07-28)", () => {
     });
 
     expect(discover.status).toBe(200);
-    expect(listA.status).toBe(200);
+    expect(listAReplicaB.status).toBe(200);
+    expect(listAReplicaA.status).toBe(200);
     expect(callA.status).toBe(200);
-    expect(listASecondReplica.status).toBe(200);
     expect(listBPrincipal.status).toBe(200);
     expect(proxy.seen.slice(0, 5)).toEqual([
       "replica-a",
@@ -202,21 +200,25 @@ describe("HTTP round-robin replica smoke (MCP 2026-07-28)", () => {
       "replica-b",
       "replica-a",
     ]);
-    for (const res of [discover, listA, callA, listASecondReplica, listBPrincipal]) {
+    for (const res of [discover, listAReplicaB, listAReplicaA, callA, listBPrincipal]) {
       expect(res.headers["mcp-session-id"]).toBeUndefined();
     }
 
-    const firstNames = parseBody(listA.body).result.tools.map(
+    const firstNames = parseBody(listAReplicaB.body).result.tools.map(
       (tool: { name: string }) => tool.name,
     );
-    const secondNames = parseBody(listASecondReplica.body).result.tools.map(
+    const secondNames = parseBody(listAReplicaA.body).result.tools.map(
       (tool: { name: string }) => tool.name,
     );
     const otherPrincipalNames = parseBody(listBPrincipal.body).result.tools.map(
       (tool: { name: string }) => tool.name,
     );
     expect(secondNames).toEqual(firstNames);
-    expect(otherPrincipalNames).toEqual(firstNames);
+    expect(firstNames).toContain("b2_create_bucket");
+    expect(otherPrincipalNames).toContain("b2_list_buckets");
+    expect(otherPrincipalNames).toContain("s3_list_objects_v2");
+    expect(otherPrincipalNames).not.toContain("b2_create_bucket");
+    expect(otherPrincipalNames).not.toEqual(firstNames);
     expect(parseBody(callA.body).result.isError).not.toBe(true);
 
     await stopReplica(replicas[0]);

--- a/tests/protocol/stdio.transport.legacy-protocol.test.ts
+++ b/tests/protocol/stdio.transport.legacy-protocol.test.ts
@@ -1,0 +1,105 @@
+import {
+  LEGACY_PROTOCOL_VERSION,
+  RawStdioSession,
+  closeClient,
+  connectLegacyStdioClient,
+} from "./support/clients";
+
+function resultOf(frame: any): any {
+  expect(frame.error).toBeUndefined();
+  expect(frame.result).toBeDefined();
+  return frame.result;
+}
+
+describe("stdio transport legacy protocol fallback (2025 era)", () => {
+  let raw: RawStdioSession | null = null;
+
+  afterEach(async () => {
+    await raw?.close();
+    raw = null;
+  });
+
+  it("serves initialize, tools/list, and representative tool calls through the SDK client", async () => {
+    const { client } = await connectLegacyStdioClient();
+    try {
+      expect(client.getProtocolEra()).toBe("legacy");
+      expect(client.getNegotiatedProtocolVersion()).toBe(LEGACY_PROTOCOL_VERSION);
+      expect(client.getServerVersion()?.name).toBe("backblaze-b2");
+
+      const listed = await client.listTools(undefined, { cacheMode: "refresh" });
+      const toolNames = listed.tools.map((tool) => tool.name);
+      expect(toolNames).toContain("b2_list_buckets");
+      expect(toolNames).toContain("s3_list_objects_v2");
+
+      const bucketName = "protocol-stdio-legacy";
+      const create = await client.callTool({
+        name: "b2_create_bucket",
+        arguments: { bucketName, bucketType: "allPrivate" },
+      });
+      expect(create.isError).not.toBe(true);
+
+      const b2Call = await client.callTool({ name: "b2_list_buckets", arguments: {} });
+      expect(b2Call.isError).not.toBe(true);
+      expect(JSON.stringify(b2Call)).toContain(bucketName);
+
+      const s3Call = await client.callTool({
+        name: "s3_list_objects_v2",
+        arguments: { bucket: bucketName },
+      });
+      expect(s3Call.isError).not.toBe(true);
+      expect(JSON.stringify(s3Call)).toContain("objects");
+    } finally {
+      await closeClient(client);
+    }
+  });
+
+  it("supports raw initialize/initialized before legacy list and call", async () => {
+    raw = new RawStdioSession();
+    raw.start();
+
+    const initialize = resultOf(
+      await raw.request("initialize", {
+        protocolVersion: LEGACY_PROTOCOL_VERSION,
+        capabilities: {},
+        clientInfo: { name: "b2-mcp-raw-legacy", version: "1.0.0" },
+      }),
+    );
+    expect(initialize.protocolVersion).toBe(LEGACY_PROTOCOL_VERSION);
+    expect(initialize.serverInfo.name).toBe("backblaze-b2");
+
+    raw.send({ jsonrpc: "2.0", method: "notifications/initialized", params: {} });
+
+    const listed = resultOf(await raw.request("tools/list"));
+    expect(listed.tools.some((tool: { name: string }) => tool.name === "b2_list_buckets")).toBe(
+      true,
+    );
+
+    const bucketName = "protocol-stdio-raw";
+    const created = resultOf(
+      await raw.request("tools/call", {
+        name: "b2_create_bucket",
+        arguments: { bucketName, bucketType: "allPrivate" },
+      }),
+    );
+    expect(created.isError).not.toBe(true);
+
+    const b2Call = resultOf(
+      await raw.request("tools/call", {
+        name: "b2_list_buckets",
+        arguments: {},
+      }),
+    );
+    const s3Call = resultOf(
+      await raw.request("tools/call", {
+        name: "s3_list_objects_v2",
+        arguments: { bucket: bucketName },
+      }),
+    );
+
+    expect(b2Call.isError).not.toBe(true);
+    expect(JSON.stringify(b2Call)).toContain(bucketName);
+    expect(s3Call.isError).not.toBe(true);
+    expect(JSON.stringify(s3Call)).toContain("objects");
+    expect(raw.stdoutLines.join("\n")).not.toMatch(/Mcp-Session-Id/i);
+  });
+});

--- a/tests/protocol/stdio.transport.modern-protocol.test.ts
+++ b/tests/protocol/stdio.transport.modern-protocol.test.ts
@@ -1,3 +1,4 @@
+import { spawnSync } from "child_process";
 import {
   MODERN_META,
   MODERN_PROTOCOL_VERSION,
@@ -37,10 +38,22 @@ describe("stdio transport (MCP 2026-07-28)", () => {
     process.env.NPM_TOKEN = "sentinel-npm-token";
     process.env.AWS_SECRET_ACCESS_KEY = "sentinel-aws-secret";
     try {
-      const env = protocolEnv();
-      expect(env.GITHUB_TOKEN).toBeUndefined();
-      expect(env.NPM_TOKEN).toBeUndefined();
-      expect(env.AWS_SECRET_ACCESS_KEY).toBeUndefined();
+      const child = spawnSync(
+        process.execPath,
+        [
+          "-e",
+          [
+            "process.stdout.write(JSON.stringify({",
+            "github: process.env.GITHUB_TOKEN ?? null,",
+            "npm: process.env.NPM_TOKEN ?? null,",
+            "aws: process.env.AWS_SECRET_ACCESS_KEY ?? null",
+            "}));",
+          ].join(""),
+        ],
+        { env: protocolEnv(), encoding: "utf8" },
+      );
+      expect(child.status).toBe(0);
+      expect(JSON.parse(child.stdout)).toEqual({ github: null, npm: null, aws: null });
     } finally {
       for (const [name, value] of Object.entries(previous)) {
         if (value === undefined) delete process.env[name];

--- a/tests/protocol/stdio.transport.modern-protocol.test.ts
+++ b/tests/protocol/stdio.transport.modern-protocol.test.ts
@@ -4,6 +4,7 @@ import {
   RawStdioSession,
   closeClient,
   connectModernStdioClient,
+  protocolEnv,
 } from "./support/clients";
 
 function resultOf(frame: any): any {
@@ -24,6 +25,28 @@ describe("stdio transport (MCP 2026-07-28)", () => {
   afterEach(async () => {
     await raw?.close();
     raw = null;
+  });
+
+  it("does not copy parent secret variables into spawned protocol processes", () => {
+    const previous = {
+      GITHUB_TOKEN: process.env.GITHUB_TOKEN,
+      NPM_TOKEN: process.env.NPM_TOKEN,
+      AWS_SECRET_ACCESS_KEY: process.env.AWS_SECRET_ACCESS_KEY,
+    };
+    process.env.GITHUB_TOKEN = "sentinel-github-token";
+    process.env.NPM_TOKEN = "sentinel-npm-token";
+    process.env.AWS_SECRET_ACCESS_KEY = "sentinel-aws-secret";
+    try {
+      const env = protocolEnv();
+      expect(env.GITHUB_TOKEN).toBeUndefined();
+      expect(env.NPM_TOKEN).toBeUndefined();
+      expect(env.AWS_SECRET_ACCESS_KEY).toBeUndefined();
+    } finally {
+      for (const [name, value] of Object.entries(previous)) {
+        if (value === undefined) delete process.env[name];
+        else process.env[name] = value;
+      }
+    }
   });
 
   it("serves discover, list, and representative tool calls through the SDK client", async () => {

--- a/tests/protocol/stdio.transport.modern-protocol.test.ts
+++ b/tests/protocol/stdio.transport.modern-protocol.test.ts
@@ -1,0 +1,141 @@
+import {
+  MODERN_META,
+  MODERN_PROTOCOL_VERSION,
+  RawStdioSession,
+  closeClient,
+  connectModernStdioClient,
+} from "./support/clients";
+
+function resultOf(frame: any): any {
+  expect(frame.error).toBeUndefined();
+  expect(frame.result).toBeDefined();
+  return frame.result;
+}
+
+function errorOf(frame: any): any {
+  expect(frame.result).toBeUndefined();
+  expect(frame.error).toBeDefined();
+  return frame.error;
+}
+
+describe("stdio transport (MCP 2026-07-28)", () => {
+  let raw: RawStdioSession | null = null;
+
+  afterEach(async () => {
+    await raw?.close();
+    raw = null;
+  });
+
+  it("serves discover, list, and representative tool calls through the SDK client", async () => {
+    const { client } = await connectModernStdioClient();
+    try {
+      expect(client.getProtocolEra()).toBe("modern");
+      expect(client.getNegotiatedProtocolVersion()).toBe(MODERN_PROTOCOL_VERSION);
+
+      const discover = client.getDiscoverResult() ?? (await client.discover());
+      expect(discover.supportedVersions).toContain(MODERN_PROTOCOL_VERSION);
+      expect(discover.capabilities.tools).toBeDefined();
+      expect(client.getServerVersion()?.name).toBe("backblaze-b2");
+
+      const listed = await client.listTools(undefined, { cacheMode: "refresh" });
+      const toolNames = listed.tools.map((tool) => tool.name);
+      expect(toolNames).toContain("b2_list_buckets");
+      expect(toolNames).toContain("s3_list_objects_v2");
+
+      const bucketName = "protocol-stdio-modern";
+      const create = await client.callTool({
+        name: "b2_create_bucket",
+        arguments: { bucketName, bucketType: "allPrivate" },
+      });
+      expect(create.isError).not.toBe(true);
+
+      const b2Call = await client.callTool({ name: "b2_list_buckets", arguments: {} });
+      expect(b2Call.isError).not.toBe(true);
+      expect(JSON.stringify(b2Call)).toContain(bucketName);
+
+      const s3Call = await client.callTool({
+        name: "s3_list_objects_v2",
+        arguments: { bucket: bucketName },
+      });
+      expect(s3Call.isError).not.toBe(true);
+      expect(JSON.stringify(s3Call)).toContain("objects");
+    } finally {
+      await closeClient(client);
+    }
+  });
+
+  it("keeps modern raw stdio frames sessionless and sends logs to stderr", async () => {
+    raw = new RawStdioSession();
+    raw.start({ LOG_LEVEL: "info" });
+
+    const discover = resultOf(
+      await raw.request("server/discover", {
+        _meta: MODERN_META,
+      }),
+    );
+    expect(discover.supportedVersions).toEqual([MODERN_PROTOCOL_VERSION]);
+    expect(discover.resultType).toBe("complete");
+    expect(discover.ttlMs).toBe(30_000);
+    expect(discover.cacheScope).toBe("private");
+    expect(discover._meta["io.modelcontextprotocol/serverInfo"]).toMatchObject({
+      name: "backblaze-b2",
+    });
+
+    const listed = resultOf(
+      await raw.request("tools/list", {
+        _meta: MODERN_META,
+      }),
+    );
+    expect(listed.resultType).toBe("complete");
+    expect(listed.ttlMs).toBe(30_000);
+    expect(listed.cacheScope).toBe("private");
+    expect(listed.tools.some((tool: { name: string }) => tool.name === "b2_list_buckets")).toBe(
+      true,
+    );
+
+    const ping = errorOf(await raw.request("ping", { _meta: MODERN_META }));
+    const logging = errorOf(
+      await raw.request("logging/setLevel", { level: "info", _meta: MODERN_META }),
+    );
+    expect(ping.code).toBe(-32601);
+    expect(logging.code).toBe(-32601);
+
+    for (const line of raw.stdoutLines) {
+      expect(() => JSON.parse(line)).not.toThrow();
+      expect(line).not.toMatch(/server\.started|server\.ready|Mcp-Session-Id/i);
+    }
+    expect(raw.stderrChunks.join("")).toMatch(/server\.(started|ready)/);
+  });
+
+  it("returns controlled modern errors for invalid tool requests", async () => {
+    raw = new RawStdioSession();
+    raw.start();
+
+    const invalidName = errorOf(
+      await raw.request("tools/call", {
+        name: "missing_tool",
+        arguments: {},
+        _meta: MODERN_META,
+      }),
+    );
+    const malformedArguments = errorOf(
+      await raw.request("tools/call", {
+        name: "b2_list_buckets",
+        arguments: "not-an-object" as unknown as Record<string, unknown>,
+        _meta: MODERN_META,
+      }),
+    );
+    const schemaFailure = resultOf(
+      await raw.request("tools/call", {
+        name: "b2_create_bucket",
+        arguments: { bucketType: "allPrivate" },
+        _meta: MODERN_META,
+      }),
+    );
+
+    expect(invalidName.code).toBe(-32602);
+    expect(malformedArguments.code).toBe(-32602);
+    expect(schemaFailure.isError).toBe(true);
+    expect(JSON.stringify(schemaFailure)).toMatch(/validation/i);
+  });
+});

--- a/tests/protocol/support/clients.ts
+++ b/tests/protocol/support/clients.ts
@@ -1,0 +1,284 @@
+import { spawn, type ChildProcessWithoutNullStreams } from "child_process";
+import { once } from "events";
+import { existsSync } from "fs";
+import { join } from "path";
+import {
+  Client,
+  StreamableHTTPClientTransport,
+  type ClientOptions,
+  type JSONRPCMessage,
+} from "@modelcontextprotocol/client";
+import { StdioClientTransport } from "@modelcontextprotocol/client/stdio";
+
+export const MODERN_PROTOCOL_VERSION = "2026-07-28";
+export const LEGACY_PROTOCOL_VERSION = "2025-11-25";
+
+export const MODERN_META = {
+  "io.modelcontextprotocol/protocolVersion": MODERN_PROTOCOL_VERSION,
+  "io.modelcontextprotocol/clientCapabilities": {},
+  "io.modelcontextprotocol/clientInfo": { name: "b2-mcp-protocol-test", version: "1.0.0" },
+};
+
+export const HTTP_CREDS = {
+  "x-b2-key-id": "protocol-key-id",
+  "x-b2-key": "protocol-key-secret",
+};
+
+export const JSON_HEADERS = {
+  "content-type": "application/json",
+  accept: "application/json, text/event-stream",
+};
+
+const ROOT = join(__dirname, "../../..");
+const DIST_INDEX = join(ROOT, "dist/index.js");
+const DIST_HTTP = join(ROOT, "dist/http-server.js");
+const REQUEST_TIMEOUT_MS = 5_000;
+
+export function requireBuiltEntrypoints(): void {
+  if (!existsSync(DIST_INDEX) || !existsSync(DIST_HTTP)) {
+    throw new Error("Protocol transport tests require built dist entry points. Run npm run build.");
+  }
+}
+
+export function protocolEnv(extra: NodeJS.ProcessEnv = {}): NodeJS.ProcessEnv {
+  const env: NodeJS.ProcessEnv = {
+    ...process.env,
+    NODE_ENV: "test",
+    B2_MCP_TEST_SDK_SIMULATOR: "true",
+    B2_REGISTER_ALL_TOOLS: "true",
+    B2_APPLICATION_KEY_ID: "protocol-key-id",
+    B2_APPLICATION_KEY: "protocol-key-secret",
+    B2_HTTP_CREDENTIAL_MODE: "headers",
+    ...extra,
+  };
+  delete env.FORCE_COLOR;
+  delete env.NO_COLOR;
+  return env;
+}
+
+function stdioEnv(extra: NodeJS.ProcessEnv = {}): Record<string, string> {
+  return Object.fromEntries(
+    Object.entries(protocolEnv(extra)).filter((entry): entry is [string, string] => {
+      return entry[1] !== undefined;
+    }),
+  );
+}
+
+export function modernBody(
+  method: string,
+  params: Record<string, unknown> = {},
+  id: string | number = 1,
+): string {
+  return JSON.stringify({
+    jsonrpc: "2.0",
+    id,
+    method,
+    params: { ...params, _meta: MODERN_META },
+  });
+}
+
+export function modernHeaders(method: string, name?: string): Record<string, string> {
+  return {
+    ...JSON_HEADERS,
+    "mcp-protocol-version": MODERN_PROTOCOL_VERSION,
+    "mcp-method": method,
+    ...(name ? { "mcp-name": name } : {}),
+  };
+}
+
+export function legacyInitializeBody(protocolVersion = LEGACY_PROTOCOL_VERSION): string {
+  return JSON.stringify({
+    jsonrpc: "2.0",
+    id: 1,
+    method: "initialize",
+    params: {
+      protocolVersion,
+      capabilities: {},
+      clientInfo: { name: "b2-mcp-protocol-test", version: "1.0.0" },
+    },
+  });
+}
+
+function createClient(options: ClientOptions): Client {
+  return new Client({ name: "b2-mcp-protocol-test", version: "1.0.0" }, options);
+}
+
+export async function connectModernStdioClient(): Promise<{
+  client: Client;
+  transport: StdioClientTransport;
+  stderr: () => string;
+}> {
+  requireBuiltEntrypoints();
+  const transport = new StdioClientTransport({
+    command: process.execPath,
+    args: [DIST_INDEX],
+    cwd: ROOT,
+    env: stdioEnv(),
+    stderr: "pipe",
+  });
+  let stderr = "";
+  transport.stderr?.on("data", (chunk) => {
+    stderr += chunk.toString();
+  });
+  const client = createClient({
+    versionNegotiation: { mode: { pin: MODERN_PROTOCOL_VERSION } },
+    defaultCacheTtlMs: 0,
+  });
+  await client.connect(transport);
+  return { client, transport, stderr: () => stderr };
+}
+
+export async function connectLegacyStdioClient(): Promise<{
+  client: Client;
+  transport: StdioClientTransport;
+  stderr: () => string;
+}> {
+  requireBuiltEntrypoints();
+  const transport = new StdioClientTransport({
+    command: process.execPath,
+    args: [DIST_INDEX],
+    cwd: ROOT,
+    env: stdioEnv(),
+    stderr: "pipe",
+  });
+  let stderr = "";
+  transport.stderr?.on("data", (chunk) => {
+    stderr += chunk.toString();
+  });
+  const client = createClient({
+    versionNegotiation: { mode: "legacy" },
+    defaultCacheTtlMs: 0,
+  });
+  await client.connect(transport);
+  return { client, transport, stderr: () => stderr };
+}
+
+export interface RecordedHttpRequest {
+  method: string;
+  url: string;
+  headers: Record<string, string>;
+  body: string;
+}
+
+export async function connectHttpClient(
+  port: number,
+  options: {
+    era: "modern" | "legacy" | "auto";
+    headers?: Record<string, string>;
+    cachePartition?: string;
+  },
+): Promise<{
+  client: Client;
+  transport: StreamableHTTPClientTransport;
+  requests: RecordedHttpRequest[];
+}> {
+  const requests: RecordedHttpRequest[] = [];
+  const transport = new StreamableHTTPClientTransport(new URL(`http://127.0.0.1:${port}/mcp`), {
+    requestInit: {
+      headers: options.headers ?? HTTP_CREDS,
+    },
+    fetch: async (input, init) => {
+      const request = new Request(input, init);
+      requests.push({
+        method: request.method,
+        url: request.url,
+        headers: Object.fromEntries(request.headers),
+        body: await request.clone().text(),
+      });
+      return fetch(request);
+    },
+  });
+  const client = createClient({
+    versionNegotiation:
+      options.era === "modern"
+        ? { mode: { pin: MODERN_PROTOCOL_VERSION } }
+        : options.era === "auto"
+          ? { mode: "auto" }
+          : { mode: "legacy" },
+    defaultCacheTtlMs: 0,
+    cachePartition: options.cachePartition,
+  });
+  await client.connect(transport);
+  return { client, transport, requests };
+}
+
+export class RawStdioSession {
+  private child: ChildProcessWithoutNullStreams | null = null;
+  private stdoutBuffer = "";
+  private nextId = 1;
+  readonly stdoutLines: string[] = [];
+  readonly stderrChunks: string[] = [];
+  readonly frames: JSONRPCMessage[] = [];
+
+  start(extraEnv: NodeJS.ProcessEnv = {}): void {
+    requireBuiltEntrypoints();
+    this.child = spawn(process.execPath, [DIST_INDEX], {
+      cwd: ROOT,
+      env: protocolEnv(extraEnv),
+      stdio: ["pipe", "pipe", "pipe"],
+    });
+    this.child.stdout.on("data", (chunk) => this.captureStdout(chunk.toString()));
+    this.child.stderr.on("data", (chunk) => this.stderrChunks.push(chunk.toString()));
+  }
+
+  async request(method: string, params: Record<string, unknown> = {}): Promise<JSONRPCMessage> {
+    const id = this.nextId++;
+    this.send({ jsonrpc: "2.0", id, method, params });
+    return this.waitForFrame((frame) => "id" in frame && frame.id === id);
+  }
+
+  send(message: JSONRPCMessage): void {
+    if (!this.child) throw new Error("Raw stdio session is not started");
+    this.child.stdin.write(`${JSON.stringify(message)}\n`);
+  }
+
+  async close(): Promise<void> {
+    const child = this.child;
+    if (!child) return;
+    this.child = null;
+    child.stdin.end();
+    child.kill("SIGTERM");
+    const timer = setTimeout(() => child.kill("SIGKILL"), 2_000);
+    timer.unref();
+    await once(child, "exit").catch(() => undefined);
+    clearTimeout(timer);
+  }
+
+  private captureStdout(chunk: string): void {
+    this.stdoutBuffer += chunk;
+    for (;;) {
+      const newline = this.stdoutBuffer.indexOf("\n");
+      if (newline === -1) return;
+      const line = this.stdoutBuffer.slice(0, newline).trim();
+      this.stdoutBuffer = this.stdoutBuffer.slice(newline + 1);
+      if (!line) continue;
+      this.stdoutLines.push(line);
+      this.frames.push(JSON.parse(line) as JSONRPCMessage);
+    }
+  }
+
+  private waitForFrame(predicate: (frame: JSONRPCMessage) => boolean): Promise<JSONRPCMessage> {
+    const existing = this.frames.find(predicate);
+    if (existing) return Promise.resolve(existing);
+    return new Promise((resolve, reject) => {
+      const started = Date.now();
+      const interval = setInterval(() => {
+        const frame = this.frames.find(predicate);
+        if (frame) {
+          clearInterval(interval);
+          clearTimeout(timer);
+          resolve(frame);
+        }
+      }, 10);
+      const timer = setTimeout(() => {
+        clearInterval(interval);
+        reject(new Error(`Timed out waiting for stdio frame after ${Date.now() - started}ms`));
+      }, REQUEST_TIMEOUT_MS);
+      timer.unref();
+    });
+  }
+}
+
+export async function closeClient(client: Client): Promise<void> {
+  await client.close().catch(() => undefined);
+}

--- a/tests/protocol/support/clients.ts
+++ b/tests/protocol/support/clients.ts
@@ -29,22 +29,39 @@ export const JSON_HEADERS = {
   accept: "application/json, text/event-stream",
 };
 
-const ROOT = join(__dirname, "../../..");
+export const ROOT = join(__dirname, "../../..");
 const DIST_INDEX = join(ROOT, "dist/index.js");
 const DIST_HTTP = join(ROOT, "dist/http-server.js");
+export const SIMULATOR_ENTRYPOINT = join(__dirname, "simulator-entrypoint.mjs");
 const REQUEST_TIMEOUT_MS = 5_000;
+const SAFE_ENV_NAMES = [
+  "PATH",
+  "Path",
+  "SystemRoot",
+  "COMSPEC",
+  "PATHEXT",
+  "HOME",
+  "USERPROFILE",
+  "TMPDIR",
+  "TMP",
+  "TEMP",
+];
 
 export function requireBuiltEntrypoints(): void {
-  if (!existsSync(DIST_INDEX) || !existsSync(DIST_HTTP)) {
+  if (!existsSync(DIST_INDEX) || !existsSync(DIST_HTTP) || !existsSync(SIMULATOR_ENTRYPOINT)) {
     throw new Error("Protocol transport tests require built dist entry points. Run npm run build.");
   }
 }
 
 export function protocolEnv(extra: NodeJS.ProcessEnv = {}): NodeJS.ProcessEnv {
+  const inherited = Object.fromEntries(
+    SAFE_ENV_NAMES.flatMap((name) =>
+      process.env[name] === undefined ? [] : [[name, process.env[name] as string]],
+    ),
+  );
   const env: NodeJS.ProcessEnv = {
-    ...process.env,
+    ...inherited,
     NODE_ENV: "test",
-    B2_MCP_TEST_SDK_SIMULATOR: "true",
     B2_REGISTER_ALL_TOOLS: "true",
     B2_APPLICATION_KEY_ID: "protocol-key-id",
     B2_APPLICATION_KEY: "protocol-key-secret",
@@ -111,7 +128,7 @@ export async function connectModernStdioClient(): Promise<{
   requireBuiltEntrypoints();
   const transport = new StdioClientTransport({
     command: process.execPath,
-    args: [DIST_INDEX],
+    args: [SIMULATOR_ENTRYPOINT, "stdio"],
     cwd: ROOT,
     env: stdioEnv(),
     stderr: "pipe",
@@ -136,7 +153,7 @@ export async function connectLegacyStdioClient(): Promise<{
   requireBuiltEntrypoints();
   const transport = new StdioClientTransport({
     command: process.execPath,
-    args: [DIST_INDEX],
+    args: [SIMULATOR_ENTRYPOINT, "stdio"],
     cwd: ROOT,
     env: stdioEnv(),
     stderr: "pipe",
@@ -212,7 +229,7 @@ export class RawStdioSession {
 
   start(extraEnv: NodeJS.ProcessEnv = {}): void {
     requireBuiltEntrypoints();
-    this.child = spawn(process.execPath, [DIST_INDEX], {
+    this.child = spawn(process.execPath, [SIMULATOR_ENTRYPOINT, "stdio"], {
       cwd: ROOT,
       env: protocolEnv(extraEnv),
       stdio: ["pipe", "pipe", "pipe"],

--- a/tests/protocol/support/clients.ts
+++ b/tests/protocol/support/clients.ts
@@ -120,11 +120,15 @@ function createClient(options: ClientOptions): Client {
   return new Client({ name: "b2-mcp-protocol-test", version: "1.0.0" }, options);
 }
 
-export async function connectModernStdioClient(): Promise<{
+type StdioClientConnection = {
   client: Client;
   transport: StdioClientTransport;
   stderr: () => string;
-}> {
+};
+
+async function connectStdioClient(
+  versionNegotiation: ClientOptions["versionNegotiation"],
+): Promise<StdioClientConnection> {
   requireBuiltEntrypoints();
   const transport = new StdioClientTransport({
     command: process.execPath,
@@ -137,37 +141,17 @@ export async function connectModernStdioClient(): Promise<{
   transport.stderr?.on("data", (chunk) => {
     stderr += chunk.toString();
   });
-  const client = createClient({
-    versionNegotiation: { mode: { pin: MODERN_PROTOCOL_VERSION } },
-    defaultCacheTtlMs: 0,
-  });
+  const client = createClient({ versionNegotiation, defaultCacheTtlMs: 0 });
   await client.connect(transport);
   return { client, transport, stderr: () => stderr };
 }
 
-export async function connectLegacyStdioClient(): Promise<{
-  client: Client;
-  transport: StdioClientTransport;
-  stderr: () => string;
-}> {
-  requireBuiltEntrypoints();
-  const transport = new StdioClientTransport({
-    command: process.execPath,
-    args: [SIMULATOR_ENTRYPOINT, "stdio"],
-    cwd: ROOT,
-    env: stdioEnv(),
-    stderr: "pipe",
-  });
-  let stderr = "";
-  transport.stderr?.on("data", (chunk) => {
-    stderr += chunk.toString();
-  });
-  const client = createClient({
-    versionNegotiation: { mode: "legacy" },
-    defaultCacheTtlMs: 0,
-  });
-  await client.connect(transport);
-  return { client, transport, stderr: () => stderr };
+export async function connectModernStdioClient(): Promise<StdioClientConnection> {
+  return connectStdioClient({ mode: { pin: MODERN_PROTOCOL_VERSION } });
+}
+
+export async function connectLegacyStdioClient(): Promise<StdioClientConnection> {
+  return connectStdioClient({ mode: "legacy" });
 }
 
 export interface RecordedHttpRequest {

--- a/tests/protocol/support/simulator-entrypoint.mjs
+++ b/tests/protocol/support/simulator-entrypoint.mjs
@@ -1,0 +1,99 @@
+#!/usr/bin/env node
+
+import { createRequire } from "module";
+
+const require = createRequire(import.meta.url);
+const { B2Client: SdkB2Client } = require("@backblaze-labs/b2-sdk");
+const { B2Simulator } = require("@backblaze-labs/b2-sdk/simulator");
+const { createMcpHttpTransport, setB2SdkClientFactoryForTests } = require("../../../dist/auth.js");
+
+const API_TIMEOUT_MS = 30_000;
+const READ_ONLY_CAPABILITIES = ["listBuckets", "listFiles", "readFiles"];
+
+class JsonResponse {
+  body = null;
+
+  constructor(status, payload, headers = {}) {
+    this.status = status;
+    this.payload = payload;
+    this.headers = new Headers(headers);
+  }
+
+  async json() {
+    return this.payload;
+  }
+
+  async text() {
+    return typeof this.payload === "string" ? this.payload : JSON.stringify(this.payload);
+  }
+
+  async arrayBuffer() {
+    return new TextEncoder().encode(await this.text()).buffer;
+  }
+}
+
+function applicationKeyIdFromBasicAuth(value) {
+  if (typeof value !== "string" || !value.startsWith("Basic ")) return "";
+  const decoded = Buffer.from(value.slice("Basic ".length), "base64").toString("utf8");
+  const separator = decoded.indexOf(":");
+  return separator === -1 ? decoded : decoded.slice(0, separator);
+}
+
+function credentialScopedTransport(inner) {
+  return {
+    async send(request) {
+      const response = await inner.send(request);
+      if (!request.url.includes("b2_authorize_account")) return response;
+      const body = await response.json();
+      const applicationKeyId = applicationKeyIdFromBasicAuth(request.headers?.Authorization);
+      if (applicationKeyId.includes("other")) {
+        body.apiInfo.storageApi.allowed.capabilities = READ_ONLY_CAPABILITIES;
+      }
+      return new JsonResponse(response.status, body, Object.fromEntries(response.headers ?? []));
+    },
+  };
+}
+
+const simulators = new Map();
+
+setB2SdkClientFactoryForTests((config) => {
+  const cacheKey = `${config.applicationKeyId}\0${config.applicationKey}`;
+  let simulator = simulators.get(cacheKey);
+  if (!simulator) {
+    simulator = new B2Simulator({ minimumPartSize: 1024, recommendedPartSize: 1024 });
+    simulators.set(cacheKey, simulator);
+  }
+  const retry = {
+    maxRetries: 0,
+    initialRetryDelayMs: 1,
+    maxRetryDelayMs: 1,
+    requestTimeoutMs: API_TIMEOUT_MS,
+  };
+  return {
+    client: new SdkB2Client({
+      applicationKeyId: config.applicationKeyId,
+      applicationKey: config.applicationKey,
+      transport: createMcpHttpTransport(credentialScopedTransport(simulator.transport()), retry),
+      retry,
+    }),
+  };
+});
+
+const mode = process.argv[2];
+if (mode === "stdio") {
+  const { startStdio } = require("../../../dist/index.js");
+  await startStdio();
+} else if (mode === "http") {
+  const { buildHttpServer, getPort } = require("../../../dist/http-server.js");
+  const port = getPort();
+  const { server, drain } = buildHttpServer();
+  server.listen(port);
+  const shutdown = () => {
+    drain();
+    server.close(() => process.exit(0));
+  };
+  process.on("SIGTERM", shutdown);
+  process.on("SIGINT", shutdown);
+} else {
+  throw new Error(`Unknown protocol simulator entrypoint mode: ${mode}`);
+}

--- a/tests/unit/auth.unit.test.ts
+++ b/tests/unit/auth.unit.test.ts
@@ -208,6 +208,29 @@ describe("B2AuthManager", () => {
     expect(transport.requests).toHaveLength(1);
   });
 
+  it("does not activate a simulator-backed SDK from environment variables alone", async () => {
+    const previous = process.env.B2_MCP_TEST_SDK_SIMULATOR;
+    process.env.B2_MCP_TEST_SDK_SIMULATOR = "true";
+    setB2SdkClientFactoryForTests(null);
+    const fetchSpy = vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      new Response(JSON.stringify(authorizeResponse(["listBuckets"])), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      }),
+    );
+
+    try {
+      const manager = new B2AuthManager(mockConfig);
+      await expect(manager.getAuth()).resolves.toMatchObject({
+        accountId: "test-account-123",
+      });
+      expect(fetchSpy).toHaveBeenCalledTimes(1);
+    } finally {
+      if (previous === undefined) delete process.env.B2_MCP_TEST_SDK_SIMULATOR;
+      else process.env.B2_MCP_TEST_SDK_SIMULATOR = previous;
+    }
+  });
+
   it("forceRefresh returns full auth data for the tool layer to redact", async () => {
     installAuthorizeTransport();
     const manager = new B2AuthManager(mockConfig);

--- a/tests/unit/http-transport.unit.test.ts
+++ b/tests/unit/http-transport.unit.test.ts
@@ -216,6 +216,7 @@ function modernBody(method: string, params: Record<string, unknown> = {}, id = 1
 function modernHeaders(method: string, name?: string): Record<string, string> {
   return {
     ...JSON_HEADERS,
+    "mcp-protocol-version": "2026-07-28",
     "mcp-method": method,
     ...(name && { "mcp-name": name }),
   };


### PR DESCRIPTION
## Summary
- Added official SDK v2 protocol client helpers and real stdio/HTTP transport tests for modern and legacy MCP flows.
- Added representative mocked `b2_*` and `s3_*` calls, raw HTTP header/version assertions, package-budget/runtime contract checks, and deterministic two-replica round-robin coverage.
- Moved SDK simulator usage into test-only harness injection; production auth no longer imports or env-activates the simulator.
- Preserved headerless modern `_meta` envelope compatibility by inferring SDK mirror headers, while logging explicit `mcp-name` mirror mismatches and routing SDK-classified protocol failures through the SDK handler.
- Hardened protocol subprocess environments with child-process secret exclusion coverage and round-robin same-principal/different-principal isolation assertions.
- Refactored duplicated stdio client setup in the protocol test harness.

## Reviewed commits
- `199dece`: test: add MCP protocol transport coverage
- `898e373`: fix: harden protocol test harness
- `d28ca3b`: test: tighten protocol review coverage

## Linked issue
Closes #52
## Tests run
- npm run build
- npm run typecheck
- npm run lint
- npm run format:check
- npm run test:unit
- npm run test:contract
- npm run test:protocol
- npm run check:runtime-policy
- npm run check:package-budget
- npm audit
- npm audit --omit=dev

## Follow-up notes
- Coverage is deterministic and uses the SDK simulator from test-support code only; no live B2 calls are required.
- Added protocol-layer transport-guard coverage (`tests/protocol/http.guards.modern-protocol.test.ts`): unsafe-Origin 403, oversized-body 413, global in-flight 503, per-credential in-flight 429, JSON-RPC batch rejection, modern request-stream cancellation reaching the handler abort signal (no late response), `subscriptions/listen` unavailability, and malformed W3C trace-context ignoring.
- Remaining #52 items are non-test: the item-10 headerless mirror-header compatibility decision is tracked in #66. Rate-limit 429 and content-type 415 are already covered (unit `rate-limiter.unit.test.ts` and the modern envelope tests), and replica-removal survivor is covered in the round-robin test.
- `baggage` passthrough is intentional as part of W3C trace context propagation, and the new dev dependency surface was scanned with dev-inclusive `npm audit`.


