### PR TITLE
fix: scope live B2 secrets to protected environments

### DIFF
--- a/.github/workflows/contract.yml
+++ b/.github/workflows/contract.yml
@@ -2,15 +2,13 @@ name: Live B2 Contract
 
 # Live B2 contract and integration evidence. Mocked tests previously missed
 # request-shape regressions in notification rules and Object Lock payloads, so
-# these reviewed main/schedule/release jobs exercise real B2 requests. They do
+# these reviewed manual/schedule/release jobs exercise real B2 requests. They do
 # not run on pull_request because protected credentials must never share a job
 # with unreviewed PR-head package code, and they create/delete only
 # `mcp-contract-*` resources in the dedicated protected live test account.
 
 on:
   workflow_dispatch:
-  push:
-    branches: [main]
   schedule:
     - cron: "17 9 * * *"
   workflow_call:
@@ -57,7 +55,7 @@ jobs:
                 exit 1
               fi
               ;;
-            push|schedule)
+            schedule)
               if [[ "$GITHUB_REF" != "refs/heads/main" ]]; then
                 echo "::error::${EVENT_NAME} live contract runs must target main; got ${GITHUB_REF}"
                 exit 1
@@ -144,7 +142,25 @@ jobs:
               missing=1
             fi
           done
-          exit "$missing"
+          if [[ "$missing" != 0 ]]; then exit "$missing"; fi
+          node --input-type=module <<'NODE'
+          import { B2AuthManager } from "./dist/auth.js";
+          import { loadConfig } from "./dist/server.js";
+
+          const requiredCapabilities = ["bypassGovernance", "deleteKeys", "listKeys", "writeKeys"];
+          const auth = await new B2AuthManager(loadConfig()).getAuth();
+          if (auth.accountId !== process.env.B2_LIVE_TEST_ACCOUNT_ID) {
+            throw new Error("authorized account does not match B2_LIVE_TEST_ACCOUNT_ID");
+          }
+          const missingCapabilities = requiredCapabilities.filter(
+            (capability) => !auth.capabilities.includes(capability),
+          );
+          if (missingCapabilities.length > 0) {
+            throw new Error(
+              `live B2 contract key is missing required capability: ${missingCapabilities.join(", ")}`,
+            );
+          }
+          NODE
       - name: Run live B2 contract and integration suites
         timeout-minutes: 12
         env:
@@ -167,35 +183,4 @@ jobs:
             echo "::notice::dist/server.js is missing; no live resources should have been created before build."
             exit 0
           fi
-          node scripts/live-b2-janitor.mjs --prefix "${B2_MCP_LIVE_RUN_PREFIX}" --best-effort
-
-  abandoned-resource-janitor:
-    name: abandoned live B2 janitor
-    needs: [guard, contract]
-    if: always() && needs.guard.outputs.should-run == 'true' && github.event_name == 'schedule'
-    runs-on: ubuntu-latest
-    environment: live-b2-contract
-    timeout-minutes: 10
-    steps:
-      # actions/checkout v6, reviewed 2026-08-06.
-      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803
-        with:
-          ref: ${{ needs.guard.outputs.checkout-sha }}
-          persist-credentials: false
-      # pnpm/action-setup v6.0.10, reviewed 2026-08-06.
-      - uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86
-        with:
-          run_install: false
-      # actions/setup-node v7, reviewed 2026-08-06.
-      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020
-        with:
-          node-version: 22.23.1
-          cache: pnpm
-      - run: pnpm install --frozen-lockfile
-      - run: pnpm run build
-      - name: Sweep abandoned test-prefixed B2 resources
-        env:
-          B2_APPLICATION_KEY_ID: ${{ secrets.LIVE_B2_KEY_ID }}
-          B2_APPLICATION_KEY: ${{ secrets.LIVE_B2_KEY }}
-          B2_LIVE_TEST_ACCOUNT_ID: ${{ vars.B2_LIVE_TEST_ACCOUNT_ID }}
-        run: node scripts/live-b2-janitor.mjs --prefix mcp-contract-
+          node scripts/live-b2-janitor.mjs --prefix "${B2_MCP_LIVE_RUN_PREFIX}"

