### PR TITLE
Fix bucket notification DNS test determinism

### DIFF
--- a/tests/unit/b2-error-paths.unit.test.ts
+++ b/tests/unit/b2-error-paths.unit.test.ts
@@ -4,6 +4,7 @@
  */
 
 import { createServer, invalidateAuthManagerCache } from "../../src/server";
+import { setWebhookDnsLookupForTests } from "../../src/b2/buckets";
 import { setB2SdkClientFactoryForTests } from "../support/sdk-factory-hook";
 import type { McpServer } from "../../src/mcp";
 import { callTool, testConfig } from "../support/deterministic-fakes";
@@ -19,6 +20,7 @@ let server: McpServer;
 
 beforeEach(() => {
   invalidateAuthManagerCache();
+  setWebhookDnsLookupForTests(async () => [{ address: "93.184.216.34" }]);
   installSdkTransport(
     new RecordingTransport((request) => {
       if (b2EndpointName(request) === "b2_authorize_account") {
@@ -36,6 +38,7 @@ beforeEach(() => {
 
 afterEach(() => {
   vi.restoreAllMocks();
+  setWebhookDnsLookupForTests(null);
   setB2SdkClientFactoryForTests(null);
   invalidateAuthManagerCache();
 });

--- a/tests/unit/b2-error-paths.unit.test.ts
+++ b/tests/unit/b2-error-paths.unit.test.ts
@@ -20,7 +20,6 @@ let server: McpServer;
 
 beforeEach(() => {
   invalidateAuthManagerCache();
-  setWebhookDnsLookupForTests(async () => [{ address: "93.184.216.34" }]);
   installSdkTransport(
     new RecordingTransport((request) => {
       if (b2EndpointName(request) === "b2_authorize_account") {
@@ -70,7 +69,6 @@ describe("B2 tool error paths (catch blocks)", () => {
     "b2_delete_bucket",
     "b2_update_bucket",
     "b2_get_bucket_notification_rules",
-    "b2_set_bucket_notification_rules",
     "b2_list_keys",
     "b2_delete_key",
     "b2_update_file_legal_hold",
@@ -79,6 +77,14 @@ describe("B2 tool error paths (catch blocks)", () => {
 
   it.each(nativeTools)("%s returns a structured SDK error", async (tool) => {
     const result = await callTool(server, tool, args);
+    expect(result.isError).toBe(true);
+    expect(result.content[0].text).toContain("bad_request");
+    expect(result.content[0].text).toContain("req-native-error");
+  });
+
+  it("b2_set_bucket_notification_rules returns a structured SDK error", async () => {
+    setWebhookDnsLookupForTests(async () => [{ address: "93.184.216.34" }]);
+    const result = await callTool(server, "b2_set_bucket_notification_rules", args);
     expect(result.isError).toBe(true);
     expect(result.content[0].text).toContain("bad_request");
     expect(result.content[0].text).toContain("req-native-error");

--- a/tests/unit/b2-tools.unit.test.ts
+++ b/tests/unit/b2-tools.unit.test.ts
@@ -1019,7 +1019,7 @@ describe("bucket notification rules", () => {
     });
 
     expect(res.isError).toBe(true);
-    expect(res.content[0].text).toMatch(/resolve|non-public|public IP/i);
+    expect(res.content[0].text).toMatch(/must not resolve to a non-public IP address/i);
   });
 
   it("rejects webhook hostnames that do not resolve", async () => {
@@ -1035,7 +1035,7 @@ describe("bucket notification rules", () => {
     });
 
     expect(res.isError).toBe(true);
-    expect(res.content[0].text).toMatch(/resolve.*public IP/i);
+    expect(res.content[0].text).toMatch(/must resolve to a public IP address/i);
   });
 
   it("rejects webhook URLs with embedded credentials", async () => {

--- a/tests/unit/b2-tools.unit.test.ts
+++ b/tests/unit/b2-tools.unit.test.ts
@@ -1022,6 +1022,22 @@ describe("bucket notification rules", () => {
     expect(res.content[0].text).toMatch(/resolve|non-public|public IP/i);
   });
 
+  it("rejects webhook hostnames that do not resolve", async () => {
+    setWebhookDnsLookupForTests(async () => {
+      throw new Error("ENOTFOUND");
+    });
+    const bucket = await createBucket("notify-dns-unresolved");
+
+    const res = await callTool(server, "b2_set_bucket_notification_rules", {
+      bucketId: bucket.id,
+      eventNotificationRules: [ruleWith("https://customer.example.com/hook")],
+      confirm: true,
+    });
+
+    expect(res.isError).toBe(true);
+    expect(res.content[0].text).toMatch(/resolve.*public IP/i);
+  });
+
   it("rejects webhook URLs with embedded credentials", async () => {
     const bucket = await createBucket("notify-userinfo");
     const res = await callTool(server, "b2_set_bucket_notification_rules", {

--- a/tests/unit/b2-tools.unit.test.ts
+++ b/tests/unit/b2-tools.unit.test.ts
@@ -1022,6 +1022,23 @@ describe("bucket notification rules", () => {
     expect(res.content[0].text).toMatch(/must not resolve to a non-public IP address/i);
   });
 
+  it("rejects webhook hostnames that resolve to mixed public and private addresses", async () => {
+    setWebhookDnsLookupForTests(async () => [
+      { address: "93.184.216.34" },
+      { address: "169.254.169.254" },
+    ]);
+    const bucket = await createBucket("notify-dns-rebind");
+
+    const res = await callTool(server, "b2_set_bucket_notification_rules", {
+      bucketId: bucket.id,
+      eventNotificationRules: [ruleWith("https://customer.example.com/hook")],
+      confirm: true,
+    });
+
+    expect(res.isError).toBe(true);
+    expect(res.content[0].text).toMatch(/must not resolve to a non-public IP address/i);
+  });
+
   it("rejects webhook hostnames that do not resolve", async () => {
     setWebhookDnsLookupForTests(async () => {
       throw new Error("ENOTFOUND");


### PR DESCRIPTION
## Summary
- Use the test-only webhook DNS resolver seam only around the `b2_set_bucket_notification_rules` SDK error-path case so the mocked `bad_request` response is reached deterministically.
- Add unresolved-host and mixed public/private-address DNS coverage for bucket notification webhook validation so DNS failures and rebinding-style responses remain rejected.
- Tighten adjacent DNS rejection assertions to match the exact private-address and unresolved-host validation messages consistently.

## Linked issue
Closes #138

## Tests run
- `pnpm run test:unit -- tests/unit/b2-error-paths.unit.test.ts tests/unit/b2-tools.unit.test.ts`
- `pnpm run test:unit -- tests/unit/b2-tools.unit.test.ts`
- `pnpm run test:unit`
- `pnpm run typecheck`
- `pnpm run lint`

## Follow-up notes
- None.