### PR TITLE
Replace ts-node with tsx for dev script

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   signed multi-platform GHCR release publishing, and Docker run docs for HTTP
   and stdio transports.
 
+### Changed
+- Replaced the `ts-node` dev runner with exact-pinned `tsx@4.23.11` and
+  explicitly denied `esbuild` install builds in `pnpm-workspace.yaml`.
+
 ## [0.1.0] - 2026-08-07
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "typecheck": "tsc --noEmit -p tsconfig.typecheck.json",
     "start": "node dist/index.js",
     "start:http": "node dist/http-server.js",
-    "dev": "ts-node src/index.ts",
+    "dev": "tsx src/index.ts",
     "test": "pnpm run typecheck && pnpm run test:unit",
     "test:unit": "node scripts/run-vitest-layer.mjs unit",
     "test:contract": "node scripts/run-vitest-layer.mjs contract",
@@ -107,7 +107,7 @@
     "eslint-plugin-jsdoc": "50.8.0",
     "eslint-plugin-tsdoc": "0.5.2",
     "semver": "7.8.5",
-    "ts-node": "^10.9.0",
+    "tsx": "4.23.11",
     "typescript": "~6.0.3",
     "typescript-eslint": "8.66.0",
     "vitest": "^4.1.10"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -47,7 +47,7 @@ importers:
         version: 2.0.0
       '@modelcontextprotocol/inspector':
         specifier: 2.1.0
-        version: 2.1.0(@modelcontextprotocol/sdk@1.30.0(supports-color@7.2.0)(zod@4.4.3))(@types/node@22.3.0)(express@5.2.1(supports-color@7.2.0))(supports-color@7.2.0)
+        version: 2.1.0(@modelcontextprotocol/sdk@1.30.0(supports-color@7.2.0)(zod@4.4.3))(@types/node@22.3.0)(esbuild@0.28.1)(express@5.2.1(supports-color@7.2.0))(supports-color@7.2.0)(tsx@4.23.11)
       '@modelcontextprotocol/node':
         specifier: 2.0.0
         version: 2.0.0(@modelcontextprotocol/server@2.0.0)(hono@4.13.0)
@@ -78,9 +78,9 @@ importers:
       semver:
         specifier: 7.8.5
         version: 7.8.5
-      ts-node:
-        specifier: ^10.9.0
-        version: 10.9.2(@types/node@22.3.0)(typescript@6.0.3)
+      tsx:
+        specifier: 4.23.11
+        version: 4.23.11
       typescript:
         specifier: ~6.0.3
         version: 6.0.3
@@ -89,7 +89,7 @@ importers:
         version: 8.66.0(eslint@9.39.1(supports-color@7.2.0))(supports-color@7.2.0)(typescript@6.0.3)
       vitest:
         specifier: ^4.1.10
-        version: 4.1.10(@types/node@22.3.0)(@vitest/coverage-v8@4.1.10)(vite@8.2.0(@types/node@22.3.0)(yaml@2.9.0))
+        version: 4.1.10(@types/node@22.3.0)(@vitest/coverage-v8@4.1.10)(vite@8.2.0(@types/node@22.3.0)(esbuild@0.28.1)(tsx@4.23.11)(yaml@2.9.0))
 
 packages:
 
@@ -494,13 +494,165 @@ packages:
     resolution: {integrity: sha512-abYYgI29wJhWIfWTYrYuzRYDcHQUQ1N5ylnhxYn1NJnIQMqUWGLbDmt12JABtZ+R6h6UNatQrS7rhP86etvJyQ==}
     engines: {node: '>=22.18.0'}
 
-  '@cspotcode/source-map-support@0.8.1':
-    resolution: {integrity: sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==}
-    engines: {node: '>=12'}
-
   '@es-joy/jsdoccomment@0.50.2':
     resolution: {integrity: sha512-YAdE/IJSpwbOTiaURNCKECdAwqrJuFiZhylmesBcIRawtYKnBR2wxPhoIewMg+Yu+QuYvHfJNReWpoxGBKOChA==}
     engines: {node: '>=18'}
