### PR TITLE
docs: record TypeScript 7 migration audit

### DIFF
--- a/.cspell/project-words.txt
+++ b/.cspell/project-words.txt
@@ -40,6 +40,7 @@ SUIDSGID
 thiennq
 tmpfs
 toon
+tsx
 tvzf
 ustar
 xvda

--- a/docs/PUBLIC_CONTRACTS.md
+++ b/docs/PUBLIC_CONTRACTS.md
@@ -13,6 +13,7 @@ current with code, CI, and GitHub release metadata.
 | [`DEPLOY.md`](DEPLOY.md)                               | Gonza              | Customer-hosted deployment and hardening runbook                        | #65, #66, #106               |
 | [`ARCHITECTURE.md`](ARCHITECTURE.md)                   | Gonza              | Runtime architecture and integration-boundary decisions                 | #71                          |
 | [`SDK_ADOPTION_CONTRACT.md`](SDK_ADOPTION_CONTRACT.md) | Gonza              | Official B2 SDK adoption and tool parity matrix                         | #71                          |
+| [`TYPESCRIPT_7_MIGRATION.md`](TYPESCRIPT_7_MIGRATION.md) | Gonza              | TypeScript 7 native compiler migration decision and trigger              | #114                         |
 | [`V1_SCOPE.md`](V1_SCOPE.md)                           | Gonza              | Phase 1 product, runtime, release, SDK, and protocol decision record    | #55, #71, #106               |
 | [`TOOL_CONTRACT.md`](TOOL_CONTRACT.md)                 | Gonza              | Tool-profile contract policy and fixture requirements                   | #49, #59                     |
 | [`TOOL_PROFILES.md`](TOOL_PROFILES.md)                 | Gonza              | Generated Phase 1 tool-profile reference                                | #49                          |

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -110,6 +110,8 @@ Node.js 22.23.1.
 TypeScript is intentionally constrained to the `6.0.x` line while
 the toolchain validates support on Node.js 22, 24, and 26. Widen the
 TypeScript range only with a matching typecheck and lint toolchain upgrade.
+The TypeScript 7 native compiler decision and trigger are recorded in
+[`TYPESCRIPT_7_MIGRATION.md`](TYPESCRIPT_7_MIGRATION.md).
 
 Biome is also the only formatter. `pnpm run format` and `pnpm run format:check`
 cover Biome-supported file types; Markdown and YAML files are not part of the

--- a/docs/TYPESCRIPT_7_MIGRATION.md
+++ b/docs/TYPESCRIPT_7_MIGRATION.md
@@ -39,7 +39,7 @@ on the TypeScript compiler API for this repository's current gates.
 | Consumer | Status | Migration note |
 | --- | --- | --- |
 | `build` | Feasible later | Native compiler output must be compared against TypeScript 6 output for CJS, `.d.ts`, `.d.ts.map`, and package exports. |
-| `typecheck` | Feasible later | Run on the Node.js 22.3.0, 22.23.1, 24, and 26 evidence paths and review any diagnostic drift. |
+| `typecheck` | Feasible later | Run on the Node.js 22.23.1, 24, and 26 deterministic toolchain matrix and review any diagnostic drift; the separate package smoke covers the Node.js 22.3.0 engine floor. |
 | `lint:docs` | Blocked now | It needs the TypeScript programmatic API through `typescript-eslint`, whose current support excludes TypeScript 7. |
 | `dev` | Already unblocked | The script uses `tsx`, avoiding `ts-node` and its compiler-API dependency. |
 
@@ -57,10 +57,7 @@ on the TypeScript compiler API for this repository's current gates.
 ## Required Evidence For The Future Migration
 
 - `pnpm install --frozen-lockfile`
-- `pnpm run typecheck`
-- `pnpm run build`
-- `pnpm run lint`
-- `pnpm run lint:docs`
+- `pnpm run verify`
 - `pnpm run test:contract`
 - `pnpm run test:protocol`
 - `pnpm run test:package`

--- a/docs/TYPESCRIPT_7_MIGRATION.md
+++ b/docs/TYPESCRIPT_7_MIGRATION.md
@@ -29,7 +29,7 @@ Until that trigger is met, do not merge a blanket `typescript@7` upgrade.
 - `typecheck` uses `tsc --noEmit -p tsconfig.typecheck.json`.
 - `lint:docs` uses ESLint, `typescript-eslint`, and type-aware parser services
   for TSDoc and JSDoc validation.
