### PR TITLE
Add persistent Quality Keeper advisory reviews

### DIFF
--- a/.github/workflows/quality-keeper.yml
+++ b/.github/workflows/quality-keeper.yml
@@ -27,8 +27,8 @@ jobs:
         github.event.pull_request.head.repo.full_name == github.repository &&
         github.event.pull_request.draft == false
       }}
-    # QK PRs #313/#315: explicit b2-mcp Repository Activation with private-runner
-    # package-manager provisioning and #213 Run Contract prerequisite support.
+    # QK PRs #313/#315: activation with package-manager provisioning and #213 prerequisites.
+    # backblaze-labs/quality-keeper/.github/workflows/quality-keeper-private-reusable.yml reviewed 2026-08-15.
     uses: backblaze-labs/quality-keeper/.github/workflows/quality-keeper-private-reusable.yml@f7abca3b354393a7d6d908547857a50c2b6f7010
     permissions:
       contents: read

--- a/.github/workflows/quality-keeper.yml
+++ b/.github/workflows/quality-keeper.yml
@@ -1,0 +1,38 @@
+# Quality Keeper private-repository caller (backblaze-labs/quality-keeper#312).
+#
+# All assessment, execution, artifact, and comment behavior lives in the QK-owned
+# reusable workflow pinned below. This repository keeps its existing test,
+# contract, smoke, and publish workflows as the authoritative product gates;
+# Quality Keeper adds an advisory quality view and does not replace them.
+#
+# Authentication boundary:
+# - GitHub's private Actions-sharing token fetches QK; no QK_INSTALL_TOKEN/PAT.
+# - Target code runs only in the reusable workflow's contents-read execute job.
+# - QK_APP_PRIVATE_KEY reaches only its separate report job, which runs no target
+#   code and mints a short-lived Quality Keeper GitHub App token.
+
+name: Quality Keeper
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
+
+# No pull_request_target: fork, draft, and unknown-head code is never trusted.
+permissions: {}
+
+jobs:
+  quality-keeper:
+    if: >-
+      ${{
+        github.event.pull_request.head.repo.full_name == github.repository &&
+        github.event.pull_request.draft == false
+      }}
+    # QK PR #313 / issue #312: explicit b2-mcp Repository Activation on top of
+    # #213 Slice 3b Repository Run Contract prerequisite support.
+    uses: backblaze-labs/quality-keeper/.github/workflows/quality-keeper-private-reusable.yml@c114f68a19ef97292dc4fa4af3f9ebb553141221
+    permissions:
+      contents: read
+      pull-requests: write
+      actions: read
+    secrets:
+      QK_APP_PRIVATE_KEY: ${{ secrets.QK_APP_PRIVATE_KEY }}

--- a/.github/workflows/quality-keeper.yml
+++ b/.github/workflows/quality-keeper.yml
@@ -27,9 +27,9 @@ jobs:
         github.event.pull_request.head.repo.full_name == github.repository &&
         github.event.pull_request.draft == false
       }}
-    # QK PR #313 / issue #312: explicit b2-mcp Repository Activation on top of
-    # #213 Slice 3b Repository Run Contract prerequisite support.
-    uses: backblaze-labs/quality-keeper/.github/workflows/quality-keeper-private-reusable.yml@c114f68a19ef97292dc4fa4af3f9ebb553141221
+    # QK PRs #313/#315: explicit b2-mcp Repository Activation with private-runner
+    # package-manager provisioning and #213 Run Contract prerequisite support.
+    uses: backblaze-labs/quality-keeper/.github/workflows/quality-keeper-private-reusable.yml@f7abca3b354393a7d6d908547857a50c2b6f7010
     permissions:
       contents: read
       pull-requests: write


### PR DESCRIPTION
Closes #150.

## What changed

Added the tiny private-repository Quality Keeper caller, pinned to reviewed QK main SHA `c114f68a19ef97292dc4fa4af3f9ebb553141221` (QK PR #313 / issue #312).

The caller runs on same-repository, non-draft pull requests and delegates all behavior to QK's private reusable workflow. Existing `test.yml`, `contract.yml`, `smoke.yml`, and `publish.yml` are unchanged and remain the repository-owned product gates. QK is advisory/non-blocking.

## Security and authentication

- No `pull_request_target`.
- No `QK_INSTALL_TOKEN` or PAT: this private repository uses GitHub Actions private-repository sharing.
- Target code executes only in QK's `contents: read` execute job.
- `QK_APP_PRIVATE_KEY` is forwarded only to the separate report job, which runs no target code.
- Fork, draft, and unknown-head PRs do not run target code.

## Validation before push

- Workflow YAML parses successfully.
- `git diff --check` clean.
- One intended workflow file; no product code or existing workflow changed.
- The reusable-workflow interface at the pinned SHA accepts the forwarded secret and requested permissions.

## Live proof question

The repository API currently shows no repository-level `QK_APP_PRIVATE_KEY`. This PR run will establish whether the existing organization secret is already shared with b2-mcp. If not, execute/artifact behavior can still run, but an org/repo admin must grant the App secret before the Advisory comment can post. No PAT fallback should be added.
