### PR TITLE
test: cover client edge branches

### DIFF
--- a/src/s3/client.ts
+++ b/src/s3/client.ts
@@ -105,11 +105,24 @@ function assertB2S3ApiUrl(raw: string, region: string): void {
   if (reason) throw new Error(`Authorized B2 S3 endpoint ${reason}.`);
 }
 
-export function accountInfoForS3Endpoint(endpoint: string): AccountInfo {
+function accountInfoForS3Endpoint(endpoint: string): AccountInfo {
   // The SDK S3 helper only needs AccountInfo for the endpoint. S3 signing uses
   // the B2 application key pair passed below, not a native B2 authorization
   // token, so this object intentionally carries no placeholder credentials.
   return new EndpointOnlyAccountInfo(endpoint);
+}
+
+/**
+ * Test-only access for the endpoint-only AccountInfo shim.
+ *
+ * @param endpoint - Trusted B2 S3 endpoint used by the shim.
+ *
+ * @returns An endpoint-only AccountInfo implementation for tests.
+ *
+ * @internal
+ */
+export function accountInfoForS3EndpointForTests(endpoint: string): AccountInfo {
+  return accountInfoForS3Endpoint(endpoint);
 }
 
 interface B2S3ClientOptions {

--- a/src/s3/client.ts
+++ b/src/s3/client.ts
@@ -105,7 +105,7 @@ function assertB2S3ApiUrl(raw: string, region: string): void {
   if (reason) throw new Error(`Authorized B2 S3 endpoint ${reason}.`);
 }
 
-function accountInfoForS3Endpoint(endpoint: string): AccountInfo {
+export function accountInfoForS3Endpoint(endpoint: string): AccountInfo {
   // The SDK S3 helper only needs AccountInfo for the endpoint. S3 signing uses
   // the B2 application key pair passed below, not a native B2 authorization
   // token, so this object intentionally carries no placeholder credentials.

--- a/src/s3/client.ts
+++ b/src/s3/client.ts
@@ -112,19 +112,6 @@ function accountInfoForS3Endpoint(endpoint: string): AccountInfo {
   return new EndpointOnlyAccountInfo(endpoint);
 }
 
-/**
- * Test-only access for the endpoint-only AccountInfo shim.
- *
- * @param endpoint - Trusted B2 S3 endpoint used by the shim.
- *
- * @returns An endpoint-only AccountInfo implementation for tests.
- *
- * @internal
- */
-export function accountInfoForS3EndpointForTests(endpoint: string): AccountInfo {
-  return accountInfoForS3Endpoint(endpoint);
-}
-
 interface B2S3ClientOptions {
   accountInfo?: AccountInfo;
   applicationKeyId?: string;

--- a/tests/unit/b2-client-edge.unit.test.ts
+++ b/tests/unit/b2-client-edge.unit.test.ts
@@ -115,13 +115,20 @@ describe("B2Client native edge branches", () => {
     const client = clientWithTransport(transport);
     circuitBreaker.open();
 
+    await expect(client.listBuckets()).rejects.toMatchObject({ code: "EOPENBREAKER" });
+    expect(transport.requests).toHaveLength(0);
+
     await vi.advanceTimersByTimeAsync(30_000);
 
-    expect((circuitBreaker as unknown as { halfOpen: boolean }).halfOpen).toBe(true);
     await expect(client.listBuckets()).resolves.toMatchObject({
       buckets: [{ bucketName: "half-open-bucket" }],
     });
-    expect((circuitBreaker as unknown as { closed: boolean }).closed).toBe(true);
+    await expect(client.listBuckets()).resolves.toMatchObject({
+      buckets: [{ bucketName: "half-open-bucket" }],
+    });
+    expect(
+      transport.requests.filter((request) => b2EndpointName(request) === "b2_list_buckets"),
+    ).toHaveLength(2);
   });
 
   it("normalizes direct native HTTP error bodies and request IDs", async () => {

--- a/tests/unit/b2-client-edge.unit.test.ts
+++ b/tests/unit/b2-client-edge.unit.test.ts
@@ -1,0 +1,217 @@
+import { B2AuthManager } from "../../src/auth";
+import { B2Client } from "../../src/b2/client";
+import { circuitBreaker } from "../../src/utils/circuit-breaker";
+import { testConfig } from "../support/deterministic-fakes";
+import { setB2SdkClientFactoryForTests } from "../support/sdk-factory-hook";
+import {
+  authorizeResponse,
+  b2EndpointName,
+  installSdkTransport,
+  RecordingTransport,
+  StaticHttpResponse,
+} from "../support/sdk-test-helpers";
+
+function authResponseWithToken(token: string) {
+  return {
+    ...authorizeResponse(["listBuckets", "listFiles"]),
+    authorizationToken: token,
+  };
+}
+
+function bucketListResponse(bucketName = "edge-bucket") {
+  return {
+    buckets: [
+      {
+        accountId: "test-account-123",
+        bucketId: "bucket-1",
+        bucketName,
+        bucketType: "allPrivate",
+        bucketInfo: {},
+        corsRules: [],
+        lifecycleRules: [],
+        revision: 1,
+        options: [],
+      },
+    ],
+  };
+}
+
+function clientWithTransport(transport: RecordingTransport): B2Client {
+  installSdkTransport(transport);
+  return new B2Client(new B2AuthManager(testConfig));
+}
+
+describe("B2Client native edge branches", () => {
+  afterEach(() => {
+    circuitBreaker.close();
+    vi.useRealTimers();
+    vi.restoreAllMocks();
+    setB2SdkClientFactoryForTests(null);
+  });
+
+  it("invalidates cached auth and re-authorizes direct native calls after a 401", async () => {
+    let authorizeCalls = 0;
+    const transport = new RecordingTransport((request) => {
+      if (b2EndpointName(request) !== "b2_authorize_account") {
+        return new StaticHttpResponse(500, {
+          status: 500,
+          code: "unexpected",
+          message: "only authorization should use the SDK transport",
+        });
+      }
+      authorizeCalls++;
+      return new StaticHttpResponse(
+        200,
+        authResponseWithToken(authorizeCalls === 1 ? "expired-token" : "fresh-token"),
+      );
+    });
+    const client = clientWithTransport(transport);
+    const fetchMock = vi
+      .spyOn(globalThis, "fetch")
+      .mockResolvedValueOnce(
+        new Response(JSON.stringify({ code: "expired_auth_token", message: "expired" }), {
+          status: 401,
+          headers: { "x-bz-request-id": "req-expired" },
+        }),
+      )
+      .mockResolvedValueOnce(Response.json({ ok: true }));
+
+    await expect(
+      client.call("b2_partner_probe", { probe: true }, { apiPath: "b2api/v3" }),
+    ).resolves.toEqual({ ok: true });
+
+    expect(authorizeCalls).toBe(2);
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    expect(
+      fetchMock.mock.calls.map(([, init]) => {
+        const headers = (init as RequestInit).headers as Record<string, string>;
+        return headers.Authorization;
+      }),
+    ).toEqual(["expired-token", "fresh-token"]);
+  });
+
+  it("rejects immediately without authorizing when the native circuit is open", async () => {
+    const transport = new RecordingTransport(() => new StaticHttpResponse(200, {}));
+    const client = clientWithTransport(transport);
+    circuitBreaker.open();
+
+    await expect(client.listBuckets()).rejects.toMatchObject({ code: "EOPENBREAKER" });
+
+    expect(transport.requests).toHaveLength(0);
+  });
+
+  it("allows the half-open probe and closes again after a successful native call", async () => {
+    vi.useFakeTimers();
+    const transport = new RecordingTransport((request) => {
+      const endpoint = b2EndpointName(request);
+      if (endpoint === "b2_authorize_account") {
+        return new StaticHttpResponse(200, authResponseWithToken("probe-token"));
+      }
+      if (endpoint === "b2_list_buckets") {
+        return new StaticHttpResponse(200, bucketListResponse("half-open-bucket"));
+      }
+      return new StaticHttpResponse(500, { status: 500, code: "unexpected", message: endpoint });
+    });
+    const client = clientWithTransport(transport);
+    circuitBreaker.open();
+
+    await vi.advanceTimersByTimeAsync(30_000);
+
+    expect((circuitBreaker as unknown as { halfOpen: boolean }).halfOpen).toBe(true);
+    await expect(client.listBuckets()).resolves.toMatchObject({
+      buckets: [{ bucketName: "half-open-bucket" }],
+    });
+    expect((circuitBreaker as unknown as { closed: boolean }).closed).toBe(true);
+  });
+
+  it("normalizes direct native HTTP error bodies and request IDs", async () => {
+    const transport = new RecordingTransport((request) => {
+      expect(b2EndpointName(request)).toBe("b2_authorize_account");
+      return new StaticHttpResponse(200, authResponseWithToken("native-token"));
+    });
+    const client = clientWithTransport(transport);
+    vi.spyOn(globalThis, "fetch").mockResolvedValueOnce(
+      new Response(JSON.stringify({ code: "bad_request", message: "bad input" }), {
+        status: 400,
+        headers: { "x-amz-request-id": "amz-request-1" },
+      }),
+    );
+
+    const error = await client.call("b2_partner_probe", undefined, { apiPath: "b2api/v3" }).then(
+      () => null,
+      (err: unknown) => err,
+    );
+
+    expect(error).toBeInstanceOf(Error);
+    expect(error).toMatchObject({
+      name: "NativeB2HttpError",
+      status: 400,
+      code: "bad_request",
+      message: "bad input",
+      requestId: "amz-request-1",
+    });
+  });
+
+  it.each([
+    ["empty", null, "unknown_error", "B2 API request failed with HTTP 503"],
+    ["non-JSON", "temporarily unavailable", "unknown_error", "B2 API request failed with HTTP 503"],
+  ])("normalizes %s direct native HTTP error responses", async (_name, body, code, message) => {
+    const transport = new RecordingTransport((request) => {
+      expect(b2EndpointName(request)).toBe("b2_authorize_account");
+      return new StaticHttpResponse(200, authResponseWithToken("native-token"));
+    });
+    const client = clientWithTransport(transport);
+    vi.spyOn(globalThis, "fetch").mockResolvedValueOnce(
+      new Response(body, { status: 503, headers: { "x-request-id": "generic-request-1" } }),
+    );
+
+    const error = await client.call("b2_partner_probe", undefined, { apiPath: "b2api/v3" }).then(
+      () => null,
+      (err: unknown) => err,
+    );
+
+    expect(error).toMatchObject({
+      name: "NativeB2HttpError",
+      status: 503,
+      code,
+      message,
+      requestId: "generic-request-1",
+    });
+  });
+
+  it("rejects S3 version IDs that resolve to a different key in the same bucket", async () => {
+    const transport = new RecordingTransport((request) => {
+      const endpoint = b2EndpointName(request);
+      if (endpoint === "b2_authorize_account") {
+        return new StaticHttpResponse(200, authResponseWithToken("version-token"));
+      }
+      if (endpoint === "b2_list_buckets") {
+        return new StaticHttpResponse(200, bucketListResponse("versioned-bucket"));
+      }
+      if (endpoint === "b2_get_file_info") {
+        return new StaticHttpResponse(200, {
+          accountId: "test-account-123",
+          bucketId: "bucket-1",
+          fileId: "version-a",
+          fileName: "other-key.txt",
+          action: "upload",
+          contentLength: 1,
+          contentSha1: "none",
+          contentType: "text/plain",
+          fileInfo: {},
+          uploadTimestamp: Date.parse("2026-01-01T00:00:00.000Z"),
+        });
+      }
+      return new StaticHttpResponse(500, { status: 500, code: "unexpected", message: endpoint });
+    });
+    const client = clientWithTransport(transport);
+
+    await expect(
+      client.resolveS3FileVersion({
+        bucket: "versioned-bucket",
+        key: "expected-key.txt",
+        versionId: "version-a",
+      }),
+    ).rejects.toMatchObject({ status: 404, code: "not_found" });
+  });
+});

--- a/tests/unit/b2-client-edge.unit.test.ts
+++ b/tests/unit/b2-client-edge.unit.test.ts
@@ -8,6 +8,7 @@ import {
   b2EndpointName,
   installSdkTransport,
   RecordingTransport,
+  requestJson,
   StaticHttpResponse,
 } from "../support/sdk-test-helpers";
 
@@ -220,5 +221,61 @@ describe("B2Client native edge branches", () => {
         versionId: "version-a",
       }),
     ).rejects.toMatchObject({ status: 404, code: "not_found" });
+  });
+
+  it("resolves the current native hide marker for S3 delete-marker synthesis", async () => {
+    const uploadTimestamp = Date.parse("2026-01-02T03:04:05.000Z");
+    const transport = new RecordingTransport((request) => {
+      const endpoint = b2EndpointName(request);
+      if (endpoint === "b2_authorize_account") {
+        return new StaticHttpResponse(200, authResponseWithToken("current-version-token"));
+      }
+      if (endpoint === "b2_list_buckets") {
+        return new StaticHttpResponse(200, bucketListResponse("versioned-bucket"));
+      }
+      if (endpoint === "b2_list_file_versions") {
+        const body = requestJson(request);
+        expect(body).toMatchObject({
+          bucketId: "bucket-1",
+          prefix: "deleted.txt",
+          maxFileCount: 1,
+        });
+        return new StaticHttpResponse(200, {
+          files: [
+            {
+              accountId: "test-account-123",
+              bucketId: "bucket-1",
+              fileId: "hide-version-1",
+              fileName: "deleted.txt",
+              action: "hide",
+              contentLength: 0,
+              contentSha1: "none",
+              contentType: "application/octet-stream",
+              fileInfo: { src_last_modified_millis: String(uploadTimestamp) },
+              uploadTimestamp,
+              serverSideEncryption: { mode: "SSE-B2", algorithm: "AES256" },
+            },
+          ],
+          nextFileName: null,
+          nextFileId: null,
+        });
+      }
+      return new StaticHttpResponse(500, { status: 500, code: "unexpected", message: endpoint });
+    });
+    const client = clientWithTransport(transport);
+
+    await expect(
+      client.getCurrentS3FileVersion({ bucket: "versioned-bucket", key: "deleted.txt" }),
+    ).resolves.toEqual({
+      fileName: "deleted.txt",
+      fileId: "hide-version-1",
+      bucketId: "bucket-1",
+      contentLength: 0,
+      contentType: "application/octet-stream",
+      uploadTimestamp,
+      fileInfo: { src_last_modified_millis: String(uploadTimestamp) },
+      action: "hide",
+      serverSideEncryption: "AES256",
+    });
   });
 });

--- a/tests/unit/oauth-resource-server.unit.test.ts
+++ b/tests/unit/oauth-resource-server.unit.test.ts
@@ -1,10 +1,12 @@
-import type { AuthInfo } from "@modelcontextprotocol/server";
+import { OAuthError, OAuthErrorCode, type AuthInfo } from "@modelcontextprotocol/server";
 import {
   OAuthDependencyError,
   OAuthIntrospectionVerifier,
   authenticateOAuthRequest,
   loadOAuthResourceServerConfig,
+  oauthMetadataOptions,
   protectedResourceMetadata,
+  protectedResourceMetadataUrl,
   resetOAuthVerifierCacheForTests,
   validatePreverifiedOAuthAuthInfo,
 } from "../../src/oauth-resource-server";
@@ -20,6 +22,8 @@ const baseConfig = {
   introspectionEndpoint: "http://localhost:9000/oauth2/introspect",
   introspectionClientId: "client",
   introspectionClientSecret: "secret",
+  introspectionBearerToken: undefined as string | undefined,
+  serviceDocumentationUrl: undefined as string | undefined,
   requiredScopes: [] as string[],
   allowedSubjects: [] as string[],
   allowedTokenTypes: ["bearer"],
@@ -141,6 +145,58 @@ describe("OAuthIntrospectionVerifier", () => {
 
     expect(authInfo.clientId).toBe("mcp-client");
     expect(authInfo.extra?.alg).toBe("RS256");
+  });
+
+  it("uses bearer authentication for token introspection when configured", async () => {
+    const fetchMock = vi.fn(async (_url: string | URL | Request, init?: RequestInit) => {
+      const headers = init?.headers as Headers;
+      expect(headers.get("authorization")).toBe("Bearer issuer-introspection-token");
+      return Response.json(claims());
+    });
+    const verifier = verifierWithFetch(fetchMock, {
+      introspectionClientId: undefined,
+      introspectionClientSecret: undefined,
+      introspectionBearerToken: "issuer-introspection-token",
+    });
+
+    await expect(verifier.verifyAccessToken("access-token")).resolves.toMatchObject({
+      clientId: "mcp-client",
+    });
+  });
+
+  it("rejects structurally invalid introspection payloads as invalid tokens", async () => {
+    const { verifier } = verifierFor(["not", "a", "record"]);
+
+    await expect(verifier.verifyAccessToken("access-token")).rejects.toThrow(
+      /Invalid introspection response/,
+    );
+  });
+
+  it("treats non-JSON introspection responses as dependency failures", async () => {
+    const warn = vi.spyOn(logger, "warn").mockImplementation(() => undefined);
+    const fetchMock = vi.fn(async () => new Response("not json", { status: 200 }));
+    const verifier = verifierWithFetch(fetchMock, { introspectionMaxRetries: 0 });
+
+    await expect(verifier.verifyAccessToken("access-token")).rejects.toBeInstanceOf(
+      OAuthDependencyError,
+    );
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(warn).toHaveBeenCalledWith(
+      expect.objectContaining({ dependency: "oauth_introspection", reason: "network_error" }),
+      "oauth.introspection.dependency_failed",
+    );
+  });
+
+  it("allows deployments that disable token algorithm checking", async () => {
+    const verifier = verifierWithFetch(
+      vi.fn(async () => Response.json(claims({ alg: undefined }))),
+      { allowedAlgorithms: [] },
+    );
+
+    const authInfo = await verifier.verifyAccessToken("access-token");
+
+    expect(authInfo.clientId).toBe("mcp-client");
+    expect(authInfo.extra?.alg).toBeUndefined();
   });
 
   it.each([
@@ -443,6 +499,33 @@ describe("OAuthIntrospectionVerifier", () => {
   });
 });
 
+describe("OAuth bearer rejection responses", () => {
+  it.each([
+    ["decline", OAuthErrorCode.AccessDenied, "declined by user"],
+    ["cancel", OAuthErrorCode.InvalidRequest, "authorization canceled"],
+  ])("maps authorization %s errors to OAuth JSON responses", async (_name, code, message) => {
+    const response = await authenticateOAuthRequest(
+      new Request(baseConfig.publicUrl, { headers: { Authorization: "Bearer access-token" } }),
+      baseConfig,
+      {
+        verifier: {
+          verifyAccessToken: vi.fn(async () => {
+            throw new OAuthError(code, message);
+          }),
+        },
+      },
+    );
+
+    expect(response).toBeInstanceOf(Response);
+    expect((response as Response).status).toBe(400);
+    expect((response as Response).headers.get("www-authenticate")).toBeNull();
+    await expect((response as Response).json()).resolves.toMatchObject({
+      error: code,
+      error_description: message,
+    });
+  });
+});
+
 describe("validatePreverifiedOAuthAuthInfo", () => {
   it("accepts preverified AuthInfo that matches the introspection policy", () => {
     expect(
@@ -518,6 +601,28 @@ describe("OAuth resource metadata", () => {
 
     expect(metadata.resource).toBe("http://localhost:3000/resources/b2-mcp");
     expect(metadata.scopes_supported).toEqual(["b2:read", "b2:write", "b2:admin", "custom:tenant"]);
+  });
+
+  it("builds auth-server metadata with service documentation and de-duplicated scopes", () => {
+    const options = oauthMetadataOptions({
+      ...baseConfig,
+      serviceDocumentationUrl: "http://localhost:3000/docs/oauth",
+      requiredScopes: ["b2:read", "custom:tenant"],
+    });
+
+    expect(options.serviceDocumentationUrl?.href).toBe("http://localhost:3000/docs/oauth");
+    expect(options.resourceServerUrl.href).toBe(baseConfig.resource);
+    expect(options.scopesSupported).toEqual(["b2:read", "b2:write", "b2:admin", "custom:tenant"]);
+    expect(options.oauthMetadata.scopes_supported).toEqual(options.scopesSupported);
+  });
+
+  it("builds the protected-resource metadata URL from the configured public URL", () => {
+    expect(
+      protectedResourceMetadataUrl({
+        ...baseConfig,
+        publicUrl: "http://localhost:3000/api/b2/mcp",
+      }),
+    ).toBe("http://localhost:3000/.well-known/oauth-protected-resource/api/b2/mcp");
   });
 
   it("fails closed without authenticated introspection credentials by default", () => {

--- a/tests/unit/s3-aws-sdk-adapter.unit.test.ts
+++ b/tests/unit/s3-aws-sdk-adapter.unit.test.ts
@@ -1,5 +1,5 @@
 import { Readable } from "stream";
-import { B2S3PeerClient } from "../../src/s3/aws-sdk-adapter";
+import { B2S3PeerClient, b2S3DeleteErrorEntry } from "../../src/s3/aws-sdk-adapter";
 import { circuitBreaker, s3CircuitBreaker } from "../../src/utils/circuit-breaker";
 
 function clientWithHandler(handle: ReturnType<typeof vi.fn>) {
@@ -130,6 +130,49 @@ describe("B2S3PeerClient object data-plane behavior", () => {
       },
     ]);
     s3.destroy();
+  });
+
+  it("maps direct provider error codes and request IDs into deleteObjects errors", () => {
+    const error = Object.assign(new Error("slow down"), {
+      code: "SlowDown",
+      name: "ThrottlingException",
+      requestId: "direct-request-id",
+    });
+
+    expect(b2S3DeleteErrorEntry({ key: "a.txt", versionId: "v1" }, error)).toEqual({
+      Key: "a.txt",
+      VersionId: "v1",
+      Code: "SlowDown",
+      Message: "slow down",
+      RequestId: "direct-request-id",
+    });
+  });
+
+  it("falls back through provider error names, messages, and extended request IDs", () => {
+    expect(
+      b2S3DeleteErrorEntry(
+        { key: "a.txt" },
+        {
+          name: "InternalError",
+          message: "provider failed",
+          $metadata: { extendedRequestId: "extended-request-id" },
+        },
+      ),
+    ).toEqual({
+      Key: "a.txt",
+      VersionId: undefined,
+      Code: "InternalError",
+      Message: "provider failed",
+      RequestId: "extended-request-id",
+    });
+
+    expect(b2S3DeleteErrorEntry({ key: "b.txt" }, "socket closed")).toEqual({
+      Key: "b.txt",
+      VersionId: undefined,
+      Code: "unknown_error",
+      Message: "socket closed",
+      RequestId: undefined,
+    });
   });
 
   it("preserves delete marker metadata in the bulk delete ledger", async () => {

--- a/tests/unit/s3-client-config.unit.test.ts
+++ b/tests/unit/s3-client-config.unit.test.ts
@@ -1,5 +1,5 @@
 import {
-  accountInfoForS3Endpoint,
+  accountInfoForS3EndpointForTests,
   buildB2S3ClientConfig,
   createReportS3Client,
   createS3ObjectClient,
@@ -146,7 +146,7 @@ describe("B2 S3 client configuration", () => {
   });
 
   it("keeps the endpoint-only AccountInfo shim credential-free", () => {
-    const accountInfo = accountInfoForS3Endpoint("https://s3.us-west-004.backblazeb2.com");
+    const accountInfo = accountInfoForS3EndpointForTests("https://s3.us-west-004.backblazeb2.com");
     const bucketId = "bucket-id" as never;
     const fileId = "file-id" as never;
     const uploadUrlEntry = {
@@ -177,7 +177,7 @@ describe("B2 S3 client configuration", () => {
     ["getRecommendedPartSize"],
     ["getAbsoluteMinimumPartSize"],
   ] as const)("throws if the S3 helper unexpectedly asks for %s", (method) => {
-    const accountInfo = accountInfoForS3Endpoint("https://s3.us-west-004.backblazeb2.com");
+    const accountInfo = accountInfoForS3EndpointForTests("https://s3.us-west-004.backblazeb2.com");
 
     expect(() => accountInfo[method]()).toThrow(
       `${method} is not used when deriving B2 S3 client configuration.`,

--- a/tests/unit/s3-client-config.unit.test.ts
+++ b/tests/unit/s3-client-config.unit.test.ts
@@ -1,5 +1,49 @@
+interface CapturedEndpointAccountInfo {
+  setAuth(auth: unknown): void;
+  getAuth(): unknown;
+  clear(): void;
+  getS3ApiUrl(): string;
+  getAllowedBucketId(): unknown;
+  getAllowedBucketIds(): readonly unknown[] | null;
+  checkoutUploadUrl(bucketId: string): unknown;
+  returnUploadUrl(bucketId: string, entry: unknown): void;
+  evictUploadUrl(bucketId: string, entry: unknown): void;
+  checkoutPartUploadUrl(fileId: string): unknown;
+  returnPartUploadUrl(fileId: string, entry: unknown): void;
+  evictPartUploadUrl(fileId: string, entry: unknown): void;
+  getApiUrl(): string;
+  getDownloadUrl(): string;
+  getAuthToken(): string;
+  getAccountId(): string;
+  getRecommendedPartSize(): number;
+  getAbsoluteMinimumPartSize(): number;
+}
+
+const capturedS3ConfigInputs = vi.hoisted(
+  () =>
+    [] as Array<{
+      accountInfo: CapturedEndpointAccountInfo;
+      applicationKeyId: string;
+      applicationKey: string;
+      region: string;
+    }>,
+);
+
+vi.mock("@backblaze-labs/b2-sdk/s3", () => ({
+  createS3ClientConfig: vi.fn((input) => {
+    capturedS3ConfigInputs.push(input);
+    return {
+      endpoint: input.accountInfo.getS3ApiUrl(),
+      region: input.region,
+      credentials: {
+        accessKeyId: input.applicationKeyId,
+        secretAccessKey: input.applicationKey,
+      },
+    };
+  }),
+}));
+
 import {
-  accountInfoForS3EndpointForTests,
   buildB2S3ClientConfig,
   createReportS3Client,
   createS3ObjectClient,
@@ -21,7 +65,18 @@ const config: B2Config = {
   transport: "stdio",
 };
 
+function capturedEndpointAccountInfo(): CapturedEndpointAccountInfo {
+  buildB2S3ClientConfig(config);
+  const accountInfo = capturedS3ConfigInputs.at(-1)?.accountInfo;
+  if (!accountInfo) throw new Error("Expected buildB2S3ClientConfig to pass AccountInfo.");
+  return accountInfo;
+}
+
 describe("B2 S3 client configuration", () => {
+  beforeEach(() => {
+    capturedS3ConfigInputs.length = 0;
+  });
+
   it("uses path-style addressing and the trusted B2 S3 endpoint", () => {
     const s3 = buildB2S3ClientConfig(config);
 
@@ -146,13 +201,13 @@ describe("B2 S3 client configuration", () => {
   });
 
   it("keeps the endpoint-only AccountInfo shim credential-free", () => {
-    const accountInfo = accountInfoForS3EndpointForTests("https://s3.us-west-004.backblazeb2.com");
-    const bucketId = "bucket-id" as never;
-    const fileId = "file-id" as never;
+    const accountInfo = capturedEndpointAccountInfo();
+    const bucketId = "bucket-id";
+    const fileId = "file-id";
     const uploadUrlEntry = {
       uploadUrl: "https://upload.example",
       authorizationToken: "upload-token",
-    } as never;
+    };
 
     accountInfo.setAuth({} as never);
     accountInfo.clear();
@@ -169,6 +224,9 @@ describe("B2 S3 client configuration", () => {
     expect(accountInfo.checkoutPartUploadUrl(fileId)).toBeNull();
   });
 
+  // This deliberately exercises the defensive credential-free shim surface. If
+  // a future SDK helper starts asking for native B2 authorization state, S3
+  // config derivation must keep failing closed instead of inventing credentials.
   it.each([
     ["getApiUrl"],
     ["getDownloadUrl"],
@@ -177,10 +235,8 @@ describe("B2 S3 client configuration", () => {
     ["getRecommendedPartSize"],
     ["getAbsoluteMinimumPartSize"],
   ] as const)("throws if the S3 helper unexpectedly asks for %s", (method) => {
-    const accountInfo = accountInfoForS3EndpointForTests("https://s3.us-west-004.backblazeb2.com");
+    const accountInfo = capturedEndpointAccountInfo();
 
-    expect(() => accountInfo[method]()).toThrow(
-      `${method} is not used when deriving B2 S3 client configuration.`,
-    );
+    expect(() => accountInfo[method]()).toThrow(Error);
   });
 });

--- a/tests/unit/s3-client-config.unit.test.ts
+++ b/tests/unit/s3-client-config.unit.test.ts
@@ -1,4 +1,5 @@
 import {
+  accountInfoForS3Endpoint,
   buildB2S3ClientConfig,
   createReportS3Client,
   createS3ObjectClient,
@@ -45,7 +46,32 @@ describe("B2 S3 client configuration", () => {
       accessKeyId: "principal-key-id",
       secretAccessKey: "principal-secret",
     });
-    expect(JSON.stringify(s3.customUserAgent)).toContain("s3-object-tools");
+    expect(s3.customUserAgent).toEqual([
+      ["backblaze-b2-mcp", expect.any(String)],
+      ["transport", "stdio"],
+      ["surface", "s3-object-tools"],
+    ]);
+  });
+
+  it("adds the optional user-agent suffix after the surface tag", () => {
+    const previous = process.env.B2_MCP_UA_SUFFIX;
+    process.env.B2_MCP_UA_SUFFIX = " tenant-a ";
+    try {
+      const s3 = buildB2S3ClientConfig(
+        { ...config, transport: "http" },
+        { surface: "s3-object-tools" },
+      );
+
+      expect(s3.customUserAgent).toEqual([
+        ["backblaze-b2-mcp", expect.any(String)],
+        ["transport", "http"],
+        ["surface", "s3-object-tools"],
+        ["suffix", "tenant-a"],
+      ]);
+    } finally {
+      if (previous === undefined) delete process.env.B2_MCP_UA_SUFFIX;
+      else process.env.B2_MCP_UA_SUFFIX = previous;
+    }
   });
 
   it("creates object clients with the configured S3 credential override", async () => {
@@ -94,9 +120,67 @@ describe("B2 S3 client configuration", () => {
     expect(validateB2S3ApiUrl("http://169.254.169.254/latest/meta-data", config.region)).toMatch(
       /https/,
     );
+    expect(
+      validateB2S3ApiUrl("https://key:secret@s3.us-west-004.backblazeb2.com", config.region),
+    ).toContain("credentials");
     expect(validateB2S3ApiUrl("https://attacker.example", config.region)).toContain(
       "s3.us-west-004.backblazeb2.com",
     );
+    expect(
+      validateB2S3ApiUrl("https://s3.us-west-004.backblazeb2.com:8443", config.region),
+    ).toContain("custom port");
+    expect(
+      validateB2S3ApiUrl("https://s3.us-west-004.backblazeb2.com/path", config.region),
+    ).toContain("path");
+    expect(validateB2S3ApiUrl("not a url", config.region)).toContain("valid URL");
     expect(validateB2S3ApiUrl("https://s3.us-west-004.backblazeb2.com", config.region)).toBeNull();
+  });
+
+  it("rejects mismatched authorized S3 endpoints while building report config", () => {
+    expect(() =>
+      buildB2S3ClientConfig(config, {
+        authorizedS3ApiUrl: "https://s3.us-east-005.backblazeb2.com",
+        surface: "b2-insights-reports",
+      }),
+    ).toThrow(/Authorized B2 S3 endpoint must match s3\.us-west-004\.backblazeb2\.com/);
+  });
+
+  it("keeps the endpoint-only AccountInfo shim credential-free", () => {
+    const accountInfo = accountInfoForS3Endpoint("https://s3.us-west-004.backblazeb2.com");
+    const bucketId = "bucket-id" as never;
+    const fileId = "file-id" as never;
+    const uploadUrlEntry = {
+      uploadUrl: "https://upload.example",
+      authorizationToken: "upload-token",
+    } as never;
+
+    accountInfo.setAuth({} as never);
+    accountInfo.clear();
+    accountInfo.returnUploadUrl(bucketId, uploadUrlEntry);
+    accountInfo.evictUploadUrl(bucketId, uploadUrlEntry);
+    accountInfo.returnPartUploadUrl(fileId, uploadUrlEntry);
+    accountInfo.evictPartUploadUrl(fileId, uploadUrlEntry);
+
+    expect(accountInfo.getAuth()).toBeNull();
+    expect(accountInfo.getS3ApiUrl()).toBe("https://s3.us-west-004.backblazeb2.com");
+    expect(accountInfo.getAllowedBucketId()).toBeNull();
+    expect(accountInfo.getAllowedBucketIds()).toBeNull();
+    expect(accountInfo.checkoutUploadUrl(bucketId)).toBeNull();
+    expect(accountInfo.checkoutPartUploadUrl(fileId)).toBeNull();
+  });
+
+  it.each([
+    ["getApiUrl"],
+    ["getDownloadUrl"],
+    ["getAuthToken"],
+    ["getAccountId"],
+    ["getRecommendedPartSize"],
+    ["getAbsoluteMinimumPartSize"],
+  ] as const)("throws if the S3 helper unexpectedly asks for %s", (method) => {
+    const accountInfo = accountInfoForS3Endpoint("https://s3.us-west-004.backblazeb2.com");
+
+    expect(() => accountInfo[method]()).toThrow(
+      `${method} is not used when deriving B2 S3 client configuration.`,
+    );
   });
 });

--- a/tests/unit/s3-coverage.unit.test.ts
+++ b/tests/unit/s3-coverage.unit.test.ts
@@ -118,4 +118,20 @@ describe("S3 tool error paths (catch blocks)", () => {
       errors: [{ Key: "k", Code: "AccessDenied", Message: "denied", RequestId: "rq" }],
     });
   });
+
+  it("surfaces the S3 master-key rejection hint for malformed access key errors", async () => {
+    sendSpy.mockRejectedValue({
+      name: "InvalidAccessKeyId",
+      message: "Malformed Access Key Id",
+      $metadata: { httpStatusCode: 403, requestId: "rq-master-key" },
+    });
+
+    const result = await callTool(server, "s3_head_bucket", args);
+
+    expect(result.isError).toBe(true);
+    expect(result.content[0].text).toContain("InvalidAccessKeyId");
+    expect(result.content[0].text).toContain("regular application key");
+    expect(result.content[0].text).toContain("master key");
+    expect(result.content[0].text).toContain("rq-master-key");
+  });
 });


### PR DESCRIPTION
## Summary
- Add deterministic B2 client edge coverage for auth invalidation/retry, native circuit open and half-open recovery behavior, native HTTP error normalization, version-ID ownership rejection, and current hide-marker resolution for S3 delete-marker synthesis.
- Expand S3 client and AWS SDK adapter coverage for client config variants, endpoint validation, S3 master-key rejection messaging, endpoint-only AccountInfo behavior captured through the mocked SDK boundary, and delete error mapping fallbacks.
- Expand OAuth resource server coverage for introspection auth/failure variants, invalid payloads, disabled algorithm checks, decline/cancel rejection responses, and metadata URL/options branches.
- Address review feedback by removing circuit-breaker state double-casts, avoiding a production test-only S3 shim export, and avoiding exact private shim error-message assertions.

## Linked issue
Closes #148

## Tests run
- `pnpm exec vitest run --config vitest.config.mts --project=unit tests/unit/b2-client-edge.unit.test.ts tests/unit/s3-client-config.unit.test.ts tests/unit/s3-aws-sdk-adapter.unit.test.ts tests/unit/s3-coverage.unit.test.ts tests/unit/oauth-resource-server.unit.test.ts --coverage=false`
- `pnpm exec vitest run --config vitest.config.mts --project=unit tests/unit/b2-client-edge.unit.test.ts tests/unit/s3-client-config.unit.test.ts --coverage=false`
- `pnpm run typecheck`
- `pnpm run test:coverage`
- `pnpm run verify`

## Follow-up notes
- Coverage after the latest `pnpm run test:coverage`: `src/b2/client.ts` branches 68.04%, `src/s3/client.ts` functions 100%, `src/s3/aws-sdk-adapter.ts` branches 84.82%, `src/oauth-resource-server.ts` branches 83.04%.
