### PR TITLE
test: cover report and insights read paths

### DIFF
--- a/tests/unit/insights-read-paths.unit.test.ts
+++ b/tests/unit/insights-read-paths.unit.test.ts
@@ -550,5 +550,9 @@ describe("insight native bucket read paths", () => {
     expect(result.wasted_gb).toBe(1.5);
     expect(result.oldest_file).toBe("old.bin");
     expect(nativeClient.listParts).toHaveBeenCalledTimes(2);
+    expect(nativeClient.listParts).toHaveBeenNthCalledWith(
+      2,
+      expect.objectContaining({ fileId: "upload-1", startPartNumber: 2 }),
+    );
   });
 });

--- a/tests/unit/insights-read-paths.unit.test.ts
+++ b/tests/unit/insights-read-paths.unit.test.ts
@@ -1,0 +1,489 @@
+import { registerInsightTools } from "../../src/b2/insights";
+import { parseResult, ToolHarness } from "../support/deterministic-fakes";
+
+const GB = 1e9;
+const DAY_MS = 86400_000;
+const bucket = { bucketId: "bucket-1", bucketName: "photos" };
+
+function daysAgo(days: number): string {
+  return new Date(Date.now() - days * DAY_MS).toISOString().slice(0, 10);
+}
+
+function csv(rows: string[]): string {
+  return (
+    "account_id,date,bucket_id,bucket_name,stored_gb,downloaded_gb,uploaded_gb,api_txn_class_c\n" +
+    rows.join("")
+  );
+}
+
+function noSuchBucket(): Error {
+  return Object.assign(new Error("report bucket missing"), {
+    name: "NoSuchBucket",
+    $metadata: { httpStatusCode: 404 },
+  });
+}
+
+function timeoutError(): Error {
+  return Object.assign(new Error("scan timed out"), { name: "TimeoutError" });
+}
+
+function createPagedReportClient(
+  csvByKey: Record<string, string>,
+  options: { pageSize?: number; listError?: Error } = {},
+) {
+  const calls: Array<{ bucketName: string; options: any }> = [];
+  const downloaded: string[] = [];
+  const allKeys = Object.keys(csvByKey).sort();
+  return {
+    calls,
+    downloaded,
+    client: {
+      async listReportObjectKeys(bucketName: string, input: any) {
+        calls.push({ bucketName, options: input });
+        if (options.listError) throw options.listError;
+        let keys = allKeys;
+        if (input.prefix) keys = keys.filter((key) => key.startsWith(input.prefix));
+        if (input.startAfter) keys = keys.filter((key) => key > input.startAfter);
+        const offset = input.continuationToken ? Number(input.continuationToken) : 0;
+        const requested = input.maxKeys ?? keys.length;
+        const pageSize = Math.min(options.pageSize ?? requested, requested);
+        const page = keys.slice(offset, offset + pageSize);
+        const nextOffset = offset + page.length;
+        return {
+          keys: page,
+          isTruncated: nextOffset < keys.length,
+          nextContinuationToken: nextOffset < keys.length ? String(nextOffset) : undefined,
+        };
+      },
+      async downloadReportObjectText(_bucketName: string, key: string) {
+        downloaded.push(key);
+        const text = csvByKey[key] ?? "";
+        return { text, bytes: Buffer.byteLength(text, "utf8"), truncated: false };
+      },
+    },
+  };
+}
+
+function createNativeClient(options: {
+  buckets?: any[];
+  filePages?: any[];
+  uploadPages?: any[];
+  partPagesByFileId?: Record<string, any[]>;
+}) {
+  const filePages = [...(options.filePages ?? [])];
+  const uploadPages = [...(options.uploadPages ?? [])];
+  const partPagesByFileId = Object.fromEntries(
+    Object.entries(options.partPagesByFileId ?? {}).map(([fileId, pages]) => [fileId, [...pages]]),
+  );
+  return {
+    listBuckets: vi.fn(async () => ({ buckets: options.buckets ?? [bucket] })),
+    listFileNames: vi.fn(async () => {
+      const reply = filePages.shift() ?? { files: [], nextFileName: null };
+      if (reply instanceof Error) throw reply;
+      return reply;
+    }),
+    listUnfinishedLargeFiles: vi.fn(async () => {
+      const reply = uploadPages.shift() ?? { files: [], nextFileId: null };
+      if (reply instanceof Error) throw reply;
+      return reply;
+    }),
+    listParts: vi.fn(async (input: { fileId: string }) => {
+      const reply = partPagesByFileId[input.fileId]?.shift() ?? {
+        parts: [],
+        nextPartNumber: null,
+      };
+      if (reply instanceof Error) throw reply;
+      return reply;
+    }),
+  };
+}
+
+function registerTools(reportClient: any, nativeClient: any = createNativeClient({})) {
+  const harness = new ToolHarness();
+  registerInsightTools(
+    harness as any,
+    nativeClient as any,
+    { getAuth: async () => ({ accountId: "test-account" }) } as any,
+    reportClient as any,
+  );
+  return harness;
+}
+
+function file(fileName: string, contentLength: number) {
+  return {
+    fileName,
+    contentLength,
+    uploadTimestamp: Date.parse("2026-01-01T00:00:00.000Z"),
+  };
+}
+
+function upload(fileName: string, fileId: string, isoDate: string) {
+  return {
+    fileName,
+    fileId,
+    uploadTimestamp: Date.parse(isoDate),
+  };
+}
+
+function part(contentLength: number, partNumber = 1) {
+  return { partNumber, contentLength };
+}
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe("insight usage-report read paths", () => {
+  it("returns not-enabled metadata when b2_usage_growth cannot list the report bucket", async () => {
+    const report = createPagedReportClient({}, { listError: noSuchBucket() });
+    const tools = registerTools(report.client);
+
+    const result = parseResult(
+      await tools.call("b2_usage_growth", { period: "month", order: "most_grown", limit: 10 }),
+    );
+
+    expect(result.reports_enabled).toBe(false);
+    expect(result.note).toContain("No b2-reports");
+  });
+
+  it("returns a clean empty-snapshot result for b2_usage_growth", async () => {
+    const report = createPagedReportClient({});
+    const tools = registerTools(report.client);
+
+    const result = parseResult(
+      await tools.call("b2_usage_growth", { period: "month", order: "most_grown", limit: 10 }),
+    );
+
+    expect(result.reports_enabled).toBe(true);
+    expect(result.note).toBe("No usage-report snapshots found yet.");
+    expect(result.report_scan.pages).toBe(3);
+  });
+
+  it("reports insufficient history when only the latest snapshot exists", async () => {
+    const latest = daysAgo(1);
+    const report = createPagedReportClient({
+      [`${latest}/usage.account-a.csv`]: csv([`account-a,${latest},bucket-a,bucket-a,10,0,0,0\n`]),
+    });
+    const tools = registerTools(report.client);
+
+    const result = parseResult(
+      await tools.call("b2_usage_growth", {
+        days: 30,
+        period: "month",
+        order: "most_grown",
+        limit: 10,
+      }),
+    );
+
+    expect(result.reports_enabled).toBe(true);
+    expect(result.latest_snapshot).toBe(latest);
+    expect(result.note).toContain("Not enough report history");
+  });
+
+  it("applies b2_usage_growth ranking modes and limits across two snapshots", async () => {
+    const thenDay = daysAgo(30);
+    const latest = daysAgo(1);
+    const report = createPagedReportClient({
+      [`${thenDay}/usage.account-then.csv`]: csv([
+        `grow,${thenDay},bucket-grow,bucket-grow,10,0,0,0\n`,
+        `flat,${thenDay},bucket-flat,bucket-flat,10,0,0,0\n`,
+        `shrink,${thenDay},bucket-shrink,bucket-shrink,20,0,0,0\n`,
+      ]),
+      [`${latest}/usage.account-now.csv`]: csv([
+        `grow,${latest},bucket-grow,bucket-grow,20,0,0,0\n`,
+        `flat,${latest},bucket-flat,bucket-flat,10,0,0,0\n`,
+        `shrink,${latest},bucket-shrink,bucket-shrink,5,0,0,0\n`,
+        `new-account,${latest},bucket-new,bucket-new,7,0,0,0\n`,
+      ]),
+    });
+    const tools = registerTools(report.client);
+
+    const shrinking = parseResult(
+      await tools.call("b2_usage_growth", {
+        days: 30,
+        period: "month",
+        order: "shrinking",
+        limit: 10,
+      }),
+    );
+    const leastGrown = parseResult(
+      await tools.call("b2_usage_growth", {
+        days: 30,
+        period: "month",
+        order: "least_grown",
+        limit: 2,
+      }),
+    );
+
+    expect(shrinking.comparison).toBe("last 30 days");
+    expect(shrinking.accounts).toEqual([
+      expect.objectContaining({ account: "shrink", growth_gb: -15, growth_pct: -75 }),
+    ]);
+    expect(leastGrown.account_count).toBe(2);
+    expect(leastGrown.accounts.map((account: any) => account.account)).toEqual(["shrink", "flat"]);
+  });
+
+  it("paginates b2_egress_leaders report keys and skips empty or malformed CSV rows", async () => {
+    const oldDay = daysAgo(120);
+    const dayOne = daysAgo(3);
+    const dayTwo = daysAgo(2);
+    const report = createPagedReportClient(
+      {
+        [`${oldDay}/usage.account-old.csv`]: csv([
+          `old,${oldDay},bucket-old,bucket-old,1,99,0,0\n`,
+        ]),
+        [`${dayOne}/notes.txt`]: "ignored",
+        [`${dayOne}/usage.audit-account-a.csv`]: csv([
+          `audit,${dayOne},bucket-a,bucket-a,1,99,0,0\n`,
+        ]),
+        [`${dayOne}/usage.account-a.csv`]: csv([
+          `account-a,${dayOne},bucket-a,bucket-a,1,2,0,0\n`,
+          `,${dayOne},bucket-bad,bucket-bad,1,50,0,0\n`,
+        ]),
+        [`${dayTwo}/usage.account-empty.csv`]: "",
+        [`${dayTwo}/usage.group-1.reportingLocations.csv`]: csv([
+          `index,${dayTwo},bucket-index,bucket-index,1,99,0,0\n`,
+        ]),
+        [`${dayTwo}/usage.account-c.csv`]: csv([`account-c,${dayTwo},bucket-c,bucket-c,1,8,0,0\n`]),
+      },
+      { pageSize: 2 },
+    );
+    const tools = registerTools(report.client);
+
+    const result = parseResult(
+      await tools.call("b2_egress_leaders", { by: "account", days: 90, limit: 2 }),
+    );
+
+    expect(result.period).toBe("last 90 days");
+    expect(result.leaders).toEqual([
+      { account: "account-c", egress_gb: 8, share_pct: 80 },
+      { account: "account-a", egress_gb: 2, share_pct: 20 },
+    ]);
+    expect(result.report_scan.pages).toBeGreaterThan(1);
+    expect(report.calls.some((call) => call.options.continuationToken)).toBe(true);
+    expect(report.downloaded).toEqual([
+      `${dayOne}/usage.account-a.csv`,
+      `${dayTwo}/usage.account-c.csv`,
+      `${dayTwo}/usage.account-empty.csv`,
+    ]);
+  });
+
+  it("returns zero share for b2_egress_leaders when total egress is zero", async () => {
+    const day = daysAgo(1);
+    const report = createPagedReportClient({
+      [`${day}/usage.account-zero.csv`]: csv([`zero,${day},bucket-zero,,1,0,0,0\n`]),
+    });
+    const tools = registerTools(report.client);
+
+    const result = parseResult(
+      await tools.call("b2_egress_leaders", { by: "bucket", days: 7, limit: 1 }),
+    );
+
+    expect(result.total_egress_gb).toBe(0);
+    expect(result.leaders).toEqual([{ bucket: "bucket-zero", egress_gb: 0, share_pct: 0 }]);
+  });
+
+  it("returns not-enabled metadata when b2_egress_leaders cannot list the report bucket", async () => {
+    const report = createPagedReportClient({}, { listError: noSuchBucket() });
+    const tools = registerTools(report.client);
+
+    const result = parseResult(
+      await tools.call("b2_egress_leaders", { by: "account", days: 7, limit: 5 }),
+    );
+
+    expect(result.reports_enabled).toBe(false);
+  });
+
+  it("maps report read failures to the MCP error shape", async () => {
+    const report = createPagedReportClient(
+      {},
+      {
+        listError: Object.assign(new Error("report service failed"), {
+          name: "InternalError",
+          $metadata: { httpStatusCode: 500 },
+        }),
+      },
+    );
+    const tools = registerTools(report.client);
+
+    const result = await tools.call("b2_egress_leaders", { by: "account", days: 7, limit: 5 });
+
+    expect(result.isError).toBe(true);
+    expect(result.content[0].text).toContain("report service failed");
+  });
+});
+
+describe("insight native bucket read paths", () => {
+  it.each([
+    ["b2_largest_files", { bucket: "missing", limit: 5, max_scan: 1000 }],
+    ["b2_unfinished_uploads", { bucket: "missing", max_uploads: 10 }],
+  ])("%s returns a bucket-resolution failure for an unknown bucket", async (toolName, args) => {
+    const tools = registerTools(
+      createPagedReportClient({}).client,
+      createNativeClient({ buckets: [] }),
+    );
+
+    const result = parseResult(await tools.call(toolName, args));
+
+    expect(result).toEqual({
+      error: "bucket_not_uniquely_resolved",
+      candidates: [],
+      note: "No bucket matches 'missing'.",
+    });
+  });
+
+  it("returns candidate buckets when b2_largest_files receives an ambiguous bucket name", async () => {
+    const nativeClient = createNativeClient({
+      buckets: [
+        { bucketId: "logs-a", bucketName: "logs-alpha" },
+        { bucketId: "logs-b", bucketName: "logs-beta" },
+      ],
+    });
+    const tools = registerTools(createPagedReportClient({}).client, nativeClient);
+
+    const result = parseResult(
+      await tools.call("b2_largest_files", { bucket: "logs", limit: 5, max_scan: 1000 }),
+    );
+
+    expect(result.error).toBe("bucket_not_uniquely_resolved");
+    expect(result.candidates).toEqual(["logs-alpha", "logs-beta"]);
+  });
+
+  it("returns an empty b2_largest_files result and passes the prefix filter", async () => {
+    const nativeClient = createNativeClient({
+      filePages: [{ files: [], nextFileName: null }],
+    });
+    const tools = registerTools(createPagedReportClient({}).client, nativeClient);
+
+    const result = parseResult(
+      await tools.call("b2_largest_files", {
+        bucket: "photos",
+        prefix: "raw/",
+        limit: 5,
+        max_scan: 1000,
+      }),
+    );
+
+    expect(result).toMatchObject({ bucket: "photos", scanned: 0, returned: 0, truncated: false });
+    expect(nativeClient.listFileNames).toHaveBeenCalledWith(
+      expect.objectContaining({ bucketId: "bucket-1", prefix: "raw/" }),
+    );
+  });
+
+  it("marks b2_largest_files as truncated when the listing deadline fires", async () => {
+    const nativeClient = createNativeClient({ filePages: [timeoutError()] });
+    const tools = registerTools(createPagedReportClient({}).client, nativeClient);
+
+    const result = parseResult(
+      await tools.call("b2_largest_files", { bucket: "photos", limit: 5, max_scan: 1000 }),
+    );
+
+    expect(result.truncated).toBe(true);
+    expect(result.scanned).toBe(0);
+    expect(result.note).toContain("time budget");
+  });
+
+  it("stops b2_largest_files after a page when the time budget is spent", async () => {
+    let clock = 0;
+    vi.spyOn(Date, "now").mockImplementation(() => clock);
+    const nativeClient = createNativeClient({
+      filePages: [
+        {
+          files: [file("raw/a.bin", 10 * GB)],
+          nextFileName: "raw/b.bin",
+        },
+      ],
+    });
+    nativeClient.listFileNames.mockImplementationOnce(async () => {
+      clock = 12_001;
+      return { files: [file("raw/a.bin", 10 * GB)], nextFileName: "raw/b.bin" };
+    });
+    const tools = registerTools(createPagedReportClient({}).client, nativeClient);
+
+    const result = parseResult(
+      await tools.call("b2_largest_files", { bucket: "photos", limit: 5, max_scan: 1000 }),
+    );
+
+    expect(result.truncated).toBe(true);
+    expect(result.scanned).toBe(1);
+    expect(result.note).toContain("time budget");
+  });
+
+  it("returns an empty b2_unfinished_uploads result after the age filter removes uploads", async () => {
+    vi.spyOn(Date, "now").mockReturnValue(Date.parse("2026-01-10T00:00:00.000Z"));
+    const nativeClient = createNativeClient({
+      uploadPages: [
+        {
+          files: [upload("recent.bin", "upload-1", "2026-01-09T00:00:00.000Z")],
+          nextFileId: null,
+        },
+      ],
+    });
+    const tools = registerTools(createPagedReportClient({}).client, nativeClient);
+
+    const result = parseResult(
+      await tools.call("b2_unfinished_uploads", {
+        bucket: "photos",
+        older_than_days: 30,
+        max_uploads: 10,
+      }),
+    );
+
+    expect(result).toMatchObject({
+      bucket: "photos",
+      unfinished_count: 0,
+      truncated: false,
+      note: "No abandoned multipart uploads found.",
+    });
+    expect(nativeClient.listParts).not.toHaveBeenCalled();
+  });
+
+  it("returns truncated empty b2_unfinished_uploads output when upload pagination times out", async () => {
+    let clock = 0;
+    vi.spyOn(Date, "now").mockImplementation(() => clock);
+    const nativeClient = createNativeClient({
+      uploadPages: [{ files: [], nextFileId: "next-upload" }],
+    });
+    nativeClient.listUnfinishedLargeFiles.mockImplementationOnce(async () => {
+      clock = 12_001;
+      return { files: [], nextFileId: "next-upload" };
+    });
+    const tools = registerTools(createPagedReportClient({}).client, nativeClient);
+
+    const result = parseResult(
+      await tools.call("b2_unfinished_uploads", { bucket: "photos", max_uploads: 10 }),
+    );
+
+    expect(result.unfinished_count).toBe(0);
+    expect(result.truncated).toBe(true);
+    expect(result.note).toContain("time budget");
+  });
+
+  it("sums paginated b2_unfinished_uploads parts", async () => {
+    const nativeClient = createNativeClient({
+      uploadPages: [
+        {
+          files: [upload("old.bin", "upload-1", "2026-01-01T00:00:00.000Z")],
+          nextFileId: null,
+        },
+      ],
+      partPagesByFileId: {
+        "upload-1": [
+          { parts: [part(GB)], nextPartNumber: 2 },
+          { parts: [part(0.5 * GB, 2)], nextPartNumber: null },
+        ],
+      },
+    });
+    const tools = registerTools(createPagedReportClient({}).client, nativeClient);
+
+    const result = parseResult(
+      await tools.call("b2_unfinished_uploads", { bucket: "photos", max_uploads: 10 }),
+    );
+
+    expect(result.truncated).toBe(false);
+    expect(result.unfinished_count).toBe(1);
+    expect(result.wasted_gb).toBe(1.5);
+    expect(result.oldest_file).toBe("old.bin");
+    expect(nativeClient.listParts).toHaveBeenCalledTimes(2);
+  });
+});

