### PR TITLE
fix: harden HTTP lifecycle entry points

### DIFF
--- a/src/http-server.ts
+++ b/src/http-server.ts
@@ -133,7 +133,7 @@ export function buildHttpServer(options: HttpServerOptions = {}): HttpServerHand
   };
 }
 
-export async function startHttp(options: HttpListenOptions = {}): Promise<HttpServerHandle> {
+export async function startHttp(options: HttpListenOptions = {}): Promise<void> {
   const port = options.port ?? getPort();
   const handle = buildHttpServer();
   const { server: httpServer, sessions, drain } = handle;
@@ -186,7 +186,6 @@ export async function startHttp(options: HttpListenOptions = {}): Promise<HttpSe
 
   process.on("SIGTERM", onSigterm);
   process.on("SIGINT", onSigint);
-  return handle;
 }
 
 if (require.main === module) {

--- a/src/http-server.ts
+++ b/src/http-server.ts
@@ -133,15 +133,33 @@ export function buildHttpServer(options: HttpServerOptions = {}): HttpServerHand
   };
 }
 
-export async function startHttp(options: HttpListenOptions = {}): Promise<void> {
+export async function startHttp(options: HttpListenOptions = {}): Promise<HttpServerHandle> {
   const port = options.port ?? getPort();
-  const { server: httpServer, sessions, drain } = buildHttpServer();
+  const handle = buildHttpServer();
+  const { server: httpServer, sessions, drain } = handle;
 
-  httpServer.listen(port, () => {
-    logger.info({ transport: "http", port }, "server.started");
+  await new Promise<void>((resolve, reject) => {
+    const onError = (err: Error) => {
+      httpServer.off("error", onError);
+      drain();
+      reject(err);
+    };
+    httpServer.once("error", onError);
+    httpServer.listen(port, () => {
+      httpServer.off("error", onError);
+      logger.info({ transport: "http", port }, "server.started");
+      resolve();
+    });
   });
 
   let shuttingDown = false;
+  let drainTimer: NodeJS.Timeout | null = null;
+  const onSigterm = () => shutdown("SIGTERM");
+  const onSigint = () => shutdown("SIGINT");
+  function removeSignalHandlers(): void {
+    process.off("SIGTERM", onSigterm);
+    process.off("SIGINT", onSigint);
+  }
   function shutdown(signal: string): void {
     if (shuttingDown) return;
     shuttingDown = true;
@@ -151,17 +169,24 @@ export async function startHttp(options: HttpListenOptions = {}): Promise<void> 
     );
     drain();
     httpServer.close(() => {
+      removeSignalHandlers();
+      if (drainTimer) {
+        clearTimeout(drainTimer);
+        drainTimer = null;
+      }
       logger.info("server.closed");
       process.exit(0);
     });
-    setTimeout(() => {
+    drainTimer = setTimeout(() => {
+      removeSignalHandlers();
       logger.error("server.drainTimeout");
       process.exit(1);
     }, SHUTDOWN_DRAIN_MS).unref();
   }
 
-  process.on("SIGTERM", () => shutdown("SIGTERM"));
-  process.on("SIGINT", () => shutdown("SIGINT"));
+  process.on("SIGTERM", onSigterm);
+  process.on("SIGINT", onSigint);
+  return handle;
 }
 
 if (require.main === module) {

--- a/src/http-server.ts
+++ b/src/http-server.ts
@@ -137,6 +137,45 @@ export async function startHttp(options: HttpListenOptions = {}): Promise<void> 
   const port = options.port ?? getPort();
   const handle = buildHttpServer();
   const { server: httpServer, sessions, drain } = handle;
+  let shuttingDown = false;
+  let drainTimer: NodeJS.Timeout | null = null;
+  const onSigterm = () => shutdown("SIGTERM");
+  const onSigint = () => shutdown("SIGINT");
+  const onRuntimeError = (err: Error) => {
+    logger.error({ err: err.message }, "server.error");
+    shutdown("server.error");
+  };
+  function removeSignalHandlers(): void {
+    process.off("SIGTERM", onSigterm);
+    process.off("SIGINT", onSigint);
+  }
+  function removeLifecycleHandlers(): void {
+    removeSignalHandlers();
+    httpServer.off("error", onRuntimeError);
+  }
+  function shutdown(signal: string): void {
+    if (shuttingDown) return;
+    shuttingDown = true;
+    logger.info(
+      { signal, drainMs: SHUTDOWN_DRAIN_MS, activeSessions: sessions.size },
+      "server.shutdown",
+    );
+    drain();
+    httpServer.close(() => {
+      removeLifecycleHandlers();
+      if (drainTimer) {
+        clearTimeout(drainTimer);
+        drainTimer = null;
+      }
+      logger.info("server.closed");
+      process.exit(0);
+    });
+    drainTimer = setTimeout(() => {
+      removeLifecycleHandlers();
+      logger.error("server.drainTimeout");
+      process.exit(1);
+    }, SHUTDOWN_DRAIN_MS).unref();
+  }
 
   await new Promise<void>((resolve, reject) => {
     const failStartup = (err: Error) => {
@@ -149,6 +188,7 @@ export async function startHttp(options: HttpListenOptions = {}): Promise<void> 
     try {
       httpServer.listen(port, () => {
         httpServer.off("error", onError);
+        httpServer.on("error", onRuntimeError);
         logger.info({ transport: "http", port }, "server.started");
         resolve();
       });
@@ -156,38 +196,6 @@ export async function startHttp(options: HttpListenOptions = {}): Promise<void> 
       failStartup(err instanceof Error ? err : new Error(String(err)));
     }
   });
-
-  let shuttingDown = false;
-  let drainTimer: NodeJS.Timeout | null = null;
-  const onSigterm = () => shutdown("SIGTERM");
-  const onSigint = () => shutdown("SIGINT");
-  function removeSignalHandlers(): void {
-    process.off("SIGTERM", onSigterm);
-    process.off("SIGINT", onSigint);
-  }
-  function shutdown(signal: string): void {
-    if (shuttingDown) return;
-    shuttingDown = true;
-    logger.info(
-      { signal, drainMs: SHUTDOWN_DRAIN_MS, activeSessions: sessions.size },
-      "server.shutdown",
-    );
-    drain();
-    httpServer.close(() => {
-      removeSignalHandlers();
-      if (drainTimer) {
-        clearTimeout(drainTimer);
-        drainTimer = null;
-      }
-      logger.info("server.closed");
-      process.exit(0);
-    });
-    drainTimer = setTimeout(() => {
-      removeSignalHandlers();
-      logger.error("server.drainTimeout");
-      process.exit(1);
-    }, SHUTDOWN_DRAIN_MS).unref();
-  }
 
   process.on("SIGTERM", onSigterm);
   process.on("SIGINT", onSigint);

--- a/src/http-server.ts
+++ b/src/http-server.ts
@@ -139,17 +139,22 @@ export async function startHttp(options: HttpListenOptions = {}): Promise<void> 
   const { server: httpServer, sessions, drain } = handle;
 
   await new Promise<void>((resolve, reject) => {
-    const onError = (err: Error) => {
+    const failStartup = (err: Error) => {
       httpServer.off("error", onError);
       drain();
       reject(err);
     };
+    const onError = (err: Error) => failStartup(err);
     httpServer.once("error", onError);
-    httpServer.listen(port, () => {
-      httpServer.off("error", onError);
-      logger.info({ transport: "http", port }, "server.started");
-      resolve();
-    });
+    try {
+      httpServer.listen(port, () => {
+        httpServer.off("error", onError);
+        logger.info({ transport: "http", port }, "server.started");
+        resolve();
+      });
+    } catch (err) {
+      failStartup(err instanceof Error ? err : new Error(String(err)));
+    }
   });
 
   let shuttingDown = false;

--- a/src/index.ts
+++ b/src/index.ts
@@ -20,6 +20,8 @@
  *   }
  */
 
+// Namespace imports keep ESM bootstrap dependencies spy-able in tests without
+// exporting dependency-injection seams from the package root.
 import * as stdioTransport from "@modelcontextprotocol/server/stdio";
 import * as serverModule from "./server.js";
 import { CredentialResolutionError } from "./credentials.js";

--- a/src/index.ts
+++ b/src/index.ts
@@ -28,12 +28,23 @@ import { VERSION } from "./version.js";
 import { CliUsageError, helpText, parseCliArgs } from "./cli.js";
 import { PortUsageError } from "./utils/config.js";
 
-export async function startStdio(): Promise<void> {
-  const config = loadConfig();
+export interface StdioBootstrapDependencies {
+  loadConfig?: typeof loadConfig;
+  fetchCapabilities?: typeof fetchCapabilities;
+  createServer?: typeof createServer;
+  serveStdio?: typeof serveStdio;
+}
+
+export async function startStdio(deps: StdioBootstrapDependencies = {}): Promise<void> {
+  const loadConfigFn = deps.loadConfig ?? loadConfig;
+  const fetchCapabilitiesFn = deps.fetchCapabilities ?? fetchCapabilities;
+  const createServerFn = deps.createServer ?? createServer;
+  const serveStdioFn = deps.serveStdio ?? serveStdio;
+  const config = loadConfigFn();
   // Right-size the surface to the key's capabilities (null → full surface).
   let capabilities: string[] | null;
   try {
-    capabilities = await fetchCapabilities(config);
+    capabilities = await fetchCapabilitiesFn(config);
   } catch (err) {
     if (
       !(err instanceof CredentialResolutionError) ||
@@ -49,31 +60,49 @@ export async function startStdio(): Promise<void> {
     );
     capabilities = null;
   }
-  serveStdio(() => createServer(config, capabilities), {
+  serveStdioFn(() => createServerFn(config, capabilities), {
     onerror: (error) => logger.warn({ err: error.message }, "mcp.stdio.error"),
   });
 
   logger.info({ transport: "stdio" }, "server.started");
 }
 
-async function runCli(argv = process.argv.slice(2)): Promise<void> {
+interface CliOutput {
+  write(chunk: string): unknown;
+}
+
+export interface CliRuntime {
+  startStdio?: () => Promise<void>;
+  startHttp?: (options: { port?: number }) => Promise<unknown>;
+  stdout?: CliOutput;
+}
+
+async function defaultStartHttp(options: { port?: number }): Promise<unknown> {
+  const { startHttp } = await import("./http-server.js");
+  return startHttp({ port: options.port });
+}
+
+export async function runCli(
+  argv = process.argv.slice(2),
+  runtime: CliRuntime = {},
+): Promise<void> {
   const options = parseCliArgs(argv);
+  const stdout = runtime.stdout ?? process.stdout;
   if (options.action === "help") {
-    process.stdout.write(`${helpText()}\n`);
+    stdout.write(`${helpText()}\n`);
     return;
   }
   if (options.action === "version") {
-    process.stdout.write(`${VERSION}\n`);
+    stdout.write(`${VERSION}\n`);
     return;
   }
 
   if (options.transport === "http") {
-    const { startHttp } = await import("./http-server.js");
-    await startHttp({ port: options.port });
+    await (runtime.startHttp ?? defaultStartHttp)({ port: options.port });
     return;
   }
 
-  await startStdio();
+  await (runtime.startStdio ?? (() => startStdio()))();
 }
 
 // Only run when invoked directly (not when imported by tests).

--- a/src/index.ts
+++ b/src/index.ts
@@ -20,31 +20,20 @@
  *   }
  */
 
-import { serveStdio } from "@modelcontextprotocol/server/stdio";
-import { createServer, fetchCapabilities, loadConfig } from "./server.js";
+import * as stdioTransport from "@modelcontextprotocol/server/stdio";
+import * as serverModule from "./server.js";
 import { CredentialResolutionError } from "./credentials.js";
 import { logger } from "./utils/logger.js";
 import { VERSION } from "./version.js";
 import { CliUsageError, helpText, parseCliArgs } from "./cli.js";
 import { PortUsageError } from "./utils/config.js";
 
-export interface StdioBootstrapDependencies {
-  loadConfig?: typeof loadConfig;
-  fetchCapabilities?: typeof fetchCapabilities;
-  createServer?: typeof createServer;
-  serveStdio?: typeof serveStdio;
-}
-
-export async function startStdio(deps: StdioBootstrapDependencies = {}): Promise<void> {
-  const loadConfigFn = deps.loadConfig ?? loadConfig;
-  const fetchCapabilitiesFn = deps.fetchCapabilities ?? fetchCapabilities;
-  const createServerFn = deps.createServer ?? createServer;
-  const serveStdioFn = deps.serveStdio ?? serveStdio;
-  const config = loadConfigFn();
+export async function startStdio(): Promise<void> {
+  const config = serverModule.loadConfig();
   // Right-size the surface to the key's capabilities (null → full surface).
   let capabilities: string[] | null;
   try {
-    capabilities = await fetchCapabilitiesFn(config);
+    capabilities = await serverModule.fetchCapabilities(config);
   } catch (err) {
     if (
       !(err instanceof CredentialResolutionError) ||
@@ -60,49 +49,35 @@ export async function startStdio(deps: StdioBootstrapDependencies = {}): Promise
     );
     capabilities = null;
   }
-  serveStdioFn(() => createServerFn(config, capabilities), {
+  stdioTransport.serveStdio(() => serverModule.createServer(config, capabilities), {
     onerror: (error) => logger.warn({ err: error.message }, "mcp.stdio.error"),
   });
 
   logger.info({ transport: "stdio" }, "server.started");
 }
 
-interface CliOutput {
-  write(chunk: string): unknown;
-}
-
-export interface CliRuntime {
-  startStdio?: () => Promise<void>;
-  startHttp?: (options: { port?: number }) => Promise<unknown>;
-  stdout?: CliOutput;
-}
-
-async function defaultStartHttp(options: { port?: number }): Promise<unknown> {
+async function startHttpTransport(options: { port?: number }): Promise<void> {
   const { startHttp } = await import("./http-server.js");
-  return startHttp({ port: options.port });
+  await startHttp({ port: options.port });
 }
 
-export async function runCli(
-  argv = process.argv.slice(2),
-  runtime: CliRuntime = {},
-): Promise<void> {
+async function runCli(argv = process.argv.slice(2)): Promise<void> {
   const options = parseCliArgs(argv);
-  const stdout = runtime.stdout ?? process.stdout;
   if (options.action === "help") {
-    stdout.write(`${helpText()}\n`);
+    process.stdout.write(`${helpText()}\n`);
     return;
   }
   if (options.action === "version") {
-    stdout.write(`${VERSION}\n`);
+    process.stdout.write(`${VERSION}\n`);
     return;
   }
 
   if (options.transport === "http") {
-    await (runtime.startHttp ?? defaultStartHttp)({ port: options.port });
+    await startHttpTransport({ port: options.port });
     return;
   }
 
-  await (runtime.startStdio ?? (() => startStdio()))();
+  await startStdio();
 }
 
 // Only run when invoked directly (not when imported by tests).

--- a/tests/unit/cli.unit.test.ts
+++ b/tests/unit/cli.unit.test.ts
@@ -12,6 +12,11 @@ describe("CLI argument parsing", () => {
       transport: "http",
       port: 3001,
     });
+    expect(parseCliArgs(["--transport=http", "--port", "3003"])).toEqual({
+      action: "run",
+      transport: "http",
+      port: 3003,
+    });
     expect(parseCliArgs(["http", "--port=3002"])).toEqual({
       action: "run",
       transport: "http",
@@ -20,7 +25,7 @@ describe("CLI argument parsing", () => {
   });
 
   it("uses B2_MCP_TRANSPORT when no transport argument is passed", () => {
-    expect(parseCliArgs([], { B2_MCP_TRANSPORT: "http" })).toEqual({
+    expect(parseCliArgs([], { B2_MCP_TRANSPORT: " HTTP " })).toEqual({
       action: "run",
       transport: "http",
     });
@@ -32,15 +37,19 @@ describe("CLI argument parsing", () => {
 
   it("supports help and version without requiring transport configuration", () => {
     expect(parseCliArgs(["--help"], { B2_MCP_TRANSPORT: "sse" }).action).toBe("help");
+    expect(parseCliArgs(["-h"], { B2_MCP_TRANSPORT: "sse" }).action).toBe("help");
     expect(parseCliArgs(["--version"], { B2_MCP_TRANSPORT: "sse" }).action).toBe("version");
+    expect(parseCliArgs(["-v"], { B2_MCP_TRANSPORT: "sse" }).action).toBe("version");
     expect(helpText()).toContain("--transport <stdio|http>");
   });
 
   it("rejects invalid transport, port, and unknown arguments", () => {
+    expect(() => parseCliArgs(["--transport"])).toThrow(CliUsageError);
     expect(() => parseCliArgs(["--transport", "sse"])).toThrow(CliUsageError);
     expect(() => parseCliArgs([], { B2_MCP_TRANSPORT: "sse" })).toThrow(CliUsageError);
     expect(() => parseCliArgs(["http", "--port", "0"])).toThrow(PortUsageError);
     expect(() => parseCliArgs(["http", "--port", "3000abc"])).toThrow("Invalid port: 3000abc");
+    expect(() => parseCliArgs(["http", "--port="])).toThrow("--port requires a value");
     expect(() => parseCliArgs(["--port", "3000"], {})).toThrow(CliUsageError);
     expect(() => parseCliArgs(["--session"])).toThrow(CliUsageError);
   });

--- a/tests/unit/http-server.unit.test.ts
+++ b/tests/unit/http-server.unit.test.ts
@@ -226,12 +226,12 @@ describe("HTTP server lifecycle", () => {
     vi.useFakeTimers();
     const setIntervalSpy = vi.spyOn(global, "setInterval");
     const clearIntervalSpy = vi.spyOn(global, "clearInterval");
+    const previousTimerCount = setIntervalSpy.mock.results.length;
 
     const handle = buildHttpServer();
-    const sweepResultIndex = setIntervalSpy.mock.calls.findIndex((call) => call[1] === 60_000);
-    const sweepTimer = setIntervalSpy.mock.results[sweepResultIndex]?.value;
+    const sweepTimer = setIntervalSpy.mock.results.at(-1)?.value;
 
-    expect(sweepResultIndex).toBeGreaterThanOrEqual(0);
+    expect(setIntervalSpy.mock.results.length).toBe(previousTimerCount + 1);
     handle.drain();
     expect(clearIntervalSpy).toHaveBeenCalledWith(sweepTimer);
   });
@@ -240,9 +240,17 @@ describe("HTTP server lifecycle", () => {
     const blocker = http.createServer();
     await new Promise<void>((resolve) => blocker.listen(0, resolve));
     const port = (blocker.address() as AddressInfo).port;
+    const setIntervalSpy = vi.spyOn(global, "setInterval");
+    const clearIntervalSpy = vi.spyOn(global, "clearInterval");
+    const previousTimerCount = setIntervalSpy.mock.results.length;
 
     try {
       await expect(startHttp({ port })).rejects.toMatchObject({ code: "EADDRINUSE" });
+      const startupTimers = setIntervalSpy.mock.results
+        .slice(previousTimerCount)
+        .map((result) => result.value);
+      expect(startupTimers.length).toBeGreaterThan(0);
+      expect(clearIntervalSpy).toHaveBeenCalledWith(startupTimers.at(-1));
     } finally {
       await new Promise<void>((resolve) => blocker.close(() => resolve()));
     }
@@ -337,20 +345,26 @@ describe("HTTP server lifecycle", () => {
       exitCodes.push(code);
       return undefined as never;
     }) as typeof process.exit);
-    const handle = await startHttp({ port: 0 });
+    const portProbe = http.createServer();
+    await new Promise<void>((resolve) => portProbe.listen(0, "127.0.0.1", resolve));
+    const port = (portProbe.address() as AddressInfo).port;
+    await new Promise<void>((resolve) => portProbe.close(() => resolve()));
+    let listener: (() => void) | undefined;
 
     try {
-      const port = (handle.server.address() as AddressInfo).port;
+      await startHttp({ port });
       const res = await request(port, "GET", "/health");
       expect(res.status).toBe(200);
 
       const before = signal === "SIGTERM" ? beforeTerm : beforeInt;
-      const listener = process.listeners(signal).find((candidate) => !before.has(candidate));
+      listener = process.listeners(signal).find((candidate) => !before.has(candidate)) as
+        | (() => void)
+        | undefined;
       expect(listener).toBeTypeOf("function");
-      (listener as () => void)();
+      listener?.();
 
       await vi.waitFor(() => expect(exitCodes).toContain(0));
-      expect(handle.server.listening).toBe(false);
+      await expect(request(port, "GET", "/health")).rejects.toThrow();
       expect(
         process.listeners("SIGTERM").filter((candidate) => !beforeTerm.has(candidate)),
       ).toEqual([]);
@@ -358,15 +372,17 @@ describe("HTTP server lifecycle", () => {
         [],
       );
     } finally {
-      exitSpy.mockRestore();
+      if (listener && !exitCodes.includes(0)) {
+        listener();
+        await vi.waitFor(() => expect(exitCodes).toContain(0)).catch(() => undefined);
+      }
       for (const listener of process.listeners("SIGTERM")) {
         if (!beforeTerm.has(listener)) process.off("SIGTERM", listener);
       }
       for (const listener of process.listeners("SIGINT")) {
         if (!beforeInt.has(listener)) process.off("SIGINT", listener);
       }
-      if (handle.server.listening)
-        await new Promise<void>((resolve) => handle.server.close(() => resolve()));
+      exitSpy.mockRestore();
     }
   });
 });

--- a/tests/unit/http-server.unit.test.ts
+++ b/tests/unit/http-server.unit.test.ts
@@ -19,7 +19,47 @@ import { createB2McpFetchHandler } from "../../src/http-fetch-handler";
 import type { AuthenticatedIncomingMessage } from "../../src/credentials";
 import { closeHttpServer, listenOnLocalhost, request } from "../support/http";
 import { getDestructivePolicy } from "../../src/utils/destructive-gate";
+import { logger } from "../../src/utils/logger";
 import { allowRequest, rateLimiterConfig, _resetRateLimiter } from "../../src/utils/rate-limiter";
+
+type ShutdownSignal = "SIGTERM" | "SIGINT";
+
+const shutdownSignals: readonly ShutdownSignal[] = ["SIGTERM", "SIGINT"];
+
+function signalListeners(signal: ShutdownSignal): NodeJS.SignalsListener[] {
+  return process.listeners(signal) as NodeJS.SignalsListener[];
+}
+
+function snapshotSignalListeners(): Record<ShutdownSignal, Set<NodeJS.SignalsListener>> {
+  return {
+    SIGTERM: new Set(signalListeners("SIGTERM")),
+    SIGINT: new Set(signalListeners("SIGINT")),
+  };
+}
+
+function findNewSignalListener(
+  signal: ShutdownSignal,
+  snapshot: Record<ShutdownSignal, Set<NodeJS.SignalsListener>>,
+): NodeJS.SignalsListener | undefined {
+  return signalListeners(signal).find((listener) => !snapshot[signal].has(listener));
+}
+
+function newSignalListeners(
+  signal: ShutdownSignal,
+  snapshot: Record<ShutdownSignal, Set<NodeJS.SignalsListener>>,
+): NodeJS.SignalsListener[] {
+  return signalListeners(signal).filter((listener) => !snapshot[signal].has(listener));
+}
+
+function removeNewSignalListeners(
+  snapshot: Record<ShutdownSignal, Set<NodeJS.SignalsListener>>,
+): void {
+  for (const signal of shutdownSignals) {
+    for (const registeredListener of newSignalListeners(signal, snapshot)) {
+      process.off(signal, registeredListener);
+    }
+  }
+}
 
 describe("configFromHeaders", () => {
   const baseEnv = { ...process.env };
@@ -351,50 +391,65 @@ describe("HTTP server lifecycle", () => {
   });
 
   it.each(["SIGTERM", "SIGINT"] as const)("handles %s by draining and closing", async (signal) => {
-    const beforeTerm = new Set(process.listeners("SIGTERM"));
-    const beforeInt = new Set(process.listeners("SIGINT"));
+    const signalSnapshot = snapshotSignalListeners();
     const exitCodes: Array<string | number | null | undefined> = [];
     const exitSpy = vi.spyOn(process, "exit").mockImplementation(((code) => {
       exitCodes.push(code);
       return undefined as never;
     }) as typeof process.exit);
-    const portProbe = http.createServer();
-    await new Promise<void>((resolve) => portProbe.listen(0, "127.0.0.1", resolve));
-    const port = (portProbe.address() as AddressInfo).port;
-    await new Promise<void>((resolve) => portProbe.close(() => resolve()));
-    let listener: (() => void) | undefined;
+    let listener: NodeJS.SignalsListener | undefined;
 
     try {
-      await startHttp({ port });
-      const res = await request(port, "GET", "/health");
-      expect(res.status).toBe(200);
-
-      const before = signal === "SIGTERM" ? beforeTerm : beforeInt;
-      listener = process.listeners(signal).find((candidate) => !before.has(candidate)) as
-        | (() => void)
-        | undefined;
+      await startHttp({ port: 0 });
+      listener = findNewSignalListener(signal, signalSnapshot);
       expect(listener).toBeTypeOf("function");
-      listener?.();
+      listener?.(signal);
 
       await vi.waitFor(() => expect(exitCodes).toContain(0));
-      await expect(request(port, "GET", "/health")).rejects.toThrow();
-      expect(
-        process.listeners("SIGTERM").filter((candidate) => !beforeTerm.has(candidate)),
-      ).toEqual([]);
-      expect(process.listeners("SIGINT").filter((candidate) => !beforeInt.has(candidate))).toEqual(
-        [],
-      );
+      expect(newSignalListeners("SIGTERM", signalSnapshot)).toEqual([]);
+      expect(newSignalListeners("SIGINT", signalSnapshot)).toEqual([]);
     } finally {
       if (listener && !exitCodes.includes(0)) {
-        listener();
+        listener(signal);
         await vi.waitFor(() => expect(exitCodes).toContain(0)).catch(() => undefined);
       }
-      for (const listener of process.listeners("SIGTERM")) {
-        if (!beforeTerm.has(listener)) process.off("SIGTERM", listener);
+      removeNewSignalListeners(signalSnapshot);
+      exitSpy.mockRestore();
+    }
+  });
+
+  it("logs runtime server errors before shutting down", async () => {
+    const signalSnapshot = snapshotSignalListeners();
+    const exitCodes: Array<string | number | null | undefined> = [];
+    const exitSpy = vi.spyOn(process, "exit").mockImplementation(((code) => {
+      exitCodes.push(code);
+      return undefined as never;
+    }) as typeof process.exit);
+    const loggerError = vi.spyOn(logger, "error").mockImplementation(() => undefined);
+    const serverOn = vi.spyOn(http.Server.prototype, "on");
+    let signalListener: NodeJS.SignalsListener | undefined;
+
+    try {
+      await startHttp({ port: 0 });
+      signalListener = findNewSignalListener("SIGTERM", signalSnapshot);
+      const serverOnCalls = serverOn.mock.calls as Array<[string | symbol, unknown, ...unknown[]]>;
+      const runtimeErrorListener = serverOnCalls
+        .filter(([event]) => event === "error")
+        .at(-1)?.[1] as ((err: Error) => void) | undefined;
+
+      expect(runtimeErrorListener).toBeTypeOf("function");
+      runtimeErrorListener?.(new Error("runtime socket failed"));
+
+      await vi.waitFor(() => expect(exitCodes).toContain(0));
+      expect(loggerError).toHaveBeenCalledWith({ err: "runtime socket failed" }, "server.error");
+      expect(newSignalListeners("SIGTERM", signalSnapshot)).toEqual([]);
+      expect(newSignalListeners("SIGINT", signalSnapshot)).toEqual([]);
+    } finally {
+      if (signalListener && !exitCodes.includes(0)) {
+        signalListener("SIGTERM");
+        await vi.waitFor(() => expect(exitCodes).toContain(0)).catch(() => undefined);
       }
-      for (const listener of process.listeners("SIGINT")) {
-        if (!beforeInt.has(listener)) process.off("SIGINT", listener);
-      }
+      removeNewSignalListeners(signalSnapshot);
       exitSpy.mockRestore();
     }
   });

--- a/tests/unit/http-server.unit.test.ts
+++ b/tests/unit/http-server.unit.test.ts
@@ -256,6 +256,19 @@ describe("HTTP server lifecycle", () => {
     }
   });
 
+  it("drains startup resources when listen throws synchronously", async () => {
+    const setIntervalSpy = vi.spyOn(global, "setInterval");
+    const clearIntervalSpy = vi.spyOn(global, "clearInterval");
+    const previousTimerCount = setIntervalSpy.mock.results.length;
+
+    await expect(startHttp({ port: 70_000 })).rejects.toThrow();
+    const startupTimers = setIntervalSpy.mock.results
+      .slice(previousTimerCount)
+      .map((result) => result.value);
+    expect(startupTimers.length).toBeGreaterThan(0);
+    expect(clearIntervalSpy).toHaveBeenCalledWith(startupTimers.at(-1));
+  });
+
   it("drains in-flight requests before closing the MCP handler", async () => {
     let controller: ReadableStreamDefaultController<Uint8Array> | undefined;
     const close = vi.fn(async () => undefined);

--- a/tests/unit/http-server.unit.test.ts
+++ b/tests/unit/http-server.unit.test.ts
@@ -3,14 +3,20 @@
  * Covers configFromHeaders parsing and getPort validation.
  */
 
+import type { AuthInfo } from "@modelcontextprotocol/server";
+import * as http from "http";
+import type { AddressInfo } from "net";
+import { ReadableStream, type ReadableStreamDefaultController } from "node:stream/web";
 import {
   buildHttpServer,
   configFromHeaders,
   createInFlightLimiter,
   deriveRateKey,
   getPort,
+  startHttp,
 } from "../../src/http-server";
 import { createB2McpFetchHandler } from "../../src/http-fetch-handler";
+import type { AuthenticatedIncomingMessage } from "../../src/credentials";
 import { closeHttpServer, listenOnLocalhost, request } from "../support/http";
 import { getDestructivePolicy } from "../../src/utils/destructive-gate";
 import { allowRequest, rateLimiterConfig, _resetRateLimiter } from "../../src/utils/rate-limiter";
@@ -194,6 +200,174 @@ describe("createInFlightLimiter", () => {
     expect(limiter.acquire("credential:c")).toMatchObject({ ok: false, status: 503 });
     limiter.release("credential:a");
     expect(limiter.acquire("credential:c")).toEqual({ ok: true });
+  });
+});
+
+describe("HTTP server lifecycle", () => {
+  const encoder = new TextEncoder();
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    vi.useRealTimers();
+  });
+
+  it("listens on an ephemeral localhost port and shuts down", async () => {
+    const handle = buildHttpServer();
+    const port = await listenOnLocalhost(handle);
+
+    const res = await request(port, "GET", "/health");
+
+    expect(res.status).toBe(200);
+    await closeHttpServer(handle);
+    expect(handle.server.listening).toBe(false);
+  });
+
+  it("schedules periodic cache sweeps and clears them on drain", () => {
+    vi.useFakeTimers();
+    const setIntervalSpy = vi.spyOn(global, "setInterval");
+    const clearIntervalSpy = vi.spyOn(global, "clearInterval");
+
+    const handle = buildHttpServer();
+    const sweepResultIndex = setIntervalSpy.mock.calls.findIndex((call) => call[1] === 60_000);
+    const sweepTimer = setIntervalSpy.mock.results[sweepResultIndex]?.value;
+
+    expect(sweepResultIndex).toBeGreaterThanOrEqual(0);
+    handle.drain();
+    expect(clearIntervalSpy).toHaveBeenCalledWith(sweepTimer);
+  });
+
+  it("rejects startup when the requested HTTP port is already bound", async () => {
+    const blocker = http.createServer();
+    await new Promise<void>((resolve) => blocker.listen(0, resolve));
+    const port = (blocker.address() as AddressInfo).port;
+
+    try {
+      await expect(startHttp({ port })).rejects.toMatchObject({ code: "EADDRINUSE" });
+    } finally {
+      await new Promise<void>((resolve) => blocker.close(() => resolve()));
+    }
+  });
+
+  it("drains in-flight requests before closing the MCP handler", async () => {
+    let controller: ReadableStreamDefaultController<Uint8Array> | undefined;
+    const close = vi.fn(async () => undefined);
+    const handle = buildHttpServer({
+      idleSweepMode: "request",
+      mcpHandler: {
+        fetch: vi.fn(
+          async () =>
+            new Response(
+              new ReadableStream<Uint8Array>({
+                start(streamController) {
+                  controller = streamController;
+                  streamController.enqueue(encoder.encode("drained"));
+                },
+              }),
+              { status: 200 },
+            ),
+        ),
+        close,
+      },
+    });
+
+    try {
+      const port = await listenOnLocalhost(handle);
+      const pending = request(port, "GET", "/mcp");
+      await vi.waitFor(() => expect(controller).toBeDefined());
+
+      handle.drain();
+      expect(close).not.toHaveBeenCalled();
+      const drainingRes = await request(port, "GET", "/health");
+      expect(drainingRes.status).toBe(503);
+
+      controller?.close();
+      const res = await pending;
+      expect(res.status).toBe(200);
+      expect(res.body).toBe("drained");
+      await vi.waitFor(() => expect(close).toHaveBeenCalledTimes(1));
+    } finally {
+      await new Promise<void>((resolve) => handle.server.close(() => resolve()));
+    }
+  });
+
+  it("passes verified authInfo from the hook into the MCP handler", async () => {
+    const authInfo: AuthInfo = {
+      token: "verified:test-token",
+      clientId: "client-1",
+      scopes: ["b2:read"],
+      expiresAt: Math.floor(Date.now() / 1000) + 600,
+      resource: new URL("http://localhost/mcp"),
+      extra: { sub: "subject-1" },
+    };
+    const getAuthInfo = vi.fn((req: AuthenticatedIncomingMessage) => {
+      expect(req.auth).toBeUndefined();
+      return authInfo;
+    });
+    const fetch = vi.fn(async (_req: Request, options?: { authInfo?: AuthInfo }) => {
+      return new Response(JSON.stringify({ clientId: options?.authInfo?.clientId }), {
+        status: 202,
+        headers: { "Content-Type": "application/json" },
+      });
+    });
+    const handle = buildHttpServer({
+      idleSweepMode: "request",
+      getAuthInfo,
+      mcpHandler: { fetch, close: vi.fn(async () => undefined) },
+    });
+
+    try {
+      const port = await listenOnLocalhost(handle);
+      const res = await request(port, "GET", "/mcp");
+
+      expect(res.status).toBe(202);
+      expect(JSON.parse(res.body)).toEqual({ clientId: "client-1" });
+      expect(getAuthInfo).toHaveBeenCalledTimes(1);
+      expect(getAuthInfo.mock.calls[0]?.[0].auth).toBe(authInfo);
+      expect(fetch.mock.calls[0]?.[1]?.authInfo).toBe(authInfo);
+    } finally {
+      await closeHttpServer(handle);
+    }
+  });
+
+  it.each(["SIGTERM", "SIGINT"] as const)("handles %s by draining and closing", async (signal) => {
+    const beforeTerm = new Set(process.listeners("SIGTERM"));
+    const beforeInt = new Set(process.listeners("SIGINT"));
+    const exitCodes: Array<string | number | null | undefined> = [];
+    const exitSpy = vi.spyOn(process, "exit").mockImplementation(((code) => {
+      exitCodes.push(code);
+      return undefined as never;
+    }) as typeof process.exit);
+    const handle = await startHttp({ port: 0 });
+
+    try {
+      const port = (handle.server.address() as AddressInfo).port;
+      const res = await request(port, "GET", "/health");
+      expect(res.status).toBe(200);
+
+      const before = signal === "SIGTERM" ? beforeTerm : beforeInt;
+      const listener = process.listeners(signal).find((candidate) => !before.has(candidate));
+      expect(listener).toBeTypeOf("function");
+      (listener as () => void)();
+
+      await vi.waitFor(() => expect(exitCodes).toContain(0));
+      expect(handle.server.listening).toBe(false);
+      expect(
+        process.listeners("SIGTERM").filter((candidate) => !beforeTerm.has(candidate)),
+      ).toEqual([]);
+      expect(process.listeners("SIGINT").filter((candidate) => !beforeInt.has(candidate))).toEqual(
+        [],
+      );
+    } finally {
+      exitSpy.mockRestore();
+      for (const listener of process.listeners("SIGTERM")) {
+        if (!beforeTerm.has(listener)) process.off("SIGTERM", listener);
+      }
+      for (const listener of process.listeners("SIGINT")) {
+        if (!beforeInt.has(listener)) process.off("SIGINT", listener);
+      }
+      if (handle.server.listening)
+        await new Promise<void>((resolve) => handle.server.close(() => resolve()));
+    }
   });
 });
 
@@ -443,6 +617,10 @@ describe("getPort", () => {
   it("uses the same strict port validation as the unified CLI", () => {
     process.argv.push("--port", "3000abc");
     expect(() => getPort()).toThrow("Invalid port: 3000abc");
+  });
+
+  it("prefers explicit argv over PORT env when resolving HTTP ports", () => {
+    expect(getPort(["http", "--port=4567"], { PORT: "1234" })).toBe(4567);
   });
 
   it("throws on port <= 0", () => {

--- a/tests/unit/index.unit.test.ts
+++ b/tests/unit/index.unit.test.ts
@@ -1,10 +1,17 @@
+import { spawnSync } from "child_process";
 import * as http from "http";
 import type { AddressInfo } from "net";
+import * as path from "path";
+import * as stdioTransport from "@modelcontextprotocol/server/stdio";
 import { CredentialResolutionError } from "../../src/credentials";
-import { runCli, startStdio, type StdioBootstrapDependencies } from "../../src/index";
+import { startStdio } from "../../src/index";
+import * as serverModule from "../../src/server";
 import { logger } from "../../src/utils/logger";
 import type { B2Config } from "../../src/utils/types";
-import { VERSION } from "../../src/version";
+
+vi.mock("@modelcontextprotocol/server/stdio", () => ({
+  serveStdio: vi.fn(),
+}));
 
 const credentialEnvKeys = [
   "B2_APPLICATION_KEY_ID",
@@ -14,6 +21,13 @@ const credentialEnvKeys = [
   "B2_MASTER_KEY_ID",
   "B2_MASTER_KEY",
 ] as const;
+
+const tsxBin = path.join(
+  process.cwd(),
+  "node_modules",
+  ".bin",
+  process.platform === "win32" ? "tsx.cmd" : "tsx",
+);
 
 function testConfig(): B2Config {
   return {
@@ -33,6 +47,23 @@ function testConfig(): B2Config {
   };
 }
 
+function executableEnv(): NodeJS.ProcessEnv {
+  const env: NodeJS.ProcessEnv = { ...process.env, NODE_ENV: "test" };
+  for (const key of credentialEnvKeys) delete env[key];
+  delete env.FORCE_COLOR;
+  delete env.NO_COLOR;
+  return env;
+}
+
+function runEntrypoint(args: string[]) {
+  return spawnSync(tsxBin, ["src/index.ts", ...args], {
+    cwd: process.cwd(),
+    encoding: "utf8",
+    env: executableEnv(),
+    timeout: 10_000,
+  });
+}
+
 describe("stdio entry point", () => {
   let savedEnv: Record<string, string | undefined>;
 
@@ -47,21 +78,24 @@ describe("stdio entry point", () => {
       else process.env[key] = value;
     }
     vi.restoreAllMocks();
+    vi.clearAllMocks();
   });
 
   it("bootstraps stdio with fetched credential capabilities", async () => {
     const config = testConfig();
     const server = { close: vi.fn(async () => undefined) };
-    const createServer = vi.fn(() => server);
-    const serveStdio = vi.fn();
+    const createServer = vi.spyOn(serverModule, "createServer").mockReturnValue(server as never);
+    vi.spyOn(serverModule, "loadConfig").mockReturnValue(config);
+    vi.spyOn(serverModule, "fetchCapabilities").mockResolvedValue(["listBuckets"]);
+    const serveStdio = vi.mocked(stdioTransport.serveStdio).mockImplementation(
+      () =>
+        ({
+          close: vi.fn(async () => undefined),
+        }) as ReturnType<typeof stdioTransport.serveStdio>,
+    );
     const warn = vi.spyOn(logger, "warn").mockImplementation(() => undefined);
 
-    await startStdio({
-      loadConfig: vi.fn(() => config),
-      fetchCapabilities: vi.fn(async () => ["listBuckets"]),
-      createServer: createServer as unknown as StdioBootstrapDependencies["createServer"],
-      serveStdio: serveStdio as unknown as StdioBootstrapDependencies["serveStdio"],
-    });
+    await startStdio();
 
     const factory = serveStdio.mock.calls[0]?.[0] as (() => unknown) | undefined;
     const options = serveStdio.mock.calls[0]?.[1] as { onerror(error: Error): void } | undefined;
@@ -74,21 +108,23 @@ describe("stdio entry point", () => {
   it("falls back to the full stdio surface when capability lookup is unavailable", async () => {
     const config = testConfig();
     const server = { close: vi.fn(async () => undefined) };
-    const createServer = vi.fn(() => server);
-    const serveStdio = vi.fn();
+    const createServer = vi.spyOn(serverModule, "createServer").mockReturnValue(server as never);
+    vi.spyOn(serverModule, "loadConfig").mockReturnValue(config);
+    vi.spyOn(serverModule, "fetchCapabilities").mockRejectedValue(
+      new CredentialResolutionError(
+        "capability service unavailable",
+        503,
+        "capability_upstream_unavailable",
+      ),
+    );
+    const serveStdio = vi.mocked(stdioTransport.serveStdio).mockImplementation(
+      () =>
+        ({
+          close: vi.fn(async () => undefined),
+        }) as ReturnType<typeof stdioTransport.serveStdio>,
+    );
 
-    await startStdio({
-      loadConfig: vi.fn(() => config),
-      fetchCapabilities: vi.fn(async () => {
-        throw new CredentialResolutionError(
-          "capability service unavailable",
-          503,
-          "capability_upstream_unavailable",
-        );
-      }),
-      createServer: createServer as unknown as StdioBootstrapDependencies["createServer"],
-      serveStdio: serveStdio as unknown as StdioBootstrapDependencies["serveStdio"],
-    });
+    await startStdio();
 
     const factory = serveStdio.mock.calls[0]?.[0] as (() => unknown) | undefined;
     expect(factory?.()).toBe(server);
@@ -109,86 +145,36 @@ describe("stdio entry point", () => {
   });
 });
 
-describe("unified CLI entry point", () => {
-  afterEach(() => {
-    vi.restoreAllMocks();
+describe("executable CLI entry point", () => {
+  it("prints usage errors with help and exit code 2", () => {
+    const result = runEntrypoint(["--transport", "sse"]);
+
+    expect(result.status).toBe(2);
+    expect(result.stderr).toContain("b2-mcp: Invalid transport: sse");
+    expect(result.stderr).toContain("Usage: b2-mcp");
   });
 
-  it("routes HTTP transport to startHttp with the parsed port", async () => {
-    const startHttp = vi.fn(async () => undefined);
-    const startStdio = vi.fn(async () => undefined);
+  it("selects stdio by default and reports missing credentials with exit code 1", () => {
+    const result = runEntrypoint([]);
 
-    await runCli(["http", "--port", "4321"], { startHttp, startStdio });
-
-    expect(startHttp).toHaveBeenCalledWith({ port: 4321 });
-    expect(startStdio).not.toHaveBeenCalled();
+    expect(result.status).toBe(1);
+    expect(result.stderr).toContain(
+      "b2-mcp: B2_APPLICATION_KEY_ID and B2_APPLICATION_KEY are required for stdio",
+    );
   });
 
-  it("routes stdio transport to startStdio", async () => {
-    const startHttp = vi.fn(async () => undefined);
-    const startStdio = vi.fn(async () => undefined);
-
-    await runCli(["--transport", "stdio"], { startHttp, startStdio });
-
-    expect(startStdio).toHaveBeenCalledTimes(1);
-    expect(startHttp).not.toHaveBeenCalled();
-  });
-
-  it("prints help and version without starting a transport", async () => {
-    const output: string[] = [];
-    const runtime = {
-      startHttp: vi.fn(async () => undefined),
-      startStdio: vi.fn(async () => undefined),
-      stdout: {
-        write(chunk: string) {
-          output.push(chunk);
-        },
-      },
-    };
-
-    await runCli(["--help"], runtime);
-    await runCli(["--version"], runtime);
-
-    expect(output[0]).toContain("Usage: b2-mcp");
-    expect(output[1]).toBe(`${VERSION}\n`);
-    expect(runtime.startHttp).not.toHaveBeenCalled();
-    expect(runtime.startStdio).not.toHaveBeenCalled();
-  });
-
-  it("uses the default HTTP starter when no runtime override is supplied", async () => {
-    const portProbe = http.createServer();
-    await new Promise<void>((resolve) => portProbe.listen(0, "127.0.0.1", resolve));
-    const port = (portProbe.address() as AddressInfo).port;
-    await new Promise<void>((resolve) => portProbe.close(() => resolve()));
-    const beforeTerm = new Set(process.listeners("SIGTERM"));
-    const beforeInt = new Set(process.listeners("SIGINT"));
-    const exitCodes: Array<string | number | null | undefined> = [];
-    const exitSpy = vi.spyOn(process, "exit").mockImplementation(((code) => {
-      exitCodes.push(code);
-      return undefined as never;
-    }) as typeof process.exit);
-    let listener: (() => void) | undefined;
+  it("selects HTTP transport and reports startup failures with exit code 1", async () => {
+    const blocker = http.createServer();
+    await new Promise<void>((resolve) => blocker.listen(0, resolve));
+    const port = (blocker.address() as AddressInfo).port;
 
     try {
-      await runCli(["http", "--port", String(port)]);
-      listener = process.listeners("SIGTERM").find((candidate) => !beforeTerm.has(candidate)) as
-        | (() => void)
-        | undefined;
-      expect(listener).toBeTypeOf("function");
-      listener?.();
-      await vi.waitFor(() => expect(exitCodes).toContain(0));
+      const result = runEntrypoint(["http", "--port", String(port)]);
+
+      expect(result.status).toBe(1);
+      expect(result.stderr).toContain("b2-mcp: listen EADDRINUSE");
     } finally {
-      if (listener && !exitCodes.includes(0)) {
-        listener();
-        await vi.waitFor(() => expect(exitCodes).toContain(0));
-      }
-      exitSpy.mockRestore();
-      for (const candidate of process.listeners("SIGTERM")) {
-        if (!beforeTerm.has(candidate)) process.off("SIGTERM", candidate);
-      }
-      for (const candidate of process.listeners("SIGINT")) {
-        if (!beforeInt.has(candidate)) process.off("SIGINT", candidate);
-      }
+      await new Promise<void>((resolve) => blocker.close(() => resolve()));
     }
   });
 });

--- a/tests/unit/index.unit.test.ts
+++ b/tests/unit/index.unit.test.ts
@@ -1,0 +1,194 @@
+import * as http from "http";
+import type { AddressInfo } from "net";
+import { CredentialResolutionError } from "../../src/credentials";
+import { runCli, startStdio, type StdioBootstrapDependencies } from "../../src/index";
+import { logger } from "../../src/utils/logger";
+import type { B2Config } from "../../src/utils/types";
+import { VERSION } from "../../src/version";
+
+const credentialEnvKeys = [
+  "B2_APPLICATION_KEY_ID",
+  "B2_APPLICATION_KEY",
+  "B2_APP_KEY_ID",
+  "B2_APP_KEY",
+  "B2_MASTER_KEY_ID",
+  "B2_MASTER_KEY",
+] as const;
+
+function testConfig(): B2Config {
+  return {
+    applicationKeyId: "app-id",
+    applicationKey: "app-secret",
+    appKeyId: "app-id",
+    appKey: "app-secret",
+    masterKeyId: "app-id",
+    masterKey: "app-secret",
+    region: "us-west-004",
+    allowLocalFiles: true,
+    fileRoot: null,
+    destructivePolicy: "confirm",
+    outputFormat: "json",
+    transport: "stdio",
+    credentialFingerprint: "credential-fingerprint",
+  };
+}
+
+describe("stdio entry point", () => {
+  let savedEnv: Record<string, string | undefined>;
+
+  beforeEach(() => {
+    savedEnv = Object.fromEntries(credentialEnvKeys.map((key) => [key, process.env[key]]));
+  });
+
+  afterEach(() => {
+    for (const key of credentialEnvKeys) {
+      const value = savedEnv[key];
+      if (value === undefined) delete process.env[key];
+      else process.env[key] = value;
+    }
+    vi.restoreAllMocks();
+  });
+
+  it("bootstraps stdio with fetched credential capabilities", async () => {
+    const config = testConfig();
+    const server = { close: vi.fn(async () => undefined) };
+    const createServer = vi.fn(() => server);
+    const serveStdio = vi.fn();
+    const warn = vi.spyOn(logger, "warn").mockImplementation(() => undefined);
+
+    await startStdio({
+      loadConfig: vi.fn(() => config),
+      fetchCapabilities: vi.fn(async () => ["listBuckets"]),
+      createServer: createServer as unknown as StdioBootstrapDependencies["createServer"],
+      serveStdio: serveStdio as unknown as StdioBootstrapDependencies["serveStdio"],
+    });
+
+    const factory = serveStdio.mock.calls[0]?.[0] as (() => unknown) | undefined;
+    const options = serveStdio.mock.calls[0]?.[1] as { onerror(error: Error): void } | undefined;
+    expect(factory?.()).toBe(server);
+    options?.onerror(new Error("stdio failed"));
+    expect(createServer).toHaveBeenCalledWith(config, ["listBuckets"]);
+    expect(warn).toHaveBeenCalledWith({ err: "stdio failed" }, "mcp.stdio.error");
+  });
+
+  it("falls back to the full stdio surface when capability lookup is unavailable", async () => {
+    const config = testConfig();
+    const server = { close: vi.fn(async () => undefined) };
+    const createServer = vi.fn(() => server);
+    const serveStdio = vi.fn();
+
+    await startStdio({
+      loadConfig: vi.fn(() => config),
+      fetchCapabilities: vi.fn(async () => {
+        throw new CredentialResolutionError(
+          "capability service unavailable",
+          503,
+          "capability_upstream_unavailable",
+        );
+      }),
+      createServer: createServer as unknown as StdioBootstrapDependencies["createServer"],
+      serveStdio: serveStdio as unknown as StdioBootstrapDependencies["serveStdio"],
+    });
+
+    const factory = serveStdio.mock.calls[0]?.[0] as (() => unknown) | undefined;
+    expect(factory?.()).toBe(server);
+    expect(createServer).toHaveBeenCalledWith(config, null);
+  });
+
+  it("writes the missing-credential message and exits non-zero", async () => {
+    for (const key of credentialEnvKeys) delete process.env[key];
+    const stderr = vi.spyOn(process.stderr, "write").mockImplementation(() => true);
+    vi.spyOn(process, "exit").mockImplementation(((code) => {
+      throw Object.assign(new Error(`process.exit(${code})`), { exitCode: code });
+    }) as typeof process.exit);
+
+    await expect(startStdio()).rejects.toMatchObject({ exitCode: 1 });
+    expect(stderr).toHaveBeenCalledWith(
+      "b2-mcp: B2_APPLICATION_KEY_ID and B2_APPLICATION_KEY are required for stdio\n",
+    );
+  });
+});
+
+describe("unified CLI entry point", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("routes HTTP transport to startHttp with the parsed port", async () => {
+    const startHttp = vi.fn(async () => undefined);
+    const startStdio = vi.fn(async () => undefined);
+
+    await runCli(["http", "--port", "4321"], { startHttp, startStdio });
+
+    expect(startHttp).toHaveBeenCalledWith({ port: 4321 });
+    expect(startStdio).not.toHaveBeenCalled();
+  });
+
+  it("routes stdio transport to startStdio", async () => {
+    const startHttp = vi.fn(async () => undefined);
+    const startStdio = vi.fn(async () => undefined);
+
+    await runCli(["--transport", "stdio"], { startHttp, startStdio });
+
+    expect(startStdio).toHaveBeenCalledTimes(1);
+    expect(startHttp).not.toHaveBeenCalled();
+  });
+
+  it("prints help and version without starting a transport", async () => {
+    const output: string[] = [];
+    const runtime = {
+      startHttp: vi.fn(async () => undefined),
+      startStdio: vi.fn(async () => undefined),
+      stdout: {
+        write(chunk: string) {
+          output.push(chunk);
+        },
+      },
+    };
+
+    await runCli(["--help"], runtime);
+    await runCli(["--version"], runtime);
+
+    expect(output[0]).toContain("Usage: b2-mcp");
+    expect(output[1]).toBe(`${VERSION}\n`);
+    expect(runtime.startHttp).not.toHaveBeenCalled();
+    expect(runtime.startStdio).not.toHaveBeenCalled();
+  });
+
+  it("uses the default HTTP starter when no runtime override is supplied", async () => {
+    const portProbe = http.createServer();
+    await new Promise<void>((resolve) => portProbe.listen(0, "127.0.0.1", resolve));
+    const port = (portProbe.address() as AddressInfo).port;
+    await new Promise<void>((resolve) => portProbe.close(() => resolve()));
+    const beforeTerm = new Set(process.listeners("SIGTERM"));
+    const beforeInt = new Set(process.listeners("SIGINT"));
+    const exitCodes: Array<string | number | null | undefined> = [];
+    const exitSpy = vi.spyOn(process, "exit").mockImplementation(((code) => {
+      exitCodes.push(code);
+      return undefined as never;
+    }) as typeof process.exit);
+    let listener: (() => void) | undefined;
+
+    try {
+      await runCli(["http", "--port", String(port)]);
+      listener = process.listeners("SIGTERM").find((candidate) => !beforeTerm.has(candidate)) as
+        | (() => void)
+        | undefined;
+      expect(listener).toBeTypeOf("function");
+      listener?.();
+      await vi.waitFor(() => expect(exitCodes).toContain(0));
+    } finally {
+      if (listener && !exitCodes.includes(0)) {
+        listener();
+        await vi.waitFor(() => expect(exitCodes).toContain(0));
+      }
+      exitSpy.mockRestore();
+      for (const candidate of process.listeners("SIGTERM")) {
+        if (!beforeTerm.has(candidate)) process.off("SIGTERM", candidate);
+      }
+      for (const candidate of process.listeners("SIGINT")) {
+        if (!beforeInt.has(candidate)) process.off("SIGINT", candidate);
+      }
+    }
+  });
+});


### PR DESCRIPTION
## Summary
- Add deterministic unit coverage for HTTP server lifecycle paths, including ephemeral listen/close, bind and synchronous listen failure cleanup, drain behavior, signal shutdown, cache-sweep scheduling/cleanup, authInfo hooks, and port resolution.
- Harden HTTP server startup and shutdown by awaiting `listen()`, rejecting and draining on startup failures, unregistering signal handlers and timers, and routing post-startup server `error` events through structured logging plus graceful shutdown.
- Add index entry-point tests for stdio bootstrap, missing credentials, actual executable CLI usage/startup failures, and HTTP vs stdio selection.
- Extend CLI parser coverage for transport aliases, short flags, env normalization, help/version output, and invalid option branches.
- Keep test-only bootstrap dependency injection out of the package-root API; the remaining namespace import seam is documented so tests can spy on ESM bootstrap dependencies without exporting internal wiring.

## Production behavior note
- `startHttp()` remains non-programmatic (`Promise<void>`) and process-owning.
- It now awaits `listen()`, rejects on bind/startup errors including synchronous `listen()` throws, drains the HTTP pipeline on startup failure, unregisters SIGTERM/SIGINT handlers after shutdown, clears drain timers, and handles post-startup server errors with `server.error` logging before graceful shutdown.

## Linked issue
Closes #146

## Tests run
- pnpm exec vitest run --config vitest.config.mts --project unit --coverage=false tests/unit/http-server.unit.test.ts tests/unit/index.unit.test.ts
- pnpm run typecheck
- pnpm run format:check
- pnpm run lint
- pnpm run test:unit
- pnpm run test:coverage
- pnpm run verify

## Follow-up notes
- No real B2 credentials or live B2 network calls are used; server tests use ephemeral local ports, mocked exits/signals, and subprocess entry-point checks.