--- a/.github/workflows/contract.yml
+++ b/.github/workflows/contract.yml
@@ -19,11 +19,6 @@ on:
         description: Exact release candidate commit SHA resolved by the caller.
         required: true
         type: string
-    secrets:
-      LIVE_B2_KEY_ID:
-        required: true
-      LIVE_B2_KEY:
-        required: true
 
 permissions:
   contents: read
@@ -103,6 +98,8 @@ jobs:
     needs: guard
     if: needs.guard.outputs.should-run == 'true'
     runs-on: ubuntu-latest
+    # Environment secrets are resolved here for every entry point, including
+    # workflow_call. Reusable-workflow callers cannot bind an environment.
     environment: live-b2-contract
     timeout-minutes: 18
     strategy:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -120,9 +120,6 @@ jobs:
     uses: ./.github/workflows/contract.yml
     with:
       checkout-sha: ${{ needs.prepare.outputs.checkout-sha }}
-    secrets:
-      LIVE_B2_KEY_ID: ${{ secrets.LIVE_B2_KEY_ID }}
-      LIVE_B2_KEY: ${{ secrets.LIVE_B2_KEY }}
 
   publish:
     needs: [prepare, live-contract]

--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -14,7 +14,7 @@ permissions:
 
 concurrency:
   group: live-b2-smoke-${{ github.repository }}-${{ github.event.deployment.environment || github.ref_name || github.run_id }}
-  cancel-in-progress: true
+  cancel-in-progress: false
 
 jobs:
   guard:
@@ -31,6 +31,8 @@ jobs:
           DEPLOYMENT_ENVIRONMENT: ${{ github.event.deployment.environment || '' }}
           DEPLOYMENT_STATE: ${{ github.event.deployment_status.state || '' }}
           DEPLOYMENT_SHA: ${{ github.event.deployment.sha || '' }}
+          # Repository or organization variable; this guard intentionally does
+          # not bind the live-b2-smoke environment before it decides to run.
           EXPECTED_DEPLOYMENT_ENVIRONMENT: ${{ vars.B2_MCP_SMOKE_DEPLOYMENT_ENVIRONMENT || 'production' }}
         run: |
           set -euo pipefail

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -51,12 +51,14 @@ Before publishing `v0.1.0`:
    issue or PR and approved by the release owner and security owner.
 7. Confirm `@backblaze-labs/b2-mcp` is owned by Backblaze on npm and package
    provenance is enabled before publishing or advertising npm install commands.
-8. Confirm the live B2 workflow environments have `LIVE_B2_KEY_ID`,
-   `LIVE_B2_KEY`, the smoke-suite `LIVE_B2_*` secrets, `MCP_URL`, and
-   `B2_SMOKE_BUCKET` populated from the dedicated test account, then manually
-   dispatch smoke and contract from `main`. Security owns rotation for the live
-   B2 credentials. The live jobs run serially on Node.js 22.23.1, Node.js 24, and
-   Node.js 26.
+8. Confirm `live-b2-contract` has environment secrets `LIVE_B2_KEY_ID` and
+   `LIVE_B2_KEY` plus environment variable `B2_LIVE_TEST_ACCOUNT_ID`. Confirm
+   `live-b2-smoke` has its four `LIVE_B2_*` environment secrets plus `MCP_URL`,
+   `B2_SMOKE_BUCKET`, and `B2_MCP_EXPECTED_TOOL_PROFILE`. Do not duplicate live
+   B2 credentials at repository scope or in `npm-publish`; the called contract
+   workflow resolves them from `live-b2-contract`. Manually dispatch smoke and
+   contract from `main`. Security owns credential rotation. The live jobs run
+   serially on Node.js 22.23.1, Node.js 24, and Node.js 26.
 9. Confirm any claimed MCP SDK package split is either implemented or tracked as
    a release-blocking follow-up once the upstream package exists.
 10. Create the GitHub Release for the publish tag, then publish only from the

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -53,8 +53,9 @@ Before publishing `v0.1.0`:
    provenance is enabled before publishing or advertising npm install commands.
 8. Confirm `live-b2-contract` has environment secrets `LIVE_B2_KEY_ID` and
    `LIVE_B2_KEY` plus environment variable `B2_LIVE_TEST_ACCOUNT_ID`. Confirm