+
+  '@esbuild/aix-ppc64@0.28.1':
+    resolution: {integrity: sha512-Svl7tq8k/08+p6CXPpRjQ1fKX+1odH/BQbb48fV6fj3CWHhsoIOoY87w1oHXm0qEpkIK3ZfVgp0hed3XBXzXMQ==}
+    engines: {node: '>=18'}
+    cpu: [ppc64]
+    os: [aix]
+
+  '@esbuild/android-arm64@0.28.1':
+    resolution: {integrity: sha512-34EGEbCIAgosYz6goLcopX6Mo7NyGv9tfwEM2/7Ce2VcVRk568iSvniGWcUXIy7wEDR1wzolcxcriFVrWYcwBg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [android]
+
+  '@esbuild/android-arm@0.28.1':
+    resolution: {integrity: sha512-0k2F129Xdio1TdJfzJ8sy1Q47vUD2NnwdhiAf7drUN1EBTfPf4hsFCtmMgu/6m8JSzsBrlmVjudMBQqOfG8usQ==}
+    engines: {node: '>=18'}
+    cpu: [arm]
+    os: [android]
+
+  '@esbuild/android-x64@0.28.1':
+    resolution: {integrity: sha512-dbwY7ltSMDWsRatcRpCnES4F+im88OCUgGZjy52shC7GqHRE/cYlxNbB4Z4UpJswpcc4Qxd2oE/ufM0p61IKng==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [android]
+
+  '@esbuild/darwin-arm64@0.28.1':
+    resolution: {integrity: sha512-TZbWkQY7kvTAXbXUT7uVACR5cMHsDiSz9z7ZKAX/RTq/WJEk3QyRr0wZpNhBDX+/0CtdqUIJlOiodQcta6tY3Q==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@esbuild/darwin-x64@0.28.1':
+    resolution: {integrity: sha512-zfdzgK9ACBNZLI/CyHTOx81SyNbM6YXn7rxSgX97VjyiPl9W1i4Ka4fgKECEoFCKGpvBj5qArWIGgQjOwkgskQ==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@esbuild/freebsd-arm64@0.28.1':
+    resolution: {integrity: sha512-wG2EA8ENdEI0qhkSZMjfqrdY+ziCYCPMmtZjjIwOmXFjmyzEHn+UUxk5of+SYsjtfs3VpnlC7QLzSI5hY/rOAw==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [freebsd]
+
+  '@esbuild/freebsd-x64@0.28.1':
+    resolution: {integrity: sha512-i7dZ9vQgnvSCzi/rYCXNgtF/U+eKZNJBzu3eTQbRgHnM7tNSizLOkRFAl3qzVc/Op/u5YkHHa4pf/3DOYHthLQ==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@esbuild/linux-arm64@0.28.1':
+    resolution: {integrity: sha512-yHs+0uc8+nvEAfAfxrWQKK5peSNzBc4PegcMO0EJ2hT71uA7vB8Ihg2e77R2P7SG5uYjPbHlLLmve4LLLRCf0g==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [linux]
+
+  '@esbuild/linux-arm@0.28.1':
+    resolution: {integrity: sha512-qVXBOHQS+d5Y722GwJzJUtOLlX7km3CraOaGormF1pDtPd2C/l1SHRPgjLunLGe51Sh5YYWKMFDyV4SxgMQYTQ==}
+    engines: {node: '>=18'}
+    cpu: [arm]
+    os: [linux]
+
+  '@esbuild/linux-ia32@0.28.1':
+    resolution: {integrity: sha512-d1z4ZuP0ajrfz/FhGT4vv278rX8KnPPJx8i5+AtK7TYbx9Le9F1hyzurZpkEyjkGa9dUGhQow4C1NmeGvqxN2w==}
+    engines: {node: '>=18'}
+    cpu: [ia32]
+    os: [linux]
+
+  '@esbuild/linux-loong64@0.28.1':
+    resolution: {integrity: sha512-M5sRjUVZrkm1OAPR3dlOYzNmN+loZKGVi1VUQGrwuqLcbR6qeAz+famMhjASeH3YVKvZz+zT1jlh/keC3Rj/lg==}
+    engines: {node: '>=18'}
+    cpu: [loong64]
+    os: [linux]
+
+  '@esbuild/linux-mips64el@0.28.1':
+    resolution: {integrity: sha512-mRObBZeHh2OxcBFPWE/FjylkRgZdYuiTR3vaTozquCGOH14iP9oN4x4Ge81CoIDYQrXmIxpFumJBu5MtZpnQJQ==}
+    engines: {node: '>=18'}
+    cpu: [mips64el]
+    os: [linux]
+
+  '@esbuild/linux-ppc64@0.28.1':
+    resolution: {integrity: sha512-slScBsMAb3GFDcdrCgLwZtPYRoH2H/youv10QiZyRjmsP48fznoveWytSgCI/R0ZcUgpc0ZhIUEx6LHts8yrfQ==}
+    engines: {node: '>=18'}
+    cpu: [ppc64]
+    os: [linux]
+
+  '@esbuild/linux-riscv64@0.28.1':
+    resolution: {integrity: sha512-kw0owk1o0GFETUJyW0jc0G4Yzs0BHZn0JDZ8JRT088vjJYX777BAs1fDGxAC+q831qOs2DTC96mNsG2opdfyyQ==}
+    engines: {node: '>=18'}
+    cpu: [riscv64]
+    os: [linux]
+
+  '@esbuild/linux-s390x@0.28.1':
+    resolution: {integrity: sha512-/lAIjX8aYFRByhh6L5rYtPEDRqa9de/4V/juOXcta5frjvzXO4/sqEtyytse0g3zZFuWu5cDN0MkLz2qRDD2Ag==}
+    engines: {node: '>=18'}
+    cpu: [s390x]
+    os: [linux]
+
+  '@esbuild/linux-x64@0.28.1':
+    resolution: {integrity: sha512-u/anNYF2mmVOEDwLtnQ1wOr3EZ9sTNGLWrsYGYwHWzGA3Si84IOkHXlbWTD1NB+9/1lcnweYKO54uhxZydNzfA==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [linux]
+
+  '@esbuild/netbsd-arm64@0.28.1':
+    resolution: {integrity: sha512-oks0DYbLwWMmaakTsCb+zL4E+aHRVLom9IJZOAthMQEPiQmydXHkziYEsGYRx0uNV/IjEKGAV941JzH02pflqw==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [netbsd]
+
+  '@esbuild/netbsd-x64@0.28.1':
+    resolution: {integrity: sha512-aeL6lAnN89Hz43Mlh1G8ARasbuoYvSITDEx0tHh5b7jJnHcssqgjy9Yx430GDpmCa6OyrKoS0aNRjKundRizGg==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [netbsd]
+
+  '@esbuild/openbsd-arm64@0.28.1':
+    resolution: {integrity: sha512-MEFJe5C3R8pwXdZ5Y21oo6m7ePiS0d9pWucn99O/wvyJZChoIQKrQDxKrGeW8F5+T0okTHesAmDeiHDTIq0V/Q==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [openbsd]
+
+  '@esbuild/openbsd-x64@0.28.1':
+    resolution: {integrity: sha512-i/ZLIOafE0Z8cI/XANJAixoJL/uRAoS2xOA3rb0xN+KK0K177cMAsQYkzHtBrtMXAKuAc7HGgcWiZ/sRC1Nxgw==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [openbsd]
+
+  '@esbuild/openharmony-arm64@0.28.1':
+    resolution: {integrity: sha512-ge+Z7EXFNt2BO1oAMsVpiQ8EwndV9i1xXerAeTIK7AtPs3bKFXQM7nlRxDSIUIMeueR1CNXxqztLzdNeReKBJg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [openharmony]
+
+  '@esbuild/sunos-x64@0.28.1':
+    resolution: {integrity: sha512-BEjgtECkL3vY+SaSQ6nzVfiALUeFxpawyp8Jmf5PtYhf1Ug40N1h/hxlhts+f1FvSvarEigdxS3BlSMI2PJLcQ==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [sunos]
+
+  '@esbuild/win32-arm64@0.28.1':
+    resolution: {integrity: sha512-lCv9eK/H6ZJWbE7bh2nw54CZ9M2nupBxJcTsdk/QQnWkdSjKGuxmmH8/GWrlT1eMmZfn4dGcCjRte397WqfQXA==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [win32]
+
+  '@esbuild/win32-ia32@0.28.1':
+    resolution: {integrity: sha512-zvb/mB2bSCoJOpoCBgYKKpX6YM6mJBlBUVUtVj41DlZJVEB6/0CKlRYxP5wWl1C1ILiCoAU5wZZ4q1P3qeS6Eg==}
+    engines: {node: '>=18'}
+    cpu: [ia32]
+    os: [win32]
+
+  '@esbuild/win32-x64@0.28.1':
+    resolution: {integrity: sha512-bm4Mowrv+GXMlpWX++EcXw/iLyd1o3+bJkC2DkWXYVvgZCqD/bSj9ctZeAMC3cIxgjRVR2Dufaiu4YPxr5gW1A==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [win32]
 
   '@eslint-community/eslint-utils@4.10.1':
     resolution: {integrity: sha512-cuadcxVFE8sDK6iWJbs8Sn0av2Nrh2QSGQhVlBW9AaAHqHwjWsZHT8LJ4hFGPh7ASBV2deFdM7H/DPjulmh8rg==}
@@ -575,9 +727,6 @@ packages:
 
   '@jridgewell/trace-mapping@0.3.31':
     resolution: {integrity: sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==}
-
-  '@jridgewell/trace-mapping@0.3.9':
-    resolution: {integrity: sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ==}
 
   '@microsoft/tsdoc-config@0.18.1':
     resolution: {integrity: sha512-9brPoVdfN9k9g0dcWkFeA7IH9bbcttzDJlXvkf8b2OBzd5MueR1V2wkKBL0abn0otvmkHJC6aapBOTJDDeMCZg==}
@@ -868,18 +1017,6 @@ packages:
   '@toon-format/toon@4.1.0':
     resolution: {integrity: sha512-dBB3pkEx9QYvHnHR6rtkaBAh+7x4W/oA5ONur4G0fh7Ow69PbPuM7OFxzNRABqyxC0t6SZ3RixiGbCuaFjPDAQ==}
 
-  '@tsconfig/node10@1.0.12':
-    resolution: {integrity: sha512-UCYBaeFvM11aU2y3YPZ//O5Rhj+xKyzy7mvcIoAjASbigy8mHMryP5cK7dgjlz2hWxh1g5pLw084E0a/wlUSFQ==}
-
-  '@tsconfig/node12@1.0.11':
-    resolution: {integrity: sha512-cqefuRsh12pWyGsIoBKJA9luFu3mRxCA+ORZvA4ktLSzIuCUtWVxGIuXigEwO5/ywWFMZ2QEGKWvkZG1zDMTag==}
-
-  '@tsconfig/node14@1.0.3':
-    resolution: {integrity: sha512-ysT8mhdixWK6Hw3i1V2AeRqZ5WfXg1G43mqoYlM2nc6388Fq5jcXyr5mRsqViLx/GJYdoL0bfXD8nmF+Zn/Iow==}
-
-  '@tsconfig/node16@1.0.4':
-    resolution: {integrity: sha512-vxhUy4J8lyeyinH7Azl1pdd43GJhZH/tP2weN8TntQblOY+A0XbT8DJk1/oCPuOOyg/Ja757rG0CgHcWC8OfMA==}
-
   '@types/chai@5.2.3':
     resolution: {integrity: sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==}
 
@@ -1054,10 +1191,6 @@ packages:
     peerDependencies:
       acorn: ^6.0.0 || ^7.0.0 || ^8.0.0
 
-  acorn-walk@8.3.5:
-    resolution: {integrity: sha512-HEHNfbars9v4pgpW6SO1KSPkfoS0xVOM/9UzkJltjlsHZmJasxg8aXkuZa7SMf8vKGIBhpUsPluQSqhJFCqebw==}
-    engines: {node: '>=0.4.0'}
-
   acorn@8.16.0:
     resolution: {integrity: sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==}
     engines: {node: '>=0.4.0'}
@@ -1096,9 +1229,6 @@ packages:
   are-docs-informative@0.0.2:
     resolution: {integrity: sha512-ixiS0nLNNG5jNQzgZJNoUpBKdo9yTYZMGJ+QgT2jmjR7G7+QHRCc4v6LQ3NgE7EBJq+o0ams3waJwkrlBom8Ig==}
     engines: {node: '>=14'}
-
-  arg@4.1.3:
-    resolution: {integrity: sha512-58S9QDqG0Xx27YwPSt9fJxivjYl432YCwfDMfZ+71RAqUrZef7LrKQZ3LHLOwCS4FLNBplP533Zx895SeOCHvA==}
 
   argparse@2.0.1:
     resolution: {integrity: sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==}
@@ -1262,9 +1392,6 @@ packages:
     resolution: {integrity: sha512-tJtZBBHA6vjIAaF6EnIaq6laBBP9aq/Y3ouVJjEfoHbRBcHBAHYcMh/w8LDrk2PvIMMq8gmopa5D4V8RmbrxGw==}
     engines: {node: '>= 0.10'}
 
-  create-require@1.1.1:
-    resolution: {integrity: sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==}
-
   cross-spawn@7.0.6:
     resolution: {integrity: sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==}
     engines: {node: '>= 8'}
@@ -1342,10 +1469,6 @@ packages:
     resolution: {integrity: sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==}
     engines: {node: '>=8'}
 
-  diff@4.0.4:
-    resolution: {integrity: sha512-X07nttJQkwkfKfvTPG/KSnE2OMdcUCao6+eXF3wmnIQRn2aPAHH3VxDbDOdegkd6JbPsXqShpvEOHfAT+nCNwQ==}
-    engines: {node: '>=0.3.1'}
-
   dunder-proto@1.0.1:
     resolution: {integrity: sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==}
     engines: {node: '>= 0.4'}
@@ -1385,6 +1508,11 @@ packages:
 
   es-toolkit@1.50.0:
     resolution: {integrity: sha512-OyZKhUVvEep9ITEiwHn8GKnMRQIVqoSIX7WnRbkWgJkllCujilqP2rD0u979tkl8wqyc8ICwlc1UBVv/Sl1G6w==}
+
+  esbuild@0.28.1:
+    resolution: {integrity: sha512-HrJrvZv5ayxBzPfwphOoNzkzOIIlifzk0KJrGK2c8R4+LKpMtpYLQeUdjnwjWv/LZlkH2laZk+4w78pi99D4Vw==}
+    engines: {node: '>=18'}
+    hasBin: true
 
   escape-html@1.0.3:
     resolution: {integrity: sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==}
@@ -1885,9 +2013,6 @@ packages:
     resolution: {integrity: sha512-hXdUTZYIVOt1Ex//jAQi+wTZZpUpwBj/0QsOzqegb3rGMMeJiSEu5xLHnYfBrRV4RH2+OCSOO95Is/7x1WJ4bw==}
     engines: {node: '>=10'}
 
-  make-error@1.3.6:
-    resolution: {integrity: sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw==}
-
   math-intrinsics@1.1.0:
     resolution: {integrity: sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==}
     engines: {node: '>= 0.4'}
@@ -2301,22 +2426,13 @@ packages:
     peerDependencies:
       typescript: '>=4.8.4'
 
-  ts-node@10.9.2:
-    resolution: {integrity: sha512-f0FFpIdcHgn8zcPSbf1dRevwt047YMnaiJM3u2w2RewrB+fob/zePZcrOyQoLMMO7aBIddLcQIEK5dYjkLnGrQ==}
-    hasBin: true
-    peerDependencies:
-      '@swc/core': '>=1.2.50'
-      '@swc/wasm': '>=1.2.50'
-      '@types/node': '*'
-      typescript: '>=2.7'
-    peerDependenciesMeta:
-      '@swc/core':
-        optional: true
-      '@swc/wasm':
-        optional: true
-
   tslib@2.8.1:
     resolution: {integrity: sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==}
+
+  tsx@4.23.11:
+    resolution: {integrity: sha512-Ry2oTEUnhBdeEdWIztY8kf3/nBGnPnjMLVGL0YfdRXMORuPER5NlKmayqxtxRxwB1xBN+RivRaJfe7PM1rtiyw==}
+    engines: {node: '>=18.0.0'}
+    hasBin: true
 
   type-check@0.4.0:
     resolution: {integrity: sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==}
@@ -2359,9 +2475,6 @@ packages:
 
   uri-js@4.4.1:
     resolution: {integrity: sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==}
-
-  v8-compile-cache-lib@3.0.1:
-    resolution: {integrity: sha512-wa7YjyUGfNZngI/vtK0UHAN+lgDCxBPCylVXGp0zu59Fz5aiGtNXaq3DhIov063MorB+VfufLh3JlF2KdTK3xg==}
 
   vary@1.1.2:
     resolution: {integrity: sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==}
@@ -2509,10 +2622,6 @@ packages:
     resolution: {integrity: sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA==}
     engines: {node: '>= 14.6'}
     hasBin: true
-
-  yn@3.1.1:
-    resolution: {integrity: sha512-Ux4ygGWsu2c7isFWe8Yu1YluJmqVhxqK2cLXNQA5AcC3QfbGNpM7fu0Y8b/z16pXLnFxZYvWhd3fhBY9DLmC6Q==}
-    engines: {node: '>=6'}
 
   yocto-queue@0.1.0:
     resolution: {integrity: sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==}
@@ -2986,10 +3095,6 @@ snapshots:
 
   '@cspell/url@10.0.1': {}
 
-  '@cspotcode/source-map-support@0.8.1':
-    dependencies:
-      '@jridgewell/trace-mapping': 0.3.9
-
   '@es-joy/jsdoccomment@0.50.2':
     dependencies:
       '@types/estree': 1.0.9
@@ -2997,6 +3102,84 @@ snapshots:
       comment-parser: 1.4.1
       esquery: 1.7.0
       jsdoc-type-pratt-parser: 4.1.0
+
+  '@esbuild/aix-ppc64@0.28.1':
+    optional: true
+
+  '@esbuild/android-arm64@0.28.1':
+    optional: true
+
+  '@esbuild/android-arm@0.28.1':
+    optional: true
+
+  '@esbuild/android-x64@0.28.1':
+    optional: true
+
+  '@esbuild/darwin-arm64@0.28.1':
+    optional: true
+
+  '@esbuild/darwin-x64@0.28.1':
+    optional: true
+
+  '@esbuild/freebsd-arm64@0.28.1':
+    optional: true
+
+  '@esbuild/freebsd-x64@0.28.1':
+    optional: true
+
+  '@esbuild/linux-arm64@0.28.1':
+    optional: true
+
+  '@esbuild/linux-arm@0.28.1':
+    optional: true
+
+  '@esbuild/linux-ia32@0.28.1':
+    optional: true
+
+  '@esbuild/linux-loong64@0.28.1':
+    optional: true
+
+  '@esbuild/linux-mips64el@0.28.1':
+    optional: true
+
+  '@esbuild/linux-ppc64@0.28.1':
+    optional: true
+
+  '@esbuild/linux-riscv64@0.28.1':
+    optional: true
+
+  '@esbuild/linux-s390x@0.28.1':
+    optional: true
+
+  '@esbuild/linux-x64@0.28.1':
+    optional: true
+
+  '@esbuild/netbsd-arm64@0.28.1':
+    optional: true
+
+  '@esbuild/netbsd-x64@0.28.1':
+    optional: true
+
+  '@esbuild/openbsd-arm64@0.28.1':
+    optional: true
+
+  '@esbuild/openbsd-x64@0.28.1':
+    optional: true
+
+  '@esbuild/openharmony-arm64@0.28.1':
+    optional: true
+
+  '@esbuild/sunos-x64@0.28.1':
+    optional: true
+
+  '@esbuild/win32-arm64@0.28.1':
+    optional: true
+
+  '@esbuild/win32-ia32@0.28.1':
+    optional: true
+
+  '@esbuild/win32-x64@0.28.1':
+    optional: true
 
   '@eslint-community/eslint-utils@4.10.1(eslint@9.39.1(supports-color@7.2.0))':
     dependencies:
@@ -3073,11 +3256,6 @@ snapshots:
       '@jridgewell/resolve-uri': 3.1.2
       '@jridgewell/sourcemap-codec': 1.5.5
 
-  '@jridgewell/trace-mapping@0.3.9':
-    dependencies:
-      '@jridgewell/resolve-uri': 3.1.2
-      '@jridgewell/sourcemap-codec': 1.5.5
-
   '@microsoft/tsdoc-config@0.18.1':
     dependencies:
       '@microsoft/tsdoc': 0.16.0
@@ -3123,7 +3301,7 @@ snapshots:
     optionalDependencies:
       react: 19.2.8
 
-  '@modelcontextprotocol/inspector@2.1.0(@modelcontextprotocol/sdk@1.30.0(supports-color@7.2.0)(zod@4.4.3))(@types/node@22.3.0)(express@5.2.1(supports-color@7.2.0))(supports-color@7.2.0)':
+  '@modelcontextprotocol/inspector@2.1.0(@modelcontextprotocol/sdk@1.30.0(supports-color@7.2.0)(zod@4.4.3))(@types/node@22.3.0)(esbuild@0.28.1)(express@5.2.1(supports-color@7.2.0))(supports-color@7.2.0)(tsx@4.23.11)':
     dependencies:
       '@hono/node-server': 2.0.10(hono@4.13.0)
       '@modelcontextprotocol/client': 2.0.0-beta.5
@@ -3132,7 +3310,7 @@ snapshots:
       '@modelcontextprotocol/server': 2.0.0-beta.5
       '@modelcontextprotocol/server-legacy': 2.0.0-beta.5(express@5.2.1(supports-color@7.2.0))(supports-color@7.2.0)
       '@napi-rs/keyring': 1.3.0
-      '@vitejs/plugin-react': 6.0.5(vite@8.2.0(@types/node@22.3.0)(yaml@2.9.0))
+      '@vitejs/plugin-react': 6.0.5(vite@8.2.0(@types/node@22.3.0)(esbuild@0.28.1)(tsx@4.23.11)(yaml@2.9.0))
       ajv: 8.18.0
       atomically: 2.1.1
       chokidar: 4.0.3
@@ -3145,7 +3323,7 @@ snapshots:
       pino: 9.14.0
       react: 19.2.8
       undici: 8.10.0
-      vite: 8.2.0(@types/node@22.3.0)(yaml@2.9.0)
+      vite: 8.2.0(@types/node@22.3.0)(esbuild@0.28.1)(tsx@4.23.11)(yaml@2.9.0)
       yaml: 2.9.0
       zod: 4.4.3
     transitivePeerDependencies:
@@ -3360,14 +3538,6 @@ snapshots:
 
   '@toon-format/toon@4.1.0': {}
 
-  '@tsconfig/node10@1.0.12': {}
-
-  '@tsconfig/node12@1.0.11': {}
-
-  '@tsconfig/node14@1.0.3': {}
-
-  '@tsconfig/node16@1.0.4': {}
-
   '@types/chai@5.2.3':
     dependencies:
       '@types/deep-eql': 4.0.2
@@ -3529,10 +3699,10 @@ snapshots:
       '@typescript-eslint/types': 8.66.0
       eslint-visitor-keys: 4.2.1
 
-  '@vitejs/plugin-react@6.0.5(vite@8.2.0(@types/node@22.3.0)(yaml@2.9.0))':
+  '@vitejs/plugin-react@6.0.5(vite@8.2.0(@types/node@22.3.0)(esbuild@0.28.1)(tsx@4.23.11)(yaml@2.9.0))':
     dependencies:
       '@rolldown/pluginutils': 1.0.1
-      vite: 8.2.0(@types/node@22.3.0)(yaml@2.9.0)
+      vite: 8.2.0(@types/node@22.3.0)(esbuild@0.28.1)(tsx@4.23.11)(yaml@2.9.0)
 
   '@vitest/coverage-v8@4.1.10(vitest@4.1.10)':
     dependencies:
@@ -3546,7 +3716,7 @@ snapshots:
       obug: 2.1.4
       std-env: 4.2.0
       tinyrainbow: 3.1.1
-      vitest: 4.1.10(@types/node@22.3.0)(@vitest/coverage-v8@4.1.10)(vite@8.2.0(@types/node@22.3.0)(yaml@2.9.0))
+      vitest: 4.1.10(@types/node@22.3.0)(@vitest/coverage-v8@4.1.10)(vite@8.2.0(@types/node@22.3.0)(esbuild@0.28.1)(tsx@4.23.11)(yaml@2.9.0))
 
   '@vitest/expect@4.1.10':
     dependencies:
@@ -3557,13 +3727,13 @@ snapshots:
       chai: 6.2.2
       tinyrainbow: 3.1.1
 
-  '@vitest/mocker@4.1.10(vite@8.2.0(@types/node@22.3.0)(yaml@2.9.0))':
+  '@vitest/mocker@4.1.10(vite@8.2.0(@types/node@22.3.0)(esbuild@0.28.1)(tsx@4.23.11)(yaml@2.9.0))':
     dependencies:
       '@vitest/spy': 4.1.10
       estree-walker: 3.0.3
       magic-string: 0.30.21
     optionalDependencies:
-      vite: 8.2.0(@types/node@22.3.0)(yaml@2.9.0)
+      vite: 8.2.0(@types/node@22.3.0)(esbuild@0.28.1)(tsx@4.23.11)(yaml@2.9.0)
 
   '@vitest/pretty-format@4.1.10':
     dependencies:
@@ -3595,10 +3765,6 @@ snapshots:
       negotiator: 1.0.0
 
   acorn-jsx@5.3.2(acorn@8.16.0):
-    dependencies:
-      acorn: 8.16.0
-
-  acorn-walk@8.3.5:
     dependencies:
       acorn: 8.16.0
 
@@ -3635,8 +3801,6 @@ snapshots:
   ansi-styles@6.2.3: {}
 
   are-docs-informative@0.0.2: {}
-
-  arg@4.1.3: {}
 
   argparse@2.0.1: {}
 
@@ -3778,8 +3942,6 @@ snapshots:
       object-assign: 4.1.1
       vary: 1.1.2
 
-  create-require@1.1.1: {}
-
   cross-spawn@7.0.6:
     dependencies:
       path-key: 3.1.1
@@ -3897,8 +4059,6 @@ snapshots:
 
   detect-libc@2.1.2: {}
 
-  diff@4.0.4: {}
-
   dunder-proto@1.0.1:
     dependencies:
       call-bind-apply-helpers: 1.0.2
@@ -3928,6 +4088,35 @@ snapshots:
       es-errors: 1.3.0
 
   es-toolkit@1.50.0: {}
+
+  esbuild@0.28.1:
+    optionalDependencies:
+      '@esbuild/aix-ppc64': 0.28.1
+      '@esbuild/android-arm': 0.28.1
+      '@esbuild/android-arm64': 0.28.1
+      '@esbuild/android-x64': 0.28.1
+      '@esbuild/darwin-arm64': 0.28.1
+      '@esbuild/darwin-x64': 0.28.1
+      '@esbuild/freebsd-arm64': 0.28.1
+      '@esbuild/freebsd-x64': 0.28.1
+      '@esbuild/linux-arm': 0.28.1
+      '@esbuild/linux-arm64': 0.28.1
+      '@esbuild/linux-ia32': 0.28.1
+      '@esbuild/linux-loong64': 0.28.1
+      '@esbuild/linux-mips64el': 0.28.1
+      '@esbuild/linux-ppc64': 0.28.1
+      '@esbuild/linux-riscv64': 0.28.1
+      '@esbuild/linux-s390x': 0.28.1
+      '@esbuild/linux-x64': 0.28.1
+      '@esbuild/netbsd-arm64': 0.28.1
+      '@esbuild/netbsd-x64': 0.28.1
+      '@esbuild/openbsd-arm64': 0.28.1
+      '@esbuild/openbsd-x64': 0.28.1
+      '@esbuild/openharmony-arm64': 0.28.1
+      '@esbuild/sunos-x64': 0.28.1
+      '@esbuild/win32-arm64': 0.28.1
+      '@esbuild/win32-ia32': 0.28.1
+      '@esbuild/win32-x64': 0.28.1
 
   escape-html@1.0.3: {}
 
@@ -4432,8 +4621,6 @@ snapshots:
     dependencies:
       semver: 7.8.5
 
-  make-error@1.3.6: {}
-
   math-intrinsics@1.1.0: {}
 
   media-typer@1.1.1: {}
@@ -4839,25 +5026,13 @@ snapshots:
     dependencies:
       typescript: 6.0.3
 
-  ts-node@10.9.2(@types/node@22.3.0)(typescript@6.0.3):
-    dependencies:
-      '@cspotcode/source-map-support': 0.8.1
-      '@tsconfig/node10': 1.0.12
-      '@tsconfig/node12': 1.0.11
-      '@tsconfig/node14': 1.0.3
-      '@tsconfig/node16': 1.0.4
-      '@types/node': 22.3.0
-      acorn: 8.16.0
-      acorn-walk: 8.3.5
-      arg: 4.1.3
-      create-require: 1.1.1
-      diff: 4.0.4
-      make-error: 1.3.6
-      typescript: 6.0.3
-      v8-compile-cache-lib: 3.0.1
-      yn: 3.1.1
-
   tslib@2.8.1: {}
+
+  tsx@4.23.11:
+    dependencies:
+      esbuild: 0.28.1
+    optionalDependencies:
+      fsevents: 2.3.3
 
   type-check@0.4.0:
     dependencies:
@@ -4898,11 +5073,9 @@ snapshots:
     dependencies:
       punycode: 2.3.1
 
-  v8-compile-cache-lib@3.0.1: {}
-
   vary@1.1.2: {}
 
-  vite@8.2.0(@types/node@22.3.0)(yaml@2.9.0):
+  vite@8.2.0(@types/node@22.3.0)(esbuild@0.28.1)(tsx@4.23.11)(yaml@2.9.0):
     dependencies:
       lightningcss: 1.33.0
       picomatch: 4.0.5
@@ -4911,13 +5084,15 @@ snapshots:
       tinyglobby: 0.2.17
     optionalDependencies:
       '@types/node': 22.3.0
+      esbuild: 0.28.1
       fsevents: 2.3.3
+      tsx: 4.23.11
       yaml: 2.9.0
 
-  vitest@4.1.10(@types/node@22.3.0)(@vitest/coverage-v8@4.1.10)(vite@8.2.0(@types/node@22.3.0)(yaml@2.9.0)):
+  vitest@4.1.10(@types/node@22.3.0)(@vitest/coverage-v8@4.1.10)(vite@8.2.0(@types/node@22.3.0)(esbuild@0.28.1)(tsx@4.23.11)(yaml@2.9.0)):
     dependencies:
       '@vitest/expect': 4.1.10
-      '@vitest/mocker': 4.1.10(vite@8.2.0(@types/node@22.3.0)(yaml@2.9.0))
+      '@vitest/mocker': 4.1.10(vite@8.2.0(@types/node@22.3.0)(esbuild@0.28.1)(tsx@4.23.11)(yaml@2.9.0))
       '@vitest/pretty-format': 4.1.10
       '@vitest/runner': 4.1.10
       '@vitest/snapshot': 4.1.10
@@ -4934,7 +5109,7 @@ snapshots:
       tinyexec: 1.3.0
       tinyglobby: 0.2.17
       tinyrainbow: 3.1.1
-      vite: 8.2.0(@types/node@22.3.0)(yaml@2.9.0)
+      vite: 8.2.0(@types/node@22.3.0)(esbuild@0.28.1)(tsx@4.23.11)(yaml@2.9.0)
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@types/node': 22.3.0
@@ -4980,8 +5155,6 @@ snapshots:
   xdg-basedir@5.1.0: {}
 
   yaml@2.9.0: {}
-
-  yn@3.1.1: {}
 
   yocto-queue@0.1.0: {}
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,5 +1,7 @@
 allowBuilds:
   '@modelcontextprotocol/inspector': false
+  # tsx depends on esbuild, whose platform packages ship native binaries.
+  # Keep install scripts disabled; esbuild only runs when dev tooling invokes it.
   esbuild: false
 overrides:
   '@istanbuljs/load-nyc-config>js-yaml': 3.15.1

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,5 +1,6 @@
 allowBuilds:
   '@modelcontextprotocol/inspector': false
+  esbuild: false
 overrides:
   '@istanbuljs/load-nyc-config>js-yaml': 3.15.1
   '@typescript-eslint/visitor-keys>eslint-visitor-keys': 4.2.1

--- a/tests/unit/supply-chain-policy.unit.test.ts
+++ b/tests/unit/supply-chain-policy.unit.test.ts
@@ -21,7 +21,8 @@ const nodeRequire = createRequire(__filename);
 const { workflowJobBlock } = nodeRequire("../../scripts/lib/workflow-yaml.cjs") as {
   workflowJobBlock: (text: string, jobName: string) => string | null;
 };
-const { readPackageManagerLock } = nodeRequire("../../scripts/lib/pnpm-lock.cjs") as {
+const { parseYaml, readPackageManagerLock } = nodeRequire("../../scripts/lib/pnpm-lock.cjs") as {
+  parseYaml: (text: string) => unknown;
   readPackageManagerLock: (root: string) => unknown;
 };
 const semver = nodeRequire("semver") as {
@@ -31,6 +32,26 @@ const semver = nodeRequire("semver") as {
 describe("supply-chain audit policy", () => {
   const workflow = readFileSync(join(root, ".github/workflows/test.yml"), "utf8");
   const publishWorkflow = readFileSync(join(root, ".github/workflows/publish.yml"), "utf8");
+  const rawPnpmLock = parseYaml(readFileSync(join(root, "pnpm-lock.yaml"), "utf8")) as {
+    importers?: Record<
+      string,
+      {
+        dependencies?: Record<string, { specifier?: string; version?: string }>;
+        devDependencies?: Record<string, { specifier?: string; version?: string }>;
+      }
+    >;
+    packages?: Record<string, { resolution?: { integrity?: string } }>;
+    snapshots?: Record<
+      string,
+      {
+        dependencies?: Record<string, string>;
+        optionalDependencies?: Record<string, string>;
+      }
+    >;
+  };
+  const pnpmWorkspace = parseYaml(readFileSync(join(root, "pnpm-workspace.yaml"), "utf8")) as {
+    allowBuilds?: Record<string, boolean>;
+  };
   const workflowDirectory = join(root, ".github/workflows");
   const allWorkflows = readdirSync(workflowDirectory)
     .filter((name) => name.endsWith(".yml") || name.endsWith(".yaml"))
@@ -79,38 +100,50 @@ describe("supply-chain audit policy", () => {
     return pkg as LockPackageWithMetadata;
   }
 
-  function requireFixtureDependency(
-    pkg: LockPackage,
-    path: string,
-    dependencyName: string,
-  ): string {
+  function packageNameFromPath(path: string): string {
+    return path.slice(path.lastIndexOf("node_modules/") + "node_modules/".length);
+  }
+
+  function findPolicyFixtureVia(dependencyName: string): {
+    dependencyRange: string;
+    name: string;
+    path: string;
+    pkg: LockPackageWithMetadata;
+  } {
+    const candidates = Object.entries(lock.packages)
+      .filter(([path, pkg]) => {
+        if (path === `node_modules/${dependencyName}`) return false;
+        return !!(pkg.version && pkg.integrity && pkg.dependencies?.[dependencyName]);
+      })
+      .sort(([left], [right]) => left.localeCompare(right));
+    const [path, pkg] = candidates[0] ?? [];
+    if (!path || !pkg?.version || !pkg.integrity) {
+      throw new Error(
+        `Missing supply-chain policy fixture package with a real ${dependencyName} dependency edge in pnpm-lock.yaml.`,
+      );
+    }
     const dependencyRange = pkg.dependencies?.[dependencyName];
     if (!dependencyRange) {
       throw new Error(
         `Supply-chain policy fixture package ${path} must depend on ${dependencyName}; pick another present transitive fixture package.`,
       );
     }
-    return dependencyRange;
+    return {
+      dependencyRange,
+      name: packageNameFromPath(path),
+      path,
+      pkg: pkg as LockPackageWithMetadata,
+    };
   }
 
   const auditFixturePackage = requirePolicyFixturePackage(
     "node_modules/acorn",
     "synthetic vulnerable package",
   );
-  const policyFixtureTransitiveName = "acorn-jsx";
-  const policyFixtureTransitivePath = `node_modules/${policyFixtureTransitiveName}`;
   // This transitive package is an arbitrary stand-in used only to exercise
-  // advisory via/effects policy matching. If the dependency graph stops
-  // including it, pick another present package with an acorn dependency.
-  const policyFixtureTransitive = requirePolicyFixturePackage(
-    policyFixtureTransitivePath,
-    "synthetic transitive via/effects package",
-  );
-  const policyFixtureDependencyRange = requireFixtureDependency(
-    policyFixtureTransitive,
-    policyFixtureTransitivePath,
-    "acorn",
-  );
+  // advisory via/effects policy matching. Select it by required lockfile shape
+  // instead of package name so unrelated tooling swaps keep the test legible.
+  const policyFixtureVia = findPolicyFixtureVia("acorn");
   const zodPackage = requirePolicyFixturePackage("node_modules/zod", "direct advisory fixture");
   const exceptionPolicy = {
     allowedAdvisories: [
@@ -120,13 +153,13 @@ describe("supply-chain audit policy", () => {
         maxSeverity: "moderate",
         isDirect: false,
         nodes: ["node_modules/acorn"],
-        effects: [policyFixtureTransitiveName],
+        effects: [policyFixtureVia.name],
         package: { version: auditFixturePackage.version, integrity: auditFixturePackage.integrity },
         via: {
-          path: policyFixtureTransitivePath,
-          name: policyFixtureTransitiveName,
-          version: policyFixtureTransitive.version,
-          dependencyRange: policyFixtureDependencyRange,
+          path: policyFixtureVia.path,
+          name: policyFixtureVia.name,
+          version: policyFixtureVia.pkg.version,
+          dependencyRange: policyFixtureVia.dependencyRange,
         },
         expires: "2026-10-01",
         reason: "Test-only exception fixture for policy behavior.",
@@ -181,20 +214,20 @@ describe("supply-chain audit policy", () => {
               range: "<8.16.1",
             },
           ],
-          effects: [policyFixtureTransitiveName],
+          effects: [policyFixtureVia.name],
           range: "<8.16.1",
           nodes: ["node_modules/acorn"],
           fixAvailable: false,
           ...overrides,
         },
-        [policyFixtureTransitiveName]: {
-          name: policyFixtureTransitiveName,
+        [policyFixtureVia.name]: {
+          name: policyFixtureVia.name,
           severity: "moderate",
           isDirect: false,
           via: ["acorn"],
           effects: [],
           range: "*",
-          nodes: [policyFixtureTransitivePath],
+          nodes: [policyFixtureVia.path],
           fixAvailable: false,
         },
       },
@@ -591,6 +624,36 @@ describe("supply-chain audit policy", () => {
     expect(publishWorkflow).toContain('--tag "$npm_tag"');
     expect(publishWorkflow).not.toContain("--ignore-scripts=false");
     expect(publishWorkflow).not.toContain("tar -xzf");
+  });
+
+  it("keeps tsx dev-only and denies esbuild install builds", () => {
+    const tsxPackage = rawPnpmLock.packages?.["tsx@4.23.11"];
+    const tsxSnapshot = rawPnpmLock.snapshots?.["tsx@4.23.11"];
+    const esbuildPackage = rawPnpmLock.packages?.["esbuild@0.28.1"];
+    const esbuildPlatformPackages = Object.entries(rawPnpmLock.packages ?? {}).filter(([key]) =>
+      key.startsWith("@esbuild/"),
+    );
+
+    expect(packageJson.dependencies).not.toHaveProperty("tsx");
+    expect(packageJson.dependencies).not.toHaveProperty("esbuild");
+    expect(packageJson.devDependencies.tsx).toBe("4.23.11");
+    expect(rawPnpmLock.importers?.["."]?.devDependencies?.tsx).toEqual({
+      specifier: "4.23.11",
+      version: "4.23.11",
+    });
+    expect(tsxPackage?.resolution?.integrity).toBe(
+      "sha512-Ry2oTEUnhBdeEdWIztY8kf3/nBGnPnjMLVGL0YfdRXMORuPER5NlKmayqxtxRxwB1xBN+RivRaJfe7PM1rtiyw==",
+    );
+    expect(tsxSnapshot?.dependencies).toEqual({ esbuild: "0.28.1" });
+    expect(tsxSnapshot?.optionalDependencies).toEqual({ fsevents: "2.3.3" });
+    expect(esbuildPackage?.resolution?.integrity).toMatch(/^sha512-/);
+    expect(esbuildPlatformPackages.length).toBeGreaterThan(0);
+    for (const [key, metadata] of esbuildPlatformPackages) {
+      expect(key).toMatch(/@0\.28\.1$/);
+      expect(metadata.resolution?.integrity).toMatch(/^sha512-/);
+    }
+    expect(npmrc).toMatch(/^ignore-scripts=true$/m);
+    expect(pnpmWorkspace.allowBuilds?.esbuild).toBe(false);
   });
 
   it("keeps release checksum entries aligned with uploaded GitHub assets", () => {

--- a/tests/unit/supply-chain-policy.unit.test.ts
+++ b/tests/unit/supply-chain-policy.unit.test.ts
@@ -67,7 +67,7 @@ describe("supply-chain audit policy", () => {
     >;
   };
   const auditFixturePackage = lock.packages["node_modules/acorn"];
-  const auditFixtureVia = lock.packages["node_modules/acorn-walk"];
+  const auditFixtureVia = lock.packages["node_modules/acorn-jsx"];
   const zodPackage = lock.packages["node_modules/zod"];
   const exceptionPolicy = {
     allowedAdvisories: [
@@ -77,11 +77,11 @@ describe("supply-chain audit policy", () => {
         maxSeverity: "moderate",
         isDirect: false,
         nodes: ["node_modules/acorn"],
-        effects: ["acorn-walk"],
+        effects: ["acorn-jsx"],
         package: { version: auditFixturePackage.version, integrity: auditFixturePackage.integrity },
         via: {
-          path: "node_modules/acorn-walk",
-          name: "acorn-walk",
+          path: "node_modules/acorn-jsx",
+          name: "acorn-jsx",
           version: auditFixtureVia.version,
           dependencyRange: auditFixtureVia.dependencies?.acorn,
         },
@@ -138,20 +138,20 @@ describe("supply-chain audit policy", () => {
               range: "<8.16.1",
             },
           ],
-          effects: ["acorn-walk"],
+          effects: ["acorn-jsx"],
           range: "<8.16.1",
           nodes: ["node_modules/acorn"],
           fixAvailable: false,
           ...overrides,
         },
-        "acorn-walk": {
-          name: "acorn-walk",
+        "acorn-jsx": {
+          name: "acorn-jsx",
           severity: "moderate",
           isDirect: false,
           via: ["acorn"],
           effects: [],
           range: "*",
-          nodes: ["node_modules/acorn-walk"],
+          nodes: ["node_modules/acorn-jsx"],
           fixAvailable: false,
         },
       },

--- a/tests/unit/supply-chain-policy.unit.test.ts
+++ b/tests/unit/supply-chain-policy.unit.test.ts
@@ -54,21 +54,64 @@ describe("supply-chain audit policy", () => {
       expires: string;
     }>;
   };
-  const lock = readPackageManagerLock(root) as {
-    packages: Record<
-      string,
-      {
-        dependencies?: Record<string, string>;
-        optionalDependencies?: Record<string, string>;
-        engines?: { node?: string };
-        integrity?: string;
-        version?: string;
-      }
-    >;
+  type LockPackage = {
+    dependencies?: Record<string, string>;
+    optionalDependencies?: Record<string, string>;
+    engines?: { node?: string };
+    integrity?: string;
+    version?: string;
   };
-  const auditFixturePackage = lock.packages["node_modules/acorn"];
-  const auditFixtureVia = lock.packages["node_modules/acorn-jsx"];
-  const zodPackage = lock.packages["node_modules/zod"];
+  type LockPackageWithMetadata = LockPackage & { integrity: string; version: string };
+  const lock = readPackageManagerLock(root) as { packages: Record<string, LockPackage> };
+
+  function requirePolicyFixturePackage(path: string, purpose: string): LockPackageWithMetadata {
+    const pkg = lock.packages[path];
+    if (!pkg) {
+      throw new Error(
+        `Missing supply-chain policy fixture package ${path} (${purpose}). Pick another present pnpm-lock.yaml package for this synthetic advisory fixture.`,
+      );
+    }
+    if (!pkg.version || !pkg.integrity) {
+      throw new Error(
+        `Supply-chain policy fixture package ${path} (${purpose}) must have version and integrity metadata in pnpm-lock.yaml.`,
+      );
+    }
+    return pkg as LockPackageWithMetadata;
+  }
+
+  function requireFixtureDependency(
+    pkg: LockPackage,
+    path: string,
+    dependencyName: string,
+  ): string {
+    const dependencyRange = pkg.dependencies?.[dependencyName];
+    if (!dependencyRange) {
+      throw new Error(
+        `Supply-chain policy fixture package ${path} must depend on ${dependencyName}; pick another present transitive fixture package.`,
+      );
+    }
+    return dependencyRange;
+  }
+
+  const auditFixturePackage = requirePolicyFixturePackage(
+    "node_modules/acorn",
+    "synthetic vulnerable package",
+  );
+  const policyFixtureTransitiveName = "acorn-jsx";
+  const policyFixtureTransitivePath = `node_modules/${policyFixtureTransitiveName}`;
+  // This transitive package is an arbitrary stand-in used only to exercise
+  // advisory via/effects policy matching. If the dependency graph stops
+  // including it, pick another present package with an acorn dependency.
+  const policyFixtureTransitive = requirePolicyFixturePackage(
+    policyFixtureTransitivePath,
+    "synthetic transitive via/effects package",
+  );
+  const policyFixtureDependencyRange = requireFixtureDependency(
+    policyFixtureTransitive,
+    policyFixtureTransitivePath,
+    "acorn",
+  );
+  const zodPackage = requirePolicyFixturePackage("node_modules/zod", "direct advisory fixture");
   const exceptionPolicy = {
     allowedAdvisories: [
       {
@@ -77,13 +120,13 @@ describe("supply-chain audit policy", () => {
         maxSeverity: "moderate",
         isDirect: false,
         nodes: ["node_modules/acorn"],
-        effects: ["acorn-jsx"],
+        effects: [policyFixtureTransitiveName],
         package: { version: auditFixturePackage.version, integrity: auditFixturePackage.integrity },
         via: {
-          path: "node_modules/acorn-jsx",
-          name: "acorn-jsx",
-          version: auditFixtureVia.version,
-          dependencyRange: auditFixtureVia.dependencies?.acorn,
+          path: policyFixtureTransitivePath,
+          name: policyFixtureTransitiveName,
+          version: policyFixtureTransitive.version,
+          dependencyRange: policyFixtureDependencyRange,
         },
         expires: "2026-10-01",
         reason: "Test-only exception fixture for policy behavior.",
@@ -138,20 +181,20 @@ describe("supply-chain audit policy", () => {
               range: "<8.16.1",
             },
           ],
-          effects: ["acorn-jsx"],
+          effects: [policyFixtureTransitiveName],
           range: "<8.16.1",
           nodes: ["node_modules/acorn"],
           fixAvailable: false,
           ...overrides,
         },
-        "acorn-jsx": {
-          name: "acorn-jsx",
+        [policyFixtureTransitiveName]: {
+          name: policyFixtureTransitiveName,
           severity: "moderate",
           isDirect: false,
           via: ["acorn"],
           effects: [],
           range: "*",
-          nodes: ["node_modules/acorn-jsx"],
+          nodes: [policyFixtureTransitivePath],
           fixAvailable: false,
         },
       },


### PR DESCRIPTION
## Summary

- Replace the dev script runner with `tsx src/index.ts`.
- Remove `ts-node` from devDependencies and the lockfile, and add exact `tsx@4.23.11`.
- Keep install-script policy explicit by denying `esbuild` builds and update the supply-chain tests so the lockfile fixture and tsx/esbuild controls are pinned by regression coverage.
- Add an `[Unreleased]` changelog entry for the dev-runner swap and `esbuild` build denial.

## Linked issue

Closes #116

## Tests run

- `pnpm run dev` bounded startup smoke with `B2_REGISTER_ALL_TOOLS=true` and fake test credentials
- `pnpm run build`
- `pnpm run check:package-budget`
- `pnpm exec vitest run tests/unit/supply-chain-policy.unit.test.ts`
- `pnpm install --lockfile-only --force --registry=https://registry.npmjs.org/` (reported `Already up to date`)
- `pnpm install --frozen-lockfile`
- Registry integrity check: `npm view tsx@4.23.11 dependencies dist.integrity --json` matches `pnpm-lock.yaml`; published deps are `{"esbuild":"~0.28.0"}` and lock resolves `esbuild@0.28.1` with matching `tsx` sha512 integrity
- `pnpm run verify`
- Verified `tsx`/`esbuild` remain dev-only, lockfile entries are exact and sha512 integrity-pinned, install scripts remain disabled, and the packed tarball file list contains no installed `tsx`, `esbuild`, `@esbuild`, or `node_modules` payload paths.

## Review follow-up notes

- A clean public-registry lockfile resolve did not change `pnpm-lock.yaml`; the current published `tsx@4.23.11` package declares only `esbuild: ~0.28.0`, so the absence of `get-tsconfig` / `resolve-pkg-maps` is reproducible from the registry metadata for this version.
- The synthetic supply-chain advisory fixture now selects a package by required lockfile shape, requires a real `acorn` dependency edge, and fails with clear messages if the fixture package, version, integrity, or dependency range is absent.
- Added regression coverage that `tsx` remains exact-pinned in `devDependencies`, `esbuild` is not in `dependencies`, `tsx@4.23.11` resolves to `esbuild@0.28.1`, all `@esbuild/*@0.28.1` platform package entries carry sha512 integrity, `.npmrc` keeps `ignore-scripts=true`, and `pnpm-workspace.yaml` keeps `allowBuilds.esbuild: false`.
- CI installs run on GitHub-hosted runners (`ubuntu-latest`, with the cross-platform matrix also using `windows-latest` and `macos-latest`).