-- `dev` uses `tsx src/index.ts` and no longer depends on `ts-node`.
+- `dev` uses `tsx` and no longer depends on `ts-node`.
 
 Vitest and Biome are not blockers for TypeScript 7 because they do not depend
 on the TypeScript compiler API for this repository's current gates.

--- a/docs/TYPESCRIPT_7_MIGRATION.md
+++ b/docs/TYPESCRIPT_7_MIGRATION.md
@@ -1,0 +1,72 @@
+# TypeScript 7 Migration Record
+
+Issue: [#114](https://github.com/backblaze-labs/b2-mcp/issues/114)
+
+This record captures the feasibility audit for moving b2-mcp from the
+TypeScript 6.0 transition line to the native TypeScript 7 compiler.
+
+## Decision
+
+Adopt Option B: keep the repository pinned to TypeScript 6.0.x until
+TypeScript 7.1 is generally available and `typescript-eslint` publishes a
+compatible release that supports TypeScript 7 for type-aware linting.
+
+The trigger to proceed is:
+
+- TypeScript 7.1 GA includes the stable programmatic compiler API;
+- `typescript-eslint` supports TypeScript 7 in its peer range and type
+  information pipeline;
+- the repository can run `pnpm install --frozen-lockfile`,
+  `pnpm run typecheck`, `pnpm run build`, `pnpm run lint:docs`, and
+  `pnpm run test:package` without a TypeScript 6 compatibility package.
+
+Until that trigger is met, do not merge a blanket `typescript@7` upgrade.
+
+## Current State
+
+- `build` uses `tsc` to emit CommonJS JavaScript, declarations, declaration
+  maps, and source maps into `dist/`.
+- `typecheck` uses `tsc --noEmit -p tsconfig.typecheck.json`.
+- `lint:docs` uses ESLint, `typescript-eslint`, and type-aware parser services
+  for TSDoc and JSDoc validation.
+- `dev` uses `tsx src/index.ts` and no longer depends on `ts-node`.
+
+Vitest and Biome are not blockers for TypeScript 7 because they do not depend
+on the TypeScript compiler API for this repository's current gates.
+
+## Feasibility
+
+| Consumer | Status | Migration note |
+| --- | --- | --- |
+| `build` | Feasible later | Native compiler output must be compared against TypeScript 6 output for CJS, `.d.ts`, `.d.ts.map`, and package exports. |
+| `typecheck` | Feasible later | Run on the Node.js 22.3.0, 22.23.1, 24, and 26 evidence paths and review any diagnostic drift. |
+| `lint:docs` | Blocked now | It needs the TypeScript programmatic API through `typescript-eslint`, whose current support excludes TypeScript 7. |
+| `dev` | Already unblocked | The script uses `tsx`, avoiding `ts-node` and its compiler-API dependency. |
+
+## Staged Path
+
+1. Keep `typescript` on `~6.0.x` and keep the README badge on TypeScript 6.x.
+2. Keep `dev` on `tsx` and do not reintroduce `ts-node`.
+3. Revisit the compiler migration only after the trigger above is met.
+4. For the migration PR, pin an exact TypeScript 7.x version, regenerate the
+   lockfile, and run the deterministic gate plus package smoke evidence.
+5. Compare `dist/` emitted by TypeScript 6 and TypeScript 7 before trusting the
+   new compiler path. Reviewed-equivalent output is acceptable only when the PR
+   explains every difference.
+
+## Required Evidence For The Future Migration
+
+- `pnpm install --frozen-lockfile`
+- `pnpm run typecheck`
+- `pnpm run build`
+- `pnpm run lint`
+- `pnpm run lint:docs`
+- `pnpm run test:contract`
+- `pnpm run test:protocol`
+- `pnpm run test:package`
+- `pnpm run check:package-budget`
+- `pnpm run audit:supply-chain`
+
+The migration must not add production dependencies or raise the production
+package budget. Any new compatibility package must stay in `devDependencies`
+and be removed once the toolchain no longer needs it.

--- a/tests/contract/readme-drift.contract.test.ts
+++ b/tests/contract/readme-drift.contract.test.ts
@@ -71,6 +71,8 @@ describe("README project badges", () => {
 
     expect(packageMetadata.name).toBe("@backblaze-labs/b2-mcp");
     expect(packageMetadata.engines.node).toBe(">=22.3.0");
+    // Intentional overlap with typescript-7-migration: this guard owns README
+    // badge sync, while the migration test owns the 6.0-line deferral record.
     expect(packageMetadata.devDependencies.typescript).toMatch(/^~6\./);
     expect(readme).toContain("actions/workflows/test.yml/badge.svg");
     expect(readme).toContain("CodeQL-enabled-brightgreen");

--- a/tests/contract/typescript-7-migration.contract.test.ts
+++ b/tests/contract/typescript-7-migration.contract.test.ts
@@ -23,19 +23,23 @@ describe("TypeScript 7 migration record", () => {
   });
 
   it("keeps the current toolchain on TypeScript 6 while doc lint is blocked", () => {
+    // Intentional overlap with readme-drift: the badge guard owns README sync,
+    // while this test owns the migration decision's stricter 6.0-line deferral.
     expect(pkg.devDependencies.typescript).toMatch(/^~6\.0\.\d+$/);
-    expect(pkg.devDependencies["typescript-eslint"]).toBe("8.66.0");
+    expect(pkg.devDependencies["typescript-eslint"]).toMatch(/^8\.\d+\.\d+$/);
     expect(pkg.dependencies).not.toHaveProperty("typescript");
     expect(pkg.dependencies).not.toHaveProperty("typescript-eslint");
     expect(migrationRecord).toContain("`lint:docs` | Blocked now");
+    expect(migrationRecord).toContain("The trigger to proceed is:");
   });
 
   it("keeps local development off ts-node", () => {
-    expect(pkg.scripts.dev).toBe("tsx src/index.ts");
-    expect(pkg.devDependencies.tsx).toBe("4.23.11");
+    expect(pkg.scripts.dev).toMatch(/\btsx\b/);
+    expect(pkg.scripts.dev).not.toMatch(/\bts-node\b/);
+    expect(pkg.devDependencies.tsx).toMatch(/^4\.\d+\.\d+$/);
     expect(pkg.dependencies).not.toHaveProperty("tsx");
     expect(pkg.dependencies).not.toHaveProperty("ts-node");
     expect(pkg.devDependencies).not.toHaveProperty("ts-node");
-    expect(migrationRecord).toContain("`dev` uses `tsx src/index.ts`");
+    expect(migrationRecord).toContain("`dev` uses `tsx`");
   });
 });

--- a/tests/contract/typescript-7-migration.contract.test.ts
+++ b/tests/contract/typescript-7-migration.contract.test.ts
@@ -26,7 +26,7 @@ describe("TypeScript 7 migration record", () => {
     // Intentional overlap with readme-drift: the badge guard owns README sync,
     // while this test owns the migration decision's stricter 6.0-line deferral.
     expect(pkg.devDependencies.typescript).toMatch(/^~6\.0\.\d+$/);
-    expect(pkg.devDependencies["typescript-eslint"]).toMatch(/^8\.\d+\.\d+$/);
+    expect(pkg.devDependencies).toHaveProperty("typescript-eslint");
     expect(pkg.dependencies).not.toHaveProperty("typescript");
     expect(pkg.dependencies).not.toHaveProperty("typescript-eslint");
     expect(migrationRecord).toContain("`lint:docs` | Blocked now");
@@ -36,7 +36,7 @@ describe("TypeScript 7 migration record", () => {
   it("keeps local development off ts-node", () => {
     expect(pkg.scripts.dev).toMatch(/\btsx\b/);
     expect(pkg.scripts.dev).not.toMatch(/\bts-node\b/);
-    expect(pkg.devDependencies.tsx).toMatch(/^4\.\d+\.\d+$/);
+    expect(pkg.devDependencies).toHaveProperty("tsx");
     expect(pkg.dependencies).not.toHaveProperty("tsx");
     expect(pkg.dependencies).not.toHaveProperty("ts-node");
     expect(pkg.devDependencies).not.toHaveProperty("ts-node");

--- a/tests/contract/typescript-7-migration.contract.test.ts
+++ b/tests/contract/typescript-7-migration.contract.test.ts
@@ -1,0 +1,41 @@
+import { readFileSync } from "fs";
+import { join } from "path";
+import { readJson, root } from "./support";
+
+const migrationRecord = readFileSync(join(root, "docs/TYPESCRIPT_7_MIGRATION.md"), "utf8");
+const testingDoc = readFileSync(join(root, "docs/TESTING.md"), "utf8");
+
+const pkg = readJson<{
+  dependencies: Record<string, string>;
+  devDependencies: Record<string, string>;
+  scripts: Record<string, string>;
+}>("package.json");
+
+describe("TypeScript 7 migration record", () => {
+  it("records the staged migration decision and trigger for issue 114", () => {
+    expect(migrationRecord).toContain("Issue: [#114]");
+    expect(migrationRecord).toContain("Adopt Option B");
+    expect(migrationRecord).toContain("TypeScript 7.1 GA");
+    expect(migrationRecord).toContain("typescript-eslint");
+    expect(migrationRecord).toContain("stable programmatic compiler API");
+    expect(migrationRecord).toContain("do not merge a blanket `typescript@7` upgrade");
+    expect(testingDoc).toContain("TYPESCRIPT_7_MIGRATION.md");
+  });
+
+  it("keeps the current toolchain on TypeScript 6 while doc lint is blocked", () => {
+    expect(pkg.devDependencies.typescript).toMatch(/^~6\.0\.\d+$/);
+    expect(pkg.devDependencies["typescript-eslint"]).toBe("8.66.0");
+    expect(pkg.dependencies).not.toHaveProperty("typescript");
+    expect(pkg.dependencies).not.toHaveProperty("typescript-eslint");
+    expect(migrationRecord).toContain("`lint:docs` | Blocked now");
+  });
+
+  it("keeps local development off ts-node", () => {
+    expect(pkg.scripts.dev).toBe("tsx src/index.ts");
+    expect(pkg.devDependencies.tsx).toBe("4.23.11");
+    expect(pkg.dependencies).not.toHaveProperty("tsx");
+    expect(pkg.dependencies).not.toHaveProperty("ts-node");
+    expect(pkg.devDependencies).not.toHaveProperty("ts-node");
+    expect(migrationRecord).toContain("`dev` uses `tsx src/index.ts`");
+  });
+});


### PR DESCRIPTION
## Summary
- Records the #114 TypeScript 7 native compiler feasibility decision as Option B: wait for TypeScript 7.1 plus `typescript-eslint` support.
- Documents the current consumer-by-consumer status, migration trigger, future evidence list, and production package-budget constraint.
- Adds a contract test that keeps the TS 6 decision record and `tsx` dev path from drifting without pinning incidental helper versions.
- Registers the migration record in `docs/PUBLIC_CONTRACTS.md` and cross-references the intentional TS6 guard overlap with `readme-drift`.
- Corrects review feedback by using the canonical `pnpm run verify` evidence item and limiting typecheck diagnostics to the actual Node.js 22.23.1, 24, and 26 toolchain matrix.

## Linked issue
Closes #114

## Tests run
- `/Users/gpenacastellanos/miniforge3/condabin/mamba run -n b2-mcp-issue-114 pnpm install --frozen-lockfile`
- `/Users/gpenacastellanos/miniforge3/condabin/mamba run -n b2-mcp-issue-114 pnpm run typecheck`
- `/Users/gpenacastellanos/miniforge3/condabin/mamba run -n b2-mcp-issue-114 pnpm exec vitest run tests/contract/typescript-7-migration.contract.test.ts`
- `/Users/gpenacastellanos/miniforge3/condabin/mamba run -n b2-mcp-issue-114 pnpm exec vitest run tests/contract/typescript-7-migration.contract.test.ts tests/contract/readme-drift.contract.test.ts`
- `/Users/gpenacastellanos/miniforge3/condabin/mamba run -n b2-mcp-issue-114 pnpm run verify`
- `/Users/gpenacastellanos/miniforge3/condabin/mamba run -n b2-mcp-issue-114 pnpm run test:contract`
- `/Users/gpenacastellanos/miniforge3/condabin/mamba run -n b2-mcp-issue-114 pnpm run lint:links`
- `/Users/gpenacastellanos/miniforge3/condabin/mamba run -n b2-mcp-issue-114 pnpm run check:package-budget`
- dev stdio smoke through `node_modules/.bin/tsx src/index.ts` with fake credentials and no-network guard (`tools=40`)

## Follow-up notes
- Do not upgrade `typescript` to 7.x until the documented TypeScript 7.1 and `typescript-eslint` support trigger is met.
- The production dependency graph and package budget are unchanged.