--- a/tests/unit/insights-read-paths.unit.test.ts
+++ b/tests/unit/insights-read-paths.unit.test.ts
@@ -1,9 +1,53 @@
+import type {
+  B2Client,
+  BucketFilters,
+  BucketInfoResult,
+  FileVersionResult,
+  ListBucketsResult,
+  ListFileNamesOptions,
+  ListFileNamesResult,
+  ListPartsOptions,
+  ListPartsResult,
+  ListUnfinishedLargeFilesOptions,
+  ListUnfinishedLargeFilesResult,
+  PartInfoResult,
+  UnfinishedLargeFileResult,
+} from "../../src/b2/client";
 import { registerInsightTools } from "../../src/b2/insights";
+import type {
+  ListReportObjectKeysOptions,
+  ReportObjectClient,
+  ReportObjectPage,
+  ReportObjectText,
+} from "../../src/b2/report-client";
 import { parseResult, ToolHarness } from "../support/deterministic-fakes";
 
 const GB = 1e9;
 const DAY_MS = 86400_000;
-const bucket = { bucketId: "bucket-1", bucketName: "photos" };
+const REPORT_CLOCK = new Date("2026-01-31T12:00:00.000Z");
+const bucket: BucketInfoResult = {
+  bucketId: "bucket-1",
+  bucketName: "photos",
+  bucketType: "allPrivate",
+};
+
+type ReportFixture = {
+  calls: Array<{ bucketName: string; options: ListReportObjectKeysOptions }>;
+  downloaded: string[];
+  client: ReportObjectClient;
+};
+
+type NativeInsightClient = Pick<
+  B2Client,
+  "listBuckets" | "listFileNames" | "listUnfinishedLargeFiles" | "listParts"
+>;
+
+type NativeClientOptions = {
+  buckets?: BucketInfoResult[];
+  filePages?: Array<ListFileNamesResult | Error>;
+  uploadPages?: Array<ListUnfinishedLargeFilesResult | Error>;
+  partPagesByFileId?: Record<string, Array<ListPartsResult | Error>>;
+};
 
 function daysAgo(days: number): string {
   return new Date(Date.now() - days * DAY_MS).toISOString().slice(0, 10);
@@ -30,20 +74,24 @@ function timeoutError(): Error {
 function createPagedReportClient(
   csvByKey: Record<string, string>,
   options: { pageSize?: number; listError?: Error } = {},
-) {
-  const calls: Array<{ bucketName: string; options: any }> = [];
+): ReportFixture {
+  const calls: ReportFixture["calls"] = [];
   const downloaded: string[] = [];
   const allKeys = Object.keys(csvByKey).sort();
   return {
     calls,
     downloaded,
     client: {
-      async listReportObjectKeys(bucketName: string, input: any) {
+      async listReportObjectKeys(
+        bucketName: string,
+        input: ListReportObjectKeysOptions = {},
+      ): Promise<ReportObjectPage> {
         calls.push({ bucketName, options: input });
         if (options.listError) throw options.listError;
         let keys = allKeys;
-        if (input.prefix) keys = keys.filter((key) => key.startsWith(input.prefix));
-        if (input.startAfter) keys = keys.filter((key) => key > input.startAfter);
+        const { prefix, startAfter } = input;
+        if (prefix) keys = keys.filter((key) => key.startsWith(prefix));
+        if (startAfter) keys = keys.filter((key) => key > startAfter);
         const offset = input.continuationToken ? Number(input.continuationToken) : 0;
         const requested = input.maxKeys ?? keys.length;
         const pageSize = Math.min(options.pageSize ?? requested, requested);
@@ -55,7 +103,7 @@ function createPagedReportClient(
           nextContinuationToken: nextOffset < keys.length ? String(nextOffset) : undefined,
         };
       },
-      async downloadReportObjectText(_bucketName: string, key: string) {
+      async downloadReportObjectText(_bucketName: string, key: string): Promise<ReportObjectText> {
         downloaded.push(key);
         const text = csvByKey[key] ?? "";
         return { text, bytes: Buffer.byteLength(text, "utf8"), truncated: false };
@@ -64,30 +112,32 @@ function createPagedReportClient(
   };
 }
 
-function createNativeClient(options: {
-  buckets?: any[];
-  filePages?: any[];
-  uploadPages?: any[];
-  partPagesByFileId?: Record<string, any[]>;
-}) {
+function createNativeClient(options: NativeClientOptions) {
   const filePages = [...(options.filePages ?? [])];
   const uploadPages = [...(options.uploadPages ?? [])];
-  const partPagesByFileId = Object.fromEntries(
-    Object.entries(options.partPagesByFileId ?? {}).map(([fileId, pages]) => [fileId, [...pages]]),
-  );
+  const partPagesByFileId: Record<string, Array<ListPartsResult | Error>> = {};
+  for (const [fileId, pages] of Object.entries(options.partPagesByFileId ?? {})) {
+    partPagesByFileId[fileId] = [...pages];
+  }
   return {
-    listBuckets: vi.fn(async () => ({ buckets: options.buckets ?? [bucket] })),
-    listFileNames: vi.fn(async () => {
+    listBuckets: vi.fn(
+      async (_input: BucketFilters = {}): Promise<ListBucketsResult> => ({
+        buckets: options.buckets ?? [bucket],
+      }),
+    ),
+    listFileNames: vi.fn(async (_input: ListFileNamesOptions): Promise<ListFileNamesResult> => {
       const reply = filePages.shift() ?? { files: [], nextFileName: null };
       if (reply instanceof Error) throw reply;
       return reply;
     }),
-    listUnfinishedLargeFiles: vi.fn(async () => {
-      const reply = uploadPages.shift() ?? { files: [], nextFileId: null };
-      if (reply instanceof Error) throw reply;
-      return reply;
-    }),
-    listParts: vi.fn(async (input: { fileId: string }) => {
+    listUnfinishedLargeFiles: vi.fn(
+      async (_input: ListUnfinishedLargeFilesOptions): Promise<ListUnfinishedLargeFilesResult> => {
+        const reply = uploadPages.shift() ?? { files: [], nextFileId: null };
+        if (reply instanceof Error) throw reply;
+        return reply;
+      },
+    ),
+    listParts: vi.fn(async (input: ListPartsOptions): Promise<ListPartsResult> => {
       const reply = partPagesByFileId[input.fileId]?.shift() ?? {
         parts: [],
         nextPartNumber: null,
@@ -98,18 +148,23 @@ function createNativeClient(options: {
   };
 }
 
-function registerTools(reportClient: any, nativeClient: any = createNativeClient({})) {
+function registerTools(
+  reportClient: ReportObjectClient,
+  nativeClient: NativeInsightClient = createNativeClient({}),
+) {
   const harness = new ToolHarness();
   registerInsightTools(
-    harness as any,
-    nativeClient as any,
-    { getAuth: async () => ({ accountId: "test-account" }) } as any,
-    reportClient as any,
+    harness,
+    nativeClient as B2Client,
+    { getAuth: async () => ({ accountId: "test-account" }) } as Parameters<
+      typeof registerInsightTools
+    >[2],
+    reportClient,
   );
   return harness;
 }
 
-function file(fileName: string, contentLength: number) {
+function file(fileName: string, contentLength: number): FileVersionResult {
   return {
     fileName,
     contentLength,
@@ -117,7 +172,7 @@ function file(fileName: string, contentLength: number) {
   };
 }
 
-function upload(fileName: string, fileId: string, isoDate: string) {
+function upload(fileName: string, fileId: string, isoDate: string): UnfinishedLargeFileResult {
   return {
     fileName,
     fileId,
@@ -125,15 +180,21 @@ function upload(fileName: string, fileId: string, isoDate: string) {
   };
 }
 
-function part(contentLength: number, partNumber = 1) {
+function part(contentLength: number, partNumber = 1): PartInfoResult {
   return { partNumber, contentLength };
 }
 
 afterEach(() => {
+  vi.useRealTimers();
   vi.restoreAllMocks();
 });
 
 describe("insight usage-report read paths", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(REPORT_CLOCK);
+  });
+
   it("returns not-enabled metadata when b2_usage_growth cannot list the report bucket", async () => {
     const report = createPagedReportClient({}, { listError: noSuchBucket() });
     const tools = registerTools(report.client);
@@ -156,7 +217,8 @@ describe("insight usage-report read paths", () => {
 
     expect(result.reports_enabled).toBe(true);
     expect(result.note).toBe("No usage-report snapshots found yet.");
-    expect(result.report_scan.pages).toBe(3);
+    expect(result.report_scan.pages).toEqual(expect.any(Number));
+    expect(result.report_scan.pages).toBeGreaterThan(0);
   });
 
   it("reports insufficient history when only the latest snapshot exists", async () => {
@@ -220,7 +282,10 @@ describe("insight usage-report read paths", () => {
       expect.objectContaining({ account: "shrink", growth_gb: -15, growth_pct: -75 }),
     ]);
     expect(leastGrown.account_count).toBe(2);
-    expect(leastGrown.accounts.map((account: any) => account.account)).toEqual(["shrink", "flat"]);
+    expect(leastGrown.accounts.map((account: { account: string }) => account.account)).toEqual([
+      "shrink",
+      "flat",
+    ]);
   });
 
   it("paginates b2_egress_leaders report keys and skips empty or malformed CSV rows", async () => {
@@ -335,8 +400,8 @@ describe("insight native bucket read paths", () => {
   it("returns candidate buckets when b2_largest_files receives an ambiguous bucket name", async () => {
     const nativeClient = createNativeClient({
       buckets: [
-        { bucketId: "logs-a", bucketName: "logs-alpha" },
-        { bucketId: "logs-b", bucketName: "logs-beta" },
+        { bucketId: "logs-a", bucketName: "logs-alpha", bucketType: "allPrivate" },
+        { bucketId: "logs-b", bucketName: "logs-beta", bucketType: "allPrivate" },
       ],
     });
     const tools = registerTools(createPagedReportClient({}).client, nativeClient);

--- a/tests/unit/insights-read-paths.unit.test.ts
+++ b/tests/unit/insights-read-paths.unit.test.ts
@@ -25,6 +25,8 @@ import { parseResult, ToolHarness } from "../support/deterministic-fakes";
 const GB = 1e9;
 const DAY_MS = 86400_000;
 const REPORT_CLOCK = new Date("2026-01-31T12:00:00.000Z");
+// Mirrors the private 12s scan budget in src/b2/insights.ts; +1 trips the deadline branch.
+const AFTER_SCAN_TIME_BUDGET_MS = 12_001;
 const bucket: BucketInfoResult = {
   bucketId: "bucket-1",
   bucketName: "photos",
@@ -460,7 +462,7 @@ describe("insight native bucket read paths", () => {
       ],
     });
     nativeClient.listFileNames.mockImplementationOnce(async () => {
-      clock = 12_001;
+      clock = AFTER_SCAN_TIME_BUDGET_MS;
       return { files: [file("raw/a.bin", 10 * GB)], nextFileName: "raw/b.bin" };
     });
     const tools = registerTools(createPagedReportClient({}).client, nativeClient);
@@ -510,7 +512,7 @@ describe("insight native bucket read paths", () => {
       uploadPages: [{ files: [], nextFileId: "next-upload" }],
     });
     nativeClient.listUnfinishedLargeFiles.mockImplementationOnce(async () => {
-      clock = 12_001;
+      clock = AFTER_SCAN_TIME_BUDGET_MS;
       return { files: [], nextFileId: "next-upload" };
     });
     const tools = registerTools(createPagedReportClient({}).client, nativeClient);

--- a/tests/unit/report-client.unit.test.ts
+++ b/tests/unit/report-client.unit.test.ts
@@ -1,8 +1,12 @@
-import { S3Client } from "@aws-sdk/client-s3";
-import type { MockInstance } from "vitest";
 import { B2ReportClient } from "../../src/b2/report-client";
 import { runWithMcpRequestSignal } from "../../src/request-context";
-import { testConfig } from "../support/deterministic-fakes";
+import { createReportS3Client } from "../../src/s3/client";
+import { DeterministicS3ClientFake, testConfig } from "../support/deterministic-fakes";
+
+vi.mock("../../src/s3/client", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("../../src/s3/client")>()),
+  createReportS3Client: vi.fn(),
+}));
 
 function reportAuth() {
   return {
@@ -17,36 +21,35 @@ function reportAuth() {
   };
 }
 
-function createReportClient() {
+function createReportClient(s3 = new DeterministicS3ClientFake()) {
   const getAuth = vi.fn(async () => reportAuth());
   const getConfig = vi.fn(() => testConfig);
+  vi.mocked(createReportS3Client).mockReturnValue(
+    s3.asPeerClient() as ReturnType<typeof createReportS3Client>,
+  );
   return {
     client: new B2ReportClient({ getAuth, getConfig } as never),
     getAuth,
-    getConfig,
+    s3,
   };
 }
 
 describe("B2ReportClient", () => {
-  let sendSpy: MockInstance;
-
-  beforeEach(() => {
-    sendSpy = vi.spyOn(S3Client.prototype as any, "send");
-  });
-
   afterEach(() => {
     vi.restoreAllMocks();
   });
 
   it("lists report object keys with paging options and reuses the S3 client", async () => {
-    sendSpy
-      .mockResolvedValueOnce({
-        Contents: [{ Key: "2026-01-09/usage.account-a.csv" }, {}, { Key: 123 }],
-        IsTruncated: true,
-        NextContinuationToken: "next-page",
-      })
-      .mockResolvedValueOnce({ Contents: [], IsTruncated: false });
-    const { client, getAuth } = createReportClient();
+    const s3 = new DeterministicS3ClientFake().respond(
+      "listReportObjectKeys",
+      {
+        keys: ["2026-01-09/usage.account-a.csv"],
+        isTruncated: true,
+        nextContinuationToken: "next-page",
+      },
+      { keys: [], isTruncated: false },
+    );
+    const { client, getAuth } = createReportClient(s3);
 
     const page = await client.listReportObjectKeys("b2-reports-test", {
       prefix: "2026-01-09/",
@@ -63,13 +66,28 @@ describe("B2ReportClient", () => {
       nextContinuationToken: "next-page",
     });
     expect(secondPage).toEqual({ keys: [], isTruncated: false, nextContinuationToken: undefined });
-    expect(sendSpy.mock.calls[0][0].input).toMatchObject({
-      Bucket: "b2-reports-test",
-      Prefix: "2026-01-09/",
-      StartAfter: "2026-01-01",
-      ContinuationToken: "page-1",
-      MaxKeys: 5,
-    });
+    expect(s3.requestsFor("listReportObjectKeys")).toEqual([
+      {
+        operation: "listReportObjectKeys",
+        input: {
+          bucketName: "b2-reports-test",
+          prefix: "2026-01-09/",
+          startAfter: "2026-01-01",
+          continuationToken: "page-1",
+          maxKeys: 5,
+        },
+        aborted: false,
+      },
+      {
+        operation: "listReportObjectKeys",
+        input: { bucketName: "b2-reports-test" },
+        aborted: false,
+      },
+    ]);
+    expect(createReportS3Client).toHaveBeenCalledWith(
+      testConfig,
+      expect.objectContaining({ accountId: "test-account-123" }),
+    );
     expect(getAuth).toHaveBeenCalledTimes(1);
   });
 
@@ -81,18 +99,29 @@ describe("B2ReportClient", () => {
         yield Buffer.from([108, 111]);
       },
     };
-    sendSpy.mockResolvedValueOnce({ Body: body });
-    const { client } = createReportClient();
+    const s3 = new DeterministicS3ClientFake().respond("downloadReportObject", {
+      body,
+    });
+    const { client } = createReportClient(s3);
 
     const result = await client.downloadReportObjectText("b2-reports-test", "usage.csv");
 
     expect(result).toEqual({ text: "hello", bytes: 5, truncated: false });
+    expect(s3.requestsFor("downloadReportObject")).toEqual([
+      {
+        operation: "downloadReportObject",
+        input: { bucketName: "b2-reports-test", key: "usage.csv" },
+        aborted: false,
+      },
+    ]);
   });
 
   it("reads transformToByteArray bodies", async () => {
     const transformToByteArray = vi.fn(async () => Uint8Array.of(97, 98, 99));
-    sendSpy.mockResolvedValueOnce({ Body: { transformToByteArray } });
-    const { client } = createReportClient();
+    const s3 = new DeterministicS3ClientFake().respond("downloadReportObject", {
+      body: { transformToByteArray },
+    });
+    const { client } = createReportClient(s3);
 
     const result = await client.downloadReportObjectText("b2-reports-test", "usage.csv");
 
@@ -109,8 +138,10 @@ describe("B2ReportClient", () => {
       cancel: vi.fn(),
       releaseLock: vi.fn(),
     };
-    sendSpy.mockResolvedValueOnce({ Body: { getReader: vi.fn(() => reader) } });
-    const { client } = createReportClient();
+    const s3 = new DeterministicS3ClientFake().respond("downloadReportObject", {
+      body: { getReader: vi.fn(() => reader) },
+    });
+    const { client } = createReportClient(s3);
 
     const result = await client.downloadReportObjectText("b2-reports-test", "usage.csv");
 
@@ -125,8 +156,10 @@ describe("B2ReportClient", () => {
       cancel: vi.fn(),
       releaseLock: vi.fn(),
     };
-    sendSpy.mockResolvedValueOnce({ Body: { getReader: vi.fn(() => reader) } });
-    const { client } = createReportClient();
+    const s3 = new DeterministicS3ClientFake().respond("downloadReportObject", {
+      body: { getReader: vi.fn(() => reader) },
+    });
+    const { client } = createReportClient(s3);
 
     const result = await client.downloadReportObjectText("b2-reports-test", "usage.csv", {
       maxBytes: 3,
@@ -139,8 +172,10 @@ describe("B2ReportClient", () => {
 
   it("returns an empty result without reading when maxBytes is zero", async () => {
     const transformToByteArray = vi.fn(async () => Uint8Array.of(97));
-    sendSpy.mockResolvedValueOnce({ Body: { transformToByteArray } });
-    const { client } = createReportClient();
+    const s3 = new DeterministicS3ClientFake().respond("downloadReportObject", {
+      body: { transformToByteArray },
+    });
+    const { client } = createReportClient(s3);
 
     const result = await client.downloadReportObjectText("b2-reports-test", "usage.csv", {
       maxBytes: 0,
@@ -156,11 +191,13 @@ describe("B2ReportClient", () => {
         yield 42;
       },
     };
-    sendSpy
-      .mockResolvedValueOnce({})
-      .mockResolvedValueOnce({ Body: unsupportedChunkBody })
-      .mockResolvedValueOnce({ Body: {} });
-    const { client } = createReportClient();
+    const s3 = new DeterministicS3ClientFake().respond(
+      "downloadReportObject",
+      { body: undefined },
+      { body: unsupportedChunkBody },
+      { body: {} },
+    );
+    const { client } = createReportClient(s3);
 
     await expect(client.downloadReportObjectText("b2-reports-test", "missing.csv")).rejects.toThrow(
       "did not include a body",
@@ -173,19 +210,23 @@ describe("B2ReportClient", () => {
     ).rejects.toThrow("Unsupported B2 report object body.");
   });
 
-  it("cleans up a report body when the parent request is already aborted", async () => {
+  it("cleans up a report body when the parent request aborts during a read", async () => {
+    const controller = new AbortController();
     const iterator = {
-      next: vi.fn(async () => ({ done: false, value: Buffer.from("ignored") })),
+      next: vi.fn(async () => {
+        controller.abort();
+        return { done: false, value: Buffer.from("ignored") };
+      }),
       return: vi.fn(async () => ({ done: true, value: undefined as never })),
     };
     const body = {
       destroy: vi.fn(),
       [Symbol.asyncIterator]: () => iterator,
     };
-    sendSpy.mockResolvedValueOnce({ Body: body });
-    const { client } = createReportClient();
-    const controller = new AbortController();
-    controller.abort();
+    const s3 = new DeterministicS3ClientFake().respond("downloadReportObject", {
+      body,
+    });
+    const { client } = createReportClient(s3);
 
     await expect(
       runWithMcpRequestSignal(controller.signal, () =>

--- a/tests/unit/report-client.unit.test.ts
+++ b/tests/unit/report-client.unit.test.ts
@@ -1,0 +1,198 @@
+import { S3Client } from "@aws-sdk/client-s3";
+import type { MockInstance } from "vitest";
+import { B2ReportClient } from "../../src/b2/report-client";
+import { runWithMcpRequestSignal } from "../../src/request-context";
+import { testConfig } from "../support/deterministic-fakes";
+
+function reportAuth() {
+  return {
+    accountId: "test-account-123",
+    authorizationToken: "mock-token-xyz",
+    apiUrl: "https://api005.backblazeb2.com",
+    downloadUrl: "https://f005.backblazeb2.com",
+    s3ApiUrl: "https://s3.us-west-004.backblazeb2.com",
+    recommendedPartSize: 100 * 1024 * 1024,
+    absoluteMinimumPartSize: 5 * 1024 * 1024,
+    capabilities: ["readFiles"],
+  };
+}
+
+function createReportClient() {
+  const getAuth = vi.fn(async () => reportAuth());
+  const getConfig = vi.fn(() => testConfig);
+  return {
+    client: new B2ReportClient({ getAuth, getConfig } as never),
+    getAuth,
+    getConfig,
+  };
+}
+
+describe("B2ReportClient", () => {
+  let sendSpy: MockInstance;
+
+  beforeEach(() => {
+    sendSpy = vi.spyOn(S3Client.prototype as any, "send");
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("lists report object keys with paging options and reuses the S3 client", async () => {
+    sendSpy
+      .mockResolvedValueOnce({
+        Contents: [{ Key: "2026-01-09/usage.account-a.csv" }, {}, { Key: 123 }],
+        IsTruncated: true,
+        NextContinuationToken: "next-page",
+      })
+      .mockResolvedValueOnce({ Contents: [], IsTruncated: false });
+    const { client, getAuth } = createReportClient();
+
+    const page = await client.listReportObjectKeys("b2-reports-test", {
+      prefix: "2026-01-09/",
+      startAfter: "2026-01-01",
+      continuationToken: "page-1",
+      maxKeys: 5,
+      timeoutMs: 100,
+    });
+    const secondPage = await client.listReportObjectKeys("b2-reports-test");
+
+    expect(page).toEqual({
+      keys: ["2026-01-09/usage.account-a.csv"],
+      isTruncated: true,
+      nextContinuationToken: "next-page",
+    });
+    expect(secondPage).toEqual({ keys: [], isTruncated: false, nextContinuationToken: undefined });
+    expect(sendSpy.mock.calls[0][0].input).toMatchObject({
+      Bucket: "b2-reports-test",
+      Prefix: "2026-01-09/",
+      StartAfter: "2026-01-01",
+      ContinuationToken: "page-1",
+      MaxKeys: 5,
+    });
+    expect(getAuth).toHaveBeenCalledTimes(1);
+  });
+
+  it("reads async iterable bodies containing strings, ArrayBuffers, and byte chunks", async () => {
+    const body = {
+      async *[Symbol.asyncIterator]() {
+        yield "h";
+        yield Uint8Array.of(101, 108).buffer;
+        yield Buffer.from([108, 111]);
+      },
+    };
+    sendSpy.mockResolvedValueOnce({ Body: body });
+    const { client } = createReportClient();
+
+    const result = await client.downloadReportObjectText("b2-reports-test", "usage.csv");
+
+    expect(result).toEqual({ text: "hello", bytes: 5, truncated: false });
+  });
+
+  it("reads transformToByteArray bodies", async () => {
+    const transformToByteArray = vi.fn(async () => Uint8Array.of(97, 98, 99));
+    sendSpy.mockResolvedValueOnce({ Body: { transformToByteArray } });
+    const { client } = createReportClient();
+
+    const result = await client.downloadReportObjectText("b2-reports-test", "usage.csv");
+
+    expect(result).toEqual({ text: "abc", bytes: 3, truncated: false });
+    expect(transformToByteArray).toHaveBeenCalledTimes(1);
+  });
+
+  it("reads web streams to completion and releases the reader lock", async () => {
+    const reader = {
+      read: vi
+        .fn()
+        .mockResolvedValueOnce({ done: false, value: Uint8Array.of(111, 107) })
+        .mockResolvedValueOnce({ done: true, value: undefined }),
+      cancel: vi.fn(),
+      releaseLock: vi.fn(),
+    };
+    sendSpy.mockResolvedValueOnce({ Body: { getReader: vi.fn(() => reader) } });
+    const { client } = createReportClient();
+
+    const result = await client.downloadReportObjectText("b2-reports-test", "usage.csv");
+
+    expect(result).toEqual({ text: "ok", bytes: 2, truncated: false });
+    expect(reader.cancel).not.toHaveBeenCalled();
+    expect(reader.releaseLock).toHaveBeenCalledTimes(1);
+  });
+
+  it("cancels web streams when the byte cap truncates a chunk", async () => {
+    const reader = {
+      read: vi.fn().mockResolvedValueOnce({ done: false, value: Buffer.from("abcdef") }),
+      cancel: vi.fn(),
+      releaseLock: vi.fn(),
+    };
+    sendSpy.mockResolvedValueOnce({ Body: { getReader: vi.fn(() => reader) } });
+    const { client } = createReportClient();
+
+    const result = await client.downloadReportObjectText("b2-reports-test", "usage.csv", {
+      maxBytes: 3,
+    });
+
+    expect(result).toEqual({ text: "abc", bytes: 3, truncated: true });
+    expect(reader.cancel).toHaveBeenCalledWith(expect.any(Error));
+    expect(reader.releaseLock).toHaveBeenCalledTimes(1);
+  });
+
+  it("returns an empty result without reading when maxBytes is zero", async () => {
+    const transformToByteArray = vi.fn(async () => Uint8Array.of(97));
+    sendSpy.mockResolvedValueOnce({ Body: { transformToByteArray } });
+    const { client } = createReportClient();
+
+    const result = await client.downloadReportObjectText("b2-reports-test", "usage.csv", {
+      maxBytes: 0,
+    });
+
+    expect(result).toEqual({ text: "", bytes: 0, truncated: false });
+    expect(transformToByteArray).not.toHaveBeenCalled();
+  });
+
+  it("rejects missing, unsupported, and malformed report bodies", async () => {
+    const unsupportedChunkBody = {
+      async *[Symbol.asyncIterator]() {
+        yield 42;
+      },
+    };
+    sendSpy
+      .mockResolvedValueOnce({})
+      .mockResolvedValueOnce({ Body: unsupportedChunkBody })
+      .mockResolvedValueOnce({ Body: {} });
+    const { client } = createReportClient();
+
+    await expect(client.downloadReportObjectText("b2-reports-test", "missing.csv")).rejects.toThrow(
+      "did not include a body",
+    );
+    await expect(
+      client.downloadReportObjectText("b2-reports-test", "bad-chunk.csv"),
+    ).rejects.toThrow("Unsupported B2 report object body chunk.");
+    await expect(
+      client.downloadReportObjectText("b2-reports-test", "unsupported.csv"),
+    ).rejects.toThrow("Unsupported B2 report object body.");
+  });
+
+  it("cleans up a report body when the parent request is already aborted", async () => {
+    const iterator = {
+      next: vi.fn(async () => ({ done: false, value: Buffer.from("ignored") })),
+      return: vi.fn(async () => ({ done: true, value: undefined as never })),
+    };
+    const body = {
+      destroy: vi.fn(),
+      [Symbol.asyncIterator]: () => iterator,
+    };
+    sendSpy.mockResolvedValueOnce({ Body: body });
+    const { client } = createReportClient();
+    const controller = new AbortController();
+    controller.abort();
+
+    await expect(
+      runWithMcpRequestSignal(controller.signal, () =>
+        client.downloadReportObjectText("b2-reports-test", "aborted.csv"),
+      ),
+    ).rejects.toMatchObject({ name: "AbortError" });
+    expect(body.destroy).toHaveBeenCalledWith(expect.objectContaining({ name: "AbortError" }));
+    expect(iterator.return).toHaveBeenCalledTimes(1);
+  });
+});


### PR DESCRIPTION
## Summary
- Add deterministic B2ReportClient tests for report listing options, body readers, truncation, aborted reads, and malformed or missing bodies.
- Add fake report/native-client insight read path tests covering missing report buckets, pagination, malformed or empty CSVs, ranking and limit boundaries, time-window filters, bucket-resolution failures, timeout branches, and MCP error mapping.
- Stabilize the new insight tests with a fixed system clock, typed report/native fakes, a looser empty-snapshot scan metadata assertion, and an explicit `startPartNumber` pagination assertion.
- Align review coverage tests with the exported contracts by mocking the `createReportS3Client`/`B2S3PeerClient` boundary, removing an unused `getConfig` helper return, and documenting the scan-budget overrun fixture.

## Linked Issue
Closes #147

## Tests
- pnpm run test:unit
- pnpm run verify
- pnpm run test:coverage
- pnpm exec vitest run --config vitest.config.mts --project=unit tests/unit/insights-read-paths.unit.test.ts --coverage=false
- pnpm exec vitest run --config vitest.config.mts --project=unit tests/unit/report-client.unit.test.ts tests/unit/insights-read-paths.unit.test.ts --coverage=false
- pnpm run typecheck
- pnpm run format:check

## Follow-up Notes
- Coverage target result: src/b2/report-client.ts 96.63% lines / 84.74% branches; src/b2/insights.ts 94.59% lines / 83.85% branches.