### PR TITLE
Add MCP external client smoke

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   profile reference, and deterministic modern/legacy `tools/list` fixtures.
 - Added an advisory `pnpm run smoke:client` external MCP SDK client smoke for
   local stdio negotiation and contract-surface evidence without live B2 calls.
+- Added a locked `pnpm run smoke:inspector` MCP Inspector CLI smoke that runs
+  with fake credentials from an isolated environment.
 
 ### Changed
 - Split unit, contract, modern protocol, legacy protocol, slow, package, and

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   enforcement and PR/release summary artifacts.
 - Added the frozen Phase 1 MCP tool-profile contract artifact, generated
   profile reference, and deterministic modern/legacy `tools/list` fixtures.
+- Added an advisory `pnpm run smoke:client` external MCP SDK client smoke for
+  local stdio negotiation and contract-surface evidence without live B2 calls.
 
 ### Changed
 - Split unit, contract, modern protocol, legacy protocol, slow, package, and

--- a/README.md
+++ b/README.md
@@ -243,9 +243,13 @@ pnpm run test:integration:live # live B2 tests; requires B2_APPLICATION_KEY_ID /
 pnpm run test:contract:live    # live B2 request-shape checks; requires B2 credentials
 pnpm start                  # stdio transport
 pnpm run start:http --port 3000      # MCP 2026-07-28 HTTP transport
-pnpm run smoke:client       # advisory SDK client smoke; fake stdio credentials, no B2 calls
-pnpm dlx @modelcontextprotocol/inspector@2.1.0 node ./dist/index.js   # interactive inspector
+pnpm run smoke:client       # advisory SDK client smoke; requires existing dist/, no B2 calls
 ```
+
+Compatible MCP Inspector release for isolated manual inspection:
+`@modelcontextprotocol/inspector@2.1.0`. It is intentionally not run through
+one-off package fetches in this repo because network-fetched smoke tooling bypasses the
+committed lockfile and supply-chain gates.
 
 ## Documentation
 

--- a/README.md
+++ b/README.md
@@ -243,7 +243,8 @@ pnpm run test:integration:live # live B2 tests; requires B2_APPLICATION_KEY_ID /
 pnpm run test:contract:live    # live B2 request-shape checks; requires B2 credentials
 pnpm start                  # stdio transport
 pnpm run start:http --port 3000      # MCP 2026-07-28 HTTP transport
-pnpm dlx @modelcontextprotocol/inspector node ./dist/index.js   # interactive inspector
+pnpm run smoke:client       # advisory SDK client smoke; fake stdio credentials, no B2 calls
+pnpm dlx @modelcontextprotocol/inspector@2.1.0 node ./dist/index.js   # interactive inspector
 ```
 
 ## Documentation

--- a/README.md
+++ b/README.md
@@ -244,12 +244,13 @@ pnpm run test:contract:live    # live B2 request-shape checks; requires B2 crede
 pnpm start                  # stdio transport
 pnpm run start:http --port 3000      # MCP 2026-07-28 HTTP transport
 pnpm run smoke:client       # advisory SDK client smoke; requires existing dist/, no B2 calls
+pnpm run smoke:inspector    # advisory locked Inspector CLI smoke; requires existing dist/
 ```
 
 Compatible MCP Inspector release for isolated manual inspection:
-`@modelcontextprotocol/inspector@2.1.0`. It is intentionally not run through
-one-off package fetches in this repo because network-fetched smoke tooling bypasses the
-committed lockfile and supply-chain gates.
+`@modelcontextprotocol/inspector@2.1.0`. Run it through
+`pnpm run smoke:inspector` so the command uses the committed lockfile and a
+sanitized temporary environment.
 
 ## Documentation
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -69,12 +69,13 @@ its `2.0.0` release pulls a vulnerable Node adapter transitively, and a package
 manager override would protect this checkout without protecting consumers of
 the published package.
 
-The monolithic `@modelcontextprotocol/sdk` v1 package is not a dependency and
-must not be imported by production or test code. HTTP serving is stateless and
-per request: Host, Origin, caller authentication, B2 credential resolution,
-rate/concurrency limits, body-size limits, drain, and shutdown checks run
-outside the SDK handler; protocol header/body validation remains inside
-`createMcpHandler`.
+The monolithic `@modelcontextprotocol/sdk` v1 package is not a direct or
+runtime dependency and must not be imported by production or test code. Its only
+allowed lockfile presence is a dev-only transitive of the pinned Inspector CLI.
+HTTP serving is stateless and per request: Host, Origin, caller authentication,
+B2 credential resolution, rate/concurrency limits, body-size limits, drain, and
+shutdown checks run outside the SDK handler; protocol header/body validation
+remains inside `createMcpHandler`.
 
 The repository-owned Node request adapter receives only an allowlisted
 MCP/header set; B2

--- a/docs/DEPLOY.md
+++ b/docs/DEPLOY.md
@@ -559,13 +559,16 @@ secrets there. Add required reviewers when the repository plan supports
 environment reviewers.
 
 For credential-free supplemental evidence before touching a live deployment, run
-the advisory stdio client smoke:
+the advisory stdio client smoke from a non-serving checkout or copied release
+artifact:
 
 ```bash
+pnpm run build
 pnpm run smoke:client
 ```
 
-That command uses fake test credentials, performs no B2 tool calls, and compares
-the negotiated `tools/list` surface to the repository-owned modern contract
-fixture. It is not a substitute for the deterministic protocol gate or the live
-deployment smoke above.
+The smoke command itself does not rebuild or remove `dist/`; it uses fake test
+credentials, blocks network access in the stdio server child, performs no B2
+tool calls, and compares the negotiated `tools/list` surface to the
+repository-owned modern contract fixture. It is not a substitute for the
+deterministic protocol gate or the live deployment smoke above.

--- a/docs/DEPLOY.md
+++ b/docs/DEPLOY.md
@@ -557,3 +557,15 @@ live secrets. It is then further gated by the `live-b2-smoke` GitHub environment
 Configure that environment with branch/tag restrictions before storing live B2
 secrets there. Add required reviewers when the repository plan supports
 environment reviewers.
+
+For credential-free supplemental evidence before touching a live deployment, run
+the advisory stdio client smoke:
+
+```bash
+pnpm run smoke:client
+```
+
+That command uses fake test credentials, performs no B2 tool calls, and compares
+the negotiated `tools/list` surface to the repository-owned modern contract
+fixture. It is not a substitute for the deterministic protocol gate or the live
+deployment smoke above.

--- a/docs/DEPLOY.md
+++ b/docs/DEPLOY.md
@@ -565,10 +565,13 @@ artifact:
 ```bash
 pnpm run build
 pnpm run smoke:client
+pnpm run smoke:inspector
 ```
 
-The smoke command itself does not rebuild or remove `dist/`; it uses fake test
-credentials, blocks network access in the stdio server child, performs no B2
-tool calls, and compares the negotiated `tools/list` surface to the
-repository-owned modern contract fixture. It is not a substitute for the
-deterministic protocol gate or the live deployment smoke above.
+The smoke commands themselves do not rebuild or remove `dist/`; they use fake
+test credentials, block network access in the stdio server child, and perform no
+B2 tool calls. `smoke:client` compares the negotiated `tools/list` surface to
+the repository-owned modern contract fixture, while `smoke:inspector` provides
+locked Inspector CLI evidence from an isolated temporary environment. They are
+not substitutes for the deterministic protocol gate or the live deployment smoke
+above.

--- a/docs/SDK_ADOPTION_CONTRACT.md
+++ b/docs/SDK_ADOPTION_CONTRACT.md
@@ -32,7 +32,9 @@ Phase 1 migration and for the public MCP tool contract freeze.
   the stable v2 server entry points through `createMcpHandler` and `serveStdio`.
   A repository-owned Node HTTP bridge adapts the web-standard handler without
   `@modelcontextprotocol/node` or its web-framework dependency. The monolithic
-  `@modelcontextprotocol/sdk` v1 package is not an allowed dependency.
+  `@modelcontextprotocol/sdk` v1 package is not an allowed direct or runtime
+  dependency; the only allowed lockfile presence is a dev-only transitive of the
+  pinned Inspector CLI.
 
 ## Package Policy
 

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -122,6 +122,82 @@ Tool-surface tests inspect the repository-owned registration registry, not SDK
 private fields. The registry is sorted by tool name and mirrors the public
 `registerTool()` calls made at server construction.
 
+## Supplemental External Client Smoke
+
+The required PR gate remains repo-native: `pnpm run verify` and the protocol
+layers above are the correctness oracle. External clients are advisory evidence
+until they prove deterministic enough for CI.
+
+Manual inspection is pinned to a reviewed Inspector release:
+
+```bash
+pnpm run build
+B2_REGISTER_ALL_TOOLS=true \
+B2_APPLICATION_KEY_ID=external-smoke-key-id \
+B2_APPLICATION_KEY=external-smoke-key-secret \
+pnpm dlx @modelcontextprotocol/inspector@2.1.0 node ./dist/index.js
+```
+
+The non-interactive external client smoke uses the official
+`@modelcontextprotocol/client@2.0.0` SDK over stdio. It sends fake test
+credentials, sets `B2_REGISTER_ALL_TOOLS=true` so startup performs no B2
+capability-discovery network call, validates `server/discover`, server
+name/version, instructions, and `tools/list`, then compares the returned surface
+to `tests/fixtures/tool-contract/full.modern.json` and
+`docs/tool-profile-contract.json`.
+
+```bash
+pnpm run smoke:client
+```
+
+The command records the SDK client's negotiated protocol era and revision, for
+example:
+
+```text
+negotiatedEra=modern negotiatedProtocol=2026-07-28
+```
+
+Modern HTTP can be checked with the same SDK client pattern. Start a local HTTP
+server with fake server-mode credentials:
+
+```bash
+pnpm run build
+B2_HTTP_CREDENTIAL_MODE=server \
+B2_REGISTER_ALL_TOOLS=true \
+B2_APPLICATION_KEY_ID=external-smoke-key-id \
+B2_APPLICATION_KEY=external-smoke-key-secret \
+B2_ALLOWED_HOSTS=127.0.0.1 \
+node dist/http-server.js --port 3333
+```
+
+Then connect with a modern-pinned SDK HTTP client and record negotiation:
+
+```bash
+node --input-type=module <<'JS'
+import { Client, StreamableHTTPClientTransport } from "@modelcontextprotocol/client";
+
+const client = new Client(
+  { name: "b2-mcp-http-smoke", version: "1.0.0" },
+  { versionNegotiation: { mode: { pin: "2026-07-28" } }, defaultCacheTtlMs: 0 },
+);
+const transport = new StreamableHTTPClientTransport(new URL("http://127.0.0.1:3333/mcp"));
+await client.connect(transport);
+await client.listTools(undefined, { cacheMode: "refresh" });
+console.log(
+  JSON.stringify({
+    era: client.getProtocolEra(),
+    protocolVersion: client.getNegotiatedProtocolVersion(),
+    server: client.getServerVersion(),
+  }),
+);
+await client.close();
+JS
+```
+
+Claude client smoke remains supplemental. Record one dated Claude Desktop or
+Claude.ai Custom Connector run after the selected Claude surface exposes the
+`2026-07-28` protocol; do not make that vendor run a required gate.
+
 ## Tool Result Serialization
 
 Credential-free unit tests cover the structured result serializer:

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -129,10 +129,19 @@ layers above are the correctness oracle. External clients are advisory evidence
 until they prove deterministic enough for CI.
 
 Manual Inspector compatibility is pinned to
-`@modelcontextprotocol/inspector@2.1.0`. The package is not invoked from this
-repo's smoke instructions because it is outside the committed lockfile and
-supply-chain gates; use it only from a separate isolated sandbox with an empty
-environment when interactive inspection is needed.
+`@modelcontextprotocol/inspector@2.1.0` in `package.json` and
+`pnpm-lock.yaml`. Install with the frozen lockfile, build from a non-serving
+checkout, then run the locked Inspector CLI through the repository wrapper:
+
+```bash
+pnpm install --frozen-lockfile
+pnpm run build
+pnpm run smoke:inspector
+```
+
+`smoke:inspector` uses `pnpm exec mcp-inspector` from the locked install, an
+isolated temporary home/cache, fake B2 credentials, and the same no-network
+server guard as `smoke:client`.
 
 The non-interactive external client smoke uses the official
 `@modelcontextprotocol/client@2.0.0` SDK over stdio. It sends fake test
@@ -189,16 +198,19 @@ const client = new Client(
   { versionNegotiation: { mode: { pin: "2026-07-28" } }, defaultCacheTtlMs: 0 },
 );
 const transport = new StreamableHTTPClientTransport(new URL("http://127.0.0.1:3333/mcp"));
-await client.connect(transport);
-await client.listTools(undefined, { cacheMode: "refresh" });
-console.log(
-  JSON.stringify({
-    era: client.getProtocolEra(),
-    protocolVersion: client.getNegotiatedProtocolVersion(),
-    server: client.getServerVersion(),
-  }),
-);
-await client.close();
+try {
+  await client.connect(transport, { timeoutMs: 10_000 });
+  await client.listTools(undefined, { cacheMode: "refresh", timeoutMs: 10_000 });
+  console.log(
+    JSON.stringify({
+      era: client.getProtocolEra(),
+      protocolVersion: client.getNegotiatedProtocolVersion(),
+      server: client.getServerVersion(),
+    }),
+  );
+} finally {
+  await client.close().catch(() => undefined);
+}
 JS
 ```
 

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -128,15 +128,11 @@ The required PR gate remains repo-native: `pnpm run verify` and the protocol
 layers above are the correctness oracle. External clients are advisory evidence
 until they prove deterministic enough for CI.
 
-Manual inspection is pinned to a reviewed Inspector release:
-
-```bash
-pnpm run build
-B2_REGISTER_ALL_TOOLS=true \
-B2_APPLICATION_KEY_ID=external-smoke-key-id \
-B2_APPLICATION_KEY=external-smoke-key-secret \
-pnpm dlx @modelcontextprotocol/inspector@2.1.0 node ./dist/index.js
-```
+Manual Inspector compatibility is pinned to
+`@modelcontextprotocol/inspector@2.1.0`. The package is not invoked from this
+repo's smoke instructions because it is outside the committed lockfile and
+supply-chain gates; use it only from a separate isolated sandbox with an empty
+environment when interactive inspection is needed.
 
 The non-interactive external client smoke uses the official
 `@modelcontextprotocol/client@2.0.0` SDK over stdio. It sends fake test
@@ -147,8 +143,15 @@ to `tests/fixtures/tool-contract/full.modern.json` and
 `docs/tool-profile-contract.json`.
 
 ```bash
+pnpm run build
 pnpm run smoke:client
 ```
+
+`smoke:client` uses the already-built `dist/` artifact and does not remove or
+rewrite it. It fails clearly when `dist/index.js` or `dist/tool-contract.js` is
+missing. On a deployment host, run it only from a non-serving checkout or from a
+copied release artifact, not from the active checkout used by a supervised
+service.
 
 The command records the SDK client's negotiated protocol era and revision, for
 example:
@@ -156,6 +159,11 @@ example:
 ```text
 negotiatedEra=modern negotiatedProtocol=2026-07-28
 ```
+
+The smoke process starts as a small bootstrap that strips sensitive environment
+variables before importing the MCP client SDK. The server child runs with fake
+B2 credentials, `B2_REGISTER_ALL_TOOLS=true`, and a no-network preload guard; if
+capability discovery or another B2 network path is attempted, the smoke fails.
 
 Modern HTTP can be checked with the same SDK client pattern. Start a local HTTP
 server with fake server-mode credentials:

--- a/docs/V1_SCOPE.md
+++ b/docs/V1_SCOPE.md
@@ -465,8 +465,10 @@ reintroduced.
 
 The modern MCP baseline is `@modelcontextprotocol/server` v2 through
 `createMcpHandler` and `serveStdio`. The monolithic
-`@modelcontextprotocol/sdk` v1 package has been removed. Add other public v2
-packages only when the implementation imports their supported APIs.
+`@modelcontextprotocol/sdk` v1 package has been removed from direct/runtime
+dependencies. Its only allowed lockfile presence is a dev-only transitive of the
+pinned Inspector CLI. Add other public v2 packages only when the implementation
+imports their supported APIs.
 
 Phase 1 does not require HTTP+SSE, protocol-level sessions, GET streams, DELETE
 session termination, event replay, Roots, Sampling, MCP Logging, Tasks, MCP Apps,

--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
     "verify": "pnpm run typecheck && pnpm run build && pnpm run lint && pnpm run lint:docs && pnpm run format:check && pnpm run spell && pnpm run test:coverage",
     "test:cross-platform": "node scripts/run-cross-platform-tests.mjs",
     "smoke": "node scripts/smoke-test.mjs",
+    "smoke:client": "pnpm run build && node scripts/mcp-client-smoke.mjs",
     "generate:tool-contract": "pnpm run build && node scripts/generate-tool-contract.mjs",
     "smoke:package": "pnpm run build && node scripts/packed-consumer-smoke.mjs",
     "check:runtime-policy": "node scripts/check-runtime-policy.mjs",

--- a/package.json
+++ b/package.json
@@ -48,6 +48,7 @@
     "test:cross-platform": "node scripts/run-cross-platform-tests.mjs",
     "smoke": "node scripts/smoke-test.mjs",
     "smoke:client": "node scripts/mcp-client-smoke.mjs",
+    "smoke:inspector": "node scripts/mcp-inspector-smoke.mjs",
     "generate:tool-contract": "pnpm run build && node scripts/generate-tool-contract.mjs",
     "smoke:package": "pnpm run build && node scripts/packed-consumer-smoke.mjs",
     "check:runtime-policy": "node scripts/check-runtime-policy.mjs",
