### PR TITLE
test: cover TOON output encoder

### DIFF
--- a/tests/unit/result-serializer.unit.test.ts
+++ b/tests/unit/result-serializer.unit.test.ts
@@ -1,5 +1,7 @@
 import {
+  MAX_TOON_INPUT_DEPTH,
   MAX_TOON_INPUT_JSON_CHARS,
+  MAX_TOON_INPUT_NODES,
   parseMcpOutputFormat,
   preflightMcpOutputFormat,
   runWithResultSerializationOptions,
@@ -7,6 +9,7 @@ import {
   TOON_IMPLEMENTATION,
   TOON_SPEC_VERSION,
 } from "../../src/utils/result-serializer";
+import type { JsonCompatible } from "../../src/utils/result-serializer";
 import {
   runWithSanitizerOptions,
   SECRET_SANITIZER_REDACTION,
@@ -53,6 +56,35 @@ describe("result serializer", () => {
 
     expect(result.content[0].text).toContain("buckets[2]{bucketName,bucketType}:");
     await expect(decodeToon(result.content[0].text)).resolves.toEqual(result.structuredContent);
+  });
+
+  it("keeps canonical structured content while only changing text rendering", async () => {
+    const data = {
+      buckets: [
+        { bucketName: "alpha", bucketType: "allPrivate" },
+        { bucketName: "beta", bucketType: "allPublic" },
+      ],
+      nextContinuationToken: "cursor==",
+    };
+
+    const jsonResult = serializeStructuredToolResult(data, {}, "json");
+    const toonResult = serializeStructuredToolResult(data, {}, "toon");
+
+    expect(jsonResult.structuredContent).toEqual(data);
+    expect(toonResult.structuredContent).toEqual(data);
+    expect(jsonResult.content[0].text).toBe(JSON.stringify(data));
+    expect(toonResult.content[0].text).toBe(
+      [
+        "buckets[2]{bucketName,bucketType}:",
+        "  alpha,allPrivate",
+        "  beta,allPublic",
+        "nextContinuationToken: cursor==",
+      ].join("\n"),
+    );
+    expect(toonResult.content[0].text).not.toBe(jsonResult.content[0].text);
+    await expect(decodeToon(toonResult.content[0].text)).resolves.toEqual(
+      toonResult.structuredContent,
+    );
   });
 
   it("serializes compact JSON when compatibility mode is selected", async () => {
@@ -164,6 +196,23 @@ describe("result serializer", () => {
     expect(result.content[0].text).toBe(JSON.stringify(result.structuredContent));
   });
 
+  it("falls back to JSON text without changing structured content at TOON bounds", () => {
+    const largeValue = { value: "x".repeat(MAX_TOON_INPUT_JSON_CHARS) };
+    const largeValueResult = serializeStructuredToolResult(largeValue, {}, "toon");
+    expect(largeValueResult.structuredContent).toEqual(largeValue);
+    expect(largeValueResult.content[0].text).toBe(JSON.stringify(largeValue));
+
+    const deepValue = nestedValue(MAX_TOON_INPUT_DEPTH + 1);
+    const deepValueResult = serializeStructuredToolResult(deepValue, {}, "toon");
+    expect(deepValueResult.structuredContent).toEqual(deepValue);
+    expect(deepValueResult.content[0].text).toBe(JSON.stringify(deepValue));
+
+    const manyNodes = Array.from({ length: MAX_TOON_INPUT_NODES + 1 }, () => "");
+    const manyNodesResult = serializeStructuredToolResult(manyNodes, {}, "toon");
+    expect(manyNodesResult.structuredContent).toEqual(manyNodes);
+    expect(manyNodesResult.content[0].text).toBe(JSON.stringify(manyNodes));
+  });
+
   it("preflights TOON mode with a smoke serialization", () => {
     expect(() => preflightMcpOutputFormat("json")).not.toThrow();
     expect(() => preflightMcpOutputFormat("toon")).not.toThrow();
@@ -269,3 +318,11 @@ describe("result serializer", () => {
     }
   });
 });
+
+function nestedValue(depth: number): JsonCompatible {
+  let value: JsonCompatible = "leaf";
+  for (let index = 0; index < depth; index++) {
+    value = { child: value };
+  }
+  return value;
+}

--- a/tests/unit/result-serializer.unit.test.ts
+++ b/tests/unit/result-serializer.unit.test.ts
@@ -189,19 +189,16 @@ describe("result serializer", () => {
   });
 
   it("falls back to compact JSON when TOON input bounds are exceeded", () => {
+    const value = { value: "x".repeat(MAX_TOON_INPUT_JSON_CHARS) };
     const result = runWithResultSerializationOptions({ outputFormat: "toon" }, () =>
-      toolJson({ value: "x".repeat(MAX_TOON_INPUT_JSON_CHARS) }),
+      toolJson(value),
     );
 
+    expect(result.structuredContent).toEqual(value);
     expect(result.content[0].text).toBe(JSON.stringify(result.structuredContent));
   });
 
-  it("falls back to JSON text without changing structured content at TOON bounds", () => {
-    const largeValue = { value: "x".repeat(MAX_TOON_INPUT_JSON_CHARS) };
-    const largeValueResult = serializeStructuredToolResult(largeValue, {}, "toon");
-    expect(largeValueResult.structuredContent).toEqual(largeValue);
-    expect(largeValueResult.content[0].text).toBe(JSON.stringify(largeValue));
-
+  it("falls back to JSON text without changing structured content at depth and node bounds", () => {
     const deepValue = nestedValue(MAX_TOON_INPUT_DEPTH + 1);
     const deepValueResult = serializeStructuredToolResult(deepValue, {}, "toon");
     expect(deepValueResult.structuredContent).toEqual(deepValue);

--- a/tests/unit/toon-encoder.unit.test.ts
+++ b/tests/unit/toon-encoder.unit.test.ts
@@ -2,6 +2,66 @@ import { encodeToon } from "../../src/utils/toon-encoder";
 
 type ToonValue = Parameters<typeof encodeToon>[0];
 type ToonObject = { [key: string]: ToonValue };
+type FallbackListItemCase = [name: string, items: ToonObject[], lines: string[]];
+
+const fallbackListItemCases: FallbackListItemCase[] = [
+  [
+    "primitive field",
+    [{ id: 1 }, { other: "sentinel" }],
+    ["items[2]:", "  - id: 1", "  - other: sentinel"],
+  ],
+  ["empty object item", [{}, { other: "sentinel" }], ["items[2]:", "  -", "  - other: sentinel"]],
+  [
+    "nested tabular array field",
+    [
+      {
+        files: [
+          { name: "a", size: 1 },
+          { name: "b", size: 2 },
+        ],
+        note: "ok",
+      },
+    ],
+    ["items[1]:", "  - files[2]{name,size}:", "      a,1", "      b,2", "    note: ok"],
+  ],
+  [
+    "keyed object field",
+    [{ lookup: { alpha: { size: 1 }, beta: { size: 2 } }, note: "map" }, { other: "sentinel" }],
+    [
+      "items[2]:",
+      "  - lookup[2:]{size}:",
+      "      alpha: 1",
+      "      beta: 2",
+      "    note: map",
+      "  - other: sentinel",
+    ],
+  ],
+  [
+    "empty array field",
+    [{ first: [], note: "empty" }],
+    ["items[1]:", "  - first: []", "    note: empty"],
+  ],
+  [
+    "inline primitive array field",
+    [{ first: [1, 2], note: "inline" }],
+    ["items[1]:", "  - first[2]: 1,2", "    note: inline"],
+  ],
+  [
+    "nested primitive array field",
+    [{ first: [[1], [2]], note: "nested" }],
+    ["items[1]:", "  - first[2]:", "      - [1]: 1", "      - [1]: 2", "    note: nested"],
+  ],
+  [
+    "empty object field",
+    [{ first: {}, note: "empty-object" }],
+    ["items[1]:", "  - first:", "    note: empty-object"],
+  ],
+  [
+    "nested object field",
+    [{ first: { nested: 1 }, note: "object" }, { other: "sentinel" }],
+    ["items[2]:", "  - first:", "      nested: 1", "    note: object", "  - other: sentinel"],
+  ],
+];
 
 describe("TOON encoder", () => {
   it.each([
@@ -40,7 +100,7 @@ describe("TOON encoder", () => {
         "bad,key": "x",
         " spaced key": "y",
         "a{b}c": "z",
-        pairedSurrogate,
+        emoji: pairedSurrogate,
       }),
     ).toBe(
       [
@@ -48,7 +108,7 @@ describe("TOON encoder", () => {
         '"bad,key": x',
         '" spaced key": y',
         '"a{b}c": z',
-        `pairedSurrogate: ${pairedSurrogate}`,
+        `emoji: ${pairedSurrogate}`,
       ].join("\n"),
     );
     expect(() => encodeToon({ bad: "\uD800" })).toThrow(/unpaired surrogate U\+D800/);
@@ -141,67 +201,10 @@ describe("TOON encoder", () => {
     ).toBe(["accounts[2:]{enabled,quota}:", "  alpha: true,null", "  beta: false,100"].join("\n"));
   });
 
-  it.each([
-    [
-      "primitive field",
-      [{ id: 1 }, { other: "sentinel" }],
-      ["items[2]:", "  - id: 1", "  - other: sentinel"],
-    ],
-    ["empty object item", [{}, { other: "sentinel" }], ["items[2]:", "  -", "  - other: sentinel"]],
-    [
-      "nested tabular array field",
-      [
-        {
-          files: [
-            { name: "a", size: 1 },
-            { name: "b", size: 2 },
-          ],
-          note: "ok",
-        },
-      ],
-      ["items[1]:", "  - files[2]{name,size}:", "      a,1", "      b,2", "    note: ok"],
-    ],
-    [
-      "keyed object field",
-      [{ lookup: { alpha: { size: 1 }, beta: { size: 2 } }, note: "map" }, { other: "sentinel" }],
-      [
-        "items[2]:",
-        "  - lookup[2:]{size}:",
-        "      alpha: 1",
-        "      beta: 2",
-        "    note: map",
-        "  - other: sentinel",
-      ],
-    ],
-    [
-      "empty array field",
-      [{ first: [], note: "empty" }],
-      ["items[1]:", "  - first: []", "    note: empty"],
-    ],
-    [
-      "inline primitive array field",
-      [{ first: [1, 2], note: "inline" }],
-      ["items[1]:", "  - first[2]: 1,2", "    note: inline"],
-    ],
-    [
-      "nested primitive array field",
-      [{ first: [[1], [2]], note: "nested" }],
-      ["items[1]:", "  - first[2]:", "      - [1]: 1", "      - [1]: 2", "    note: nested"],
-    ],
-    [
-      "empty object field",
-      [{ first: {}, note: "empty-object" }],
-      ["items[1]:", "  - first:", "    note: empty-object"],
-    ],
-    [
-      "nested object field",
-      [{ first: { nested: 1 }, note: "object" }, { other: "sentinel" }],
-      ["items[2]:", "  - first:", "      nested: 1", "    note: object", "  - other: sentinel"],
-    ],
-  ])(
+  it.each(fallbackListItemCases)(
     "falls back to list items for non-tabular arrays of objects with %s",
     (_name, items, lines) => {
-      expect(encodeToon({ items: items as ToonObject[] })).toBe(lines.join("\n"));
+      expect(encodeToon({ items })).toBe(lines.join("\n"));
     },
   );
 

--- a/tests/unit/toon-encoder.unit.test.ts
+++ b/tests/unit/toon-encoder.unit.test.ts
@@ -1,0 +1,259 @@
+import { encodeToon } from "../../src/utils/toon-encoder";
+import {
+  MAX_TOON_INPUT_DEPTH,
+  MAX_TOON_INPUT_JSON_CHARS,
+  MAX_TOON_INPUT_NODES,
+  serializeStructuredToolResult,
+} from "../../src/utils/result-serializer";
+import type { JsonCompatible } from "../../src/utils/result-serializer";
+import { decodeToon } from "./toon-decoder-helper";
+
+describe("TOON encoder", () => {
+  it.each([
+    ["plain string", "plain", "plain"],
+    ["empty string", "", '""'],
+    ["leading whitespace", " leading", '" leading"'],
+    ["trailing whitespace", "trailing ", '"trailing "'],
+    ["boolean-like string", "true", '"true"'],
+    ["null-like string", "null", '"null"'],
+    ["numeric-like string", "1e3", '"1e3"'],
+    ["colon delimiter", "name:value", '"name:value"'],
+    ["comma delimiter", "alpha,beta", '"alpha,beta"'],
+    ["brackets", "a[b]", '"a[b]"'],
+    ["braces", "a{b}", '"a{b}"'],
+    ["dash prefix", "-dash", '"-dash"'],
+    ["comment prefix", "#hash", '"#hash"'],
+    [
+      "escaped characters",
+      'quote " slash \\ tab\t cr\r newline\n ctrl\u0001',
+      '"quote \\" slash \\\\ tab\\t cr\\r newline\\n ctrl\\u0001"',
+    ],
+    ["number", 42, "42"],
+    ["true boolean", true, "true"],
+    ["false boolean", false, "false"],
+    ["null", null, "null"],
+  ])("encodes primitive %s deterministically", (_name, value, expected) => {
+    expect(encodeToon(value)).toBe(expected);
+  });
+
+  it("quotes unsafe object keys and rejects unpaired surrogates", () => {
+    const pairedSurrogate = "\u{1f600}";
+
+    expect(
+      encodeToon({
+        "safe.key_1": "v",
+        "bad,key": "x",
+        " spaced key": "y",
+        "a{b}c": "z",
+        pairedSurrogate,
+      }),
+    ).toBe(
+      [
+        "safe.key_1: v",
+        '"bad,key": x',
+        '" spaced key": y',
+        '"a{b}c": z',
+        `pairedSurrogate: ${pairedSurrogate}`,
+      ].join("\n"),
+    );
+    expect(() => encodeToon({ bad: "\uD800" })).toThrow(/unpaired surrogate U\+D800/);
+    expect(() => encodeToon({ low: "\uDC00" })).toThrow(/unpaired surrogate U\+DC00/);
+    expect(() => encodeToon({ ["bad\uD800"]: "v" })).toThrow(
+      /object key containing an unpaired surrogate U\+D800/,
+    );
+  });
+
+  it("encodes empty containers and deeply nested mixed values with stable indentation", () => {
+    expect(encodeToon({})).toBe("");
+    expect(encodeToon([])).toBe("[]");
+    expect(encodeToon({ emptyObject: {}, emptyArray: [] })).toBe(
+      ["emptyObject:", "emptyArray: []"].join("\n"),
+    );
+
+    expect(
+      encodeToon({
+        outer: {
+          deep: { level: { value: "done" } },
+          empty: {},
+          list: [1, { two: 2 }, [3, [4]], []],
+        },
+      }),
+    ).toBe(
+      [
+        "outer:",
+        "  deep:",
+        "    level:",
+        "      value: done",
+        "  empty:",
+        "  list[4]:",
+        "    - 1",
+        "    - two: 2",
+        "    - [2]:",
+        "      - 3",
+        "      - [1]: 4",
+        "    - [0]:",
+      ].join("\n"),
+    );
+  });
+
+  it("encodes arrays of primitive arrays as list items", () => {
+    expect(
+      encodeToon({
+        matrix: [
+          ["a", 1],
+          ["b", 2],
+        ],
+      }),
+    ).toBe(["matrix[2]:", "  - [2]: a,1", "  - [2]: b,2"].join("\n"));
+    expect(
+      encodeToon([
+        ["a", 1],
+        ["b", 2],
+      ]),
+    ).toBe(["[2]:", "  - [2]: a,1", "  - [2]: b,2"].join("\n"));
+  });
+
+  it("uses tabular encoding for compatible arrays and keyed objects", () => {
+    expect(
+      encodeToon({
+        buckets: [
+          { bucketName: "alpha", stats: { objects: 2, bytes: 10 }, isPublic: false },
+          { bucketName: "beta", stats: { objects: 0, bytes: 0 }, isPublic: true },
+        ],
+      }),
+    ).toBe(
+      [
+        "buckets[2]{bucketName,stats{objects,bytes},isPublic}:",
+        "  alpha,2,10,false",
+        "  beta,0,0,true",
+      ].join("\n"),
+    );
+
+    expect(
+      encodeToon({
+        alpha: { fileCount: 1, bytes: 10 },
+        beta: { fileCount: 2, bytes: 20 },
+      }),
+    ).toBe(["[2:]{fileCount,bytes}:", "  alpha: 1,10", "  beta: 2,20"].join("\n"));
+
+    expect(
+      encodeToon({
+        accounts: {
+          alpha: { enabled: true, quota: null },
+          beta: { enabled: false, quota: 100 },
+        },
+      }),
+    ).toBe(["accounts[2:]{enabled,quota}:", "  alpha: true,null", "  beta: false,100"].join("\n"));
+  });
+
+  it("falls back to list items for non-tabular arrays of objects", () => {
+    expect(encodeToon({ items: [{ id: 1 }, { name: "beta" }, {}] })).toBe(
+      ["items[3]:", "  - id: 1", "  - name: beta", "  -"].join("\n"),
+    );
+
+    expect(
+      encodeToon({
+        items: [
+          {
+            files: [
+              { name: "a", size: 1 },
+              { name: "b", size: 2 },
+            ],
+            note: "ok",
+          },
+          { lookup: { alpha: { size: 1 }, beta: { size: 2 } }, note: "map" },
+          { first: [], note: "empty" },
+          { first: [1, 2], note: "inline" },
+          { first: [[1], [2]], note: "nested" },
+          { first: {}, note: "empty-object" },
+          { first: { nested: 1 }, note: "object" },
+        ],
+      }),
+    ).toBe(
+      [
+        "items[7]:",
+        "  - files[2]{name,size}:",
+        "      a,1",
+        "      b,2",
+        "    note: ok",
+        "  - lookup[2:]{size}:",
+        "      alpha: 1",
+        "      beta: 2",
+        "    note: map",
+        "  - first: []",
+        "    note: empty",
+        "  - first[2]: 1,2",
+        "    note: inline",
+        "  - first[2]:",
+        "      - [1]: 1",
+        "      - [1]: 2",
+        "    note: nested",
+        "  - first:",
+        "    note: empty-object",
+        "  - first:",
+        "      nested: 1",
+        "    note: object",
+      ].join("\n"),
+    );
+  });
+
+  it("keeps canonical structured content while only changing text rendering", async () => {
+    const data = {
+      buckets: [
+        { bucketName: "alpha", bucketType: "allPrivate" },
+        { bucketName: "beta", bucketType: "allPublic" },
+      ],
+      nextContinuationToken: "cursor==",
+    };
+
+    const jsonResult = serializeStructuredToolResult(data, {}, "json");
+    const toonResult = serializeStructuredToolResult(data, {}, "toon");
+
+    expect(jsonResult.structuredContent).toEqual(data);
+    expect(toonResult.structuredContent).toEqual(data);
+    expect(jsonResult.content[0].text).toBe(JSON.stringify(data));
+    expect(toonResult.content[0].text).toBe(
+      [
+        "buckets[2]{bucketName,bucketType}:",
+        "  alpha,allPrivate",
+        "  beta,allPublic",
+        "nextContinuationToken: cursor==",
+      ].join("\n"),
+    );
+    expect(toonResult.content[0].text).not.toBe(jsonResult.content[0].text);
+    await expect(decodeToon(toonResult.content[0].text)).resolves.toEqual(
+      toonResult.structuredContent,
+    );
+  });
+
+  it("falls back to JSON text without changing structured content at TOON bounds", () => {
+    const largeValue = { value: "x".repeat(MAX_TOON_INPUT_JSON_CHARS) };
+    const largeValueResult = serializeStructuredToolResult(largeValue, {}, "toon");
+    expect(largeValueResult.structuredContent).toEqual(largeValue);
+    expect(largeValueResult.content[0].text).toBe(JSON.stringify(largeValue));
+
+    const deepValue = nestedValue(MAX_TOON_INPUT_DEPTH + 1);
+    const deepValueResult = serializeStructuredToolResult(deepValue, {}, "toon");
+    expect(deepValueResult.structuredContent).toEqual(deepValue);
+    expect(deepValueResult.content[0].text).toBe(JSON.stringify(deepValue));
+
+    const manyNodes = Array.from({ length: MAX_TOON_INPUT_NODES + 1 }, () => "");
+    const manyNodesResult = serializeStructuredToolResult(manyNodes, {}, "toon");
+    expect(manyNodesResult.structuredContent).toEqual(manyNodes);
+    expect(manyNodesResult.content[0].text).toBe(JSON.stringify(manyNodes));
+  });
+
+  it("encodes large primitive values directly when they are inside encoder limits", () => {
+    const value = "x".repeat(4096);
+
+    expect(encodeToon(value)).toBe(value);
+  });
+});
+
+function nestedValue(depth: number): JsonCompatible {
+  let value: JsonCompatible = "leaf";
+  for (let index = 0; index < depth; index++) {
+    value = { child: value };
+  }
+  return value;
+}

--- a/tests/unit/toon-encoder.unit.test.ts
+++ b/tests/unit/toon-encoder.unit.test.ts
@@ -1,12 +1,7 @@
 import { encodeToon } from "../../src/utils/toon-encoder";
-import {
-  MAX_TOON_INPUT_DEPTH,
-  MAX_TOON_INPUT_JSON_CHARS,
-  MAX_TOON_INPUT_NODES,
-  serializeStructuredToolResult,
-} from "../../src/utils/result-serializer";
-import type { JsonCompatible } from "../../src/utils/result-serializer";
-import { decodeToon } from "./toon-decoder-helper";
+
+type ToonValue = Parameters<typeof encodeToon>[0];
+type ToonObject = { [key: string]: ToonValue };
 
 describe("TOON encoder", () => {
   it.each([
@@ -146,102 +141,69 @@ describe("TOON encoder", () => {
     ).toBe(["accounts[2:]{enabled,quota}:", "  alpha: true,null", "  beta: false,100"].join("\n"));
   });
 
-  it("falls back to list items for non-tabular arrays of objects", () => {
-    expect(encodeToon({ items: [{ id: 1 }, { name: "beta" }, {}] })).toBe(
-      ["items[3]:", "  - id: 1", "  - name: beta", "  -"].join("\n"),
-    );
-
-    expect(
-      encodeToon({
-        items: [
-          {
-            files: [
-              { name: "a", size: 1 },
-              { name: "b", size: 2 },
-            ],
-            note: "ok",
-          },
-          { lookup: { alpha: { size: 1 }, beta: { size: 2 } }, note: "map" },
-          { first: [], note: "empty" },
-          { first: [1, 2], note: "inline" },
-          { first: [[1], [2]], note: "nested" },
-          { first: {}, note: "empty-object" },
-          { first: { nested: 1 }, note: "object" },
-        ],
-      }),
-    ).toBe(
+  it.each([
+    [
+      "primitive field",
+      [{ id: 1 }, { other: "sentinel" }],
+      ["items[2]:", "  - id: 1", "  - other: sentinel"],
+    ],
+    ["empty object item", [{}, { other: "sentinel" }], ["items[2]:", "  -", "  - other: sentinel"]],
+    [
+      "nested tabular array field",
       [
-        "items[7]:",
-        "  - files[2]{name,size}:",
-        "      a,1",
-        "      b,2",
-        "    note: ok",
+        {
+          files: [
+            { name: "a", size: 1 },
+            { name: "b", size: 2 },
+          ],
+          note: "ok",
+        },
+      ],
+      ["items[1]:", "  - files[2]{name,size}:", "      a,1", "      b,2", "    note: ok"],
+    ],
+    [
+      "keyed object field",
+      [{ lookup: { alpha: { size: 1 }, beta: { size: 2 } }, note: "map" }, { other: "sentinel" }],
+      [
+        "items[2]:",
         "  - lookup[2:]{size}:",
         "      alpha: 1",
         "      beta: 2",
         "    note: map",
-        "  - first: []",
-        "    note: empty",
-        "  - first[2]: 1,2",
-        "    note: inline",
-        "  - first[2]:",
-        "      - [1]: 1",
-        "      - [1]: 2",
-        "    note: nested",
-        "  - first:",
-        "    note: empty-object",
-        "  - first:",
-        "      nested: 1",
-        "    note: object",
-      ].join("\n"),
-    );
-  });
-
-  it("keeps canonical structured content while only changing text rendering", async () => {
-    const data = {
-      buckets: [
-        { bucketName: "alpha", bucketType: "allPrivate" },
-        { bucketName: "beta", bucketType: "allPublic" },
+        "  - other: sentinel",
       ],
-      nextContinuationToken: "cursor==",
-    };
-
-    const jsonResult = serializeStructuredToolResult(data, {}, "json");
-    const toonResult = serializeStructuredToolResult(data, {}, "toon");
-
-    expect(jsonResult.structuredContent).toEqual(data);
-    expect(toonResult.structuredContent).toEqual(data);
-    expect(jsonResult.content[0].text).toBe(JSON.stringify(data));
-    expect(toonResult.content[0].text).toBe(
-      [
-        "buckets[2]{bucketName,bucketType}:",
-        "  alpha,allPrivate",
-        "  beta,allPublic",
-        "nextContinuationToken: cursor==",
-      ].join("\n"),
-    );
-    expect(toonResult.content[0].text).not.toBe(jsonResult.content[0].text);
-    await expect(decodeToon(toonResult.content[0].text)).resolves.toEqual(
-      toonResult.structuredContent,
-    );
-  });
-
-  it("falls back to JSON text without changing structured content at TOON bounds", () => {
-    const largeValue = { value: "x".repeat(MAX_TOON_INPUT_JSON_CHARS) };
-    const largeValueResult = serializeStructuredToolResult(largeValue, {}, "toon");
-    expect(largeValueResult.structuredContent).toEqual(largeValue);
-    expect(largeValueResult.content[0].text).toBe(JSON.stringify(largeValue));
-
-    const deepValue = nestedValue(MAX_TOON_INPUT_DEPTH + 1);
-    const deepValueResult = serializeStructuredToolResult(deepValue, {}, "toon");
-    expect(deepValueResult.structuredContent).toEqual(deepValue);
-    expect(deepValueResult.content[0].text).toBe(JSON.stringify(deepValue));
-
-    const manyNodes = Array.from({ length: MAX_TOON_INPUT_NODES + 1 }, () => "");
-    const manyNodesResult = serializeStructuredToolResult(manyNodes, {}, "toon");
-    expect(manyNodesResult.structuredContent).toEqual(manyNodes);
-    expect(manyNodesResult.content[0].text).toBe(JSON.stringify(manyNodes));
-  });
+    ],
+    [
+      "empty array field",
+      [{ first: [], note: "empty" }],
+      ["items[1]:", "  - first: []", "    note: empty"],
+    ],
+    [
+      "inline primitive array field",
+      [{ first: [1, 2], note: "inline" }],
+      ["items[1]:", "  - first[2]: 1,2", "    note: inline"],
+    ],
+    [
+      "nested primitive array field",
+      [{ first: [[1], [2]], note: "nested" }],
+      ["items[1]:", "  - first[2]:", "      - [1]: 1", "      - [1]: 2", "    note: nested"],
+    ],
+    [
+      "empty object field",
+      [{ first: {}, note: "empty-object" }],
+      ["items[1]:", "  - first:", "    note: empty-object"],
+    ],
+    [
+      "nested object field",
+      [{ first: { nested: 1 }, note: "object" }, { other: "sentinel" }],
+      ["items[2]:", "  - first:", "      nested: 1", "    note: object", "  - other: sentinel"],
+    ],
+  ])(
+    "falls back to list items for non-tabular arrays of objects with %s",
+    (_name, items, lines) => {
+      expect(encodeToon({ items: items as ToonObject[] })).toBe(lines.join("\n"));
+    },
+  );
 
   it("encodes large primitive values directly when they are inside encoder limits", () => {
     const value = "x".repeat(4096);
@@ -249,11 +211,3 @@ describe("TOON encoder", () => {
     expect(encodeToon(value)).toBe(value);
   });
 });
-
-function nestedValue(depth: number): JsonCompatible {
-  let value: JsonCompatible = "leaf";
-  for (let index = 0; index < depth; index++) {
-    value = { child: value };
-  }
-  return value;
-}


### PR DESCRIPTION
## Summary
- Add deterministic `encodeToon` unit coverage for primitives, escaping, unsafe keys, nesting, tabular rows, keyed objects, non-tabular list fallbacks, empty containers, and large primitive values.
- Split non-tabular fallback golden assertions into named cases and type the fallback table at declaration so each rendering behavior fails independently without assertion-time casts.
- Clarify the paired-surrogate value fixture with an explicit `emoji` key.
- Keep serializer-owned assertions in `result-serializer.unit.test.ts`, including canonical `structuredContent` stability and JSON fallback at TOON bounds, with the JSON-size bound fixture consolidated into a single test.
- Confirm focused TOON encoder coverage reaches 98.55% lines and 95.75% branches.

## Linked issue
Closes #145

## Tests run
- `pnpm exec vitest run --config vitest.config.mts --project=unit tests/unit/toon-encoder.unit.test.ts tests/unit/result-serializer.unit.test.ts --coverage=false`
- `pnpm exec vitest run --config vitest.config.mts --project=unit tests/unit/toon-encoder.unit.test.ts --coverage --coverage.include=src/utils/toon-encoder.ts --coverage.reporter=text`
- `pnpm run typecheck`
- `pnpm run format:check`
- `pnpm run lint`
- `pnpm run test:unit`
- `pnpm run verify`

## Follow-up notes
- None.