-   `live-b2-smoke` has its four `LIVE_B2_*` environment secrets plus `MCP_URL`,
-   `B2_SMOKE_BUCKET`, and `B2_MCP_EXPECTED_TOOL_PROFILE`. Do not duplicate live
+   `live-b2-smoke` has its four `LIVE_B2_*` environment secrets plus
+   environment variables `MCP_URL`, `B2_SMOKE_BUCKET`, and
+   `B2_MCP_EXPECTED_TOOL_PROFILE`. Do not duplicate live
    B2 credentials at repository scope or in `npm-publish`; the called contract
    workflow resolves them from `live-b2-contract`. Manually dispatch smoke and
    contract from `main`. Security owns credential rotation. The live jobs run

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -55,11 +55,16 @@ Before publishing `v0.1.0`:
    `LIVE_B2_KEY` plus environment variable `B2_LIVE_TEST_ACCOUNT_ID`. Confirm
    `live-b2-smoke` has its four `LIVE_B2_*` environment secrets plus
    environment variables `MCP_URL`, `B2_SMOKE_BUCKET`, and
-   `B2_MCP_EXPECTED_TOOL_PROFILE`. Do not duplicate live
-   B2 credentials at repository scope or in `npm-publish`; the called contract
-   workflow resolves them from `live-b2-contract`. Manually dispatch smoke and
-   contract from `main`. Security owns credential rotation. The live jobs run
-   serially on Node.js 22.23.1, Node.js 24, and Node.js 26.
+   `B2_MCP_EXPECTED_TOOL_PROFILE`. If deployment smoke should accept an
+   environment other than `production`, set repository or organization variable
+   `B2_MCP_SMOKE_DEPLOYMENT_ENVIRONMENT`; do not put it only in
+   `live-b2-smoke`. Confirm the contract key authorizes the configured
+   `B2_LIVE_TEST_ACCOUNT_ID` and has `bypassGovernance`, `deleteKeys`,
+   `listKeys`, and `writeKeys`. Do not duplicate live B2 credentials at
+   repository scope or in `npm-publish`; the called contract workflow resolves
+   them from `live-b2-contract`. Manually dispatch smoke and contract from
+   `main`. Security owns credential rotation. The live jobs run serially on
+   Node.js 22.23.1, Node.js 24, and Node.js 26.
 9. Confirm any claimed MCP SDK package split is either implemented or tracked as
    a release-blocking follow-up once the upstream package exists.
 10. Create the GitHub Release for the publish tag, then publish only from the

--- a/docs/DEPLOY.md
+++ b/docs/DEPLOY.md
@@ -592,6 +592,12 @@ The daily schedule also sweeps abandoned `mcp-contract-*` resources, with the
 sweep sharing the live-resource concurrency lock used by contract runs so it
 cannot overlap an active release gate.
 
+Configure the live contract credentials only on the `live-b2-contract`
+environment. GitHub does not let a reusable-workflow caller bind an environment,
+so `publish.yml` passes only `checkout-sha`; the jobs inside `contract.yml` bind
+the environment and resolve its secrets and variables for every trigger. Do not
+duplicate these B2 credentials as repository-level or `npm-publish` secrets.
+
 Set `vars.B2_LIVE_TEST_ACCOUNT_ID` to the dedicated test account ID in the
 `live-b2-contract` environment. The janitor compares it with the account ID
 returned by authorization and refuses cleanup before issuing any delete when the