@@ -86,6 +87,7 @@
   "devDependencies": {
     "@biomejs/biome": "2.5.7",
     "@modelcontextprotocol/client": "2.0.0",
+    "@modelcontextprotocol/inspector": "2.1.0",
     "@modelcontextprotocol/node": "2.0.0",
     "@toon-format/toon": "4.1.0",
     "@types/node": "22.3.0",

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "verify": "pnpm run typecheck && pnpm run build && pnpm run lint && pnpm run lint:docs && pnpm run format:check && pnpm run spell && pnpm run test:coverage",
     "test:cross-platform": "node scripts/run-cross-platform-tests.mjs",
     "smoke": "node scripts/smoke-test.mjs",
-    "smoke:client": "pnpm run build && node scripts/mcp-client-smoke.mjs",
+    "smoke:client": "node scripts/mcp-client-smoke.mjs",
     "generate:tool-contract": "pnpm run build && node scripts/generate-tool-contract.mjs",
     "smoke:package": "pnpm run build && node scripts/packed-consumer-smoke.mjs",
     "check:runtime-policy": "node scripts/check-runtime-policy.mjs",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -42,6 +42,9 @@ importers:
       '@modelcontextprotocol/client':
         specifier: 2.0.0
         version: 2.0.0
+      '@modelcontextprotocol/inspector':
+        specifier: 2.1.0
+        version: 2.1.0(@modelcontextprotocol/sdk@1.30.0(supports-color@8.1.1)(zod@4.4.3))(@types/node@22.3.0)(express@5.2.1(supports-color@8.1.1))(supports-color@8.1.1)
       '@modelcontextprotocol/node':
         specifier: 2.0.0
         version: 2.0.0(@modelcontextprotocol/server@2.0.0)(hono@4.13.0)
@@ -86,6 +89,10 @@ importers:
         version: 4.1.10(@types/node@22.3.0)(@vitest/coverage-v8@4.1.10)(vite@8.2.0(@types/node@22.3.0)(yaml@2.9.0))
 
 packages:
+
+  '@alcalzone/ansi-tokenize@0.2.5':
+    resolution: {integrity: sha512-3NX/MpTdroi0aKz134A6RC2Gb2iXVECN4QaAXnvCIxxIm3C3AVB1mkUe8NaaiyvOpDfsrqWhYtj+Q6a62RrTsw==}
+    engines: {node: '>=18'}
 
   '@aws-sdk/checksums@3.1000.26':
     resolution: {integrity: sha512-CGznePoL+1oWCSzqmkvlYMpWQEZohPR3LntjKXXfVH+oh6Kd8d+yHLkjpiAGwPIHAxFe4OAq3aKfRnv/wqWIyA==}
@@ -579,9 +586,36 @@ packages:
     resolution: {integrity: sha512-8f1OghQ2rjzIOfqgUCP+8GiUWqRs89njoWLNqAe8kWmDePv3s1fZXseej+QXemssEuuOvLLmLO/kqM3IQHtISw==}
     engines: {node: '>=20'}
 
+  '@modelcontextprotocol/client@2.0.0-beta.5':
+    resolution: {integrity: sha512-YuuNm5f2TMoFQRje1UqVP8TJRjijCXMz4ckvoVpx1cUXuBEmykWQ2d8R536pek6UKcXT41T5nWc4qR1JFIbEmg==}
+    engines: {node: '>=20'}
+
   '@modelcontextprotocol/core@2.0.0':
     resolution: {integrity: sha512-pJCEwGG7Lfr/+PQp9ZTwKXNeO5wzbfKL7H3MYpCorM4oFBoQrdjnBgEoqG+RjhsvS1FKrDbKux+M1HhlnGWqcA==}
     engines: {node: '>=20'}
+
+  '@modelcontextprotocol/core@2.0.0-beta.5':
+    resolution: {integrity: sha512-HKbY9XTbsDy1Y6r2I55TGE3JEapM0vg96e1MUmBIF9LGjos5gjhcIrTz1yvBPLg2aFKHjwhUAQfRdrCEnPxNew==}
+    engines: {node: '>=20'}
+
+  '@modelcontextprotocol/ext-apps@1.7.5':
+    resolution: {integrity: sha512-TjPH2S2y5UEGKhmI6+XGFuqfqOV4ppe1x6DA3txnUaEWkgtA4G5vo14jGKFZmegdkZ1H4QMLyujLvoU1BEdnAg==}
+    engines: {node: '>=20'}
+    peerDependencies:
+      '@modelcontextprotocol/sdk': ^1.29.0
+      react: ^17.0.0 || ^18.0.0 || ^19.0.0
+      react-dom: ^17.0.0 || ^18.0.0 || ^19.0.0
+      zod: ^3.25.0 || ^4.0.0
+    peerDependenciesMeta:
+      react:
+        optional: true
+      react-dom:
+        optional: true
+
+  '@modelcontextprotocol/inspector@2.1.0':
+    resolution: {integrity: sha512-Fp3kvgW5W6tcttErlYKy9iud6nE1oKUUB+qpFgh+ImfvYDJDgtGtx7IHJ+E6K1rXAerr9HQvYQenWrGP8lAqPQ==}
+    engines: {node: '>=22.19.0'}
+    hasBin: true
 
   '@modelcontextprotocol/node@2.0.0':
     resolution: {integrity: sha512-Y4hAC2XdGDUdDOCbLDOCA4+aL3NUldjsOWlDL/YwpAxrPhRm1xHd7lZ+mLacvZ9t3PaH28wgNoaLQGrIk1P2pg==}
@@ -593,9 +627,114 @@ packages:
       hono:
         optional: true
 
+  '@modelcontextprotocol/sdk@1.30.0':
+    resolution: {integrity: sha512-xKd8OIzlqNzcqcNumGAa6g+PW2kjD5vrpcKOnfldAUPP3j7lnqMPwlTXQm8gF+UwH72z0lqaRbjr9hqGz0eITA==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@cfworker/json-schema': ^4.1.1
+      zod: ^3.25 || ^4.0
+    peerDependenciesMeta:
+      '@cfworker/json-schema':
+        optional: true
+
+  '@modelcontextprotocol/server-legacy@2.0.0-beta.5':
+    resolution: {integrity: sha512-8BemN4avQnG6Fu660fZCqnPGpeyL7gg5kxUceZQh7JCt8oqzX1bwJkNV+cKS01LPAaPbl93INneD+mBtJWKWvQ==}
+    engines: {node: '>=20'}
+    deprecated: This package is a frozen copy of v1's SSE transport and OAuth Authorization Server helpers for migration purposes only. Use StreamableHTTP from @modelcontextprotocol/server and a dedicated OAuth server in production. Will not receive new features.
+    peerDependencies:
+      express: ^4.18.0 || ^5.0.0
+    peerDependenciesMeta:
+      express:
+        optional: true
+
   '@modelcontextprotocol/server@2.0.0':
     resolution: {integrity: sha512-YhHWdHfpFMQfd0prsEnxKeS3Qz3ytIGmsS0sth4KDjnacIT7hxk6hXHkJ9KysxlkvTM+WZAtQbbcUhdoP4Hvtw==}
     engines: {node: '>=20'}
+
+  '@modelcontextprotocol/server@2.0.0-beta.5':
+    resolution: {integrity: sha512-i1E5l75rQKsgY/AKAIspgMBH1vEL7dqiK7tHr0L+raYcb0SWOziqNGJXGIG6NY4AlXDWIKGJQGB7Nqfs3oUi5g==}
+    engines: {node: '>=20'}
+
+  '@napi-rs/keyring-darwin-arm64@1.3.0':
+    resolution: {integrity: sha512-pl76hJvdYUBn6I24bXiOBMA9nbDapo3I5B+f3OorjDU4dUMSypXeKbOVehJe8fhgTiH24flMyTS3aAIy43xegQ==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@napi-rs/keyring-darwin-x64@1.3.0':
+    resolution: {integrity: sha512-YcJtEV5LA3cvA4z3BurgxH5IhTsW1JfIvcAAcqcecwk06Si9F9NqkxbZVIfDwQ8oRHgaBmT3zZJnLAotCrVahw==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@napi-rs/keyring-freebsd-x64@1.3.0':
+    resolution: {integrity: sha512-vlLf31TGhfRAaxLDBhg8b89ss0HHD/lyNmL5F3UjSaz5CUXElsJmKYq9fqA/B+cZKUEUcLHHGhF0I/CqcFdaVw==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@napi-rs/keyring-linux-arm-gnueabihf@1.3.0':
+    resolution: {integrity: sha512-KiWdMMu/Inz/bHHIAGrnF7r54FZDYXuHO6UFF/rhIrshUsxbMG1Rl9lEymNtqqsVo927G0VYcb02FzWQ3iBQRQ==}
+    engines: {node: '>= 10'}
+    cpu: [arm]
+    os: [linux]
+
+  '@napi-rs/keyring-linux-arm64-gnu@1.3.0':
+    resolution: {integrity: sha512-eyKGpY40lm9Jvs1aD294XRH4y7+TlJM0YVAryZeXA6TX0mb4gMkxVXwSQv7MCwgah7raeUd0dKUb4BPAYIgcMg==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [linux]
+    libc: [glibc]
+
+  '@napi-rs/keyring-linux-arm64-musl@1.3.0':
+    resolution: {integrity: sha512-iIK6JWHXAJqDrEyLY3TmswwloVyt2vj+04TZnew+uSJ9gnDO8EwRbp3/iw3LpWaXiDO7VomGO6y8I0Id8uBZSw==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [linux]
+    libc: [musl]
+
+  '@napi-rs/keyring-linux-riscv64-gnu@1.3.0':
+    resolution: {integrity: sha512-/PGqrwn6EwgtK6vccASSXJRfOSP4vN1F4ASsIQ+7MdrK6hNvAJ1FZPrIuD5gGGdxezo3F++To2Wq7DbuGIeuNQ==}
+    engines: {node: '>= 10'}
+    cpu: [riscv64]
+    os: [linux]
+    libc: [glibc]
+
+  '@napi-rs/keyring-linux-x64-gnu@1.3.0':
+    resolution: {integrity: sha512-2PDK1WKWTu9lBGq9VvNEkSlQD3O7YwVpmnyN2M3cy4v7NJ/8gDMd9GXv3G+FVXN13uhp4gnnPBS+ScefmEeD2A==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [linux]
+    libc: [glibc]
+
+  '@napi-rs/keyring-linux-x64-musl@1.3.0':
+    resolution: {integrity: sha512-oJ2HkX8YUo46QBkn0pG+HuIKQNqr523q6vBobCn+P95s4C4K6/kLBqHY/1bg5J4ap31DzsznhnFKcfBNBsjCnw==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [linux]
+    libc: [musl]
+
+  '@napi-rs/keyring-win32-arm64-msvc@1.3.0':
+    resolution: {integrity: sha512-tOd3c/uAaeoE4ycVlmAdSvygz0Zt3zdca6Y7gokBeIbaRDWpjDIUOpU3MvML59XAaqyuKGsVVu0F/DZb1lHPmw==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [win32]
+
+  '@napi-rs/keyring-win32-ia32-msvc@1.3.0':
+    resolution: {integrity: sha512-sPSqeAFZMGqP1R++M2JTza7GQJJ/TpCo6JU6Vcd4jnebvOaEDs9b7eipakU1PJdSvhpC2yXMCNRk9gXfrhuwHQ==}
+    engines: {node: '>= 10'}
+    cpu: [ia32]
+    os: [win32]
+
+  '@napi-rs/keyring-win32-x64-msvc@1.3.0':
+    resolution: {integrity: sha512-4DnCWXwDc0HRKwyRlG5y0VhKZW2tNRQfKKfyj6IX/KWfDNyq9hn4n+GL1auyDcOO/v8PwnhmYo2+rOOqCkvvOg==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [win32]
+
+  '@napi-rs/keyring@1.3.0':
+    resolution: {integrity: sha512-WrOw/bcXm0f9qHkumlT1QlArXSTWqaY9sunsDpOk+yCCorCKMxvWT/a3xko4EYHVdeZoh00yI2TydXn6eyICDA==}
+    engines: {node: '>= 10'}
 
   '@oxc-project/types@0.142.0':
     resolution: {integrity: sha512-7W+2q5AKQVU36fkaryontrHn3YDt1RyUYXatw9i5H8ocYe2sPKSFB6eS8WNPeRKiN1qAWWZUPm7gwFzJGrccqQ==}
@@ -852,6 +991,19 @@ packages:
     resolution: {integrity: sha512-dkKR8q+lKciskj1Y3vthHktl+3cMLWGyVUP23bRiPZ5O9BRT++4EqDDV+TVeIKBL1VXVEqrJlz8MYbcnvJcAlg==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
+  '@vitejs/plugin-react@6.0.5':
+    resolution: {integrity: sha512-BOVzne/NL162sMdResB25mUv+vWMF5NoAjNf09TeGlE7ZpszZWSD3winycicLJw72yeVsoCn/2kOhEuCvEShMA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    peerDependencies:
+      '@rolldown/plugin-babel': ^0.1.7 || ^0.2.0
+      babel-plugin-react-compiler: ^1.0.0
+      vite: ^8.0.0
+    peerDependenciesMeta:
+      '@rolldown/plugin-babel':
+        optional: true
+      babel-plugin-react-compiler:
+        optional: true
+
   '@vitest/coverage-v8@4.1.10':
     resolution: {integrity: sha512-IM49HmthevbgAO4anp1hwtoT9wYe59w0LR00gr+eagHE+ZJ5lK4sLPeO0ubgoJcwLk6dehU3R24N+FbEEKDc8g==}
     peerDependencies:
@@ -890,6 +1042,10 @@ packages:
   '@vitest/utils@4.1.10':
     resolution: {integrity: sha512-fy9am/HWxbaGt/Sawrp90vt6Y6jQwf1RX77cz3uwoJwJVMli/e1IEwRPnMNJ7vKfPTwo0diXifkpPvwH9v7nGA==}
 
+  accepts@2.0.0:
+    resolution: {integrity: sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng==}
+    engines: {node: '>= 0.6'}
+
   acorn-jsx@5.3.2:
     resolution: {integrity: sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==}
     peerDependencies:
@@ -904,11 +1060,23 @@ packages:
     engines: {node: '>=0.4.0'}
     hasBin: true
 
+  ajv-formats@3.0.1:
+    resolution: {integrity: sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==}
+    peerDependencies:
+      ajv: ^8.0.0
+    peerDependenciesMeta:
+      ajv:
+        optional: true
+
   ajv@6.15.0:
     resolution: {integrity: sha512-fgFx7Hfoq60ytK2c7DhnF8jIvzYgOMxfugjLOSMHjLIPgenqa7S7oaagATUq99mV6IYvN2tRmC0wnTYX6iPbMw==}
 
   ajv@8.18.0:
     resolution: {integrity: sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==}
+
+  ansi-escapes@7.3.0:
+    resolution: {integrity: sha512-BvU8nYgGQBxcmMuEeUEmNTvrMVjJNSH7RgW24vXexN4Ven6qCvy4TntnvlnwnMLTVlcRQQdbRY8NKnaIoeWDNg==}
+    engines: {node: '>=18'}
 
   ansi-regex@6.2.2:
     resolution: {integrity: sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==}
@@ -917,6 +1085,10 @@ packages:
   ansi-styles@4.3.0:
     resolution: {integrity: sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==}
     engines: {node: '>=8'}
+
+  ansi-styles@6.2.3:
+    resolution: {integrity: sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==}
+    engines: {node: '>=12'}
 
   are-docs-informative@0.0.2:
     resolution: {integrity: sha512-ixiS0nLNNG5jNQzgZJNoUpBKdo9yTYZMGJ+QgT2jmjR7G7+QHRCc4v6LQ3NgE7EBJq+o0ams3waJwkrlBom8Ig==}
@@ -927,6 +1099,10 @@ packages:
 
   argparse@2.0.1:
     resolution: {integrity: sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==}
+
+  arr-rotate@1.0.0:
+    resolution: {integrity: sha512-yOzOZcR9Tn7enTF66bqKorGGH0F36vcPaSWg8fO0c0UYb3LX3VMXj5ZxEqQLNOecAhlRJ7wYZja5i4jTlnbIfQ==}
+    engines: {node: '>=4'}
 
   array-timsort@1.0.3:
     resolution: {integrity: sha512-/+3GRL7dDAGEfM6TseQk/U+mi18TU2Ms9I3UlLdUMhz2hbvGNTKdj9xniwXfUqgYhHxRx0+8UnKkvlNwVU+cWQ==}
@@ -942,12 +1118,23 @@ packages:
     resolution: {integrity: sha512-kNOjDqAh7px0XWNI+4QbzoiR/nTkHAWNud2uvnJquD1/x5a7EQZMJT0AczqK0Qn67oY/TTQ1LbUKajZpp3I9tQ==}
     engines: {node: '>=8.0.0'}
 
+  atomically@2.1.1:
+    resolution: {integrity: sha512-P4w9o2dqARji6P7MHprklbfiArZAWvo07yW7qs3pdljb3BWr12FIB7W+p0zJiuiVsUpRO0iZn1kFFcpPegg0tQ==}
+
+  auto-bind@5.0.1:
+    resolution: {integrity: sha512-ooviqdwwgfIfNmDwo94wlshcdzfO64XV0Cg6oDsDYBJfITDz1EngD2z7DkbvCWn+XIMsIqW27sEVF6qcpJrRcg==}
+    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
+
   balanced-match@1.0.2:
     resolution: {integrity: sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==}
 
   balanced-match@4.0.4:
     resolution: {integrity: sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==}
     engines: {node: 18 || 20 || >=22}
+
+  body-parser@2.3.0:
+    resolution: {integrity: sha512-2cGmJupaNgg+QUwVLAucDuWuoMZ6EX9iHDRswZ5lsNYEmwPaRknMPCLZz07yTzVq/83p4o/wzbDZbBrTvGGTIw==}
+    engines: {node: '>=18'}
 
   bowser@2.14.1:
     resolution: {integrity: sha512-tzPjzCxygAKWFOJP011oxFHs57HzIhOEracIgAePE4pqB3LikALKnSzUyU4MGs9/iCEUuHlAJTjTc5M+u7YEGg==}
@@ -958,6 +1145,22 @@ packages:
   brace-expansion@5.0.9:
     resolution: {integrity: sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==}
     engines: {node: 20 || >=22}
+
+  bundle-name@4.1.0:
+    resolution: {integrity: sha512-tjwM5exMg6BGRI+kNmTntNsvdZS1X8BFYS6tnJ2hdH0kVxM6/eVZ2xy+FqStSWvYmtfFMDLIxurorHwDKfDz5Q==}
+    engines: {node: '>=18'}
+
+  bytes@3.1.2:
+    resolution: {integrity: sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==}
+    engines: {node: '>= 0.8'}
+
+  call-bind-apply-helpers@1.0.2:
+    resolution: {integrity: sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==}
+    engines: {node: '>= 0.4'}
+
+  call-bound@1.0.4:
+    resolution: {integrity: sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==}
+    engines: {node: '>= 0.4'}
 
   callsites@3.1.0:
     resolution: {integrity: sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==}
@@ -979,12 +1182,36 @@ packages:
     resolution: {integrity: sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA==}
     engines: {node: ^12.17.0 || ^14.13 || >=16.0.0}
 
+  chokidar@4.0.3:
+    resolution: {integrity: sha512-Qgzu8kfBvo+cA4962jnP1KkS6Dop5NS6g7R5LFYJr4b8Ub94PPQXUksCw9PvXoeXPRRddRNC5C1JQUR2SMGtnA==}
+    engines: {node: '>= 14.16.0'}
+
+  cli-boxes@3.0.0:
+    resolution: {integrity: sha512-/lzGpEWL/8PfI0BmBOPRwp0c/wFNX1RdUML3jK/RcSBA9T8mZDdQpqYBKtCFTOfQbwPqWEOpjqW+Fnayc0969g==}
+    engines: {node: '>=10'}
+
+  cli-cursor@4.0.0:
+    resolution: {integrity: sha512-VGtlMu3x/4DOtIUwEkRezxUZ2lBacNJCHash0N0WeZDBS+7Ux1dm3XWAgWYxLJFMMdOeXMHXorshEFhbMSGelg==}
+    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
+
+  cli-truncate@5.2.0:
+    resolution: {integrity: sha512-xRwvIOMGrfOAnM1JYtqQImuaNtDEv9v6oIYAs4LIHwTiKee8uwvIi363igssOC0O5U04i4AlENs79LQLu9tEMw==}
+    engines: {node: '>=20'}
+
+  code-excerpt@4.0.0:
+    resolution: {integrity: sha512-xxodCmBen3iy2i0WtAK8FlFNrRzjUqjRsMfho58xT/wvZU1YTM3fCnRjcy1gJPMepaRlgm/0e6w8SpWHpn3/cA==}
+    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
+
   color-convert@2.0.1:
     resolution: {integrity: sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==}
     engines: {node: '>=7.0.0'}
 
   color-name@1.1.4:
     resolution: {integrity: sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==}
+
+  commander@13.1.0:
+    resolution: {integrity: sha512-/rFeCpNJQbhSZjGVwO9RFV3xPqbnERS8MmIQzCtD/zl6gpJuV/bMLuN92oG3F7d8oDEHHRrujSXNUr8fpjntKw==}
+    engines: {node: '>=18'}
 
   commander@14.0.3:
     resolution: {integrity: sha512-H+y0Jo/T1RZ9qPP4Eh1pkcQcLRglraJaSLoyOtHxu6AapkjWVCy2Sit1QQ4x3Dng8qDlSsZEet7g5Pq06MvTgw==}
@@ -1001,8 +1228,36 @@ packages:
   concat-map@0.0.1:
     resolution: {integrity: sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==}
 
+  content-disposition@1.1.0:
+    resolution: {integrity: sha512-5jRCH9Z/+DRP7rkvY83B+yGIGX96OYdJmzngqnw2SBSxqCFPd0w2km3s5iawpGX8krnwSGmF0FW5Nhr0Hfai3g==}
+    engines: {node: '>=18'}
+
+  content-type@1.0.5:
+    resolution: {integrity: sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==}
+    engines: {node: '>= 0.6'}
+
+  content-type@2.0.0:
+    resolution: {integrity: sha512-j/O/d7GcZCyNl7/hwZAb606rzqkyvaDctLmckbxLzHvFBzTJHuGEdodATcP3yIRoDrLHkIATJuvzbFlp/ki2cQ==}
+    engines: {node: '>=18'}
+
   convert-source-map@2.0.0:
     resolution: {integrity: sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==}
+
+  convert-to-spaces@2.0.1:
+    resolution: {integrity: sha512-rcQ1bsQO9799wq24uE5AM2tAILy4gXGIK/njFWcVQkGNZ96edlpY+A7bjwvzjYvLDyzmG1MmMLZhpcsb+klNMQ==}
+    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
+
+  cookie-signature@1.2.2:
+    resolution: {integrity: sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg==}
+    engines: {node: '>=6.6.0'}
+
+  cookie@0.7.2:
+    resolution: {integrity: sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==}
+    engines: {node: '>= 0.6'}
+
+  cors@2.8.6:
+    resolution: {integrity: sha512-tJtZBBHA6vjIAaF6EnIaq6laBBP9aq/Y3ouVJjEfoHbRBcHBAHYcMh/w8LDrk2PvIMMq8gmopa5D4V8RmbrxGw==}
+    engines: {node: '>= 0.10'}
 
   create-require@1.1.1:
     resolution: {integrity: sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==}
@@ -1064,6 +1319,22 @@ packages:
   deep-is@0.1.4:
     resolution: {integrity: sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==}
 
+  default-browser-id@5.0.1:
+    resolution: {integrity: sha512-x1VCxdX4t+8wVfd1so/9w+vQ4vx7lKd2Qp5tDRutErwmR85OgmfX7RlLRMWafRMY7hbEiXIbudNrjOAPa/hL8Q==}
+    engines: {node: '>=18'}
+
+  default-browser@5.5.0:
+    resolution: {integrity: sha512-H9LMLr5zwIbSxrmvikGuI/5KGhZ8E2zH3stkMgM5LpOWDutGM2JZaj460Udnf1a+946zc7YBgrqEWwbk7zHvGw==}
+    engines: {node: '>=18'}
+
+  define-lazy-prop@3.0.0:
+    resolution: {integrity: sha512-N+MeXYoqr3pOgn8xfyRPREN7gHakLYjhsHhWGT3fWAiL4IkAt0iDw14QiiEm2bE30c5XX5q0FtAA3CK5f9/BUg==}
+    engines: {node: '>=12'}
+
+  depd@2.0.0:
+    resolution: {integrity: sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==}
+    engines: {node: '>= 0.8'}
+
   detect-libc@2.1.2:
     resolution: {integrity: sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==}
     engines: {node: '>=8'}
@@ -1072,9 +1343,31 @@ packages:
     resolution: {integrity: sha512-X07nttJQkwkfKfvTPG/KSnE2OMdcUCao6+eXF3wmnIQRn2aPAHH3VxDbDOdegkd6JbPsXqShpvEOHfAT+nCNwQ==}
     engines: {node: '>=0.3.1'}
 
+  dunder-proto@1.0.1:
+    resolution: {integrity: sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==}
+    engines: {node: '>= 0.4'}
+
+  ee-first@1.1.1:
+    resolution: {integrity: sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==}
+
+  emoji-regex@10.6.0:
+    resolution: {integrity: sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A==}
+
+  encodeurl@2.0.0:
+    resolution: {integrity: sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==}
+    engines: {node: '>= 0.8'}
+
   env-paths@4.0.0:
     resolution: {integrity: sha512-pxP8eL2SwwaTRi/KHYwLYXinDs7gL3jxFcBYmEdYfZmZXbaVDvdppd0XBU8qVz03rDfKZMXg1omHCbsJjZrMsw==}
     engines: {node: '>=20'}
+
+  environment@1.1.0:
+    resolution: {integrity: sha512-xUtoPkMggbz0MPyPiIWr1Kp4aeWJjDZ6SMvURhimjdZgsRuDplF5/s9hcgGhyXMhs+6vpnuoiZ2kFiu3FMnS8Q==}
+    engines: {node: '>=18'}
+
+  es-define-property@1.0.1:
+    resolution: {integrity: sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==}
+    engines: {node: '>= 0.4'}
 
   es-errors@1.3.0:
     resolution: {integrity: sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==}
@@ -1083,9 +1376,27 @@ packages:
   es-module-lexer@2.3.1:
     resolution: {integrity: sha512-shc1dbU90Yl/xq1QrC7QRtfcwURZuVRfPhZbDoldJ1cn1gzDvBaBWlv0eFolj5+0znnPJz5TXLxsN77X/12KTA==}
 
+  es-object-atoms@1.1.2:
+    resolution: {integrity: sha512-HWcBoN6NileqtSydK2FqHbS/LoDd2pqrnQHLyJzBj4kOp/ky2MWMN694xOfkK8/SnUsW2DH7EfyVlydKCsm1Zw==}
+    engines: {node: '>= 0.4'}
+
+  es-toolkit@1.50.0:
+    resolution: {integrity: sha512-OyZKhUVvEep9ITEiwHn8GKnMRQIVqoSIX7WnRbkWgJkllCujilqP2rD0u979tkl8wqyc8ICwlc1UBVv/Sl1G6w==}
+
+  escape-html@1.0.3:
+    resolution: {integrity: sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==}
+
+  escape-string-regexp@2.0.0:
+    resolution: {integrity: sha512-UpzcLCXolUWcNu5HtVMHYdXJjArjsF9C0aNnquZYY4uW/Vu0miy5YoWvbV345HauVvcAUnpRuhMMcqTcGOY2+w==}
+    engines: {node: '>=8'}
+
   escape-string-regexp@4.0.0:
     resolution: {integrity: sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==}
     engines: {node: '>=10'}
+
+  escape-string-regexp@5.0.0:
+    resolution: {integrity: sha512-/veY75JbMK4j1yjvuUxuVsiS/hr/4iHs9FTT6cgTexxdE0Ly/glccBAkloH/DofkjRbZU3bnoj38mOmhkZ0lHw==}
+    engines: {node: '>=12'}
 
   eslint-plugin-jsdoc@50.8.0:
     resolution: {integrity: sha512-UyGb5755LMFWPrZTEqqvTJ3urLz1iqj+bYOHFNag+sw3NvaMWP9K2z+uIn37XfNALmQLQyrBlJ5mkiVPL7ADEg==}
@@ -1150,6 +1461,10 @@ packages:
     resolution: {integrity: sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==}
     engines: {node: '>=0.10.0'}
 
+  etag@1.8.1:
+    resolution: {integrity: sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==}
+    engines: {node: '>= 0.6'}
+
   eventsource-parser@3.1.0:
     resolution: {integrity: sha512-kJezFj9YFAMLeORyi7aCLxLbD5/qWMQnoMVlVPyHIll7lgRJCc3JVln9Vgl9nwQi0YkMnhdGTMNn7CkRRAptMg==}
     engines: {node: '>=18.0.0'}
@@ -1161,6 +1476,16 @@ packages:
   expect-type@1.4.0:
     resolution: {integrity: sha512-KfYbmpRm0VbLjEvVa9yGwCi9GI34xvi7A/HXYWQO65CSD2u3MczUJSuwXKFIxlGsgBQizV9q5J9NHj4VG0n+pA==}
     engines: {node: '>=12.0.0'}
+
+  express-rate-limit@8.6.2:
+    resolution: {integrity: sha512-YH4ru+eOJxQABscKFfRCy9R7x9QFGdezclVMwwgFFndzS2Xnm0uo6B0ABZsLhcpeptGv2qvuJVWlQr9gQZoC3A==}
+    engines: {node: '>= 16'}
+    peerDependencies:
+      express: '>= 4.11'
+
+  express@5.2.1:
+    resolution: {integrity: sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==}
+    engines: {node: '>= 18'}
 
   fast-deep-equal@3.1.3:
     resolution: {integrity: sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==}
@@ -1187,9 +1512,17 @@ packages:
       picomatch:
         optional: true
 
+  figures@5.0.0:
+    resolution: {integrity: sha512-ej8ksPF4x6e5wvK9yevct0UCXh8TTFlWGVLlgjZuoBH1HwjIfKE/IdL5mq89sFA7zELi1VhKpmtDnrs7zWyeyg==}
+    engines: {node: '>=14'}
+
   file-entry-cache@8.0.0:
     resolution: {integrity: sha512-XXTUwCvisa5oacNGRP9SfNtYBNAMi+RPwBFmblZEF7N7swHYQS6/Zfk7SRwx4D5j3CH211YNRco1DEMNVfZCnQ==}
     engines: {node: '>=16.0.0'}
+
+  finalhandler@2.1.1:
+    resolution: {integrity: sha512-S8KoZgRZN+a5rNwqTxlZZePjT/4cnm0ROV70LedRHZ0p8u9fRID0hJUZQpkKLzro8LfmC8sx23bY6tVNxv8pQA==}
+    engines: {node: '>= 18.0.0'}
 
   find-up@5.0.0:
     resolution: {integrity: sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==}
@@ -1201,6 +1534,14 @@ packages:
 
   flatted@3.4.4:
     resolution: {integrity: sha512-5+ybhBZANEJxaH3X5evAFatUxLfEHSr7n6kYJ+1Qd0mUqr4eu9gIf6GDbWHf8RJijHrjjO8G+la14SlL2SeS1Q==}
+
+  forwarded@0.2.0:
+    resolution: {integrity: sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==}
+    engines: {node: '>= 0.6'}
+
+  fresh@2.0.0:
+    resolution: {integrity: sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A==}
+    engines: {node: '>= 0.8'}
 
   fsevents@2.3.3:
     resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
@@ -1214,6 +1555,18 @@ packages:
     resolution: {integrity: sha512-omMVniXEXpdx/vKxGnPRoO2394Otlze28TyxECbFVyoSpZ9H3EO7lemjcB12OpQJzRW4e5tt/dL1rOxry6aMHg==}
     engines: {node: '>=20'}
 
+  get-east-asian-width@1.6.0:
+    resolution: {integrity: sha512-QRbvDIbx6YklUe6RxeTeleMR0yv3cYH6PsPZHcnVn7xv7zO1BHN8r0XETu8n6Ye3Q+ahtSarc3WgtNWmehIBfA==}
+    engines: {node: '>=18'}
+
+  get-intrinsic@1.3.0:
+    resolution: {integrity: sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==}
+    engines: {node: '>= 0.4'}
+
+  get-proto@1.0.1:
+    resolution: {integrity: sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==}
+    engines: {node: '>= 0.4'}
+
   glob-parent@6.0.2:
     resolution: {integrity: sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==}
     engines: {node: '>=10.13.0'}
@@ -1226,9 +1579,17 @@ packages:
     resolution: {integrity: sha512-oahGvuMGQlPw/ivIYBjVSrWAfWLBeku5tpPE2fOPLi+WHffIWbuh2tCjhyQhTBPMf5E9jDEH4FOmTYgYwbKwtQ==}
     engines: {node: '>=18'}
 
+  gopd@1.2.0:
+    resolution: {integrity: sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==}
+    engines: {node: '>= 0.4'}
+
   has-flag@4.0.0:
     resolution: {integrity: sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==}
     engines: {node: '>=8'}
+
+  has-symbols@1.1.0:
+    resolution: {integrity: sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==}
+    engines: {node: '>= 0.4'}
 
   hasown@2.0.4:
     resolution: {integrity: sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==}
@@ -1240,6 +1601,14 @@ packages:
 
   html-escaper@2.0.2:
     resolution: {integrity: sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==}
+
+  http-errors@2.0.1:
+    resolution: {integrity: sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==}
+    engines: {node: '>= 0.8'}
+
+  iconv-lite@0.7.3:
+    resolution: {integrity: sha512-IKXpvIzjnC9XTAUbVBcMfGS0EPaIXtW6v+zr+RRp+hqULEpo0owZax6wyRwPOJbWbzjYspQwusTsfVr0ifh4uQ==}
+    engines: {node: '>=0.10.0'}
 
   ignore@5.3.2:
     resolution: {integrity: sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==}
@@ -1264,25 +1633,109 @@ packages:
     resolution: {integrity: sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==}
     engines: {node: '>=0.8.19'}
 
+  indent-string@5.0.0:
+    resolution: {integrity: sha512-m6FAo/spmsW2Ab2fU35JTYwtOKa2yAwXSwgjSv1TJzh4Mh7mC3lzAOVLBprb72XsTrgkEIsl7YrFNAiDiRhIGg==}
+    engines: {node: '>=12'}
+
+  inherits@2.0.4:
+    resolution: {integrity: sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==}
+
   ini@6.0.0:
     resolution: {integrity: sha512-IBTdIkzZNOpqm7q3dRqJvMaldXjDHWkEDfrwGEQTs5eaQMWV+djAhR+wahyNNMAa+qpbDUhBMVt4ZKNwpPm7xQ==}
     engines: {node: ^20.17.0 || >=22.9.0}
+
+  ink-form@2.0.1:
+    resolution: {integrity: sha512-vo0VMwHf+HOOJo7026K4vJEN8xm4sP9iWlQLx4bngNEEY5K8t30CUvVjQCCNAV6Mt2ODt2Aq+2crCuBONReJUg==}
+    peerDependencies:
+      ink: '>=4'
+      react: '>=18'
+
+  ink-scroll-view@0.3.7:
+    resolution: {integrity: sha512-lUBLxSbVry/+UtJhuvRu6wumP43+ScVp69J7e+hmYwz1kTkahWfkVwWOu7Mn1DMPb8AU8bnsmEsr6kvSJvnaRw==}
+    peerDependencies:
+      ink: ^5 || ^6 || ^7
+      react: ^18 || ^19
+
+  ink-select-input@5.0.0:
+    resolution: {integrity: sha512-VkLEogN3KTgAc0W/u9xK3+44x8JyKfmBvPQyvniJ/Hj0ftg9vWa/YecvZirevNv2SAvgoA2GIlTLCQouzgPKDg==}
+    engines: {node: '>=14.16'}
+    peerDependencies:
+      ink: ^4.0.0
+      react: ^18.0.0
+
+  ink-text-input@6.0.0:
+    resolution: {integrity: sha512-Fw64n7Yha5deb1rHY137zHTAbSTNelUKuB5Kkk2HACXEtwIHBCf9OH2tP/LQ9fRYTl1F0dZgbW0zPnZk6FA9Lw==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      ink: '>=5'
+      react: '>=18'
+
+  ink@6.8.0:
+    resolution: {integrity: sha512-sbl1RdLOgkO9isK42WCZlJCFN9hb++sX9dsklOvfd1YQ3bQ2AiFu12Q6tFlr0HvEUvzraJntQCCpfEoUe9DSzA==}
+    engines: {node: '>=20'}
+    peerDependencies:
+      '@types/react': '>=19.0.0'
+      react: '>=19.0.0'
+      react-devtools-core: '>=6.1.2'
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      react-devtools-core:
+        optional: true
+
+  ip-address@10.4.0:
+    resolution: {integrity: sha512-oSK96Grm3aP6OrS263xVxbNDGVL7rzBtYdpGqlDG8iQdoenDoTs/nkki+DflYbAEE8Xl6o5YxhxlrKvI3nqKXQ==}
+    engines: {node: '>= 12'}
+
+  ipaddr.js@1.9.1:
+    resolution: {integrity: sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==}
+    engines: {node: '>= 0.10'}
 
   is-core-module@2.16.1:
     resolution: {integrity: sha512-UfoeMA6fIJ8wTYFEUjelnaGI67v6+N7qXJEvQuIGa99l4xsCruSYOVSQ0uPANn4dAzm8lkYPaKLrrijLq7x23w==}
     engines: {node: '>= 0.4'}
 
+  is-docker@3.0.0:
+    resolution: {integrity: sha512-eljcgEDlEns/7AXFosB5K/2nCM4P7FQPkGc/DWLy5rmFEWvZayGrik1d9/QIY5nJ4f9YsVvBkA6kJpHn9rISdQ==}
+    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
+    hasBin: true
+
   is-extglob@2.1.1:
     resolution: {integrity: sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==}
     engines: {node: '>=0.10.0'}
+
+  is-fullwidth-code-point@5.1.0:
+    resolution: {integrity: sha512-5XHYaSyiqADb4RnZ1Bdad6cPp8Toise4TzEjcOYDHZkTCbKgiUl7WTUCpNWHuxmDt91wnsZBc9xinNzopv3JMQ==}
+    engines: {node: '>=18'}
 
   is-glob@4.0.3:
     resolution: {integrity: sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==}
     engines: {node: '>=0.10.0'}
 
+  is-in-ci@2.0.0:
+    resolution: {integrity: sha512-cFeerHriAnhrQSbpAxL37W1wcJKUUX07HyLWZCW1URJT/ra3GyUTzBgUnh24TMVfNTV2Hij2HLxkPHFZfOZy5w==}
+    engines: {node: '>=20'}
+    hasBin: true
+
+  is-inside-container@1.0.0:
+    resolution: {integrity: sha512-KIYLCCJghfHZxqjYBE7rEy0OBuTd5xCHS7tHVgvCLkx7StIoaxwNW3hCALgEUjFfeRk+MG/Qxmp/vtETEF3tRA==}
+    engines: {node: '>=14.16'}
+    hasBin: true
+
+  is-promise@4.0.0:
+    resolution: {integrity: sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==}
+
   is-safe-filename@0.1.1:
     resolution: {integrity: sha512-4SrR7AdnY11LHfDKTZY1u6Ga3RuxZdl3YKWWShO5iyuG5h8QS4GD2tOb04peBJ5I7pXbR+CGBNEhTcwK+FzN3g==}
     engines: {node: '>=20'}
+
+  is-unicode-supported@1.3.0:
+    resolution: {integrity: sha512-43r2mRvz+8JRIKnWJ+3j8JtjRKZ6GmjzfaE/qiBJnikNnYv/6bagRJ1kUhNk8R5EX/GkobD+r+sfxCPJsiKBLQ==}
+    engines: {node: '>=12'}
+
+  is-wsl@3.1.1:
+    resolution: {integrity: sha512-e6rvdUCiQCAuumZslxRJWR/Doq4VpPR82kqclvcS0efgt430SlGIk05vdCN58+VrzgtIcfNODjozVielycD4Sw==}
+    engines: {node: '>=16'}
 
   isexe@2.0.0:
     resolution: {integrity: sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==}
@@ -1324,6 +1777,9 @@ packages:
 
   json-schema-traverse@1.0.0:
     resolution: {integrity: sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==}
+
+  json-schema-typed@8.0.2:
+    resolution: {integrity: sha512-fQhoXdcvc3V28x7C7BMs4P5+kNlgUURe2jmUT1T//oBRMDrqy1QPelJimwZGo7Hg9VPV3EQV5Bnq4hbFy2vetA==}
 
   json-stable-stringify-without-jsonify@1.0.1:
     resolution: {integrity: sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==}
@@ -1413,6 +1869,10 @@ packages:
     resolution: {integrity: sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==}
     engines: {node: '>=10'}
 
+  lodash.isequal@4.5.0:
+    resolution: {integrity: sha512-pDo3lu8Jhfjqls6GkMgpahsF9kCyayhgykjyLMNFTKWrpVdAQtYyB4muAMWozBB4ig/dtWAmsMxLEI8wuz+DYQ==}
+    deprecated: This package is deprecated. Use require('node:util').isDeepStrictEqual instead.
+
   lodash.merge@4.6.2:
     resolution: {integrity: sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==}
 
@@ -1428,6 +1888,30 @@ packages:
 
   make-error@1.3.6:
     resolution: {integrity: sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw==}
+
+  math-intrinsics@1.1.0:
+    resolution: {integrity: sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==}
+    engines: {node: '>= 0.4'}
+
+  media-typer@1.1.1:
+    resolution: {integrity: sha512-yz3xRaG20c6/BOzvYoDaGtPmGscs7YivItZEEqe6GbwNfHuxu9YNmvnEkMzKldAGY4/80pRcQRZSEnhquk9XuQ==}
+    engines: {node: '>= 0.8'}
+
+  merge-descriptors@2.0.0:
+    resolution: {integrity: sha512-Snk314V5ayFLhp3fkUREub6WtjBfPdCPY1Ln8/8munuLuiYhsABgBVWsozAG+MWMbVEvcdcpbi9R7ww22l9Q3g==}
+    engines: {node: '>=18'}
+
+  mime-db@1.54.0:
+    resolution: {integrity: sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==}
+    engines: {node: '>= 0.6'}
+
+  mime-types@3.0.2:
+    resolution: {integrity: sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==}
+    engines: {node: '>=18'}
+
+  mimic-fn@2.1.0:
+    resolution: {integrity: sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==}
+    engines: {node: '>=6'}
 
   minimatch@10.2.6:
     resolution: {integrity: sha512-vpLQEs+VLCr1nU0BXS07maYoFwlDAH0gngQuuttxIwutDFEMHq2blX+8vpgxDdK3J1PwjCJiep77OitTZ4Ll1A==}
@@ -1447,6 +1931,18 @@ packages:
   natural-compare@1.4.0:
     resolution: {integrity: sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==}
 
+  negotiator@1.0.0:
+    resolution: {integrity: sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg==}
+    engines: {node: '>= 0.6'}
+
+  object-assign@4.1.1:
+    resolution: {integrity: sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==}
+    engines: {node: '>=0.10.0'}
+
+  object-inspect@1.13.4:
+    resolution: {integrity: sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==}
+    engines: {node: '>= 0.4'}
+
   obug@2.1.4:
     resolution: {integrity: sha512-4a+OsYv9UktOJKE+l1A4OufDgdRF9PifWj+tJnHURo/P+WOxpG4GzUFL9qCalmWauao6ogiG+QvnCovwPoyAWA==}
     engines: {node: '>=12.20.0'}
@@ -1454,6 +1950,21 @@ packages:
   on-exit-leak-free@2.1.2:
     resolution: {integrity: sha512-0eJJY6hXLGf1udHwfNftBqH+g73EU4B504nZeKpz1sYRKafAghwxEJunB2O7rDZkL4PGfsMVnTXZ2EjibbqcsA==}
     engines: {node: '>=14.0.0'}
+
+  on-finished@2.4.1:
+    resolution: {integrity: sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==}
+    engines: {node: '>= 0.8'}
+
+  once@1.4.0:
+    resolution: {integrity: sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==}
+
+  onetime@5.1.2:
+    resolution: {integrity: sha512-kbpaSSGJTWdAY5KPVeMOKXSrPtr8C8C7wodJbcsd51jRnmD+GZu8Y0VoU6Dm5Z4vWr0Ig/1NKuWRKf7j5aaYSg==}
+    engines: {node: '>=6'}
+
+  open@10.2.0:
+    resolution: {integrity: sha512-YgBpdJHPyQ2UE5x+hlSXcnejzAvD0b22U2OuAP+8OnlJT+PjWPxtgmGqKKc+RgTM63U9gN0YzrYc71R2WT/hTA==}
+    engines: {node: '>=18'}
 
   opossum@10.0.0:
     resolution: {integrity: sha512-sghtqL8Usj+et06Zui0nyn0R6FFsl7cyuoU+d7MctYU0nbS7Htzjleh+tWohFqk1Rp1srrFwbFa8Vxd0O64w6A==}
@@ -1481,6 +1992,14 @@ packages:
   parse-statements@1.0.11:
     resolution: {integrity: sha512-HlsyYdMBnbPQ9Jr/VgJ1YF4scnldvJpJxCVx6KgqPL4dxppsWrJHCIIxQXMJrqGnsRkNPATbeMJ8Yxu7JMsYcA==}
 
+  parseurl@1.3.3:
+    resolution: {integrity: sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==}
+    engines: {node: '>= 0.8'}
+
+  patch-console@2.0.0:
+    resolution: {integrity: sha512-0YNdUceMdaQwoKce1gatDScmMo5pu/tfABfnzEqeG0gtTmd7mh/WcwgUjtAeOU7N8nFFlbQBnFK2gXW5fGvmMA==}
+    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
+
   path-exists@4.0.0:
     resolution: {integrity: sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==}
     engines: {node: '>=8'}
@@ -1492,6 +2011,9 @@ packages:
   path-parse@1.0.7:
     resolution: {integrity: sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==}
 
+  path-to-regexp@8.4.2:
+    resolution: {integrity: sha512-qRcuIdP69NPm4qbACK+aDogI5CBDMi1jKe0ry5rSQJz8JVLsC7jV8XpiJjGRLLol3N+R5ihGYcrPLTno6pAdBA==}
+
   pathe@2.0.3:
     resolution: {integrity: sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==}
 
@@ -1502,6 +2024,9 @@ packages:
     resolution: {integrity: sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==}
     engines: {node: '>=12'}
 
+  pino-abstract-transport@2.0.0:
+    resolution: {integrity: sha512-F63x5tizV6WCh4R6RHyi2Ml+M70DNRXt/+HANowMflpgGFMAym/VKm6G7ZOQRjqN7XbGxK1Lg9t6ZrtzOaivMw==}
+
   pino-abstract-transport@3.0.0:
     resolution: {integrity: sha512-wlfUczU+n7Hy/Ha5j9a/gZNy7We5+cXp8YL+X+PG8S0KXxw7n/JXA3c46Y0zQznIJ83URJiwy7Lh56WLokNuxg==}
 
@@ -1510,6 +2035,10 @@ packages:
 
   pino@10.3.1:
     resolution: {integrity: sha512-r34yH/GlQpKZbU1BvFFqOjhISRo1MNx1tWYsYvmj6KIRHSPMT2+yHOEb1SG6NMvRoHRF0a07kCOox/9yakl1vg==}
+    hasBin: true
+
+  pino@9.14.0:
+    resolution: {integrity: sha512-8OEwKp5juEvb/MjpIc4hjqfgCNysrS94RIOMXYvpYCdm/jglrKEiAYmiumbmGhCvs+IcInsphYDFwqrjr7398w==}
     hasBin: true
 
   pkce-challenge@5.0.1:
@@ -1527,12 +2056,42 @@ packages:
   process-warning@5.1.0:
     resolution: {integrity: sha512-jQSaVHsPgtyw60e1rQ/A+/ArPEj/S8pS/vFnyGa/gYFXrKk/6RuDkoqVDQ5NI5MmS01698ltlAk0NoDBNLujRw==}
 
+  proxy-addr@2.0.7:
+    resolution: {integrity: sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==}
+    engines: {node: '>= 0.10'}
+
   punycode@2.3.1:
     resolution: {integrity: sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==}
     engines: {node: '>=6'}
 
+  qs@6.15.3:
+    resolution: {integrity: sha512-O9gl3zCl5h5blw1KGUzQKhA5oUXSl8rwUIM5o0S3nCXMliSvy5Dzx7/DJcI+SwgICv+IneSZwhBh1oSyEHA71A==}
+    engines: {node: '>=0.6'}
+
   quick-format-unescaped@4.0.4:
     resolution: {integrity: sha512-tYC1Q1hgyRuHgloV/YXs2w15unPVh8qfu/qCTfhTYamaw7fyhumKa2yGpdSo87vY32rIclj+4fWYQXUMs9EHvg==}
+
+  range-parser@1.3.0:
+    resolution: {integrity: sha512-hek2mFQpPuI4E1BBKrSto+BU3e3x4xuarsbiwr3+lf7p44juvFMV0XFWQAP3xUyqXA4RrXLIoaSUGbSt056ZMw==}
+    engines: {node: '>= 0.6'}
+
+  raw-body@3.0.2:
+    resolution: {integrity: sha512-K5zQjDllxWkf7Z5xJdV0/B0WTNqx6vxG70zJE4N0kBs4LovmEYWJzQGxC9bS9RAKu3bgM40lrd5zoLJ12MQ5BA==}
+    engines: {node: '>= 0.10'}
+
+  react-reconciler@0.33.0:
+    resolution: {integrity: sha512-KetWRytFv1epdpJc3J4G75I4WrplZE5jOL7Yq0p34+OVOKF4Se7WrdIdVC45XsSSmUTlht2FM/fM1FZb1mfQeA==}
+    engines: {node: '>=0.10.0'}
+    peerDependencies:
+      react: ^19.2.0
+
+  react@19.2.8:
+    resolution: {integrity: sha512-PWaYA1L/q9u2u7xYQi+Y3L3Yfnie7XyLeaJICV1MGD6LprsBxcAqGjYyr0eY3p+QdsA+x/Irkt4Qif8D63+Sbw==}
+    engines: {node: '>=0.10.0'}
+
+  readdirp@4.1.2:
+    resolution: {integrity: sha512-GDhwkLfywWL2s6vEjyhri+eXmfH6j1L7JE27WhqLeYzoh/A3DBaYGEj2H/HFZCn/kMfim73FXxEJTw06WtxQwg==}
+    engines: {node: '>= 14.18.0'}
 
   real-require@0.2.0:
     resolution: {integrity: sha512-57frrGM/OCTLqLOAh0mhVA9VBMHd+9U7Zb2THMGdBUoZVOtGbJzjxsYGDJ3A9AYYCP4hn6y1TVbaOfzWtm5GFg==}
@@ -1558,19 +2117,48 @@ packages:
     engines: {node: '>= 0.4'}
     hasBin: true
 
+  restore-cursor@4.0.0:
+    resolution: {integrity: sha512-I9fPXU9geO9bHOt9pHHOhOkYerIMsmVaWB0rA2AI9ERh/+x/i7MV5HKBNrg+ljO5eoPVgCcnFuRjJ9uH6I/3eg==}
+    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
+
   rolldown@1.2.2:
     resolution: {integrity: sha512-opwpo1tQBAcpSUJDt94B7hhLNGOKjCdE//XXjeLrnx9b83bjnw45tXdg1b09yEw/VLFBJGZpwRULMmOZo7ol+A==}
     engines: {node: ^20.19.0 || >=22.12.0}
     hasBin: true
 
+  router@2.2.0:
+    resolution: {integrity: sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ==}
+    engines: {node: '>= 18'}
+
+  run-applescript@7.1.0:
+    resolution: {integrity: sha512-DPe5pVFaAsinSaV6QjQ6gdiedWDcRCbUuiQfQa2wmWV7+xC9bGulGI8+TdRmoFkAPaBXk8CrAbnlY2ISniJ47Q==}
+    engines: {node: '>=18'}
+
   safe-stable-stringify@2.5.0:
     resolution: {integrity: sha512-b3rppTKm9T+PsVCBEOUR46GWI7fdOs00VKZ1+9c1EWDaDMvjQc6tUwuFyIprgGgTcWoVHSKrU8H31ZHA2e0RHA==}
     engines: {node: '>=10'}
+
+  safer-buffer@2.1.2:
+    resolution: {integrity: sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==}
+
+  scheduler@0.27.0:
+    resolution: {integrity: sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==}
 
   semver@7.8.5:
     resolution: {integrity: sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==}
     engines: {node: '>=10'}
     hasBin: true
+
+  send@1.2.1:
+    resolution: {integrity: sha512-1gnZf7DFcoIcajTjTwjwuDjzuz4PPcY2StKPlsGAQ1+YH20IRVrBaXSWmdjowTJ6u8Rc01PoYOGHXfP1mYcZNQ==}
+    engines: {node: '>= 18'}
+
+  serve-static@2.2.1:
+    resolution: {integrity: sha512-xRXBn0pPqQTVQiC8wyQrKs2MOlX24zQ0POGaj0kultvoOCstBQM5yvOhAVSUwOMjQtTvsPWoNCHfPGwaaQJhTw==}
+    engines: {node: '>= 18'}
+
+  setprototypeof@1.2.0:
+    resolution: {integrity: sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==}
 
   shebang-command@2.0.0:
     resolution: {integrity: sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==}
@@ -1580,8 +2168,31 @@ packages:
     resolution: {integrity: sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==}
     engines: {node: '>=8'}
 
+  side-channel-list@1.0.1:
+    resolution: {integrity: sha512-mjn/0bi/oUURjc5Xl7IaWi/OJJJumuoJFQJfDDyO46+hBWsfaVM65TBHq2eoZBhzl9EchxOijpkbRC8SVBQU0w==}
+    engines: {node: '>= 0.4'}
+
+  side-channel-map@1.0.1:
+    resolution: {integrity: sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==}
+    engines: {node: '>= 0.4'}
+
+  side-channel-weakmap@1.0.2:
+    resolution: {integrity: sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==}
+    engines: {node: '>= 0.4'}
+
+  side-channel@1.1.1:
+    resolution: {integrity: sha512-6x6dK6zJdpTzF4sQeNYxwtvBzf6Eg4GtlesS94HOvTudUeyK2WXAaIfmDgsyslYrRBeFIlsi54AYsFGUuhmvrQ==}
+    engines: {node: '>= 0.4'}
+
   siginfo@2.0.0:
     resolution: {integrity: sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==}
+
+  signal-exit@3.0.7:
+    resolution: {integrity: sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==}
+
+  slice-ansi@8.0.0:
+    resolution: {integrity: sha512-stxByr12oeeOyY2BlviTNQlYV5xOj47GirPr4yA1hE9JCtxfQN0+tVbkxwCtYDQWhEKWFHsEK48ORg5jrouCAg==}
+    engines: {node: '>=20'}
 
   smol-toml@1.7.1:
     resolution: {integrity: sha512-PPlsspAZ4jbMBu5DMFhfUGDQLu/vrL4SyBROVS37x8ynnVmFIs1VPBz1Co8Xks3TvpIaZXmU85y4DrQ+UyVFoQ==}
@@ -1607,15 +2218,41 @@ packages:
     resolution: {integrity: sha512-UcjcJOWknrNkF6PLX83qcHM6KHgVKNkV62Y8a5uYDVv9ydGQVwAHMKqHdJje1VTWpljG0WYpCDhrCdAOYH4TWg==}
     engines: {node: '>= 10.x'}
 
+  stack-utils@2.0.6:
+    resolution: {integrity: sha512-XlkWvfIm6RmsWtNJx+uqtKLS8eqFbxUg0ZzLXqY0caEy9l7hruX8IpiDnjsLavoBgqCCR71TqWO8MaXYheJ3RQ==}
+    engines: {node: '>=10'}
+
   stackback@0.0.2:
     resolution: {integrity: sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==}
+
+  statuses@2.0.2:
+    resolution: {integrity: sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==}
+    engines: {node: '>= 0.8'}
 
   std-env@4.2.0:
     resolution: {integrity: sha512-oCUKSupKTHX53EyjDtuZQ64pjLJ6yYCtpmEw0goYxtjG9KpbRe8KAsl2tBUGU9DyMcJ0RwJ8GqJAFzMXcXW1Rw==}
 
+  string-width@7.2.0:
+    resolution: {integrity: sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ==}
+    engines: {node: '>=18'}
+
+  string-width@8.2.2:
+    resolution: {integrity: sha512-GaPUh5gfdrYzqeVNZvUfT23vYYxXzKYidUcnMtJg/3rxRV63EFZy3k6xfKlmfeJD0176lnUV/Usr3XcwSvFzpg==}
+    engines: {node: '>=20'}
+
+  strip-ansi@7.2.0:
+    resolution: {integrity: sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==}
+    engines: {node: '>=12'}
+
   strip-json-comments@3.1.1:
     resolution: {integrity: sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==}
     engines: {node: '>=8'}
+
+  stubborn-fs@2.0.0:
+    resolution: {integrity: sha512-Y0AvSwDw8y+nlSNFXMm2g6L51rBGdAQT20J3YSOqxC53Lo3bjWRtr2BKcfYoAf352WYpsZSTURrA0tqhfgudPA==}
+
+  stubborn-utils@1.0.2:
+    resolution: {integrity: sha512-zOh9jPYI+xrNOyisSelgym4tolKTJCQd5GBhK0+0xJvcYDcwlOoxF/rnFKQ2KRZknXSG9jWAp66fwP6AxN9STg==}
 
   supports-color@7.2.0:
     resolution: {integrity: sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==}
@@ -1628,6 +2265,17 @@ packages:
   supports-preserve-symlinks-flag@1.0.0:
     resolution: {integrity: sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==}
     engines: {node: '>= 0.4'}
+
+  tagged-tag@1.0.0:
+    resolution: {integrity: sha512-yEFYrVhod+hdNyx7g5Bnkkb0G6si8HJurOoOEgC8B/O0uXLHlaey/65KRv6cuWBNhBgHKAROVpc7QyYqE5gFng==}
+    engines: {node: '>=20'}
+
+  terminal-size@4.0.1:
+    resolution: {integrity: sha512-avMLDQpUI9I5XFrklECw1ZEUPJhqzcwSWsyyI8blhRLT+8N1jLJWLWWYQpB2q2xthq8xDvjZPISVh53T/+CLYQ==}
+    engines: {node: '>=18'}
+
+  thread-stream@3.2.0:
+    resolution: {integrity: sha512-zLBvqpwr4Esa0kRjcrzGU6zL25lePWaCLMx0RQFrmteozIfeNdaMLpG5U7PeHzvlFkAWaRKA9/KVW4F60iB+qw==}
 
   thread-stream@4.2.0:
     resolution: {integrity: sha512-e2zZ96wSChazBsbENf/Pcm/4swHt2cEKQ92rhUjkL9GCKiTDJIaTBenjE/m9DXi0QBmTMDkFDdOomUy20A1tDQ==}
@@ -1647,6 +2295,10 @@ packages:
   tinyrainbow@3.1.1:
     resolution: {integrity: sha512-yau8yJdTt989Mm0Bd/236QnzEiPf2xLLTqUZRUJOo/3CB078LSwzei343DgtJVmfJKJE3TMINY1u42SQsP6mXw==}
     engines: {node: '>=14.0.0'}
+
+  toidentifier@1.0.1:
+    resolution: {integrity: sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==}
+    engines: {node: '>=0.6'}
 
   ts-api-utils@2.5.0:
     resolution: {integrity: sha512-OJ/ibxhPlqrMM0UiNHJ/0CKQkoKF243/AEmplt3qpRgkW8VG7IfOS41h7V8TjITqdByHzrjcS/2si+y4lIh8NA==}
@@ -1675,6 +2327,18 @@ packages:
     resolution: {integrity: sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==}
     engines: {node: '>= 0.8.0'}
 
+  type-fest@4.41.0:
+    resolution: {integrity: sha512-TeTSQ6H5YHvpqVwBRcnLDCBnDOHWYu7IvGbHT6N8AOymcr9PJGjc1GTtiWZTYg0NCgYwvnYWEkVChQAr9bjfwA==}
+    engines: {node: '>=16'}
+
+  type-fest@5.8.0:
+    resolution: {integrity: sha512-YGYEVz3Fm5iy/AybuA0oyNFq7H4CgQNfRp/qfe8nurE1kuCeNm3/vfm9X4Mtl+qLyaKJUh5xrFZwogr41SMjYA==}
+    engines: {node: '>=20'}
+
+  type-is@2.1.0:
+    resolution: {integrity: sha512-faYHw0anBbc/kWF3zFTEnxSFOAGUX9GFbOBthvDdLsIlEoWOFOtS0zgCiQYwIskL9iGXZL3kAXD8OoZ4GmMATA==}
+    engines: {node: '>= 18'}
+
   typescript-eslint@8.66.0:
     resolution: {integrity: sha512-QlEbBPz/RuJ1XUHj29nm3t0F/O/cSlEnntozqPOYHnnTGAXFamnMBu5i9Vn6vhUPHGAjR+Vl+5J8vPN/BMUrJw==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
@@ -1690,11 +2354,23 @@ packages:
   undici-types@6.18.2:
     resolution: {integrity: sha512-5ruQbENj95yDYJNS3TvcaxPMshV7aizdv/hWYjGIKoANWKjhWNBsr2YEuYZKodQulB1b8l7ILOuDQep3afowQQ==}
 
+  undici@8.10.0:
+    resolution: {integrity: sha512-HvltHd7avK13QIw/oLe4qoOLyoVSoafqJ2jYOrtMRBkbYT31eiBQ8O0ehRKZiEZCMEyLFQNIADpgCWC5fALvYQ==}
+    engines: {node: '>=22.19.0'}
+
+  unpipe@1.0.0:
+    resolution: {integrity: sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==}
+    engines: {node: '>= 0.8'}
+
   uri-js@4.4.1:
     resolution: {integrity: sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==}
 
   v8-compile-cache-lib@3.0.1:
     resolution: {integrity: sha512-wa7YjyUGfNZngI/vtK0UHAN+lgDCxBPCylVXGp0zu59Fz5aiGtNXaq3DhIov063MorB+VfufLh3JlF2KdTK3xg==}
+
+  vary@1.1.2:
+    resolution: {integrity: sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==}
+    engines: {node: '>= 0.8'}
 
   vite@8.2.0:
     resolution: {integrity: sha512-pn+CFpM0lwDeKwmOq1ZaBK/9sjorZcgqxki6MbY/jPEVd9vichIlmlD4HmQ5wdP5EgqQCFRaACBxMC7uEGc6lQ==}
@@ -1786,6 +2462,9 @@ packages:
   vscode-uri@3.1.0:
     resolution: {integrity: sha512-/BpdSx+yCQGnCvecbyXdxHDkuk55/G3xwnC0GqY4gmQ3j+A+g8kzzgB4Nk/SINjqn6+waqw3EgbVF2QKExkRxQ==}
 
+  when-exit@2.1.5:
+    resolution: {integrity: sha512-VGkKJ564kzt6Ms1dbgPP/yuIoQCrsFAnRbptpC5wOEsDaNsbCB2bnfnaA8i/vRs5tjUSEOtIuvl9/MyVsvQZCg==}
+
   which@2.0.2:
     resolution: {integrity: sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==}
     engines: {node: '>= 8'}
@@ -1796,9 +2475,36 @@ packages:
     engines: {node: '>=8'}
     hasBin: true
 
+  widest-line@6.0.0:
+    resolution: {integrity: sha512-U89AsyEeAsyoF0zVJBkG9zBgekjgjK7yk9sje3F4IQpXBJ10TF6ByLlIfjMhcmHMJgHZI4KHt4rdNfktzxIAMA==}
+    engines: {node: '>=20'}
+
   word-wrap@1.2.5:
     resolution: {integrity: sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==}
     engines: {node: '>=0.10.0'}
+
+  wrap-ansi@9.0.2:
+    resolution: {integrity: sha512-42AtmgqjV+X1VpdOfyTGOYRi0/zsoLqtXQckTmqTeybT+BDIbM/Guxo7x3pE2vtpr1ok6xRqM9OpBe+Jyoqyww==}
+    engines: {node: '>=18'}
+
+  wrappy@1.0.2:
+    resolution: {integrity: sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==}
+
+  ws@8.21.2:
+    resolution: {integrity: sha512-54dMVAo4WIe6SKy3vBgN+9bJZqqQ8IMRevAkOLQALhi49qkkQDQfWdAZ8KQlXiEabw88ARXXdUrlvtbKQX+aKw==}
+    engines: {node: '>=10.0.0'}
+    peerDependencies:
+      bufferutil: ^4.0.1
+      utf-8-validate: '>=5.0.2'
+    peerDependenciesMeta:
+      bufferutil:
+        optional: true
+      utf-8-validate:
+        optional: true
+
+  wsl-utils@0.1.0:
+    resolution: {integrity: sha512-h3Fbisa2nKGPxCpm89Hk33lBLsnaGBvctQopaBSOW/uIs6FTe1ATyAnKFJrzVs9vpGdsTe73WF3V4lIsk4Gacw==}
+    engines: {node: '>=18'}
 
   xdg-basedir@5.1.0:
     resolution: {integrity: sha512-GCPAHLvrIH13+c0SuacwvRYj2SxJXQ4kaVTT5xgL3kPrz56XxkF21IGhjSE1+W0aw7gpBWRGXLCPnPby6lSpmQ==}
@@ -1817,10 +2523,23 @@ packages:
     resolution: {integrity: sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==}
     engines: {node: '>=10'}
 
+  yoga-layout@3.2.1:
+    resolution: {integrity: sha512-0LPOt3AxKqMdFBZA3HBAt/t/8vIKq7VaQYbuA8WxCgung+p9TVyKRYdpvCb80HcdTN2NkbIKbhNwKUfm3tQywQ==}
+
+  zod-to-json-schema@3.25.2:
+    resolution: {integrity: sha512-O/PgfnpT1xKSDeQYSCfRI5Gy3hPf91mKVDuYLUHZJMiDFptvP41MSnWofm8dnCm0256ZNfZIM7DSzuSMAFnjHA==}
+    peerDependencies:
+      zod: ^3.25.28 || ^4
+
   zod@4.4.3:
     resolution: {integrity: sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==}
 
 snapshots:
+
+  '@alcalzone/ansi-tokenize@0.2.5':
+    dependencies:
+      ansi-styles: 6.2.3
+      is-fullwidth-code-point: 5.1.0
 
   '@aws-sdk/checksums@3.1000.26':
     dependencies:
@@ -2383,9 +3102,79 @@ snapshots:
       pkce-challenge: 5.0.1
       zod: 4.4.3
 
+  '@modelcontextprotocol/client@2.0.0-beta.5':
+    dependencies:
+      '@modelcontextprotocol/core': 2.0.0-beta.5
+      cross-spawn: 7.0.6
+      eventsource: 3.0.7
+      eventsource-parser: 3.1.0
+      jose: 6.2.8
+      pkce-challenge: 5.0.1
+      zod: 4.4.3
+
   '@modelcontextprotocol/core@2.0.0':
     dependencies:
       zod: 4.4.3
+
+  '@modelcontextprotocol/core@2.0.0-beta.5':
+    dependencies:
+      zod: 4.4.3
+
+  '@modelcontextprotocol/ext-apps@1.7.5(@modelcontextprotocol/sdk@1.30.0(supports-color@8.1.1)(zod@4.4.3))(react@19.2.8)(zod@4.4.3)':
+    dependencies:
+      '@modelcontextprotocol/sdk': 1.30.0(supports-color@8.1.1)(zod@4.4.3)
+      '@standard-schema/spec': 1.1.0
+      zod: 4.4.3
+    optionalDependencies:
+      react: 19.2.8
+
+  '@modelcontextprotocol/inspector@2.1.0(@modelcontextprotocol/sdk@1.30.0(supports-color@8.1.1)(zod@4.4.3))(@types/node@22.3.0)(express@5.2.1(supports-color@8.1.1))(supports-color@8.1.1)':
+    dependencies:
+      '@hono/node-server': 2.0.10(hono@4.13.0)
+      '@modelcontextprotocol/client': 2.0.0-beta.5
+      '@modelcontextprotocol/core': 2.0.0-beta.5
+      '@modelcontextprotocol/ext-apps': 1.7.5(@modelcontextprotocol/sdk@1.30.0(supports-color@8.1.1)(zod@4.4.3))(react@19.2.8)(zod@4.4.3)
+      '@modelcontextprotocol/server': 2.0.0-beta.5
+      '@modelcontextprotocol/server-legacy': 2.0.0-beta.5(express@5.2.1(supports-color@8.1.1))(supports-color@8.1.1)
+      '@napi-rs/keyring': 1.3.0
+      '@vitejs/plugin-react': 6.0.5(vite@8.2.0(@types/node@22.3.0)(yaml@2.9.0))
+      ajv: 8.18.0
+      atomically: 2.1.1
+      chokidar: 4.0.3
+      commander: 13.1.0
+      hono: 4.13.0
+      ink: 6.8.0(react@19.2.8)
+      ink-form: 2.0.1(ink@6.8.0(react@19.2.8))(react@19.2.8)
+      ink-scroll-view: 0.3.7(ink@6.8.0(react@19.2.8))(react@19.2.8)
+      open: 10.2.0
+      pino: 9.14.0
+      react: 19.2.8
+      undici: 8.10.0
+      vite: 8.2.0(@types/node@22.3.0)(yaml@2.9.0)
+      yaml: 2.9.0
+      zod: 4.4.3
+    transitivePeerDependencies:
+      - '@modelcontextprotocol/sdk'
+      - '@rolldown/plugin-babel'
+      - '@types/node'
+      - '@types/react'
+      - '@vitejs/devtools'
+      - babel-plugin-react-compiler
+      - bufferutil
+      - esbuild
+      - express
+      - jiti
+      - less
+      - react-devtools-core
+      - react-dom
+      - sass
+      - sass-embedded
+      - stylus
+      - sugarss
+      - supports-color
+      - terser
+      - tsx
+      - utf-8-validate
 
   '@modelcontextprotocol/node@2.0.0(@modelcontextprotocol/server@2.0.0)(hono@4.13.0)':
     dependencies:
@@ -2394,10 +3183,102 @@ snapshots:
     optionalDependencies:
       hono: 4.13.0
 
+  '@modelcontextprotocol/sdk@1.30.0(supports-color@8.1.1)(zod@4.4.3)':
+    dependencies:
+      '@hono/node-server': 2.0.10(hono@4.13.0)
+      ajv: 8.18.0
+      ajv-formats: 3.0.1(ajv@8.18.0)
+      content-type: 1.0.5
+      cors: 2.8.6
+      cross-spawn: 7.0.6
+      eventsource: 3.0.7
+      eventsource-parser: 3.1.0
+      express: 5.2.1(supports-color@8.1.1)
+      express-rate-limit: 8.6.2(express@5.2.1(supports-color@8.1.1))(supports-color@8.1.1)
+      hono: 4.13.0
+      jose: 6.2.8
+      json-schema-typed: 8.0.2
+      pkce-challenge: 5.0.1
+      raw-body: 3.0.2
+      zod: 4.4.3
+      zod-to-json-schema: 3.25.2(zod@4.4.3)
+    transitivePeerDependencies:
+      - supports-color
+
+  '@modelcontextprotocol/server-legacy@2.0.0-beta.5(express@5.2.1(supports-color@8.1.1))(supports-color@8.1.1)':
+    dependencies:
+      '@modelcontextprotocol/core': 2.0.0-beta.5
+      content-type: 1.0.5
+      cors: 2.8.6
+      express-rate-limit: 8.6.2(express@5.2.1(supports-color@8.1.1))(supports-color@8.1.1)
+      pkce-challenge: 5.0.1
+      raw-body: 3.0.2
+      zod: 4.4.3
+    optionalDependencies:
+      express: 5.2.1(supports-color@8.1.1)
+    transitivePeerDependencies:
+      - supports-color
+
   '@modelcontextprotocol/server@2.0.0':
     dependencies:
       '@modelcontextprotocol/core': 2.0.0
       zod: 4.4.3
+
+  '@modelcontextprotocol/server@2.0.0-beta.5':
+    dependencies:
+      '@modelcontextprotocol/core': 2.0.0-beta.5
+      zod: 4.4.3
+
+  '@napi-rs/keyring-darwin-arm64@1.3.0':
+    optional: true
+
+  '@napi-rs/keyring-darwin-x64@1.3.0':
+    optional: true
+
+  '@napi-rs/keyring-freebsd-x64@1.3.0':
+    optional: true
+
+  '@napi-rs/keyring-linux-arm-gnueabihf@1.3.0':
+    optional: true
+
+  '@napi-rs/keyring-linux-arm64-gnu@1.3.0':
+    optional: true
+
+  '@napi-rs/keyring-linux-arm64-musl@1.3.0':
+    optional: true
+
+  '@napi-rs/keyring-linux-riscv64-gnu@1.3.0':
+    optional: true
+
+  '@napi-rs/keyring-linux-x64-gnu@1.3.0':
+    optional: true
+
+  '@napi-rs/keyring-linux-x64-musl@1.3.0':
+    optional: true
+
+  '@napi-rs/keyring-win32-arm64-msvc@1.3.0':
+    optional: true
+
+  '@napi-rs/keyring-win32-ia32-msvc@1.3.0':
+    optional: true
+
+  '@napi-rs/keyring-win32-x64-msvc@1.3.0':
+    optional: true
+
+  '@napi-rs/keyring@1.3.0':
+    optionalDependencies:
+      '@napi-rs/keyring-darwin-arm64': 1.3.0
+      '@napi-rs/keyring-darwin-x64': 1.3.0
+      '@napi-rs/keyring-freebsd-x64': 1.3.0
+      '@napi-rs/keyring-linux-arm-gnueabihf': 1.3.0
+      '@napi-rs/keyring-linux-arm64-gnu': 1.3.0
+      '@napi-rs/keyring-linux-arm64-musl': 1.3.0
+      '@napi-rs/keyring-linux-riscv64-gnu': 1.3.0
+      '@napi-rs/keyring-linux-x64-gnu': 1.3.0
+      '@napi-rs/keyring-linux-x64-musl': 1.3.0
+      '@napi-rs/keyring-win32-arm64-msvc': 1.3.0
+      '@napi-rs/keyring-win32-ia32-msvc': 1.3.0
+      '@napi-rs/keyring-win32-x64-msvc': 1.3.0
 
   '@oxc-project/types@0.142.0': {}
 
@@ -2653,6 +3534,11 @@ snapshots:
       '@typescript-eslint/types': 8.66.0
       eslint-visitor-keys: 5.0.1
 
+  '@vitejs/plugin-react@6.0.5(vite@8.2.0(@types/node@22.3.0)(yaml@2.9.0))':
+    dependencies:
+      '@rolldown/pluginutils': 1.0.1
+      vite: 8.2.0(@types/node@22.3.0)(yaml@2.9.0)
+
   '@vitest/coverage-v8@4.1.10(vitest@4.1.10)':
     dependencies:
       '@bcoe/v8-coverage': 1.0.2
@@ -2708,6 +3594,11 @@ snapshots:
       convert-source-map: 2.0.0
       tinyrainbow: 3.1.1
 
+  accepts@2.0.0:
+    dependencies:
+      mime-types: 3.0.2
+      negotiator: 1.0.0
+
   acorn-jsx@5.3.2(acorn@8.16.0):
     dependencies:
       acorn: 8.16.0
@@ -2717,6 +3608,10 @@ snapshots:
       acorn: 8.16.0
 
   acorn@8.16.0: {}
+
+  ajv-formats@3.0.1(ajv@8.18.0):
+    optionalDependencies:
+      ajv: 8.18.0
 
   ajv@6.15.0:
     dependencies:
@@ -2732,17 +3627,25 @@ snapshots:
       json-schema-traverse: 1.0.0
       require-from-string: 2.0.2
 
+  ansi-escapes@7.3.0:
+    dependencies:
+      environment: 1.1.0
+
   ansi-regex@6.2.2: {}
 
   ansi-styles@4.3.0:
     dependencies:
       color-convert: 2.0.1
 
+  ansi-styles@6.2.3: {}
+
   are-docs-informative@0.0.2: {}
 
   arg@4.1.3: {}
 
   argparse@2.0.1: {}
+
+  arr-rotate@1.0.0: {}
 
   array-timsort@1.0.3: {}
 
@@ -2756,9 +3659,30 @@ snapshots:
 
   atomic-sleep@1.0.0: {}
 
+  atomically@2.1.1:
+    dependencies:
+      stubborn-fs: 2.0.0
+      when-exit: 2.1.5
+
+  auto-bind@5.0.1: {}
+
   balanced-match@1.0.2: {}
 
   balanced-match@4.0.4: {}
+
+  body-parser@2.3.0(supports-color@8.1.1):
+    dependencies:
+      bytes: 3.1.2
+      content-type: 2.0.0
+      debug: 4.4.3(supports-color@8.1.1)
+      http-errors: 2.0.1
+      iconv-lite: 0.7.3
+      on-finished: 2.4.1
+      qs: 6.15.3
+      raw-body: 3.0.2
+      type-is: 2.1.0
+    transitivePeerDependencies:
+      - supports-color
 
   bowser@2.14.1: {}
 
@@ -2770,6 +3694,22 @@ snapshots:
   brace-expansion@5.0.9:
     dependencies:
       balanced-match: 4.0.4
+
+  bundle-name@4.1.0:
+    dependencies:
+      run-applescript: 7.1.0
+
+  bytes@3.1.2: {}
+
+  call-bind-apply-helpers@1.0.2:
+    dependencies:
+      es-errors: 1.3.0
+      function-bind: 1.1.2
+
+  call-bound@1.0.4:
+    dependencies:
+      call-bind-apply-helpers: 1.0.2
+      get-intrinsic: 1.3.0
 
   callsites@3.1.0: {}
 
@@ -2786,11 +3726,32 @@ snapshots:
 
   chalk@5.6.2: {}
 
+  chokidar@4.0.3:
+    dependencies:
+      readdirp: 4.1.2
+
+  cli-boxes@3.0.0: {}
+
+  cli-cursor@4.0.0:
+    dependencies:
+      restore-cursor: 4.0.0
+
+  cli-truncate@5.2.0:
+    dependencies:
+      slice-ansi: 8.0.0
+      string-width: 8.2.2
+
+  code-excerpt@4.0.0:
+    dependencies:
+      convert-to-spaces: 2.0.1
+
   color-convert@2.0.1:
     dependencies:
       color-name: 1.1.4
 
   color-name@1.1.4: {}
+
+  commander@13.1.0: {}
 
   commander@14.0.3: {}
 
@@ -2803,7 +3764,24 @@ snapshots:
 
   concat-map@0.0.1: {}
 
+  content-disposition@1.1.0: {}
+
+  content-type@1.0.5: {}
+
+  content-type@2.0.0: {}
+
   convert-source-map@2.0.0: {}
+
+  convert-to-spaces@2.0.1: {}
+
+  cookie-signature@1.2.2: {}
+
+  cookie@0.7.2: {}
+
+  cors@2.8.6:
+    dependencies:
+      object-assign: 4.1.1
+      vary: 1.1.2
 
   create-require@1.1.1: {}
 
@@ -2911,19 +3889,58 @@ snapshots:
 
   deep-is@0.1.4: {}
 
+  default-browser-id@5.0.1: {}
+
+  default-browser@5.5.0:
+    dependencies:
+      bundle-name: 4.1.0
+      default-browser-id: 5.0.1
+
+  define-lazy-prop@3.0.0: {}
+
+  depd@2.0.0: {}
+
   detect-libc@2.1.2: {}
 
   diff@4.0.4: {}
+
+  dunder-proto@1.0.1:
+    dependencies:
+      call-bind-apply-helpers: 1.0.2
+      es-errors: 1.3.0
+      gopd: 1.2.0
+
+  ee-first@1.1.1: {}
+
+  emoji-regex@10.6.0: {}
+
+  encodeurl@2.0.0: {}
 
   env-paths@4.0.0:
     dependencies:
       is-safe-filename: 0.1.1
 
+  environment@1.1.0: {}
+
+  es-define-property@1.0.1: {}
+
   es-errors@1.3.0: {}
 
   es-module-lexer@2.3.1: {}
 
+  es-object-atoms@1.1.2:
+    dependencies:
+      es-errors: 1.3.0
+
+  es-toolkit@1.50.0: {}
+
+  escape-html@1.0.3: {}
+
+  escape-string-regexp@2.0.0: {}
+
   escape-string-regexp@4.0.0: {}
+
+  escape-string-regexp@5.0.0: {}
 
   eslint-plugin-jsdoc@50.8.0(eslint@9.39.1(supports-color@8.1.1))(supports-color@8.1.1):
     dependencies:
@@ -3025,6 +4042,8 @@ snapshots:
 
   esutils@2.0.3: {}
 
+  etag@1.8.1: {}
+
   eventsource-parser@3.1.0: {}
 
   eventsource@3.0.7:
@@ -3032,6 +4051,47 @@ snapshots:
       eventsource-parser: 3.1.0
 
   expect-type@1.4.0: {}
+
+  express-rate-limit@8.6.2(express@5.2.1(supports-color@8.1.1))(supports-color@8.1.1):
+    dependencies:
+      debug: 4.4.3(supports-color@8.1.1)
+      express: 5.2.1(supports-color@8.1.1)
+      ip-address: 10.4.0
+    transitivePeerDependencies:
+      - supports-color
+
+  express@5.2.1(supports-color@8.1.1):
+    dependencies:
+      accepts: 2.0.0
+      body-parser: 2.3.0(supports-color@8.1.1)
+      content-disposition: 1.1.0
+      content-type: 1.0.5
+      cookie: 0.7.2
+      cookie-signature: 1.2.2
+      debug: 4.4.3(supports-color@8.1.1)
+      depd: 2.0.0
+      encodeurl: 2.0.0
+      escape-html: 1.0.3
+      etag: 1.8.1
+      finalhandler: 2.1.1(supports-color@8.1.1)
+      fresh: 2.0.0
+      http-errors: 2.0.1
+      merge-descriptors: 2.0.0
+      mime-types: 3.0.2
+      on-finished: 2.4.1
+      once: 1.4.0
+      parseurl: 1.3.3
+      proxy-addr: 2.0.7
+      qs: 6.15.3
+      range-parser: 1.3.0
+      router: 2.2.0(supports-color@8.1.1)
+      send: 1.2.1(supports-color@8.1.1)
+      serve-static: 2.2.1(supports-color@8.1.1)
+      statuses: 2.0.2
+      type-is: 2.1.0
+      vary: 1.1.2
+    transitivePeerDependencies:
+      - supports-color
 
   fast-deep-equal@3.1.3: {}
 
@@ -3047,9 +4107,25 @@ snapshots:
     optionalDependencies:
       picomatch: 4.0.5
 
+  figures@5.0.0:
+    dependencies:
+      escape-string-regexp: 5.0.0
+      is-unicode-supported: 1.3.0
+
   file-entry-cache@8.0.0:
     dependencies:
       flat-cache: 4.0.1
+
+  finalhandler@2.1.1(supports-color@8.1.1):
+    dependencies:
+      debug: 4.4.3(supports-color@8.1.1)
+      encodeurl: 2.0.0
+      escape-html: 1.0.3
+      on-finished: 2.4.1
+      parseurl: 1.3.3
+      statuses: 2.0.2
+    transitivePeerDependencies:
+      - supports-color
 
   find-up@5.0.0:
     dependencies:
@@ -3063,12 +4139,36 @@ snapshots:
 
   flatted@3.4.4: {}
 
+  forwarded@0.2.0: {}
+
+  fresh@2.0.0: {}
+
   fsevents@2.3.3:
     optional: true
 
   function-bind@1.1.2: {}
 
   gensequence@8.0.8: {}
+
+  get-east-asian-width@1.6.0: {}
+
+  get-intrinsic@1.3.0:
+    dependencies:
+      call-bind-apply-helpers: 1.0.2
+      es-define-property: 1.0.1
+      es-errors: 1.3.0
+      es-object-atoms: 1.1.2
+      function-bind: 1.1.2
+      get-proto: 1.0.1
+      gopd: 1.2.0
+      has-symbols: 1.1.0
+      hasown: 2.0.4
+      math-intrinsics: 1.1.0
+
+  get-proto@1.0.1:
+    dependencies:
+      dunder-proto: 1.0.1
+      es-object-atoms: 1.1.2
 
   glob-parent@6.0.2:
     dependencies:
@@ -3080,7 +4180,11 @@ snapshots:
 
   globals@14.0.0: {}
 
+  gopd@1.2.0: {}
+
   has-flag@4.0.0: {}
+
+  has-symbols@1.1.0: {}
 
   hasown@2.0.4:
     dependencies:
@@ -3089,6 +4193,18 @@ snapshots:
   hono@4.13.0: {}
 
   html-escaper@2.0.2: {}
+
+  http-errors@2.0.1:
+    dependencies:
+      depd: 2.0.0
+      inherits: 2.0.4
+      setprototypeof: 1.2.0
+      statuses: 2.0.2
+      toidentifier: 1.0.1
+
+  iconv-lite@0.7.3:
+    dependencies:
+      safer-buffer: 2.1.2
 
   ignore@5.3.2: {}
 
@@ -3105,19 +4221,106 @@ snapshots:
 
   imurmurhash@0.1.4: {}
 
+  indent-string@5.0.0: {}
+
+  inherits@2.0.4: {}
+
   ini@6.0.0: {}
+
+  ink-form@2.0.1(ink@6.8.0(react@19.2.8))(react@19.2.8):
+    dependencies:
+      ink: 6.8.0(react@19.2.8)
+      ink-select-input: 5.0.0(ink@6.8.0(react@19.2.8))(react@19.2.8)
+      ink-text-input: 6.0.0(ink@6.8.0(react@19.2.8))(react@19.2.8)
+      react: 19.2.8
+
+  ink-scroll-view@0.3.7(ink@6.8.0(react@19.2.8))(react@19.2.8):
+    dependencies:
+      ink: 6.8.0(react@19.2.8)
+      react: 19.2.8
+
+  ink-select-input@5.0.0(ink@6.8.0(react@19.2.8))(react@19.2.8):
+    dependencies:
+      arr-rotate: 1.0.0
+      figures: 5.0.0
+      ink: 6.8.0(react@19.2.8)
+      lodash.isequal: 4.5.0
+      react: 19.2.8
+
+  ink-text-input@6.0.0(ink@6.8.0(react@19.2.8))(react@19.2.8):
+    dependencies:
+      chalk: 5.6.2
+      ink: 6.8.0(react@19.2.8)
+      react: 19.2.8
+      type-fest: 4.41.0
+
+  ink@6.8.0(react@19.2.8):
+    dependencies:
+      '@alcalzone/ansi-tokenize': 0.2.5
+      ansi-escapes: 7.3.0
+      ansi-styles: 6.2.3
+      auto-bind: 5.0.1
+      chalk: 5.6.2
+      cli-boxes: 3.0.0
+      cli-cursor: 4.0.0
+      cli-truncate: 5.2.0
+      code-excerpt: 4.0.0
+      es-toolkit: 1.50.0
+      indent-string: 5.0.0
+      is-in-ci: 2.0.0
+      patch-console: 2.0.0
+      react: 19.2.8
+      react-reconciler: 0.33.0(react@19.2.8)
+      scheduler: 0.27.0
+      signal-exit: 3.0.7
+      slice-ansi: 8.0.0
+      stack-utils: 2.0.6
+      string-width: 8.2.2
+      terminal-size: 4.0.1
+      type-fest: 5.8.0
+      widest-line: 6.0.0
+      wrap-ansi: 9.0.2
+      ws: 8.21.2
+      yoga-layout: 3.2.1
+    transitivePeerDependencies:
+      - bufferutil
+      - utf-8-validate
+
+  ip-address@10.4.0: {}
+
+  ipaddr.js@1.9.1: {}
 
   is-core-module@2.16.1:
     dependencies:
       hasown: 2.0.4
 
+  is-docker@3.0.0: {}
+
   is-extglob@2.1.1: {}
+
+  is-fullwidth-code-point@5.1.0:
+    dependencies:
+      get-east-asian-width: 1.6.0
 
   is-glob@4.0.3:
     dependencies:
       is-extglob: 2.1.1
 
+  is-in-ci@2.0.0: {}
+
+  is-inside-container@1.0.0:
+    dependencies:
+      is-docker: 3.0.0
+
+  is-promise@4.0.0: {}
+
   is-safe-filename@0.1.1: {}
+
+  is-unicode-supported@1.3.0: {}
+
+  is-wsl@3.1.1:
+    dependencies:
+      is-inside-container: 1.0.0
 
   isexe@2.0.0: {}
 
@@ -3151,6 +4354,8 @@ snapshots:
   json-schema-traverse@0.4.1: {}
 
   json-schema-traverse@1.0.0: {}
+
+  json-schema-typed@8.0.2: {}
 
   json-stable-stringify-without-jsonify@1.0.1: {}
 
@@ -3216,6 +4421,8 @@ snapshots:
     dependencies:
       p-locate: 5.0.0
 
+  lodash.isequal@4.5.0: {}
+
   lodash.merge@4.6.2: {}
 
   magic-string@0.30.21:
@@ -3234,6 +4441,20 @@ snapshots:
 
   make-error@1.3.6: {}
 
+  math-intrinsics@1.1.0: {}
+
+  media-typer@1.1.1: {}
+
+  merge-descriptors@2.0.0: {}
+
+  mime-db@1.54.0: {}
+
+  mime-types@3.0.2:
+    dependencies:
+      mime-db: 1.54.0
+
+  mimic-fn@2.1.0: {}
+
   minimatch@10.2.6:
     dependencies:
       brace-expansion: 5.0.9
@@ -3248,9 +4469,34 @@ snapshots:
 
   natural-compare@1.4.0: {}
 
+  negotiator@1.0.0: {}
+
+  object-assign@4.1.1: {}
+
+  object-inspect@1.13.4: {}
+
   obug@2.1.4: {}
 
   on-exit-leak-free@2.1.2: {}
+
+  on-finished@2.4.1:
+    dependencies:
+      ee-first: 1.1.1
+
+  once@1.4.0:
+    dependencies:
+      wrappy: 1.0.2
+
+  onetime@5.1.2:
+    dependencies:
+      mimic-fn: 2.1.0
+
+  open@10.2.0:
+    dependencies:
+      default-browser: 5.5.0
+      define-lazy-prop: 3.0.0
+      is-inside-container: 1.0.0
+      wsl-utils: 0.1.0
 
   opossum@10.0.0: {}
 
@@ -3281,17 +4527,27 @@ snapshots:
 
   parse-statements@1.0.11: {}
 
+  parseurl@1.3.3: {}
+
+  patch-console@2.0.0: {}
+
   path-exists@4.0.0: {}
 
   path-key@3.1.1: {}
 
   path-parse@1.0.7: {}
 
+  path-to-regexp@8.4.2: {}
+
   pathe@2.0.3: {}
 
   picocolors@1.1.1: {}
 
   picomatch@4.0.5: {}
+
+  pino-abstract-transport@2.0.0:
+    dependencies:
+      split2: 4.2.0
 
   pino-abstract-transport@3.0.0:
     dependencies:
@@ -3313,6 +4569,20 @@ snapshots:
       sonic-boom: 4.2.1
       thread-stream: 4.2.0
 
+  pino@9.14.0:
+    dependencies:
+      '@pinojs/redact': 0.4.0
+      atomic-sleep: 1.0.0
+      on-exit-leak-free: 2.1.2
+      pino-abstract-transport: 2.0.0
+      pino-std-serializers: 7.1.0
+      process-warning: 5.1.0
+      quick-format-unescaped: 4.0.4
+      real-require: 0.2.0
+      safe-stable-stringify: 2.5.0
+      sonic-boom: 4.2.1
+      thread-stream: 3.2.0
+
   pkce-challenge@5.0.1: {}
 
   postcss@8.5.25:
@@ -3325,9 +4595,37 @@ snapshots:
 
   process-warning@5.1.0: {}
 
+  proxy-addr@2.0.7:
+    dependencies:
+      forwarded: 0.2.0
+      ipaddr.js: 1.9.1
+
   punycode@2.3.1: {}
 
+  qs@6.15.3:
+    dependencies:
+      es-define-property: 1.0.1
+      side-channel: 1.1.1
+
   quick-format-unescaped@4.0.4: {}
+
+  range-parser@1.3.0: {}
+
+  raw-body@3.0.2:
+    dependencies:
+      bytes: 3.1.2
+      http-errors: 2.0.1
+      iconv-lite: 0.7.3
+      unpipe: 1.0.0
+
+  react-reconciler@0.33.0(react@19.2.8):
+    dependencies:
+      react: 19.2.8
+      scheduler: 0.27.0
+
+  react@19.2.8: {}
+
+  readdirp@4.1.2: {}
 
   real-require@0.2.0: {}
 
@@ -3345,6 +4643,11 @@ snapshots:
       is-core-module: 2.16.1
       path-parse: 1.0.7
       supports-preserve-symlinks-flag: 1.0.0
+
+  restore-cursor@4.0.0:
+    dependencies:
+      onetime: 5.1.2
+      signal-exit: 3.0.7
 
   rolldown@1.2.2:
     dependencies:
@@ -3366,9 +4669,52 @@ snapshots:
       '@rolldown/binding-win32-arm64-msvc': 1.2.2
       '@rolldown/binding-win32-x64-msvc': 1.2.2
 
+  router@2.2.0(supports-color@8.1.1):
+    dependencies:
+      debug: 4.4.3(supports-color@8.1.1)
+      depd: 2.0.0
+      is-promise: 4.0.0
+      parseurl: 1.3.3
+      path-to-regexp: 8.4.2
+    transitivePeerDependencies:
+      - supports-color
+
+  run-applescript@7.1.0: {}
+
   safe-stable-stringify@2.5.0: {}
 
+  safer-buffer@2.1.2: {}
+
+  scheduler@0.27.0: {}
+
   semver@7.8.5: {}
+
+  send@1.2.1(supports-color@8.1.1):
+    dependencies:
+      debug: 4.4.3(supports-color@8.1.1)
+      encodeurl: 2.0.0
+      escape-html: 1.0.3
+      etag: 1.8.1
+      fresh: 2.0.0
+      http-errors: 2.0.1
+      mime-types: 3.0.2
+      ms: 2.1.3
+      on-finished: 2.4.1
+      range-parser: 1.3.0
+      statuses: 2.0.2
+    transitivePeerDependencies:
+      - supports-color
+
+  serve-static@2.2.1(supports-color@8.1.1):
+    dependencies:
+      encodeurl: 2.0.0
+      escape-html: 1.0.3
+      parseurl: 1.3.3
+      send: 1.2.1(supports-color@8.1.1)
+    transitivePeerDependencies:
+      - supports-color
+
+  setprototypeof@1.2.0: {}
 
   shebang-command@2.0.0:
     dependencies:
@@ -3376,7 +4722,42 @@ snapshots:
 
   shebang-regex@3.0.0: {}
 
+  side-channel-list@1.0.1:
+    dependencies:
+      es-errors: 1.3.0
+      object-inspect: 1.13.4
+
+  side-channel-map@1.0.1:
+    dependencies:
+      call-bound: 1.0.4
+      es-errors: 1.3.0
+      get-intrinsic: 1.3.0
+      object-inspect: 1.13.4
+
+  side-channel-weakmap@1.0.2:
+    dependencies:
+      call-bound: 1.0.4
+      es-errors: 1.3.0
+      get-intrinsic: 1.3.0
+      object-inspect: 1.13.4
+      side-channel-map: 1.0.1
+
+  side-channel@1.1.1:
+    dependencies:
+      es-errors: 1.3.0
+      object-inspect: 1.13.4
+      side-channel-list: 1.0.1
+      side-channel-map: 1.0.1
+      side-channel-weakmap: 1.0.2
+
   siginfo@2.0.0: {}
+
+  signal-exit@3.0.7: {}
+
+  slice-ansi@8.0.0:
+    dependencies:
+      ansi-styles: 6.2.3
+      is-fullwidth-code-point: 5.1.0
 
   smol-toml@1.7.1: {}
 
@@ -3397,11 +4778,38 @@ snapshots:
 
   split2@4.2.0: {}
 
+  stack-utils@2.0.6:
+    dependencies:
+      escape-string-regexp: 2.0.0
+
   stackback@0.0.2: {}
+
+  statuses@2.0.2: {}
 
   std-env@4.2.0: {}
 
+  string-width@7.2.0:
+    dependencies:
+      emoji-regex: 10.6.0
+      get-east-asian-width: 1.6.0
+      strip-ansi: 7.2.0
+
+  string-width@8.2.2:
+    dependencies:
+      get-east-asian-width: 1.6.0
+      strip-ansi: 7.2.0
+
+  strip-ansi@7.2.0:
+    dependencies:
+      ansi-regex: 6.2.2
+
   strip-json-comments@3.1.1: {}
+
+  stubborn-fs@2.0.0:
+    dependencies:
+      stubborn-utils: 1.0.2
+
+  stubborn-utils@1.0.2: {}
 
   supports-color@7.2.0:
     dependencies:
@@ -3413,6 +4821,14 @@ snapshots:
     optional: true
 
   supports-preserve-symlinks-flag@1.0.0: {}
+
+  tagged-tag@1.0.0: {}
+
+  terminal-size@4.0.1: {}
+
+  thread-stream@3.2.0:
+    dependencies:
+      real-require: 0.2.0
 
   thread-stream@4.2.0:
     dependencies:
@@ -3428,6 +4844,8 @@ snapshots:
       picomatch: 4.0.5
 
   tinyrainbow@3.1.1: {}
+
+  toidentifier@1.0.1: {}
 
   ts-api-utils@2.5.0(typescript@6.0.3):
     dependencies:
@@ -3457,6 +4875,18 @@ snapshots:
     dependencies:
       prelude-ls: 1.2.1
 
+  type-fest@4.41.0: {}
+
+  type-fest@5.8.0:
+    dependencies:
+      tagged-tag: 1.0.0
+
+  type-is@2.1.0:
+    dependencies:
+      content-type: 2.0.0
+      media-typer: 1.1.1
+      mime-types: 3.0.2
+
   typescript-eslint@8.66.0(eslint@9.39.1(supports-color@8.1.1))(supports-color@8.1.1)(typescript@6.0.3):
     dependencies:
       '@typescript-eslint/eslint-plugin': 8.66.0(@typescript-eslint/parser@8.66.0(eslint@9.39.1(supports-color@8.1.1))(supports-color@8.1.1)(typescript@6.0.3))(eslint@9.39.1(supports-color@8.1.1))(supports-color@8.1.1)(typescript@6.0.3)
@@ -3472,11 +4902,17 @@ snapshots:
 
   undici-types@6.18.2: {}
 
+  undici@8.10.0: {}
+
+  unpipe@1.0.0: {}
+
   uri-js@4.4.1:
     dependencies:
       punycode: 2.3.1
 
   v8-compile-cache-lib@3.0.1: {}
+
+  vary@1.1.2: {}
 
   vite@8.2.0(@types/node@22.3.0)(yaml@2.9.0):
     dependencies:
@@ -3522,6 +4958,8 @@ snapshots:
 
   vscode-uri@3.1.0: {}
 
+  when-exit@2.1.5: {}
+
   which@2.0.2:
     dependencies:
       isexe: 2.0.0
@@ -3531,7 +4969,25 @@ snapshots:
       siginfo: 2.0.0
       stackback: 0.0.2
 
+  widest-line@6.0.0:
+    dependencies:
+      string-width: 8.2.2
+
   word-wrap@1.2.5: {}
+
+  wrap-ansi@9.0.2:
+    dependencies:
+      ansi-styles: 6.2.3
+      string-width: 7.2.0
+      strip-ansi: 7.2.0
+
+  wrappy@1.0.2: {}
+
+  ws@8.21.2: {}
+
+  wsl-utils@0.1.0:
+    dependencies:
+      is-wsl: 3.1.1
 
   xdg-basedir@5.1.0: {}
 
@@ -3540,5 +4996,11 @@ snapshots:
   yn@3.1.1: {}
 
   yocto-queue@0.1.0: {}
+
+  yoga-layout@3.2.1: {}
+
+  zod-to-json-schema@3.25.2(zod@4.4.3):
+    dependencies:
+      zod: 4.4.3
 
   zod@4.4.3: {}

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,2 +1,6 @@
+allowBuilds:
+  '@modelcontextprotocol/inspector': false
+minimumReleaseAgeExclude:
+  - '@modelcontextprotocol/inspector@2.1.0'
 overrides:
   '@hono/node-server': 2.0.10

--- a/scripts/check-package-budget.mjs
+++ b/scripts/check-package-budget.mjs
@@ -217,7 +217,11 @@ function requireNonEmptyString(value, label) {
 }
 
 function directLockEntry(name) {
-  return packageLock.packages?.[`node_modules/${name}`];
+  const expectedVersion = productionDependencySections
+    .map((section) => packageJson[section]?.[name])
+    .find((specifier) => specifier !== undefined);
+  const entries = productionPackagesFromLock(packageLock).filter((entry) => entry.name === name);
+  return entries.find((entry) => entry.version === expectedVersion) ?? entries[0];
 }
 
 function packageProductionDependencyEntries() {
@@ -521,7 +525,7 @@ function assertDirectDependencyPolicy() {
     if (forbiddenSection) {
       fail(`forbidden runtime dependency is present in package.json: ${name}`);
     }
-    if (packageLock.packages?.[`node_modules/${name}`] !== undefined) {
+    if (productionPackagesFromLock(packageLock).some((entry) => entry.name === name)) {
       fail(`forbidden runtime dependency is present in pnpm-lock.yaml: ${name}`);
     }
   }

--- a/scripts/mcp-client-smoke.mjs
+++ b/scripts/mcp-client-smoke.mjs
@@ -141,10 +141,6 @@ function recordCheck(checks, name, ok, detail = "") {
   console.log(`  [${mark}] ${name}${detail ? " - " + detail : ""}`);
 }
 
-function arraysEqual(left, right) {
-  return left.length === right.length && left.every((value, index) => value === right[index]);
-}
-
 async function runWorker() {
   assertBuiltArtifacts();
   assertWorkerEnvIsSanitized();
@@ -158,7 +154,9 @@ async function runWorker() {
   const helpers = loadContractHelpers();
   const expectedFixture = readJson(EXPECTED_FIXTURE);
   const toolContract = readJson("docs/tool-profile-contract.json");
-  const { evaluateProfileContract } = require(join(root, "scripts/lib/smoke-contract.cjs"));
+  const { arraysEqual, evaluateProfileContract } = require(
+    join(root, "scripts/lib/smoke-contract.cjs"),
+  );
   const serverEnv = createServerEnv();
   assertSmokeServerPreconditions(serverEnv);
 

--- a/scripts/mcp-client-smoke.mjs
+++ b/scripts/mcp-client-smoke.mjs
@@ -1,0 +1,209 @@
+#!/usr/bin/env node
+/**
+ * Supplemental MCP client smoke for the local stdio entry point.
+ *
+ * This uses the official MCP TypeScript SDK v2 client against dist/index.js,
+ * negotiates the 2026-07-28 protocol, and compares tools/list to the
+ * repository-owned modern full-profile contract fixture. It intentionally does
+ * not call any B2 tool, and B2_REGISTER_ALL_TOOLS=true prevents startup
+ * capability discovery from making a live B2 network call.
+ */
+
+import { readFileSync } from "node:fs";
+import { createRequire } from "node:module";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { Client } from "@modelcontextprotocol/client";
+import { StdioClientTransport } from "@modelcontextprotocol/client/stdio";
+
+const require = createRequire(import.meta.url);
+const root = dirname(dirname(fileURLToPath(import.meta.url)));
+const TARGET_PROTOCOL_VERSION = "2026-07-28";
+const EXPECTED_PROFILE = "full";
+const EXPECTED_FIXTURE = "tests/fixtures/tool-contract/full.modern.json";
+const SAFE_ENV_NAMES = [
+  "PATH",
+  "Path",
+  "SystemRoot",
+  "COMSPEC",
+  "PATHEXT",
+  "HOME",
+  "USERPROFILE",
+  "TMPDIR",
+  "TMP",
+  "TEMP",
+];
+
+const checks = [];
+
+function readJson(relativePath) {
+  return JSON.parse(readFileSync(join(root, relativePath), "utf8"));
+}
+
+function check(name, ok, detail = "") {
+  checks.push({ name, ok, detail });
+  const mark = ok ? "PASS" : "FAIL";
+  console.log(`  [${mark}] ${name}${detail ? " - " + detail : ""}`);
+}
+
+function arraysEqual(left, right) {
+  return left.length === right.length && left.every((value, index) => value === right[index]);
+}
+
+function smokeEnv() {
+  const inherited = Object.fromEntries(
+    SAFE_ENV_NAMES.flatMap((name) =>
+      process.env[name] === undefined ? [] : [[name, process.env[name]]],
+    ),
+  );
+  const env = {
+    ...inherited,
+    NODE_ENV: "test",
+    B2_REGISTER_ALL_TOOLS: "true",
+    B2_APPLICATION_KEY_ID: "external-smoke-key-id",
+    B2_APPLICATION_KEY: "external-smoke-key-secret",
+  };
+  delete env.FORCE_COLOR;
+  delete env.NO_COLOR;
+  return env;
+}
+
+function loadContractHelpers() {
+  try {
+    const helpers = require(join(root, "dist/tool-contract.js"));
+    if (typeof helpers.normalizeTool !== "function" || typeof helpers.fixtureHash !== "function") {
+      throw new Error("dist/tool-contract.js does not export contract helpers");
+    }
+    return helpers;
+  } catch (err) {
+    console.error(
+      `Unable to load compiled contract helpers. Run pnpm run build before this smoke. ${err.message}`,
+    );
+    process.exit(2);
+  }
+}
+
+function snapshotFromTools(tools, helpers) {
+  const sortedTools = [...tools]
+    .filter((tool) => tool?.name)
+    .sort((a, b) => a.name.localeCompare(b.name));
+  const names = sortedTools.map((tool) => tool.name);
+  const normalizedTools = sortedTools.map(helpers.normalizeTool);
+  return {
+    names,
+    hash: helpers.fixtureHash({ names, tools: normalizedTools }),
+  };
+}
+
+async function main() {
+  const helpers = loadContractHelpers();
+  const expectedFixture = readJson(EXPECTED_FIXTURE);
+  const toolContract = readJson("docs/tool-profile-contract.json");
+  const { evaluateProfileContract } = require(join(root, "scripts/lib/smoke-contract.cjs"));
+
+  console.log("MCP external client smoke (advisory)");
+  console.log(`  transport=stdio targetProtocol=${TARGET_PROTOCOL_VERSION}`);
+
+  const transport = new StdioClientTransport({
+    command: process.execPath,
+    args: [join(root, "dist/index.js")],
+    cwd: root,
+    env: smokeEnv(),
+    stderr: "pipe",
+  });
+  let stderr = "";
+  transport.stderr?.on("data", (chunk) => {
+    stderr += chunk.toString();
+  });
+
+  const client = new Client(
+    { name: "b2-mcp-external-smoke", version: "1.0.0" },
+    {
+      versionNegotiation: { mode: "auto", probe: { timeoutMs: 5_000 } },
+      defaultCacheTtlMs: 0,
+    },
+  );
+
+  try {
+    await client.connect(transport, { timeoutMs: 10_000 });
+
+    const era = client.getProtocolEra();
+    const protocolVersion = client.getNegotiatedProtocolVersion();
+    const server = client.getServerVersion();
+    const instructions = client.getInstructions() ?? "";
+    const discover = client.getDiscoverResult() ?? (await client.discover({ timeoutMs: 5_000 }));
+
+    console.log(
+      `  negotiatedEra=${era ?? "unknown"} negotiatedProtocol=${protocolVersion ?? "unknown"}`,
+    );
+    console.log(`  server=${server?.name ?? "unknown"}@${server?.version ?? "unknown"}`);
+
+    check("client negotiated modern protocol era", era === "modern", `era=${era ?? "unknown"}`);
+    check(
+      "client negotiated target protocol revision",
+      protocolVersion === TARGET_PROTOCOL_VERSION,
+      `protocol=${protocolVersion ?? "unknown"}`,
+    );
+    check(
+      "server/discover advertises target protocol",
+      discover.supportedVersions?.includes(TARGET_PROTOCOL_VERSION) === true,
+      `supported=${(discover.supportedVersions ?? []).join(",")}`,
+    );
+    check("server/discover resultType is complete", discover.resultType === "complete");
+    check(
+      "server/discover exposes tool capability",
+      typeof discover.capabilities?.tools === "object" && discover.capabilities.tools !== null,
+    );
+    check(
+      "server name/version is reported",
+      server?.name === "backblaze-b2" && typeof server.version === "string",
+      `server=${server?.name ?? "unknown"}@${server?.version ?? "unknown"}`,
+    );
+    check(
+      "instructions are reported",
+      instructions.includes("Backblaze B2 operational flow.") &&
+        instructions.includes("Never log, print, persist, or echo back application keys"),
+    );
+
+    const listed = await client.listTools(undefined, { cacheMode: "refresh", timeoutMs: 10_000 });
+    const snapshot = snapshotFromTools(listed.tools, helpers);
+    const profileResult = evaluateProfileContract({
+      snapshot,
+      toolContract,
+      expectedProfile: EXPECTED_PROFILE,
+    });
+    for (const result of profileResult.checks) {
+      check(result.name, result.ok, result.detail);
+    }
+    check(
+      `tools/list names match ${EXPECTED_FIXTURE}`,
+      arraysEqual(snapshot.names, expectedFixture.names),
+      `${snapshot.names.length} tools`,
+    );
+    check(
+      `tools/list hash matches ${EXPECTED_FIXTURE}`,
+      snapshot.hash === expectedFixture.hash,
+      `hash=${snapshot.hash.slice(0, 12)}`,
+    );
+    check(
+      "tools/list includes representative B2 and S3 tools",
+      snapshot.names.includes("b2_list_buckets") && snapshot.names.includes("s3_list_objects_v2"),
+    );
+    check("startup avoided B2 capability discovery", !stderr.includes("capability.fetch"));
+
+    const failed = checks.filter((result) => !result.ok);
+    if (failed.length > 0) {
+      console.error(`FAILED (${failed.length}): ${failed.map((result) => result.name).join(", ")}`);
+      process.exitCode = 1;
+    } else {
+      console.log("All checks passed.");
+    }
+  } finally {
+    await client.close().catch(() => undefined);
+  }
+}
+
+main().catch((err) => {
+  console.error("Fatal:", err.message ?? err);
+  process.exit(1);
+});

--- a/scripts/mcp-client-smoke.mjs
+++ b/scripts/mcp-client-smoke.mjs
@@ -2,45 +2,140 @@
 /**
  * Supplemental MCP client smoke for the local stdio entry point.
  *
- * This uses the official MCP TypeScript SDK v2 client against dist/index.js,
- * negotiates the 2026-07-28 protocol, and compares tools/list to the
- * repository-owned modern full-profile contract fixture. It intentionally does
- * not call any B2 tool, and B2_REGISTER_ALL_TOOLS=true prevents startup
- * capability discovery from making a live B2 network call.
+ * The top-level process is a bootstrap: it builds an allowlisted environment
+ * and spawns a worker. SDK modules are imported only inside the worker after
+ * sensitive parent environment variables have been removed.
  */
 
-import { readFileSync } from "node:fs";
+import { spawn } from "node:child_process";
+import { once } from "node:events";
+import { existsSync, readFileSync } from "node:fs";
 import { createRequire } from "node:module";
 import { dirname, join } from "node:path";
-import { fileURLToPath } from "node:url";
-import { Client } from "@modelcontextprotocol/client";
-import { StdioClientTransport } from "@modelcontextprotocol/client/stdio";
+import { fileURLToPath, pathToFileURL } from "node:url";
+import { liveToolContractSnapshot } from "./smoke-test.mjs";
 
 const require = createRequire(import.meta.url);
+const { sanitizedEnv, secretNamePattern } = require("./lib/sanitized-env.cjs");
+
 const root = dirname(dirname(fileURLToPath(import.meta.url)));
+const scriptPath = fileURLToPath(import.meta.url);
 const TARGET_PROTOCOL_VERSION = "2026-07-28";
 const EXPECTED_PROFILE = "full";
 const EXPECTED_FIXTURE = "tests/fixtures/tool-contract/full.modern.json";
-const SAFE_ENV_NAMES = [
-  "PATH",
-  "Path",
-  "SystemRoot",
-  "COMSPEC",
-  "PATHEXT",
-  "HOME",
-  "USERPROFILE",
-  "TMPDIR",
-  "TMP",
-  "TEMP",
-];
+const WORKER_ENV_NAME = "MCP_CLIENT_SMOKE_WORKER";
+const NETWORK_GUARD_SCRIPT = "scripts/no-network-guard.mjs";
+const NETWORK_GUARD_SIGNAL = "MCP_CLIENT_SMOKE_NETWORK_BLOCKED";
+const DEFAULT_STDERR_TAIL_BYTES = 8192;
 
-const checks = [];
+const fakeServerCredentials = {
+  B2_APPLICATION_KEY_ID: "external-smoke-key-id",
+  B2_APPLICATION_KEY: "external-smoke-key-secret",
+};
 
-function readJson(relativePath) {
+export function readJson(relativePath) {
   return JSON.parse(readFileSync(join(root, relativePath), "utf8"));
 }
 
-function check(name, ok, detail = "") {
+export function createWorkerEnv(sourceEnv = process.env) {
+  return sanitizedEnv(
+    {
+      [WORKER_ENV_NAME]: "1",
+    },
+    { sourceEnv },
+  );
+}
+
+export function createServerEnv(sourceEnv = process.env, options = {}) {
+  const registerAllTools = options.registerAllTools !== false;
+  return sanitizedEnv(
+    {
+      ...(registerAllTools ? { B2_REGISTER_ALL_TOOLS: "true" } : {}),
+      ...fakeServerCredentials,
+      LOG_LEVEL: "info",
+      NODE_OPTIONS: `--import ${pathToFileURL(join(root, NETWORK_GUARD_SCRIPT)).href}`,
+    },
+    {
+      sourceEnv,
+      nonSecretEnvNames: ["B2_REGISTER_ALL_TOOLS", "B2_APPLICATION_KEY_ID", "B2_APPLICATION_KEY"],
+    },
+  );
+}
+
+export function sensitiveEnvNames(env) {
+  return Object.keys(env)
+    .filter((name) => secretNamePattern.test(name))
+    .sort();
+}
+
+export function assertWorkerEnvIsSanitized(env = process.env) {
+  const leaked = sensitiveEnvNames(env);
+  if (leaked.length > 0) {
+    throw new Error(
+      `Refusing to import MCP client SDK with sensitive environment variables present: ${leaked.join(
+        ", ",
+      )}`,
+    );
+  }
+}
+
+export function assertSmokeServerPreconditions(env) {
+  if (env.B2_REGISTER_ALL_TOOLS !== "true") {
+    throw new Error("B2_REGISTER_ALL_TOOLS=true is required for no-network client smoke");
+  }
+  if (!env.NODE_OPTIONS?.includes(NETWORK_GUARD_SCRIPT)) {
+    throw new Error("No-network preload guard is required for client smoke");
+  }
+}
+
+export function createBoundedStderrMonitor({
+  signal = NETWORK_GUARD_SIGNAL,
+  maxTailBytes = DEFAULT_STDERR_TAIL_BYTES,
+} = {}) {
+  let tail = "";
+  let signalSeen = false;
+
+  return {
+    observe(chunk) {
+      const text = chunk.toString();
+      if (text.includes(signal)) signalSeen = true;
+      tail = `${tail}${text}`.slice(-maxTailBytes);
+    },
+    get signalSeen() {
+      return signalSeen;
+    },
+    get tail() {
+      return tail;
+    },
+  };
+}
+
+export function instructionsIncludeRequiredSnippets(instructions, snippets) {
+  return snippets.every((snippet) => instructions.includes(snippet));
+}
+
+function assertBuiltArtifacts() {
+  const missing = ["dist/index.js", "dist/tool-contract.js"].filter(
+    (relativePath) => !existsSync(join(root, relativePath)),
+  );
+  if (missing.length > 0) {
+    throw new Error(
+      `Missing built artifact(s): ${missing.join(
+        ", ",
+      )}. Run pnpm run build from a non-serving checkout before pnpm run smoke:client.`,
+    );
+  }
+}
+
+function loadContractHelpers() {
+  const helpers = require(join(root, "dist/tool-contract.js"));
+  if (typeof helpers.normalizeTool !== "function" || typeof helpers.fixtureHash !== "function") {
+    throw new Error("dist/tool-contract.js does not export contract helpers");
+  }
+  return helpers;
+}
+
+function recordCheck(checks, name, ok, detail = "") {
   checks.push({ name, ok, detail });
   const mark = ok ? "PASS" : "FAIL";
   console.log(`  [${mark}] ${name}${detail ? " - " + detail : ""}`);
@@ -50,57 +145,24 @@ function arraysEqual(left, right) {
   return left.length === right.length && left.every((value, index) => value === right[index]);
 }
 
-function smokeEnv() {
-  const inherited = Object.fromEntries(
-    SAFE_ENV_NAMES.flatMap((name) =>
-      process.env[name] === undefined ? [] : [[name, process.env[name]]],
-    ),
-  );
-  const env = {
-    ...inherited,
-    NODE_ENV: "test",
-    B2_REGISTER_ALL_TOOLS: "true",
-    B2_APPLICATION_KEY_ID: "external-smoke-key-id",
-    B2_APPLICATION_KEY: "external-smoke-key-secret",
-  };
-  delete env.FORCE_COLOR;
-  delete env.NO_COLOR;
-  return env;
-}
+async function runWorker() {
+  assertBuiltArtifacts();
+  assertWorkerEnvIsSanitized();
 
-function loadContractHelpers() {
-  try {
-    const helpers = require(join(root, "dist/tool-contract.js"));
-    if (typeof helpers.normalizeTool !== "function" || typeof helpers.fixtureHash !== "function") {
-      throw new Error("dist/tool-contract.js does not export contract helpers");
-    }
-    return helpers;
-  } catch (err) {
-    console.error(
-      `Unable to load compiled contract helpers. Run pnpm run build before this smoke. ${err.message}`,
-    );
-    process.exit(2);
-  }
-}
+  const [{ Client }, { StdioClientTransport }, serverExports] = await Promise.all([
+    import("@modelcontextprotocol/client"),
+    import("@modelcontextprotocol/client/stdio"),
+    import(pathToFileURL(join(root, "dist/server.js")).href),
+  ]);
 
-function snapshotFromTools(tools, helpers) {
-  const sortedTools = [...tools]
-    .filter((tool) => tool?.name)
-    .sort((a, b) => a.name.localeCompare(b.name));
-  const names = sortedTools.map((tool) => tool.name);
-  const normalizedTools = sortedTools.map(helpers.normalizeTool);
-  return {
-    names,
-    hash: helpers.fixtureHash({ names, tools: normalizedTools }),
-  };
-}
-
-async function main() {
   const helpers = loadContractHelpers();
   const expectedFixture = readJson(EXPECTED_FIXTURE);
   const toolContract = readJson("docs/tool-profile-contract.json");
   const { evaluateProfileContract } = require(join(root, "scripts/lib/smoke-contract.cjs"));
+  const serverEnv = createServerEnv();
+  assertSmokeServerPreconditions(serverEnv);
 
+  const checks = [];
   console.log("MCP external client smoke (advisory)");
   console.log(`  transport=stdio targetProtocol=${TARGET_PROTOCOL_VERSION}`);
 
@@ -108,13 +170,11 @@ async function main() {
     command: process.execPath,
     args: [join(root, "dist/index.js")],
     cwd: root,
-    env: smokeEnv(),
+    env: serverEnv,
     stderr: "pipe",
   });
-  let stderr = "";
-  transport.stderr?.on("data", (chunk) => {
-    stderr += chunk.toString();
-  });
+  const stderrMonitor = createBoundedStderrMonitor();
+  transport.stderr?.on("data", (chunk) => stderrMonitor.observe(chunk));
 
   const client = new Client(
     { name: "b2-mcp-external-smoke", version: "1.0.0" },
@@ -138,58 +198,73 @@ async function main() {
     );
     console.log(`  server=${server?.name ?? "unknown"}@${server?.version ?? "unknown"}`);
 
-    check("client negotiated modern protocol era", era === "modern", `era=${era ?? "unknown"}`);
-    check(
+    recordCheck(checks, "client negotiated modern protocol era", era === "modern", `era=${era}`);
+    recordCheck(
+      checks,
       "client negotiated target protocol revision",
       protocolVersion === TARGET_PROTOCOL_VERSION,
       `protocol=${protocolVersion ?? "unknown"}`,
     );
-    check(
+    recordCheck(
+      checks,
       "server/discover advertises target protocol",
       discover.supportedVersions?.includes(TARGET_PROTOCOL_VERSION) === true,
       `supported=${(discover.supportedVersions ?? []).join(",")}`,
     );
-    check("server/discover resultType is complete", discover.resultType === "complete");
-    check(
+    recordCheck(
+      checks,
+      "server/discover resultType is complete",
+      discover.resultType === "complete",
+    );
+    recordCheck(
+      checks,
       "server/discover exposes tool capability",
       typeof discover.capabilities?.tools === "object" && discover.capabilities.tools !== null,
     );
-    check(
+    recordCheck(
+      checks,
       "server name/version is reported",
       server?.name === "backblaze-b2" && typeof server.version === "string",
       `server=${server?.name ?? "unknown"}@${server?.version ?? "unknown"}`,
     );
-    check(
+    recordCheck(
+      checks,
       "instructions are reported",
-      instructions.includes("Backblaze B2 operational flow.") &&
-        instructions.includes("Never log, print, persist, or echo back application keys"),
+      instructionsIncludeRequiredSnippets(instructions, [
+        serverExports.SERVER_INSTRUCTION_OPENING,
+        serverExports.SERVER_CREDENTIAL_SAFETY_INSTRUCTION,
+      ]),
     );
 
     const listed = await client.listTools(undefined, { cacheMode: "refresh", timeoutMs: 10_000 });
-    const snapshot = snapshotFromTools(listed.tools, helpers);
+    const snapshot = liveToolContractSnapshot(listed.tools, helpers);
     const profileResult = evaluateProfileContract({
       snapshot,
       toolContract,
       expectedProfile: EXPECTED_PROFILE,
     });
     for (const result of profileResult.checks) {
-      check(result.name, result.ok, result.detail);
+      recordCheck(checks, result.name, result.ok, result.detail);
     }
-    check(
+    recordCheck(
+      checks,
       `tools/list names match ${EXPECTED_FIXTURE}`,
       arraysEqual(snapshot.names, expectedFixture.names),
       `${snapshot.names.length} tools`,
     );
-    check(
+    recordCheck(
+      checks,
       `tools/list hash matches ${EXPECTED_FIXTURE}`,
       snapshot.hash === expectedFixture.hash,
       `hash=${snapshot.hash.slice(0, 12)}`,
     );
-    check(
+    recordCheck(
+      checks,
       "tools/list includes representative B2 and S3 tools",
       snapshot.names.includes("b2_list_buckets") && snapshot.names.includes("s3_list_objects_v2"),
     );
-    check("startup avoided B2 capability discovery", !stderr.includes("capability.fetch"));
+    await new Promise((resolve) => setImmediate(resolve));
+    recordCheck(checks, "startup avoided B2 network access", !stderrMonitor.signalSeen);
 
     const failed = checks.filter((result) => !result.ok);
     if (failed.length > 0) {
@@ -203,7 +278,30 @@ async function main() {
   }
 }
 
-main().catch((err) => {
-  console.error("Fatal:", err.message ?? err);
-  process.exit(1);
-});
+async function runBootstrap() {
+  assertBuiltArtifacts();
+  const child = spawn(process.execPath, [scriptPath], {
+    cwd: root,
+    env: createWorkerEnv(),
+    stdio: "inherit",
+  });
+  const [code, signal] = await once(child, "exit");
+  if (signal) {
+    console.error(`client smoke worker terminated by ${signal}`);
+    process.exitCode = 1;
+    return;
+  }
+  process.exitCode = typeof code === "number" ? code : 1;
+}
+
+async function main() {
+  if (process.env[WORKER_ENV_NAME] === "1") await runWorker();
+  else await runBootstrap();
+}
+
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+  main().catch((err) => {
+    console.error("Fatal:", err.message ?? err);
+    process.exit(1);
+  });
+}

--- a/scripts/mcp-inspector-smoke.mjs
+++ b/scripts/mcp-inspector-smoke.mjs
@@ -1,0 +1,117 @@
+#!/usr/bin/env node
+import { spawn } from "node:child_process";
+import { once } from "node:events";
+import { existsSync, mkdtempSync, rmSync } from "node:fs";
+import { createRequire } from "node:module";
+import { dirname, join } from "node:path";
+import { tmpdir } from "node:os";
+import { fileURLToPath, pathToFileURL } from "node:url";
+
+const require = createRequire(import.meta.url);
+const { sanitizedEnv } = require("./lib/sanitized-env.cjs");
+
+const root = dirname(dirname(fileURLToPath(import.meta.url)));
+const scriptPath = fileURLToPath(import.meta.url);
+const NETWORK_GUARD_SCRIPT = "scripts/no-network-guard.mjs";
+
+export const INSPECTOR_PACKAGE = "@modelcontextprotocol/inspector";
+export const INSPECTOR_VERSION = "2.1.0";
+
+export function createInspectorEnv({ sourceEnv = process.env, homeDir } = {}) {
+  if (!homeDir) throw new Error("homeDir is required for isolated Inspector smoke");
+  return sanitizedEnv(
+    {
+      HOME: homeDir,
+      USERPROFILE: homeDir,
+      NO_COLOR: "1",
+      npm_config_cache: join(homeDir, "npm-cache"),
+      npm_config_ignore_scripts: "true",
+      npm_config_userconfig: join(homeDir, ".npmrc"),
+    },
+    {
+      sourceEnv,
+      nonSecretEnvNames: ["npm_config_cache", "npm_config_ignore_scripts", "npm_config_userconfig"],
+    },
+  );
+}
+
+export function defaultInspectorCliArgs(rootDir = root) {
+  return [
+    "--cli",
+    process.execPath,
+    join(rootDir, "dist/index.js"),
+    "--method",
+    "tools/list",
+    "--format",
+    "json",
+    "--connect-timeout",
+    "10000",
+    "--cwd",
+    rootDir,
+    "-e",
+    "B2_REGISTER_ALL_TOOLS=true",
+    "-e",
+    "B2_APPLICATION_KEY_ID=external-smoke-key-id",
+    "-e",
+    "B2_APPLICATION_KEY=external-smoke-key-secret",
+    "-e",
+    "LOG_LEVEL=silent",
+    "-e",
+    `NODE_OPTIONS=--import ${pathToFileURL(join(rootDir, NETWORK_GUARD_SCRIPT)).href}`,
+  ];
+}
+
+export function pnpmInvocation(sourceEnv = process.env) {
+  if (typeof sourceEnv.npm_execpath === "string" && sourceEnv.npm_execpath.includes("pnpm")) {
+    return { command: process.execPath, argsPrefix: [sourceEnv.npm_execpath] };
+  }
+  throw new Error(
+    "Run pnpm run smoke:inspector after pnpm install --frozen-lockfile; refusing to invoke a package-manager shim from a sanitized environment.",
+  );
+}
+
+export function pnpmExecArgs(userArgs = [], rootDir = root) {
+  return [
+    "exec",
+    "mcp-inspector",
+    ...(userArgs.length > 0 ? userArgs : defaultInspectorCliArgs(rootDir)),
+  ];
+}
+
+function assertBuiltArtifact(rootDir) {
+  if (!existsSync(join(rootDir, "dist/index.js"))) {
+    throw new Error(
+      "Missing built artifact: dist/index.js. Run pnpm run build from a non-serving checkout before pnpm run smoke:inspector.",
+    );
+  }
+}
+
+export async function runInspectorSmoke({ userArgs = process.argv.slice(2), rootDir = root } = {}) {
+  if (userArgs.length === 0) assertBuiltArtifact(rootDir);
+
+  const workspace = mkdtempSync(join(tmpdir(), "b2-mcp-inspector-"));
+  try {
+    const pnpm = pnpmInvocation();
+    const child = spawn(pnpm.command, [...pnpm.argsPrefix, ...pnpmExecArgs(userArgs, rootDir)], {
+      cwd: rootDir,
+      env: createInspectorEnv({ homeDir: workspace }),
+      stdio: "inherit",
+    });
+    const [code, signal] = await once(child, "exit");
+    if (signal) throw new Error(`mcp-inspector exited from signal ${signal}`);
+    return typeof code === "number" ? code : 1;
+  } finally {
+    rmSync(workspace, { recursive: true, force: true });
+  }
+}
+
+if (import.meta.url === pathToFileURL(scriptPath).href) {
+  runInspectorSmoke()
+    .then((code) => {
+      process.exitCode = code;
+    })
+    .catch((error) => {
+      console.error(error instanceof Error ? error.message : error);
+      process.exitCode = 1;
+    });
+}

--- a/scripts/no-network-guard.mjs
+++ b/scripts/no-network-guard.mjs
@@ -1,0 +1,24 @@
+import { createRequire } from "node:module";
+
+const require = createRequire(import.meta.url);
+const http = require("node:http");
+const https = require("node:https");
+const net = require("node:net");
+const tls = require("node:tls");
+const SIGNAL = "MCP_CLIENT_SMOKE_NETWORK_BLOCKED";
+
+function block(kind) {
+  return () => {
+    process.stderr.write(`${SIGNAL}:${kind}\n`);
+    throw new Error(`Network access blocked during MCP client smoke: ${kind}`);
+  };
+}
+
+globalThis.fetch = block("fetch");
+http.request = block("http.request");
+http.get = block("http.get");
+https.request = block("https.request");
+https.get = block("https.get");
+net.connect = block("net.connect");
+net.createConnection = block("net.createConnection");
+tls.connect = block("tls.connect");

--- a/src/server.ts
+++ b/src/server.ts
@@ -54,6 +54,9 @@ import { isDestructiveTool } from "./utils/destructive-gate.js";
 
 const COMPATIBILITY_STUB_CONFIRM_DESC =
   "Confirm this destructive/irreversible compatibility stub. Required if this tool is re-enabled with a real handler under the default destructive policy.";
+export const SERVER_INSTRUCTION_OPENING = "Backblaze B2 operational flow.";
+export const SERVER_CREDENTIAL_SAFETY_INSTRUCTION =
+  "Never log, print, persist, or echo back application keys or master keys. Treat all credentials as sensitive.";
 
 /**
  * Load and validate configuration from environment variables.
@@ -138,7 +141,7 @@ export function createServer(config: B2Config, capabilities?: string[] | null): 
     },
     {
       instructions: [
-        "Backblaze B2 operational flow.",
+        SERVER_INSTRUCTION_OPENING,
         "",
         "Before making a B2 call:",
         "",
@@ -156,7 +159,7 @@ export function createServer(config: B2Config, capabilities?: string[] | null): 
         "   - For normal B2 operations, identify the missing capability and suggest a scoped key with that capability.",
         "   - For Partner API / Groups API operations, verify that a master application key is being used and that the account is enabled for the relevant partner/group feature.",
         "",
-        "Never log, print, persist, or echo back application keys or master keys. Treat all credentials as sensitive.",
+        SERVER_CREDENTIAL_SAFETY_INSTRUCTION,
         "",
         "Tool result text format:",
         outputFormatInstructions(outputFormat),

--- a/tests/contract/mcp-sdk.contract.test.ts
+++ b/tests/contract/mcp-sdk.contract.test.ts
@@ -32,7 +32,9 @@ describe("MCP SDK and protocol contract", () => {
     expect(lock.packages["node_modules/@hono/node-server"]?.dev).toBe(true);
     expect(pkg.dependencies).not.toHaveProperty("@modelcontextprotocol/sdk");
     expect(pkg.devDependencies).not.toHaveProperty("@modelcontextprotocol/sdk");
-    expect(lock.packages["node_modules/@modelcontextprotocol/sdk"]).toBeUndefined();
+    // The pinned Inspector CLI carries the v1 SDK as a dev-only transitive; runtime code must not.
+    const legacySdk = lock.packages["node_modules/@modelcontextprotocol/sdk"];
+    expect(legacySdk?.dev).toBe(true);
   });
 
   it("exposes the SDK v2 entry points required by the serving adapters", async () => {

--- a/tests/contract/smoke-script-policy.contract.test.ts
+++ b/tests/contract/smoke-script-policy.contract.test.ts
@@ -3,10 +3,17 @@ import { join } from "path";
 import { createRequire } from "module";
 
 const smokeScript = readFileSync(join(__dirname, "../../scripts/smoke-test.mjs"), "utf8");
+const clientSmokeScript = readFileSync(
+  join(__dirname, "../../scripts/mcp-client-smoke.mjs"),
+  "utf8",
+);
 const smokeContractScript = readFileSync(
   join(__dirname, "../../scripts/lib/smoke-contract.cjs"),
   "utf8",
 );
+const packageJson = readFileSync(join(__dirname, "../../package.json"), "utf8");
+const parsedPackageJson = JSON.parse(packageJson) as { scripts: Record<string, string> };
+const testingDoc = readFileSync(join(__dirname, "../../docs/TESTING.md"), "utf8");
 const nodeRequire = createRequire(__filename);
 const { evaluateProfileContract } = nodeRequire("../../scripts/lib/smoke-contract.cjs") as {
   evaluateProfileContract: (args: {
@@ -72,6 +79,25 @@ describe("smoke script release contract", () => {
     expect(smokeScript).toContain("B2_SMOKE_BUCKET");
     expect(smokeScript).toContain("s3_head_bucket");
     expect(smokeScript).not.toContain("s3_list_buckets");
+  });
+
+  it("keeps the supplemental SDK client smoke advisory and contract-backed", () => {
+    expect(parsedPackageJson.scripts["smoke:client"]).toBe(
+      "pnpm run build && node scripts/mcp-client-smoke.mjs",
+    );
+    expect(parsedPackageJson.scripts.verify).not.toContain("smoke:client");
+    expect(clientSmokeScript).toContain('@modelcontextprotocol/client"');
+    expect(clientSmokeScript).toContain('@modelcontextprotocol/client/stdio"');
+    expect(clientSmokeScript).toContain("StdioClientTransport");
+    expect(clientSmokeScript).toContain("B2_REGISTER_ALL_TOOLS");
+    expect(clientSmokeScript).toContain("tests/fixtures/tool-contract/full.modern.json");
+    expect(clientSmokeScript).toContain("docs/tool-profile-contract.json");
+    expect(clientSmokeScript).toContain("getProtocolEra");
+    expect(clientSmokeScript).toContain("getNegotiatedProtocolVersion");
+    expect(clientSmokeScript).not.toContain("@modelcontextprotocol/sdk");
+    expect(clientSmokeScript).not.toContain("initialize");
+    expect(testingDoc).toContain("@modelcontextprotocol/inspector@2.1.0");
+    expect(testingDoc).toContain("Claude client smoke remains supplemental");
   });
 
   it("fails closed unless a profile is expected or any-profile mode is explicit", () => {

--- a/tests/contract/smoke-script-policy.contract.test.ts
+++ b/tests/contract/smoke-script-policy.contract.test.ts
@@ -2,16 +2,23 @@ import { readFileSync } from "fs";
 import { join } from "path";
 import { createRequire } from "module";
 import { pathToFileURL } from "url";
+import { readLock } from "./support";
 
 const smokeScript = readFileSync(join(__dirname, "../../scripts/smoke-test.mjs"), "utf8");
 const clientSmokePath = join(__dirname, "../../scripts/mcp-client-smoke.mjs");
+const inspectorSmokePath = join(__dirname, "../../scripts/mcp-inspector-smoke.mjs");
 const clientSmokeScript = readFileSync(clientSmokePath, "utf8");
+const inspectorSmokeScript = readFileSync(inspectorSmokePath, "utf8");
 const smokeContractScript = readFileSync(
   join(__dirname, "../../scripts/lib/smoke-contract.cjs"),
   "utf8",
 );
 const packageJson = readFileSync(join(__dirname, "../../package.json"), "utf8");
-const parsedPackageJson = JSON.parse(packageJson) as { scripts: Record<string, string> };
+const parsedPackageJson = JSON.parse(packageJson) as {
+  devDependencies: Record<string, string>;
+  scripts: Record<string, string>;
+};
+const pnpmWorkspace = readFileSync(join(__dirname, "../../pnpm-workspace.yaml"), "utf8");
 const testingDoc = readFileSync(join(__dirname, "../../docs/TESTING.md"), "utf8");
 const readme = readFileSync(join(__dirname, "../../README.md"), "utf8");
 const nodeRequire = createRequire(__filename);
@@ -46,8 +53,24 @@ interface ClientSmokeModule {
   sensitiveEnvNames(env: Record<string, string>): string[];
 }
 
+interface InspectorSmokeModule {
+  INSPECTOR_PACKAGE: string;
+  INSPECTOR_VERSION: string;
+  createInspectorEnv(options: {
+    sourceEnv?: Record<string, string>;
+    homeDir?: string;
+  }): Record<string, string>;
+  defaultInspectorCliArgs(rootDir?: string): string[];
+  pnpmInvocation(sourceEnv?: Record<string, string>): { command: string; argsPrefix: string[] };
+  pnpmExecArgs(userArgs?: string[], rootDir?: string): string[];
+}
+
 async function loadClientSmokeModule(): Promise<ClientSmokeModule> {
   return import(pathToFileURL(clientSmokePath).href) as Promise<ClientSmokeModule>;
+}
+
+async function loadInspectorSmokeModule(): Promise<InspectorSmokeModule> {
+  return import(pathToFileURL(inspectorSmokePath).href) as Promise<InspectorSmokeModule>;
 }
 
 const profileContract = {
@@ -109,6 +132,7 @@ describe("smoke script release contract", () => {
     expect(parsedPackageJson.scripts.verify).not.toContain("smoke:client");
     expect(clientSmokeScript).toContain("liveToolContractSnapshot");
     expect(clientSmokeScript).not.toContain("function snapshotFromTools");
+    expect(clientSmokeScript).not.toContain("function arraysEqual");
     expect(clientSmokeScript).not.toMatch(
       /import\s+[^;]*["']@modelcontextprotocol\/client(?:\/stdio)?["']/,
     );
@@ -152,6 +176,97 @@ describe("smoke script release contract", () => {
     expect(
       clientSmoke.instructionsIncludeRequiredSnippets("alpha beta gamma", ["alpha", "gamma"]),
     ).toBe(true);
+  });
+
+  it("keeps Inspector smoke locked, sanitized, and supplemental", async () => {
+    const inspectorSmoke = await loadInspectorSmokeModule();
+    const lock = readLock<{
+      packages: Record<string, { dev?: boolean; integrity?: string; version?: string }>;
+    }>();
+    const lockedInspector = lock.packages["node_modules/@modelcontextprotocol/inspector"];
+    const sourceEnv = {
+      PATH: "/usr/bin",
+      B2_APPLICATION_KEY: "real-b2-secret",
+      AWS_SECRET_ACCESS_KEY: "real-aws-secret",
+      GITHUB_TOKEN: "real-github-token",
+      NPM_TOKEN: "real-npm-token",
+    };
+
+    expect(parsedPackageJson.devDependencies["@modelcontextprotocol/inspector"]).toBe("2.1.0");
+    expect(parsedPackageJson.scripts["smoke:inspector"]).toBe(
+      "node scripts/mcp-inspector-smoke.mjs",
+    );
+    expect(parsedPackageJson.scripts.verify).not.toContain("smoke:inspector");
+    expect(lockedInspector?.version).toBe("2.1.0");
+    expect(lockedInspector?.dev).toBe(true);
+    expect(lockedInspector?.integrity).toMatch(/^sha512-/);
+    expect(pnpmWorkspace).toContain("'@modelcontextprotocol/inspector': false");
+    expect(pnpmWorkspace).toContain("@modelcontextprotocol/inspector@2.1.0");
+    expect(inspectorSmoke.INSPECTOR_PACKAGE).toBe("@modelcontextprotocol/inspector");
+    expect(inspectorSmoke.INSPECTOR_VERSION).toBe("2.1.0");
+    expect(inspectorSmoke.pnpmExecArgs()).toEqual([
+      "exec",
+      "mcp-inspector",
+      ...inspectorSmoke.defaultInspectorCliArgs(),
+    ]);
+    expect(inspectorSmoke.pnpmExecArgs(["--cli", "--help"])).toEqual([
+      "exec",
+      "mcp-inspector",
+      "--cli",
+      "--help",
+    ]);
+
+    const defaultArgs = inspectorSmoke.defaultInspectorCliArgs("/repo");
+    expect(defaultArgs).toEqual(
+      expect.arrayContaining([
+        "--cli",
+        process.execPath,
+        "/repo/dist/index.js",
+        "--method",
+        "tools/list",
+        "--format",
+        "json",
+        "--connect-timeout",
+        "10000",
+        "--cwd",
+        "/repo",
+        "-e",
+        "B2_REGISTER_ALL_TOOLS=true",
+        "-e",
+        "B2_APPLICATION_KEY_ID=external-smoke-key-id",
+        "-e",
+        "B2_APPLICATION_KEY=external-smoke-key-secret",
+        "-e",
+        "LOG_LEVEL=silent",
+      ]),
+    );
+    expect(defaultArgs.some((arg) => arg.includes("scripts/no-network-guard.mjs"))).toBe(true);
+    expect(inspectorSmoke.pnpmInvocation({ npm_execpath: "/tools/pnpm.cjs" })).toEqual({
+      command: process.execPath,
+      argsPrefix: ["/tools/pnpm.cjs"],
+    });
+    expect(() => inspectorSmoke.pnpmInvocation({})).toThrow(/pnpm run smoke:inspector/);
+
+    const env = inspectorSmoke.createInspectorEnv({
+      sourceEnv,
+      homeDir: "/tmp/b2-mcp-inspector-home",
+    });
+    expect(env).toMatchObject({
+      PATH: "/usr/bin",
+      HOME: "/tmp/b2-mcp-inspector-home",
+      USERPROFILE: "/tmp/b2-mcp-inspector-home",
+      NO_COLOR: "1",
+      npm_config_ignore_scripts: "true",
+    });
+    expect(env).not.toHaveProperty("B2_APPLICATION_KEY");
+    expect(env).not.toHaveProperty("AWS_SECRET_ACCESS_KEY");
+    expect(env).not.toHaveProperty("GITHUB_TOKEN");
+    expect(env).not.toHaveProperty("NPM_TOKEN");
+    expect(`${readme}\n${testingDoc}\n${packageJson}`).not.toContain(
+      ["pnpm", "dlx", "@modelcontextprotocol/inspector"].join(" "),
+    );
+    expect(inspectorSmokeScript).toContain("pnpmExecArgs");
+    expect(inspectorSmokeScript).not.toContain("pnpm dlx");
   });
 
   it("fails closed unless a profile is expected or any-profile mode is explicit", () => {

--- a/tests/contract/smoke-script-policy.contract.test.ts
+++ b/tests/contract/smoke-script-policy.contract.test.ts
@@ -1,12 +1,11 @@
 import { readFileSync } from "fs";
 import { join } from "path";
 import { createRequire } from "module";
+import { pathToFileURL } from "url";
 
 const smokeScript = readFileSync(join(__dirname, "../../scripts/smoke-test.mjs"), "utf8");
-const clientSmokeScript = readFileSync(
-  join(__dirname, "../../scripts/mcp-client-smoke.mjs"),
-  "utf8",
-);
+const clientSmokePath = join(__dirname, "../../scripts/mcp-client-smoke.mjs");
+const clientSmokeScript = readFileSync(clientSmokePath, "utf8");
 const smokeContractScript = readFileSync(
   join(__dirname, "../../scripts/lib/smoke-contract.cjs"),
   "utf8",
@@ -14,6 +13,7 @@ const smokeContractScript = readFileSync(
 const packageJson = readFileSync(join(__dirname, "../../package.json"), "utf8");
 const parsedPackageJson = JSON.parse(packageJson) as { scripts: Record<string, string> };
 const testingDoc = readFileSync(join(__dirname, "../../docs/TESTING.md"), "utf8");
+const readme = readFileSync(join(__dirname, "../../README.md"), "utf8");
 const nodeRequire = createRequire(__filename);
 const { evaluateProfileContract } = nodeRequire("../../scripts/lib/smoke-contract.cjs") as {
   evaluateProfileContract: (args: {
@@ -28,6 +28,27 @@ const { evaluateProfileContract } = nodeRequire("../../scripts/lib/smoke-contrac
     checks: Array<{ name: string; ok: boolean; detail: string }>;
   };
 };
+
+interface ClientSmokeModule {
+  assertSmokeServerPreconditions(env: Record<string, string>): void;
+  assertWorkerEnvIsSanitized(env: Record<string, string>): void;
+  createBoundedStderrMonitor(options?: { signal?: string; maxTailBytes?: number }): {
+    observe(chunk: string): void;
+    readonly signalSeen: boolean;
+    readonly tail: string;
+  };
+  createServerEnv(
+    sourceEnv?: Record<string, string>,
+    options?: { registerAllTools?: boolean },
+  ): Record<string, string>;
+  createWorkerEnv(sourceEnv?: Record<string, string>): Record<string, string>;
+  instructionsIncludeRequiredSnippets(instructions: string, snippets: string[]): boolean;
+  sensitiveEnvNames(env: Record<string, string>): string[];
+}
+
+async function loadClientSmokeModule(): Promise<ClientSmokeModule> {
+  return import(pathToFileURL(clientSmokePath).href) as Promise<ClientSmokeModule>;
+}
 
 const profileContract = {
   profiles: {
@@ -81,23 +102,56 @@ describe("smoke script release contract", () => {
     expect(smokeScript).not.toContain("s3_list_buckets");
   });
 
-  it("keeps the supplemental SDK client smoke advisory and contract-backed", () => {
-    expect(parsedPackageJson.scripts["smoke:client"]).toBe(
-      "pnpm run build && node scripts/mcp-client-smoke.mjs",
-    );
+  it("keeps the supplemental SDK client smoke advisory and contract-backed", async () => {
+    const clientSmoke = await loadClientSmokeModule();
+    expect(parsedPackageJson.scripts["smoke:client"]).toBe("node scripts/mcp-client-smoke.mjs");
+    expect(parsedPackageJson.scripts["smoke:client"]).not.toContain("build");
     expect(parsedPackageJson.scripts.verify).not.toContain("smoke:client");
-    expect(clientSmokeScript).toContain('@modelcontextprotocol/client"');
-    expect(clientSmokeScript).toContain('@modelcontextprotocol/client/stdio"');
-    expect(clientSmokeScript).toContain("StdioClientTransport");
-    expect(clientSmokeScript).toContain("B2_REGISTER_ALL_TOOLS");
-    expect(clientSmokeScript).toContain("tests/fixtures/tool-contract/full.modern.json");
-    expect(clientSmokeScript).toContain("docs/tool-profile-contract.json");
-    expect(clientSmokeScript).toContain("getProtocolEra");
-    expect(clientSmokeScript).toContain("getNegotiatedProtocolVersion");
+    expect(clientSmokeScript).toContain("liveToolContractSnapshot");
+    expect(clientSmokeScript).not.toContain("function snapshotFromTools");
+    expect(clientSmokeScript).not.toMatch(
+      /import\s+[^;]*["']@modelcontextprotocol\/client(?:\/stdio)?["']/,
+    );
+    expect(clientSmokeScript).not.toMatch(/stderr\s*\+=|let\s+stderr\s*=\s*["']/);
     expect(clientSmokeScript).not.toContain("@modelcontextprotocol/sdk");
     expect(clientSmokeScript).not.toContain("initialize");
     expect(testingDoc).toContain("@modelcontextprotocol/inspector@2.1.0");
-    expect(testingDoc).toContain("Claude client smoke remains supplemental");
+    expect(`${readme}\n${testingDoc}\n${packageJson}`).not.toMatch(/\bpnpm\s+dlx\b/);
+    expect(testingDoc).toMatch(/Claude[\s\S]{0,120}supplemental/);
+
+    const sourceEnv = {
+      PATH: "/usr/bin",
+      B2_APPLICATION_KEY: "real-b2-secret",
+      AWS_SECRET_ACCESS_KEY: "real-aws-secret",
+      GITHUB_TOKEN: "real-github-token",
+      NPM_TOKEN: "real-npm-token",
+      CUSTOM_TOKEN: "real-custom-token",
+    };
+    const workerEnv = clientSmoke.createWorkerEnv(sourceEnv);
+    expect(workerEnv).toMatchObject({ PATH: "/usr/bin", MCP_CLIENT_SMOKE_WORKER: "1" });
+    expect(clientSmoke.sensitiveEnvNames(workerEnv)).toEqual([]);
+    expect(() => clientSmoke.assertWorkerEnvIsSanitized(sourceEnv)).toThrow(/sensitive/);
+
+    const serverEnv = clientSmoke.createServerEnv(sourceEnv);
+    expect(serverEnv.B2_REGISTER_ALL_TOOLS).toBe("true");
+    expect(serverEnv.B2_APPLICATION_KEY_ID).toBe("external-smoke-key-id");
+    expect(serverEnv.B2_APPLICATION_KEY).toBe("external-smoke-key-secret");
+    expect(serverEnv.NODE_OPTIONS).toContain("scripts/no-network-guard.mjs");
+    expect(serverEnv).not.toHaveProperty("AWS_SECRET_ACCESS_KEY");
+    expect(() =>
+      clientSmoke.assertSmokeServerPreconditions(
+        clientSmoke.createServerEnv({}, { registerAllTools: false }),
+      ),
+    ).toThrow(/B2_REGISTER_ALL_TOOLS/);
+
+    const monitor = clientSmoke.createBoundedStderrMonitor({ maxTailBytes: 8 });
+    monitor.observe("prefix");
+    monitor.observe(`MCP_CLIENT_SMOKE_NETWORK_BLOCKED:${"x".repeat(64)}`);
+    expect(monitor.signalSeen).toBe(true);
+    expect(monitor.tail.length).toBeLessThanOrEqual(8);
+    expect(
+      clientSmoke.instructionsIncludeRequiredSnippets("alpha beta gamma", ["alpha", "gamma"]),
+    ).toBe(true);
   });
 
   it("fails closed unless a profile is expected or any-profile mode is explicit", () => {

--- a/tests/unit/package-budget-policy.unit.test.ts
+++ b/tests/unit/package-budget-policy.unit.test.ts
@@ -211,6 +211,53 @@ describe("package budget policy gate", () => {
     }
   });
 
+  it("ignores dev-only pnpm duplicates when checking runtime provenance", () => {
+    const fixtureRoot = writeFixture('import "@backblaze-labs/b2-sdk";', {
+      pnpmLockText: [
+        "lockfileVersion: '9.0'",
+        "",
+        "settings:",
+        "  autoInstallPeers: true",
+        "  excludeLinksFromLockfile: false",
+        "",
+        "importers:",
+        "",
+        "  .:",
+        "    dependencies:",
+        "      '@backblaze-labs/b2-sdk':",
+        "        specifier: 0.2.0",
+        "        version: 0.2.0",
+        "    devDependencies:",
+        "      '@backblaze-labs/b2-sdk':",
+        "        specifier: 0.1.0",
+        "        version: 0.1.0",
+        "",
+        "packages:",
+        "",
+        "  '@backblaze-labs/b2-sdk@0.1.0':",
+        "    resolution: {integrity: sha512-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa}",
+        "",
+        "  '@backblaze-labs/b2-sdk@0.2.0':",
+        `    resolution: {integrity: ${sdkProvenance.integrity}}`,
+        "",
+        "snapshots:",
+        "",
+        "  '@backblaze-labs/b2-sdk@0.1.0': {}",
+        "",
+        "  '@backblaze-labs/b2-sdk@0.2.0': {}",
+        "",
+      ].join("\n"),
+    });
+    try {
+      const result = runPolicyFixture(fixtureRoot);
+
+      expect(result.status).toBe(0);
+      expect(result.stdout).toContain("Status: policy checks passed.");
+    } finally {
+      rmSync(fixtureRoot, { recursive: true, force: true });
+    }
+  });
+
   it("rejects transitive production lockfile entries outside the npm registry", () => {
     const fixtureRoot = writeFixture('import "@backblaze-labs/b2-sdk";', {
       lockPackages: {


### PR DESCRIPTION
## Summary
- Add an advisory `pnpm run smoke:client` command that uses the official MCP SDK v2 client over stdio with fake credentials and `B2_REGISTER_ALL_TOOLS=true`.
- Harden the smoke bootstrap so SDK imports run only after environment sanitization, the stdio server child has a no-network guard, stderr capture is bounded, and `tools/list` uses shared repo-owned snapshot/contract helpers.
- Add a locked `pnpm run smoke:inspector` wrapper for `@modelcontextprotocol/inspector@2.1.0` that runs through `pnpm exec` with an isolated sanitized environment, fake B2 credentials, and no one-off package fetch.
- Update package-budget policy handling so dev-only duplicate lockfile entries from supplemental tooling are not treated as runtime dependencies.
- Document advisory status, deploy-safe use from non-serving artifacts, bounded modern HTTP SDK invocation, and Claude vendor-smoke follow-up.

## Linked Issue
Closes #51

## Tests Run
- `pnpm install --frozen-lockfile`
- `pnpm run build`
- `pnpm run smoke:client`
- `pnpm run smoke:inspector`
- `pnpm run format:check`
- `pnpm run lint`
- `pnpm run typecheck`
- `pnpm run lint:docs`
- `pnpm run spell`
- `pnpm run test:unit -- package-budget-policy.unit.test.ts`
- `pnpm run test:contract`
- `pnpm run test:protocol:modern`
- `pnpm run check:runtime-policy`
- `pnpm run check:package-budget`
- `pnpm run audit:supply-chain`
- Manual HTTP SDK example from `docs/TESTING.md` (negotiated `modern` / `2026-07-28`, 40 tools)

## Follow-up Notes
- The external client and Inspector smokes are advisory and intentionally not part of `verify`; repo-native protocol tests remain the required gate.
- Claude Desktop/Claude.ai vendor smoke remains supplemental and should be recorded after the selected Claude surface exposes the `2026-07-28` protocol.