--- a/docs/DEPLOY.md
+++ b/docs/DEPLOY.md
@@ -551,17 +551,20 @@ deployments for unmerged PR code are ignored before secrets are exposed. It
 does not run on `pull_request`, because live smoke credentials must not share a
 job with unreviewed PR-head code.
 
-It depends on these protected `live-b2-smoke` environment secrets and variable:
+It depends on these protected `live-b2-smoke` environment secrets and variables:
 
 - `vars.MCP_URL` — full `/mcp` endpoint (e.g. `https://mcp.example.com/mcp`)
 - `vars.B2_SMOKE_BUCKET` — dedicated test-owned bucket for the `s3_head_bucket`
   probe
 - `vars.B2_MCP_EXPECTED_TOOL_PROFILE` — expected frozen profile for the live
   credential set (`phase1-default`, `read-only`, or `full`)
-- `vars.B2_MCP_SMOKE_DEPLOYMENT_ENVIRONMENT` — approved deployment environment
-  for deployment-triggered smoke, defaulting to `production`
 - `secrets.LIVE_B2_KEY_ID`, `secrets.LIVE_B2_KEY`
 - `secrets.LIVE_B2_APP_KEY_ID`, `secrets.LIVE_B2_APP_KEY`
+
+The deployment-status guard also reads repository or organization variable
+`B2_MCP_SMOKE_DEPLOYMENT_ENVIRONMENT` before binding the `live-b2-smoke`
+environment, defaulting to `production`. Do not configure this one only as an
+environment variable.
 
 The workflow is gated to the canonical repo, fails loudly when dispatched from a
 non-main ref, and runs only reviewed `main` code with live secrets. It is
@@ -570,27 +573,28 @@ environment with branch restrictions before storing live B2 secrets there. Add
 required reviewers when the repository plan supports environment reviewers.
 
 The protected live contract workflow runs through
-`.github/workflows/contract.yml` on manual dispatch from `main`, pushes to
-`main`, a daily schedule, and `workflow_call` from the publish workflow. The
+`.github/workflows/contract.yml` on manual dispatch from `main`, a daily
+schedule, and `workflow_call` from the publish workflow. The
 reusable release path validates that the checkout SHA is reachable from the
 protected `ci-green` ref before exposing live credentials. It uses the
 `live-b2-contract` environment with `LIVE_B2_KEY_ID` / `LIVE_B2_KEY` and
 `vars.B2_LIVE_TEST_ACCOUNT_ID`, sets
 `B2_INTEGRATION_REQUIRE_CREDENTIALS=1`, and fails a trusted run when credentials
-are missing instead of accepting skipped live tests. It does not run on
-`pull_request`, because redaction and `add-mask` are only best-effort log
-hygiene and cannot contain secrets from code running in the same job. Each
-matrix entry uses a unique `B2_MCP_LIVE_RUN_PREFIX` rooted at `mcp-contract-`,
-creates only test-owned
+are missing instead of accepting skipped live tests. The validation step also
+authorizes the key before package tests run, fails if the authorized account
+does not match `B2_LIVE_TEST_ACCOUNT_ID`, and requires the `bypassGovernance`,
+`deleteKeys`, `listKeys`, and `writeKeys` capabilities needed to clean up every
+live fixture it creates. Live Object Lock cases use only governance-mode
+retention with short retain-until windows, not compliance mode. It does not run
+on `pull_request` or every push to `main`, because redaction and `add-mask` are
+only best-effort log hygiene and cannot contain secrets from code running in the
+same job. Each matrix entry uses a unique `B2_MCP_LIVE_RUN_PREFIX` rooted at
+`mcp-contract-`, creates only test-owned
 buckets, objects, multipart uploads, keys, and notification rules, runs
 serially on Node.js 22.23.1, 24, and 26, and invokes
 `scripts/live-b2-janitor.mjs` after the run. The janitor verifies the authorized
-account matches `B2_LIVE_TEST_ACCOUNT_ID` before any delete; the per-run cleanup
-logs best-effort failures without flipping an otherwise-passing test job, while
-the scheduled abandoned-resource sweep still exits non-zero on residual errors.
-The daily schedule also sweeps abandoned `mcp-contract-*` resources, with the
-sweep sharing the live-resource concurrency lock used by contract runs so it
-cannot overlap an active release gate.
+account matches `B2_LIVE_TEST_ACCOUNT_ID` before any delete; per-run cleanup
+failures or leaked buckets fail the workflow run that caused them.
 
 Configure the live contract credentials only on the `live-b2-contract`
 environment. GitHub does not let a reusable-workflow caller bind an environment,

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -397,32 +397,35 @@ Required properties:
 - dedicated account-level application key with the bucket, file, Object Lock,
   notification, lifecycle, and key-management capabilities needed by the suite;
   it must not be bucket- or prefix-restricted, and the dedicated account is the
-  isolation boundary because `writeKeys` grants full account access;
+  isolation boundary because `writeKeys` grants full account access. The
+  workflow validation step and fixture helpers both enforce the
+  `B2_LIVE_TEST_ACCOUNT_ID` allowlist before live fixture mutation or cleanup;
 - unique `B2_MCP_LIVE_RUN_PREFIX` for every run, rooted at `mcp-contract-`;
 - test-owned buckets, objects, multipart uploads, notification rules, and keys
   only; live tests must never choose an arbitrary listed bucket as writable;
-- best-effort `afterAll` cleanup plus workflow janitor cleanup through
-  `scripts/live-b2-janitor.mjs`;
+- Object Lock live fixtures use only governance-mode retention with short
+  retain-until windows, never compliance mode, so cleanup can clear retention
+  with the required `bypassGovernance` capability;
+- best-effort test `afterAll` cleanup plus strict workflow cleanup through
+  `scripts/live-b2-janitor.mjs`; leaked buckets or cleanup errors fail the run
+  that caused them;
 - best-effort log hygiene redacting B2 credentials, account IDs, presigned URLs,
   live run prefixes, and smoke bucket names. This is not a containment boundary;
   live secrets must never share a job with unreviewed pull-request code.
 
 The live path runs through `.github/workflows/contract.yml` and
 `.github/workflows/smoke.yml`. Both run on manual dispatch from `main` and
-trusted scheduled paths; contract also runs on pushes to `main`, while smoke
-runs on successful deployment status events using the deployed SHA after
-checking that the deployment environment is approved and the SHA is reachable
-from protected `main` or `ci-green`. Neither workflow runs on `pull_request`,
+trusted scheduled paths; smoke also runs on successful deployment status events
+using the deployed SHA after checking that the deployment environment is approved
+from a repository or organization variable and the SHA is reachable from
+protected `main` or `ci-green`. Neither workflow runs on `pull_request`,
 because live credentials must not be exposed to PR-head code. Trusted runs set
 `B2_INTEGRATION_REQUIRE_CREDENTIALS=1` or the smoke equivalent and fail loudly
 when credentials or required variables are absent; a skipped-only trusted run is
-not accepted as release evidence. The contract janitor also requires
-`B2_LIVE_TEST_ACCOUNT_ID` and refuses deletion when the authorized account ID
-does not match that dedicated test-account allowlist. The protected live matrix
-is serialized on Node.js 22.23.1, Node.js 24, and Node.js 26. Contract runs and
-the scheduled abandoned-resource janitor also share a live-resource concurrency
-lock, so a global `mcp-contract-*` sweep cannot delete fixtures from an active
-release gate.
+not accepted as release evidence. The contract validation step and janitor both
+require `B2_LIVE_TEST_ACCOUNT_ID` and refuse to proceed when the authorized
+account ID does not match that dedicated test-account allowlist. The protected
+live matrix is serialized on Node.js 22.23.1, Node.js 24, and Node.js 26.
 
 Release publication uses `.github/workflows/publish.yml`, which resolves the
 publish tag against `ci-green` and then calls the protected live contract

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -394,8 +394,10 @@ normal PRs and untrusted forks.
 Required properties:
 
 - dedicated live B2 test account, not a customer account;
-- least-privilege non-master application key with bucket, file, Object Lock,
-  notification, lifecycle, and S3-compatible capabilities needed by the suite;
+- dedicated account-level application key with the bucket, file, Object Lock,
+  notification, lifecycle, and key-management capabilities needed by the suite;
+  it must not be bucket- or prefix-restricted, and the dedicated account is the
+  isolation boundary because `writeKeys` grants full account access;
 - unique `B2_MCP_LIVE_RUN_PREFIX` for every run, rooted at `mcp-contract-`;
 - test-owned buckets, objects, multipart uploads, notification rules, and keys
   only; live tests must never choose an arbitrary listed bucket as writable;
@@ -424,5 +426,9 @@ release gate.
 
 Release publication uses `.github/workflows/publish.yml`, which resolves the
 publish tag against `ci-green` and then calls the protected live contract
-workflow through `workflow_call` before npm publish. `release.published` is not
-a pre-release gate and is not used for live contract evidence.
+workflow through `workflow_call` before npm publish. The caller passes only the
+reviewed checkout SHA. The called workflow's jobs bind `live-b2-contract` and
+resolve `LIVE_B2_KEY_ID`, `LIVE_B2_KEY`, and `B2_LIVE_TEST_ACCOUNT_ID` there;
+those values must not be duplicated or forwarded from repository or
+`npm-publish` secrets. `release.published` is not a pre-release gate and is not
+used for live contract evidence.

--- a/tests/contract/ci-workflow-policy.contract.test.ts
+++ b/tests/contract/ci-workflow-policy.contract.test.ts
@@ -306,8 +306,8 @@ describe("CI workflow policy", () => {
     expect(liveContract).toContain("needs: prepare");
     expect(liveContract).toContain("uses: ./.github/workflows/contract.yml");
     expect(liveContract).toContain("checkout-sha: ${{ needs.prepare.outputs.checkout-sha }}");
-    expect(liveContract).toContain("LIVE_B2_KEY_ID: ${{ secrets.LIVE_B2_KEY_ID }}");
-    expect(liveContract).toContain("LIVE_B2_KEY: ${{ secrets.LIVE_B2_KEY }}");
+    expect(liveContract).not.toContain("secrets:");
+    expect(liveContract).not.toContain("${{ secrets.");
     expect(liveContract).not.toContain("for attempt in 1 2 3");
     expect(liveContract).not.toContain("retrying");
     expect(publish).toContain("attach-sbom:");

--- a/tests/contract/live-workflows-policy.contract.test.ts
+++ b/tests/contract/live-workflows-policy.contract.test.ts
@@ -4,9 +4,10 @@ import { createRequire } from "module";
 import { root } from "./support";
 
 const nodeRequire = createRequire(__filename);
-const { workflowJobBlock, yamlValuesForKey } = nodeRequire(
+const { workflowJobBlock, yamlBlockForKey, yamlValuesForKey } = nodeRequire(
   "../../scripts/lib/workflow-yaml.cjs",
 ) as {
+  yamlBlockForKey: (text: string, key: string) => string | null;
   workflowJobBlock: (text: string, jobName: string) => string | null;
   yamlValuesForKey: (text: string, key: string) => Array<string | string[]>;
 };
@@ -29,7 +30,7 @@ const liveWorkflows = [
     environment: "live-b2-smoke",
     concurrency:
       "live-b2-smoke-${{ github.repository }}-${{ github.event.deployment.environment || github.ref_name || github.run_id }}",
-    cancelsInProgress: true,
+    cancelsInProgress: false,
     b2Secrets: ["LIVE_B2_KEY_ID", "LIVE_B2_KEY", "LIVE_B2_APP_KEY_ID", "LIVE_B2_APP_KEY"],
   },
 ];
@@ -79,7 +80,8 @@ describe("live secret workflow policy", () => {
       expect(text).toMatch(/if: github\.repository == 'backblaze-labs\/b2-mcp'/);
       expect(text).toMatch(/^\s{2}schedule:\s*$/m);
       if (path.endsWith("contract.yml")) {
-        expect(text).toMatch(/^\s{2}push:\s*$/m);
+        expect(text).not.toMatch(/^\s{2}push:\s*$/m);
+        expect(text).toMatch(/^\s{2}workflow_call:\s*$/m);
         expect(text).toContain('[[ "$GITHUB_REF" != "refs/heads/main" ]]');
       } else {
         expect(text).toMatch(/^\s{2}deployment_status:\s*$/m);
@@ -87,6 +89,9 @@ describe("live secret workflow policy", () => {
         expect(text).toContain("DEPLOYMENT_ENVIRONMENT: ${{ github.event.deployment.environment");
         expect(text).toContain("DEPLOYMENT_STATE: ${{ github.event.deployment_status.state");
         expect(text).toContain("DEPLOYMENT_SHA: ${{ github.event.deployment.sha");
+        expect(text).toContain(
+          "# Repository or organization variable; this guard intentionally does",
+        );
         expect(text).toContain(
           "EXPECTED_DEPLOYMENT_ENVIRONMENT: ${{ vars.B2_MCP_SMOKE_DEPLOYMENT_ENVIRONMENT || 'production' }}",
         );
@@ -136,12 +141,11 @@ describe("live secret workflow policy", () => {
 
   it("runs live contracts through workflow_call for release gating", () => {
     const text = workflowText(".github/workflows/contract.yml");
-    const workflowCall = text.slice(
-      text.indexOf("  workflow_call:"),
-      text.indexOf("\n\npermissions:"),
-    );
+    const workflowCall = yamlBlockForKey(text, "workflow_call") ?? "";
     expect(text).toMatch(/^\s{2}workflow_call:\s*$/m);
+    expect(workflowCall).not.toBe("");
     expect(text).toContain("checkout-sha:");
+    expect(workflowCall).toContain("checkout-sha:");
     expect(workflowCall).not.toContain("secrets:");
     expect(workflowCall).not.toContain("LIVE_B2_KEY_ID");
     expect(workflowCall).not.toContain("LIVE_B2_KEY");
@@ -153,16 +157,17 @@ describe("live secret workflow policy", () => {
     expect(text).toContain("workflow_call checkout-sha must be reachable from refs/heads/ci-green");
   });
 
-  it("adds a scheduled janitor for abandoned test-prefixed resources", () => {
+  it("fails the live run when per-run cleanup leaks resources", () => {
     const text = workflowText(".github/workflows/contract.yml");
     const contractJob = workflowJobBlock(text, "contract") ?? "";
-    const janitorJob = workflowJobBlock(text, "abandoned-resource-janitor") ?? "";
-    expect(text).toContain("abandoned-resource-janitor:");
-    expect(text).toContain("github.event_name == 'schedule'");
-    expect(text).toContain("node scripts/live-b2-janitor.mjs --prefix mcp-contract-");
+    expect(text).not.toContain("abandoned-resource-janitor:");
+    expect(text).not.toContain("node scripts/live-b2-janitor.mjs --prefix mcp-contract-");
     expect(text).toContain("Clean current live B2 run resources");
     expect(text).toContain("B2_LIVE_TEST_ACCOUNT_ID: ${{ vars.B2_LIVE_TEST_ACCOUNT_ID }}");
-    expect(text).toContain("--best-effort");
+    expect(contractJob).toContain(
+      'node scripts/live-b2-janitor.mjs --prefix "${B2_MCP_LIVE_RUN_PREFIX}"',
+    );
+    expect(contractJob).not.toContain("--best-effort");
     expect(text).toContain("B2_MCP_LIVE_RUN_PREFIX");
     expect(text).toContain('cron: "17 9 * * *"');
     expect(text).toMatch(
@@ -173,7 +178,6 @@ describe("live secret workflow policy", () => {
       ),
     );
     expect(contractJob).not.toContain("concurrency:");
-    expect(janitorJob).not.toContain("concurrency:");
   });
 
   it("keeps package-budget off the live contract dependency chain", () => {
@@ -197,6 +201,17 @@ describe("live secret workflow policy", () => {
     expect(text.indexOf("await assertLiveTestAccount(server)")).toBeLessThan(
       text.indexOf('callTool(server, "b2_create_bucket"'),
     );
+    const workflow = workflowText(".github/workflows/contract.yml");
+    expect(workflow).toContain("authorized account does not match B2_LIVE_TEST_ACCOUNT_ID");
+    expect(workflow).toContain(
+      'const requiredCapabilities = ["bypassGovernance", "deleteKeys", "listKeys", "writeKeys"];',
+    );
+    const liveTests = [
+      workflowText("tests/live/b2.integration.live.test.ts"),
+      workflowText("tests/live/request-shape.contract.live.test.ts"),
+    ].join("\n");
+    expect(liveTests).toContain('mode: "governance"');
+    expect(liveTests).not.toContain('mode: "compliance"');
   });
 
   it("runs the explicit live contract layer with B2 credentials", () => {

--- a/tests/contract/live-workflows-policy.contract.test.ts
+++ b/tests/contract/live-workflows-policy.contract.test.ts
@@ -136,10 +136,15 @@ describe("live secret workflow policy", () => {
 
   it("runs live contracts through workflow_call for release gating", () => {
     const text = workflowText(".github/workflows/contract.yml");
+    const workflowCall = text.slice(
+      text.indexOf("  workflow_call:"),
+      text.indexOf("\n\npermissions:"),
+    );
     expect(text).toMatch(/^\s{2}workflow_call:\s*$/m);
     expect(text).toContain("checkout-sha:");
-    expect(text).toContain("LIVE_B2_KEY_ID:");
-    expect(text).toContain("LIVE_B2_KEY:");
+    expect(workflowCall).not.toContain("secrets:");
+    expect(workflowCall).not.toContain("LIVE_B2_KEY_ID");
+    expect(workflowCall).not.toContain("LIVE_B2_KEY");
     expect(text).toContain("WORKFLOW_CALL_CHECKOUT_SHA");
     expect(text).toContain('event_kind="workflow_call"');
     expect(text).toContain("workflow_call requires a full checkout-sha commit");


### PR DESCRIPTION
## Summary

- resolve live contract credentials only from the protected `live-b2-contract` environment
- remove impossible caller-side Environment secret forwarding from the publish workflow
- enforce the reusable-workflow secret boundary with fail-closed contract tests
- validate the live contract account allowlist and required cleanup capabilities before running package code
- remove push-triggered live contract churn and make per-run cleanup leaks fail the causing run
- prevent skipped deployment-status events from canceling live smoke evidence
- document the exact contract and smoke configuration, including the repository/org-scoped smoke deployment variable

GitHub does not allow a reusable-workflow caller to bind an environment. The called `contract.yml` jobs bind `live-b2-contract`, so they own secret and variable resolution for schedule, manual, and publish-time entry points.

## Verification

- `pnpm run test:contract` (202 tests)
- `pnpm run lint:docs`
- `pnpm run format:check`
- `pnpm run typecheck`
- `pnpm run spell`
- `pnpm run lint`
- `pnpm run build`
- `git diff --check`

Refs #63
Refs #64
