### PR TITLE
fix: fail loudly for required live tests

### DIFF
--- a/.github/workflows/contract.yml
+++ b/.github/workflows/contract.yml
@@ -149,8 +149,10 @@ jobs:
           import { loadConfig } from "./dist/server.js";
           import liveB2Capabilities from "./scripts/lib/live-b2-capabilities.cjs";
 
-          const { LIVE_B2_CONTRACT_REQUIRED_CAPABILITIES: requiredCapabilities } =
-            liveB2Capabilities;
+          const {
+            LIVE_B2_CONTRACT_FORBIDDEN_CAPABILITIES: forbiddenCapabilities,
+            LIVE_B2_CONTRACT_REQUIRED_CAPABILITIES: requiredCapabilities,
+          } = liveB2Capabilities;
           const auth = await new B2AuthManager(loadConfig()).getAuth();
           if (auth.accountId !== process.env.B2_LIVE_TEST_ACCOUNT_ID) {
             throw new Error("authorized account does not match B2_LIVE_TEST_ACCOUNT_ID");
@@ -161,6 +163,14 @@ jobs:
           if (missingCapabilities.length > 0) {
             throw new Error(
               `live B2 contract key is missing required capability: ${missingCapabilities.join(", ")}`,
+            );
+          }
+          const forbiddenGrantedCapabilities = forbiddenCapabilities.filter((capability) =>
+            auth.capabilities.includes(capability),
+          );
+          if (forbiddenGrantedCapabilities.length > 0) {
+            throw new Error(
+              `live B2 contract key grants forbidden capability: ${forbiddenGrantedCapabilities.join(", ")}`,
             );
           }
           NODE

--- a/.github/workflows/contract.yml
+++ b/.github/workflows/contract.yml
@@ -147,20 +147,10 @@ jobs:
           node --input-type=module <<'NODE'
           import { B2AuthManager } from "./dist/auth.js";
           import { loadConfig } from "./dist/server.js";
+          import liveB2Capabilities from "./scripts/lib/live-b2-capabilities.cjs";
 
-          const requiredCapabilities = [
-            "bypassGovernance",
-            "deleteBuckets",
-            "deleteFiles",
-            "listBuckets",
-            "listFiles",
-            "listKeys",
-            "readFiles",
-            "writeBuckets",
-            "writeFileLegalHolds",
-            "writeFileRetentions",
-            "writeFiles",
-          ];
+          const { LIVE_B2_CONTRACT_REQUIRED_CAPABILITIES: requiredCapabilities } =
+            liveB2Capabilities;
           const auth = await new B2AuthManager(loadConfig()).getAuth();
           if (auth.accountId !== process.env.B2_LIVE_TEST_ACCOUNT_ID) {
             throw new Error("authorized account does not match B2_LIVE_TEST_ACCOUNT_ID");

--- a/.github/workflows/contract.yml
+++ b/.github/workflows/contract.yml
@@ -106,6 +106,7 @@ jobs:
       matrix:
         node-version: [22.23.1, 24, 26]
     env:
+      B2_REQUIRE_LIVE_TESTS: "1"
       B2_INTEGRATION_REQUIRE_CREDENTIALS: "1"
       B2_MCP_LIVE_RUN_PREFIX: ${{ needs.guard.outputs.run-prefix }}-n${{ matrix.node-version }}
     steps:
@@ -136,7 +137,7 @@ jobs:
           echo "::add-mask::${B2_MCP_LIVE_RUN_PREFIX}"
           if [[ -n "${B2_LIVE_TEST_ACCOUNT_ID:-}" ]]; then echo "::add-mask::${B2_LIVE_TEST_ACCOUNT_ID}"; fi
           missing=0
-          for name in B2_APPLICATION_KEY_ID B2_APPLICATION_KEY B2_LIVE_TEST_ACCOUNT_ID B2_INTEGRATION_REQUIRE_CREDENTIALS B2_MCP_LIVE_RUN_PREFIX; do
+          for name in B2_APPLICATION_KEY_ID B2_APPLICATION_KEY B2_LIVE_TEST_ACCOUNT_ID B2_REQUIRE_LIVE_TESTS B2_INTEGRATION_REQUIRE_CREDENTIALS B2_MCP_LIVE_RUN_PREFIX; do
             if [[ -z "${!name:-}" ]]; then
               echo "::error::Missing required live-b2-contract variable or secret for ${name}"
               missing=1
@@ -147,7 +148,19 @@ jobs:
           import { B2AuthManager } from "./dist/auth.js";
           import { loadConfig } from "./dist/server.js";
 
-          const requiredCapabilities = ["bypassGovernance", "deleteKeys", "listKeys", "writeKeys"];
+          const requiredCapabilities = [
+            "bypassGovernance",
+            "deleteBuckets",
+            "deleteFiles",
+            "listBuckets",
+            "listFiles",
+            "listKeys",
+            "readFiles",
+            "writeBuckets",
+            "writeFileLegalHolds",
+            "writeFileRetentions",
+            "writeFiles",
+          ];
           const auth = await new B2AuthManager(loadConfig()).getAuth();
           if (auth.accountId !== process.env.B2_LIVE_TEST_ACCOUNT_ID) {
             throw new Error("authorized account does not match B2_LIVE_TEST_ACCOUNT_ID");
@@ -168,6 +181,7 @@ jobs:
           B2_APPLICATION_KEY: ${{ secrets.LIVE_B2_KEY }}
           B2_LIVE_TEST_ACCOUNT_ID: ${{ vars.B2_LIVE_TEST_ACCOUNT_ID }}
           B2_MCP_LIVE_RUN_PREFIX: ${{ env.B2_MCP_LIVE_RUN_PREFIX }}
+          B2_REQUIRE_LIVE_TESTS: "1"
           B2_INTEGRATION_REQUIRE_CREDENTIALS: "1"
         run: pnpm run test:live:b2
       - name: Clean current live B2 run resources

--- a/.github/workflows/contract.yml
+++ b/.github/workflows/contract.yml
@@ -106,6 +106,8 @@ jobs:
       matrix:
         node-version: [22.23.1, 24, 26]
     env:
+      # Trusted live contract runs require these together: the Vitest guard fails
+      # loudly on missing credentials, and fixture helpers enforce account scope.
       B2_REQUIRE_LIVE_TESTS: "1"
       B2_INTEGRATION_REQUIRE_CREDENTIALS: "1"
       B2_MCP_LIVE_RUN_PREFIX: ${{ needs.guard.outputs.run-prefix }}-n${{ matrix.node-version }}
@@ -137,12 +139,16 @@ jobs:
           echo "::add-mask::${B2_MCP_LIVE_RUN_PREFIX}"
           if [[ -n "${B2_LIVE_TEST_ACCOUNT_ID:-}" ]]; then echo "::add-mask::${B2_LIVE_TEST_ACCOUNT_ID}"; fi
           missing=0
-          for name in B2_APPLICATION_KEY_ID B2_APPLICATION_KEY B2_LIVE_TEST_ACCOUNT_ID B2_REQUIRE_LIVE_TESTS B2_INTEGRATION_REQUIRE_CREDENTIALS B2_MCP_LIVE_RUN_PREFIX; do
+          for name in B2_APPLICATION_KEY_ID B2_APPLICATION_KEY B2_LIVE_TEST_ACCOUNT_ID B2_MCP_LIVE_RUN_PREFIX; do
             if [[ -z "${!name:-}" ]]; then
               echo "::error::Missing required live-b2-contract variable or secret for ${name}"
               missing=1
             fi
           done
+          if [[ "${B2_REQUIRE_LIVE_TESTS:-}" != "1" || "${B2_INTEGRATION_REQUIRE_CREDENTIALS:-}" != "1" ]]; then
+            echo "::error::Trusted live-b2-contract runs must set B2_REQUIRE_LIVE_TESTS=1 and B2_INTEGRATION_REQUIRE_CREDENTIALS=1 together"
+            missing=1
+          fi
           if [[ "$missing" != 0 ]]; then exit "$missing"; fi
           node --input-type=module <<'NODE'
           import { B2AuthManager } from "./dist/auth.js";
@@ -181,8 +187,6 @@ jobs:
           B2_APPLICATION_KEY: ${{ secrets.LIVE_B2_KEY }}
           B2_LIVE_TEST_ACCOUNT_ID: ${{ vars.B2_LIVE_TEST_ACCOUNT_ID }}
           B2_MCP_LIVE_RUN_PREFIX: ${{ env.B2_MCP_LIVE_RUN_PREFIX }}
-          B2_REQUIRE_LIVE_TESTS: "1"
-          B2_INTEGRATION_REQUIRE_CREDENTIALS: "1"
         run: pnpm run test:live:b2
       - name: Clean current live B2 run resources
         if: always()

--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -107,6 +107,8 @@ jobs:
       max-parallel: 1
       matrix:
         node-version: [22.23.1, 24, 26]
+    env:
+      B2_REQUIRE_LIVE_TESTS: "1"
     steps:
       # actions/checkout v6, reviewed 2026-08-06.
       - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803

--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -107,8 +107,6 @@ jobs:
       max-parallel: 1
       matrix:
         node-version: [22.23.1, 24, 26]
-    env:
-      B2_REQUIRE_LIVE_TESTS: "1"
     steps:
       # actions/checkout v6, reviewed 2026-08-06.
       - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Replaced the `ts-node` dev runner with exact-pinned `tsx@4.23.11` and
   explicitly denied `esbuild` install builds in `pnpm-workspace.yaml`.
 
+### Fixed
+- Made hosted live B2 test selection fail loudly with `B2_REQUIRE_LIVE_TESTS=1`
+  when credentials are missing, and documented the required live-test secrets
+  and key capabilities.
+
 ## [0.1.0] - 2026-08-07
 
 ### Added

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -35,7 +35,9 @@ mamba run -n b2-mcp pnpm install --frozen-lockfile
 Live tests need real B2 credentials and are not run in the default suite. Use
 `pnpm run test:live:b2-integration` for live integration behavior and
 `pnpm run test:live:b2-contract` for live request-shape checks; both require
-`B2_APPLICATION_KEY_ID` and `B2_APPLICATION_KEY`.
+`B2_APPLICATION_KEY_ID` and `B2_APPLICATION_KEY`. The required GitHub
+Environment secrets, buckets, and key capabilities are documented in
+[`docs/TESTING.md#live-and-integration-test-credentials`](./docs/TESTING.md#live-and-integration-test-credentials).
 
 Biome is the sole formatter in this repository. The `format` and `format:check`
 scripts intentionally cover Biome-supported file types; Markdown and YAML files

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -478,9 +478,10 @@ trusted scheduled paths; smoke also runs on successful deployment status events
 using the deployed SHA after checking that the deployment environment is approved
 from a repository or organization variable and the SHA is reachable from
 protected `main` or `ci-green`. Neither workflow runs on `pull_request`,
-because live credentials must not be exposed to PR-head code. Trusted runs set
-`B2_REQUIRE_LIVE_TESTS=1` and `B2_INTEGRATION_REQUIRE_CREDENTIALS=1` for
-Vitest live-suite selection. Smoke uses its own credential scheme and fails
+because live credentials must not be exposed to PR-head code. Trusted Vitest
+live-suite runs set `B2_REQUIRE_LIVE_TESTS=1` and
+`B2_INTEGRATION_REQUIRE_CREDENTIALS=1` together; the workflow validation step
+fails if either flag is not set to `1`. Smoke uses its own credential scheme and fails
 loudly through the `Validate live B2 smoke environment` steps and
 `B2_MCP_REQUIRE_SMOKE_BUCKET=1`. Missing credentials or required variables fail
 trusted live jobs; a skipped-only trusted run is not accepted as release

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -393,6 +393,56 @@ is still `refs/heads/main`, then have a maintainer with write access advance
 records the override. Do not use this path for new dependency changes or any
 audit-policy expiry.
 
+## Live And Integration Test Credentials
+
+The default deterministic gate must stay credential-free. Local direct Vitest
+selection skips live cases when B2 credentials are absent, but trusted hosted
+live jobs set `B2_REQUIRE_LIVE_TESTS=1`; with that flag set, missing or partial
+`B2_APPLICATION_KEY_ID` / `B2_APPLICATION_KEY` credentials fail the live layer
+instead of reporting skipped tests as a pass.
+
+For the 17 integration and request-shape contract tests, use the
+`live-b2-contract` GitHub Environment:
+
+- Buckets to pre-create: NONE. The tests create and delete their own run-owned
+  buckets through `b2_create_bucket` in `tests/live/support/contract-buckets.ts`,
+  with strict cleanup by the live B2 janitor.
+- Keys: one non-master B2 application key. Because it creates buckets, it cannot
+  be scoped to a single bucket; it is account-wide. Capabilities:
+  `listBuckets`, `writeBuckets`, `deleteBuckets`, `listKeys`, `listFiles`,
+  `readFiles`, `writeFiles`, `deleteFiles`, `writeFileLegalHolds`,
+  `writeFileRetentions`, and `bypassGovernance`. Do not grant `writeKeys`,
+  `deleteKeys`, master-key access, or account-admin capabilities.
+- Secrets: `LIVE_B2_KEY_ID` and `LIVE_B2_KEY`, mapped by
+  `.github/workflows/contract.yml` to `B2_APPLICATION_KEY_ID` and
+  `B2_APPLICATION_KEY`.
+- Variables: `B2_LIVE_TEST_ACCOUNT_ID` and the workflow-generated
+  `B2_MCP_LIVE_RUN_PREFIX`.
+- Use a dedicated, disposable key in an isolated test account. A bucket-creating
+  key is account-wide, so the test account is the isolation boundary.
+
+For the deployed MCP smoke, use the `live-b2-smoke` GitHub Environment. This
+path needs a reviewed deployment from issue #137 before it can provide release
+evidence.
+
+- Buckets to pre-create: ONE. The smoke probes a known bucket with
+  `s3_head_bucket` in `scripts/smoke-test.mjs`; it does not create a bucket.
+  Put that bucket name in `B2_SMOKE_BUCKET`.
+- Keys: `LIVE_B2_KEY_ID` / `LIVE_B2_KEY`, which the smoke client sends to the
+  deployed MCP, and `LIVE_B2_APP_KEY_ID` / `LIVE_B2_APP_KEY`, a non-master key
+  for the S3 path because B2's S3 endpoint rejects master keys. Both pairs can
+  point at the same non-master key when the primary key is already non-master.
+  They only need read access to the smoke bucket: `listBuckets`, `listFiles`,
+  and `readFiles`; they may be bucket-scoped.
+- Also required as variables or secrets: `MCP_URL`,
+  `B2_MCP_EXPECTED_TOOL_PROFILE`, `B2_MCP_REQUIRE_SMOKE_BUCKET=1`, and
+  `MCP_AUTHORIZATION` / `VERCEL_PROTECTION_BYPASS` according to the deployment.
+
+Remove obsolete repository-level B2 secrets named `B2_KEY`, `B2_KEY_ID`,
+`B2_APP_KEY`, and `B2_APP_KEY_ID` in the GitHub UI. The live workflows use the
+environment-scoped secrets above and do not reference those repository-level
+secrets.
+
 ## Live B2 Smoke Gate
 
 Live B2 evidence is required before release sign-off but must be isolated from
@@ -402,14 +452,13 @@ Required properties:
 
 - dedicated live B2 test account, not a customer account;
 - dedicated account-level application key with the bucket, file, Object Lock,
-  notification, lifecycle, and key-management capabilities needed by the suite;
-  it must not be bucket- or prefix-restricted, and the dedicated account is the
-  isolation boundary because `writeKeys` grants full account access. The
-  workflow validation step and fixture helpers both enforce the
+  notification, and lifecycle capabilities needed by the suite; it must not be
+  bucket- or prefix-restricted, and the dedicated account is the isolation
+  boundary. The workflow validation step and fixture helpers both enforce the
   `B2_LIVE_TEST_ACCOUNT_ID` allowlist before live fixture mutation or cleanup;
 - unique `B2_MCP_LIVE_RUN_PREFIX` for every run, rooted at `mcp-contract-`;
-- test-owned buckets, objects, multipart uploads, notification rules, and keys
-  only; live tests must never choose an arbitrary listed bucket as writable;
+- test-owned buckets, objects, multipart uploads, and notification rules only;
+  live tests must never choose an arbitrary listed bucket as writable;
 - Object Lock live fixtures use only governance-mode retention with short
   retain-until windows, never compliance mode, so cleanup can clear retention
   with the required `bypassGovernance` capability;
@@ -427,9 +476,10 @@ using the deployed SHA after checking that the deployment environment is approve
 from a repository or organization variable and the SHA is reachable from
 protected `main` or `ci-green`. Neither workflow runs on `pull_request`,
 because live credentials must not be exposed to PR-head code. Trusted runs set
-`B2_INTEGRATION_REQUIRE_CREDENTIALS=1` or the smoke equivalent and fail loudly
-when credentials or required variables are absent; a skipped-only trusted run is
-not accepted as release evidence. The contract validation step and janitor both
+`B2_REQUIRE_LIVE_TESTS=1`, `B2_INTEGRATION_REQUIRE_CREDENTIALS=1`, or the smoke
+equivalent and fail loudly when credentials or required variables are absent; a
+skipped-only trusted run is not accepted as release evidence. The contract
+validation step and janitor both
 require `B2_LIVE_TEST_ACCOUNT_ID` and refuse to proceed when the authorized
 account ID does not match that dedicated test-account allowlist. The protected
 live matrix is serialized on Node.js 22.23.1, Node.js 24, and Node.js 26.

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -397,11 +397,11 @@ audit-policy expiry.
 
 The default deterministic gate must stay credential-free. Local direct Vitest
 selection skips live cases when B2 credentials are absent, but trusted hosted
-live jobs set `B2_REQUIRE_LIVE_TESTS=1`; with that flag set, missing or partial
-`B2_APPLICATION_KEY_ID` / `B2_APPLICATION_KEY` credentials fail the live layer
-instead of reporting skipped tests as a pass.
+Vitest live-suite jobs set `B2_REQUIRE_LIVE_TESTS=1`; with that flag set,
+missing or partial `B2_APPLICATION_KEY_ID` / `B2_APPLICATION_KEY` credentials
+fail the live layer instead of reporting skipped tests as a pass.
 
-For the 17 integration and request-shape contract tests, use the
+For the integration and request-shape contract suites, use the
 `live-b2-contract` GitHub Environment:
 
 - Buckets to pre-create: NONE. The tests create and delete their own run-owned
@@ -409,10 +409,13 @@ For the 17 integration and request-shape contract tests, use the
   with strict cleanup by the live B2 janitor.
 - Keys: one non-master B2 application key. Because it creates buckets, it cannot
   be scoped to a single bucket; it is account-wide. Capabilities:
-  `listBuckets`, `writeBuckets`, `deleteBuckets`, `listKeys`, `listFiles`,
-  `readFiles`, `writeFiles`, `deleteFiles`, `writeFileLegalHolds`,
-  `writeFileRetentions`, and `bypassGovernance`. Do not grant `writeKeys`,
-  `deleteKeys`, master-key access, or account-admin capabilities.
+  `bypassGovernance`, `deleteBuckets`, `deleteFiles`, `listBuckets`,
+  `listFiles`, `listKeys`, `readBucketEncryption`, `readBucketRetentions`,
+  `readBuckets`, `readFileLegalHolds`, `readFileRetentions`, `readFiles`,
+  `writeBucketEncryption`, `writeBucketNotifications`, `writeBucketRetentions`,
+  `writeBuckets`, `writeFileLegalHolds`, `writeFileRetentions`, and
+  `writeFiles`. Do not grant `writeKeys`, `deleteKeys`, master-key access, or
+  account-admin capabilities.
 - Secrets: `LIVE_B2_KEY_ID` and `LIVE_B2_KEY`, mapped by
   `.github/workflows/contract.yml` to `B2_APPLICATION_KEY_ID` and
   `B2_APPLICATION_KEY`.
@@ -476,10 +479,12 @@ using the deployed SHA after checking that the deployment environment is approve
 from a repository or organization variable and the SHA is reachable from
 protected `main` or `ci-green`. Neither workflow runs on `pull_request`,
 because live credentials must not be exposed to PR-head code. Trusted runs set
-`B2_REQUIRE_LIVE_TESTS=1`, `B2_INTEGRATION_REQUIRE_CREDENTIALS=1`, or the smoke
-equivalent and fail loudly when credentials or required variables are absent; a
-skipped-only trusted run is not accepted as release evidence. The contract
-validation step and janitor both
+`B2_REQUIRE_LIVE_TESTS=1` and `B2_INTEGRATION_REQUIRE_CREDENTIALS=1` for
+Vitest live-suite selection. Smoke uses its own credential scheme and fails
+loudly through the `Validate live B2 smoke environment` steps and
+`B2_MCP_REQUIRE_SMOKE_BUCKET=1`. Missing credentials or required variables fail
+trusted live jobs; a skipped-only trusted run is not accepted as release
+evidence. The contract validation step and janitor both
 require `B2_LIVE_TEST_ACCOUNT_ID` and refuse to proceed when the authorized
 account ID does not match that dedicated test-account allowlist. The protected
 live matrix is serialized on Node.js 22.23.1, Node.js 24, and Node.js 26.

--- a/scripts/lib/live-b2-capabilities.cjs
+++ b/scripts/lib/live-b2-capabilities.cjs
@@ -1,0 +1,30 @@
+"use strict";
+
+const LIVE_B2_CONTRACT_REQUIRED_CAPABILITIES = Object.freeze([
+  "bypassGovernance",
+  "deleteBuckets",
+  "deleteFiles",
+  "listBuckets",
+  "listFiles",
+  "listKeys",
+  "readBucketEncryption",
+  "readBucketRetentions",
+  "readBuckets",
+  "readFileLegalHolds",
+  "readFileRetentions",
+  "readFiles",
+  "writeBucketEncryption",
+  "writeBucketNotifications",
+  "writeBucketRetentions",
+  "writeBuckets",
+  "writeFileLegalHolds",
+  "writeFileRetentions",
+  "writeFiles",
+]);
+
+const LIVE_B2_CONTRACT_FORBIDDEN_CAPABILITIES = Object.freeze(["deleteKeys", "writeKeys"]);
+
+module.exports = {
+  LIVE_B2_CONTRACT_FORBIDDEN_CAPABILITIES,
+  LIVE_B2_CONTRACT_REQUIRED_CAPABILITIES,
+};

--- a/scripts/live-b2-janitor.mjs
+++ b/scripts/live-b2-janitor.mjs
@@ -10,7 +10,6 @@ import liveB2Contract from "./lib/live-b2-contract.cjs";
 
 const {
   CONTRACT_BUCKET_PREFIX,
-  CLEANUP_PAGINATION_GUARD_PAGES,
   bucketMatchesPrefix,
   cleanupContractBucketWithTools,
   createCleanupStats,
@@ -98,54 +97,6 @@ async function callTool(tools, name, args) {
   return tool.execute(args, {});
 }
 
-export async function cleanupKeys(b2Client, stats, options) {
-  let startApplicationKeyId;
-  for (let page = 0; page < CLEANUP_PAGINATION_GUARD_PAGES; page++) {
-    let listed;
-    try {
-      listed = await b2Client.listKeys({
-        maxKeyCount: 1000,
-        ...(startApplicationKeyId ? { startApplicationKeyId } : {}),
-      });
-    } catch (err) {
-      stats.errors++;
-      console.error(
-        `live-b2-janitor: key listing failed: ${redactDetail(err?.message ?? err, options.prefix)}`,
-      );
-      return;
-    }
-
-    for (const key of listed.keys ?? []) {
-      if (!bucketMatchesPrefix(key.keyName, options.prefix)) continue;
-      if (
-        (options.excludePrefixes ?? []).some((prefix) => bucketMatchesPrefix(key.keyName, prefix))
-      ) {
-        continue;
-      }
-      if (key.applicationKeyId === process.env.B2_APPLICATION_KEY_ID) continue;
-      stats.keys++;
-      console.log(`live-b2-janitor: deleting key fingerprint=${fingerprint(key.keyName)}`);
-      if (options.dryRun) continue;
-      try {
-        await b2Client.deleteKey(key.applicationKeyId);
-      } catch (err) {
-        stats.errors++;
-        console.error(
-          `live-b2-janitor: key cleanup failed key=${fingerprint(key.keyName)} ${redactDetail(
-            err?.message ?? err,
-            options.prefix,
-          )}`,
-        );
-      }
-    }
-
-    if (!listed.nextApplicationKeyId) return;
-    startApplicationKeyId = listed.nextApplicationKeyId;
-  }
-  stats.errors++;
-  console.error("live-b2-janitor: key cleanup exceeded pagination guard");
-}
-
 export async function assertExpectedLiveTestAccount(authManager, expectedAccountId, options) {
   if (!expectedAccountId) {
     throw new Error("B2_LIVE_TEST_ACCOUNT_ID is required before live B2 janitor deletion.");
@@ -228,10 +179,9 @@ async function main() {
       cleanupOptions,
     );
   }
-  await cleanupKeys(b2Client, stats, options);
 
   console.log(
-    `live-b2-janitor: summary buckets=${stats.buckets} objectVersions=${stats.objectVersions} multipartUploads=${stats.multipartUploads} keys=${stats.keys} leakedBuckets=${stats.leakedBuckets} errors=${stats.errors}`,
+    `live-b2-janitor: summary buckets=${stats.buckets} objectVersions=${stats.objectVersions} multipartUploads=${stats.multipartUploads} leakedBuckets=${stats.leakedBuckets} errors=${stats.errors}`,
   );
   if (stats.errors || stats.leakedBuckets) {
     const annotation = options.bestEffort ? "warning" : "error";

--- a/tests/contract/live-workflows-policy.contract.test.ts
+++ b/tests/contract/live-workflows-policy.contract.test.ts
@@ -11,6 +11,11 @@ const { workflowJobBlock, yamlBlockForKey, yamlValuesForKey } = nodeRequire(
   workflowJobBlock: (text: string, jobName: string) => string | null;
   yamlValuesForKey: (text: string, key: string) => Array<string | string[]>;
 };
+const { LIVE_B2_CONTRACT_FORBIDDEN_CAPABILITIES, LIVE_B2_CONTRACT_REQUIRED_CAPABILITIES } =
+  nodeRequire("../../scripts/lib/live-b2-capabilities.cjs") as {
+    LIVE_B2_CONTRACT_FORBIDDEN_CAPABILITIES: readonly string[];
+    LIVE_B2_CONTRACT_REQUIRED_CAPABILITIES: readonly string[];
+  };
 const runtimePolicy = JSON.parse(readFileSync(join(root, "runtime-policy.json"), "utf8")) as {
   liveNodeMatrix: string[];
 };
@@ -73,6 +78,82 @@ function workflowStepBlock(text: string, stepName: string): string {
   if (start === -1) return "";
   const next = text.indexOf("\n      - name:", start + marker.length);
   return text.slice(start, next === -1 ? undefined : next);
+}
+
+const liveSuiteSources = [
+  "tests/live/b2.integration.live.test.ts",
+  "tests/live/request-shape.contract.live.test.ts",
+  "tests/live/support/contract-buckets.ts",
+  "scripts/lib/live-b2-contract.cjs",
+];
+
+const liveToolCapabilities: Record<string, readonly string[]> = {
+  b2_authorize_account: [],
+  b2_create_bucket: [
+    "readBucketEncryption",
+    "readBucketRetentions",
+    "writeBucketEncryption",
+    "writeBucketRetentions",
+    "writeBuckets",
+  ],
+  b2_delete_bucket: ["deleteBuckets", "readBucketEncryption", "readBucketRetentions"],
+  b2_largest_files: ["listFiles"],
+  b2_list_buckets: ["listBuckets", "readBucketEncryption", "readBucketRetentions"],
+  b2_list_group_members: [],
+  b2_list_groups: [],
+  b2_list_keys: ["listKeys"],
+  b2_set_bucket_notification_rules: ["writeBucketNotifications"],
+  b2_unfinished_uploads: ["listFiles"],
+  b2_update_bucket: [
+    "readBucketEncryption",
+    "readBucketRetentions",
+    "writeBucketEncryption",
+    "writeBucketRetentions",
+    "writeBuckets",
+  ],
+  b2_update_file_legal_hold: ["writeFileLegalHolds"],
+  b2_update_file_retention: ["bypassGovernance", "writeFileRetentions"],
+  s3_abort_multipart_upload: ["writeFiles"],
+  s3_copy_object: ["readFiles", "writeFiles"],
+  s3_create_multipart_upload: ["readFileLegalHolds", "readFileRetentions", "writeFiles"],
+  s3_delete_object: ["deleteFiles"],
+  s3_delete_objects: ["bypassGovernance", "deleteFiles"],
+  s3_get_bucket_location: ["readBuckets"],
+  s3_get_object: ["readFiles"],
+  s3_get_presigned_url: ["readFiles", "writeFiles"],
+  s3_head_bucket: ["listBuckets"],
+  s3_head_object: ["readFileLegalHolds", "readFileRetentions", "readFiles"],
+  s3_list_multipart_uploads: ["listFiles"],
+  s3_list_object_versions: ["listFiles", "readFileLegalHolds", "readFileRetentions"],
+  s3_list_objects_v2: ["listFiles"],
+  s3_presign_upload_part: ["writeFiles"],
+  s3_put_object: ["readFileLegalHolds", "readFileRetentions", "writeFiles"],
+};
+
+function liveSuiteToolNames(): string[] {
+  const names = new Set<string>();
+  for (const sourcePath of liveSuiteSources) {
+    const text = workflowText(sourcePath);
+    for (const match of text.matchAll(/["']((?:b2|s3)_[a-z0-9_]+)["']/g)) {
+      names.add(match[1]);
+    }
+  }
+  return [...names].sort();
+}
+
+function sortedUnique(values: Iterable<string>): string[] {
+  return [...new Set(values)].sort();
+}
+
+function documentedContractCapabilities(): string[] {
+  const testingDoc = workflowText("docs/TESTING.md");
+  const match =
+    /use the\s+`live-b2-contract` GitHub Environment:[\s\S]*?Capabilities:\s*([\s\S]*?)\. Do not grant/.exec(
+      testingDoc,
+    );
+  if (!match)
+    throw new Error("Could not locate live-b2-contract capability list in docs/TESTING.md");
+  return sortedUnique([...match[1].matchAll(/`([^`]+)`/g)].map((capability) => capability[1]));
 }
 
 describe("live secret workflow policy", () => {
@@ -211,18 +292,33 @@ describe("live secret workflow policy", () => {
     );
     const workflow = workflowText(".github/workflows/contract.yml");
     expect(workflow).toContain("authorized account does not match B2_LIVE_TEST_ACCOUNT_ID");
-    expect(workflow).toContain(
-      'const requiredCapabilities = [\n            "bypassGovernance",\n            "deleteBuckets",',
-    );
-    expect(workflow).toContain('"writeFileRetentions",');
-    expect(workflow).not.toContain('"writeKeys"');
-    expect(workflow).not.toContain('"deleteKeys"');
+    expect(workflow).toContain("scripts/lib/live-b2-capabilities.cjs");
+    expect(workflow).toContain("LIVE_B2_CONTRACT_REQUIRED_CAPABILITIES");
     const liveTests = [
       workflowText("tests/live/b2.integration.live.test.ts"),
       workflowText("tests/live/request-shape.contract.live.test.ts"),
     ].join("\n");
     expect(liveTests).toContain('mode: "governance"');
     expect(liveTests).not.toContain('mode: "compliance"');
+  });
+
+  it("keeps the live contract capability policy aligned with exercised live tools", () => {
+    const missingMappings = liveSuiteToolNames().filter((name) => !(name in liveToolCapabilities));
+    expect(missingMappings).toEqual([]);
+
+    const exercisedCapabilities = sortedUnique(
+      liveSuiteToolNames().flatMap((name) => liveToolCapabilities[name]),
+    );
+    expect(sortedUnique(LIVE_B2_CONTRACT_REQUIRED_CAPABILITIES)).toEqual(exercisedCapabilities);
+    for (const forbidden of LIVE_B2_CONTRACT_FORBIDDEN_CAPABILITIES) {
+      expect(LIVE_B2_CONTRACT_REQUIRED_CAPABILITIES).not.toContain(forbidden);
+    }
+  });
+
+  it("documents the same live contract capability list used by workflow preflight", () => {
+    expect(documentedContractCapabilities()).toEqual(
+      sortedUnique(LIVE_B2_CONTRACT_REQUIRED_CAPABILITIES),
+    );
   });
 
   it("runs the explicit live contract layer with B2 credentials", () => {
@@ -245,7 +341,7 @@ describe("live secret workflow policy", () => {
     expect(smokeJob).toContain(
       "B2_MCP_EXPECTED_TOOL_PROFILE: ${{ vars.B2_MCP_EXPECTED_TOOL_PROFILE }}",
     );
-    expect(smokeJob).toContain('B2_REQUIRE_LIVE_TESTS: "1"');
+    expect(smokeJob).not.toContain("B2_REQUIRE_LIVE_TESTS");
     expect(smokeJob).toContain(
       "MCP_URL B2_KEY_ID B2_KEY B2_APP_KEY_ID B2_APP_KEY B2_SMOKE_BUCKET B2_MCP_EXPECTED_TOOL_PROFILE B2_MCP_REQUIRE_SMOKE_BUCKET",
     );

--- a/tests/contract/live-workflows-policy.contract.test.ts
+++ b/tests/contract/live-workflows-policy.contract.test.ts
@@ -293,7 +293,9 @@ describe("live secret workflow policy", () => {
     const workflow = workflowText(".github/workflows/contract.yml");
     expect(workflow).toContain("authorized account does not match B2_LIVE_TEST_ACCOUNT_ID");
     expect(workflow).toContain("scripts/lib/live-b2-capabilities.cjs");
+    expect(workflow).toContain("LIVE_B2_CONTRACT_FORBIDDEN_CAPABILITIES");
     expect(workflow).toContain("LIVE_B2_CONTRACT_REQUIRED_CAPABILITIES");
+    expect(workflow).toContain("live B2 contract key grants forbidden capability");
     const liveTests = [
       workflowText("tests/live/b2.integration.live.test.ts"),
       workflowText("tests/live/request-shape.contract.live.test.ts"),

--- a/tests/contract/live-workflows-policy.contract.test.ts
+++ b/tests/contract/live-workflows-policy.contract.test.ts
@@ -84,6 +84,7 @@ const liveSuiteSources = [
   "tests/live/b2.integration.live.test.ts",
   "tests/live/request-shape.contract.live.test.ts",
   "tests/live/support/contract-buckets.ts",
+  "scripts/live-b2-janitor.mjs",
   "scripts/lib/live-b2-contract.cjs",
 ];
 
@@ -249,6 +250,7 @@ describe("live secret workflow policy", () => {
   it("fails the live run when per-run cleanup leaks resources", () => {
     const text = workflowText(".github/workflows/contract.yml");
     const contractJob = workflowJobBlock(text, "contract") ?? "";
+    const janitor = workflowText("scripts/live-b2-janitor.mjs");
     expect(text).not.toContain("abandoned-resource-janitor:");
     expect(text).not.toContain("node scripts/live-b2-janitor.mjs --prefix mcp-contract-");
     expect(text).toContain("Clean current live B2 run resources");
@@ -257,6 +259,8 @@ describe("live secret workflow policy", () => {
       'node scripts/live-b2-janitor.mjs --prefix "${B2_MCP_LIVE_RUN_PREFIX}"',
     );
     expect(contractJob).not.toContain("--best-effort");
+    expect(janitor).not.toMatch(/\.(?:listKeys|deleteKey)\s*\(/);
+    expect(janitor).not.toContain("keys=");
     expect(text).toContain("B2_MCP_LIVE_RUN_PREFIX");
     expect(text).toContain('cron: "17 9 * * *"');
     expect(text).toMatch(
@@ -334,6 +338,12 @@ describe("live secret workflow policy", () => {
     expect(contractJob).toContain("B2_APPLICATION_KEY: ${{ secrets.LIVE_B2_KEY }}");
     expect(contractJob).toContain('B2_REQUIRE_LIVE_TESTS: "1"');
     expect(contractJob).toContain('B2_INTEGRATION_REQUIRE_CREDENTIALS: "1"');
+    expect(contractJob).toContain(
+      "must set B2_REQUIRE_LIVE_TESTS=1 and B2_INTEGRATION_REQUIRE_CREDENTIALS=1 together",
+    );
+    expect(contractJob).not.toContain(
+      "B2_APPLICATION_KEY B2_LIVE_TEST_ACCOUNT_ID B2_REQUIRE_LIVE_TESTS B2_INTEGRATION_REQUIRE_CREDENTIALS B2_MCP_LIVE_RUN_PREFIX",
+    );
   });
 
   it("pins the expected tool profile and required test bucket for live smoke", () => {

--- a/tests/contract/live-workflows-policy.contract.test.ts
+++ b/tests/contract/live-workflows-policy.contract.test.ts
@@ -212,8 +212,11 @@ describe("live secret workflow policy", () => {
     const workflow = workflowText(".github/workflows/contract.yml");
     expect(workflow).toContain("authorized account does not match B2_LIVE_TEST_ACCOUNT_ID");
     expect(workflow).toContain(
-      'const requiredCapabilities = ["bypassGovernance", "deleteKeys", "listKeys", "writeKeys"];',
+      'const requiredCapabilities = [\n            "bypassGovernance",\n            "deleteBuckets",',
     );
+    expect(workflow).toContain('"writeFileRetentions",');
+    expect(workflow).not.toContain('"writeKeys"');
+    expect(workflow).not.toContain('"deleteKeys"');
     const liveTests = [
       workflowText("tests/live/b2.integration.live.test.ts"),
       workflowText("tests/live/request-shape.contract.live.test.ts"),
@@ -231,6 +234,7 @@ describe("live secret workflow policy", () => {
     expect(contractJob).not.toContain("pnpm run test:contract\n");
     expect(contractJob).toContain("B2_APPLICATION_KEY_ID: ${{ secrets.LIVE_B2_KEY_ID }}");
     expect(contractJob).toContain("B2_APPLICATION_KEY: ${{ secrets.LIVE_B2_KEY }}");
+    expect(contractJob).toContain('B2_REQUIRE_LIVE_TESTS: "1"');
     expect(contractJob).toContain('B2_INTEGRATION_REQUIRE_CREDENTIALS: "1"');
   });
 
@@ -241,6 +245,7 @@ describe("live secret workflow policy", () => {
     expect(smokeJob).toContain(
       "B2_MCP_EXPECTED_TOOL_PROFILE: ${{ vars.B2_MCP_EXPECTED_TOOL_PROFILE }}",
     );
+    expect(smokeJob).toContain('B2_REQUIRE_LIVE_TESTS: "1"');
     expect(smokeJob).toContain(
       "MCP_URL B2_KEY_ID B2_KEY B2_APP_KEY_ID B2_APP_KEY B2_SMOKE_BUCKET B2_MCP_EXPECTED_TOOL_PROFILE B2_MCP_REQUIRE_SMOKE_BUCKET",
     );

--- a/tests/live/b2.integration.live.test.ts
+++ b/tests/live/b2.integration.live.test.ts
@@ -27,10 +27,10 @@ import {
   redactedLiveResourceDetail,
   type CreatedContractBucket,
 } from "./support/contract-buckets";
-import { hasLiveB2Credentials, selectLiveB2Test } from "../support/live-b2-test-guard";
+import { hasLiveB2Credentials, assertAndSelectLiveB2Test } from "../support/live-b2-test-guard";
 
 const HAS_CREDS = hasLiveB2Credentials();
-const liveIt = selectLiveB2Test(test);
+const liveIt = assertAndSelectLiveB2Test(test);
 
 function isError(result: any): boolean {
   return result?.isError === true;

--- a/tests/live/b2.integration.live.test.ts
+++ b/tests/live/b2.integration.live.test.ts
@@ -15,14 +15,11 @@
 
 import { loadConfig, createServer } from "../../src/server";
 import type { McpServer } from "../../src/mcp";
-import { B2AuthManager } from "../../src/auth";
-import { B2Client } from "../../src/b2/client";
 import { runWithMcpRequestSignal } from "../../src/request-context";
 import { parseErrorText } from "../../src/utils/errors";
 import { callTool, parseResult } from "../support/deterministic-fakes";
 import {
   contractObjectKey,
-  contractRuleName,
   createContractBucketTracker,
   type ContractBucketTracker,
   liveErrorText,
@@ -30,9 +27,10 @@ import {
   redactedLiveResourceDetail,
   type CreatedContractBucket,
 } from "./support/contract-buckets";
+import { hasLiveB2Credentials, selectLiveB2Test } from "../support/live-b2-test-guard";
 
-const HAS_CREDS = !!(process.env.B2_APPLICATION_KEY_ID && process.env.B2_APPLICATION_KEY);
-const liveIt = HAS_CREDS ? test : test.skip;
+const HAS_CREDS = hasLiveB2Credentials();
+const liveIt = selectLiveB2Test(test);
 
 function isError(result: any): boolean {
   return result?.isError === true;
@@ -51,51 +49,16 @@ function base64(value: string): string {
 let server: McpServer;
 let bucketTracker: ContractBucketTracker;
 let primaryBucket: CreatedContractBucket;
-let liveB2Client: B2Client;
-
-interface LiveRestrictedKey {
-  applicationKeyId: string;
-  keyName: string;
-  capabilities: string[];
-  bucketId?: string;
-  namePrefix?: string;
-}
 
 function bucketName(): string {
   if (!primaryBucket?.bucketName) throw new Error("Live primary bucket was not created.");
   return primaryBucket.bucketName;
 }
 
-async function createRestrictedKeyFixture(label: string): Promise<LiveRestrictedKey> {
-  const authData = parseResult(await callTool(server, "b2_authorize_account", {}));
-  const created = await liveB2Client.call<Record<string, unknown>>("b2_create_key", {
-    accountId: authData.accountId,
-    keyName: contractRuleName(`restricted-${label}`),
-    capabilities: ["listFiles", "readFiles"],
-    bucketId: primaryBucket.bucketId,
-    namePrefix: `${liveRunPrefix()}/restricted-key/`,
-    validDurationInSeconds: 3600,
-  });
-  const { applicationKey: _applicationKey, ...safe } = created;
-  if (typeof safe.applicationKeyId !== "string" || typeof safe.keyName !== "string") {
-    throw new Error("Live restricted-key fixture did not return key metadata.");
-  }
-  return safe as unknown as LiveRestrictedKey;
-}
-
-async function deleteRestrictedKeyFixture(key: LiveRestrictedKey): Promise<void> {
-  const deleted = await callTool(server, "b2_delete_key", {
-    applicationKeyId: key.applicationKeyId,
-    confirm: true,
-  });
-  expectLiveSuccess(deleted, `b2_delete_key ${key.keyName}`);
-}
-
 beforeAll(async () => {
   if (!HAS_CREDS) return;
   const config = loadConfig();
   server = createServer({ ...config, destructivePolicy: "allow" });
-  liveB2Client = new B2Client(new B2AuthManager(config));
   bucketTracker = createContractBucketTracker(server);
   primaryBucket = await bucketTracker.createBucket("integration", {
     lifecycleRules: [
@@ -144,49 +107,17 @@ describe("B2 Bucket and key tools", () => {
     },
   );
 
-  liveIt("b2_list_keys paginates restricted key metadata without exposing secrets", async () => {
-    const createdKeys: LiveRestrictedKey[] = [];
-    try {
-      createdKeys.push(await createRestrictedKeyFixture("page-a"));
-      createdKeys.push(await createRestrictedKeyFixture("page-b"));
-      const expectedNames = new Set(createdKeys.map((key) => key.keyName));
-      const seenNames = new Set<string>();
-      const usedCursors: string[] = [];
-      let cursor: string | undefined;
-
-      for (let page = 0; page < 1000; page++) {
-        const result = parseResult(
-          await callTool(server, "b2_list_keys", {
-            maxKeyCount: 1,
-            ...(cursor ? { startApplicationKeyId: cursor } : {}),
-          }),
-        );
-        expect(result).toHaveProperty("keys");
-        expect(Array.isArray(result.keys)).toBe(true);
-        for (const key of result.keys) {
-          expect(key).not.toHaveProperty("applicationKey");
-          if (expectedNames.has(key.keyName)) {
-            seenNames.add(key.keyName);
-            expect(key.capabilities).toEqual(expect.arrayContaining(["listFiles", "readFiles"]));
-            expect(key.bucketId).toBe(primaryBucket.bucketId);
-            expect(key.namePrefix).toBe(`${liveRunPrefix()}/restricted-key/`);
-          }
-        }
-        if (seenNames.size === expectedNames.size && usedCursors.length > 0) break;
-        const nextCursor =
-          typeof result.nextApplicationKeyId === "string" ? result.nextApplicationKeyId : undefined;
-        if (!nextCursor) break;
-        expect(nextCursor).not.toBe(cursor);
-        cursor = nextCursor;
-        usedCursors.push(nextCursor);
-      }
-
-      expect(usedCursors.length).toBeGreaterThan(0);
-      expect(seenNames).toEqual(expectedNames);
-    } finally {
-      for (const key of createdKeys.reverse()) {
-        await deleteRestrictedKeyFixture(key);
-      }
+  liveIt("b2_list_keys returns key metadata without exposing secrets", async () => {
+    const result = parseResult(await callTool(server, "b2_list_keys", { maxKeyCount: 100 }));
+    expect(result).toHaveProperty("keys");
+    expect(Array.isArray(result.keys)).toBe(true);
+    expect(result.keys.length).toBeGreaterThan(0);
+    for (const key of result.keys) {
+      expect(key).toHaveProperty("applicationKeyId");
+      expect(key).toHaveProperty("keyName");
+      expect(key).toHaveProperty("capabilities");
+      expect(key).not.toHaveProperty("applicationKey");
+      expect(key).not.toHaveProperty("masterApplicationKey");
     }
   });
 });

--- a/tests/live/request-shape.contract.live.test.ts
+++ b/tests/live/request-shape.contract.live.test.ts
@@ -30,9 +30,10 @@ import {
   redactedLiveResourceDetail,
   type ContractBucketRef,
 } from "./support/contract-buckets";
+import { hasLiveB2Credentials, selectLiveB2Test } from "../support/live-b2-test-guard";
 
-const HAS_CREDS = !!(process.env.B2_APPLICATION_KEY_ID && process.env.B2_APPLICATION_KEY);
-const liveIt = HAS_CREDS ? test : test.skip;
+const HAS_CREDS = hasLiveB2Credentials();
+const liveIt = selectLiveB2Test(test);
 
 const isError = (r: any): boolean => r?.isError === true;
 

--- a/tests/live/request-shape.contract.live.test.ts
+++ b/tests/live/request-shape.contract.live.test.ts
@@ -30,10 +30,10 @@ import {
   redactedLiveResourceDetail,
   type ContractBucketRef,
 } from "./support/contract-buckets";
-import { hasLiveB2Credentials, selectLiveB2Test } from "../support/live-b2-test-guard";
+import { hasLiveB2Credentials, assertAndSelectLiveB2Test } from "../support/live-b2-test-guard";
 
 const HAS_CREDS = hasLiveB2Credentials();
-const liveIt = selectLiveB2Test(test);
+const liveIt = assertAndSelectLiveB2Test(test);
 
 const isError = (r: any): boolean => r?.isError === true;
 

--- a/tests/support/live-b2-test-guard.ts
+++ b/tests/support/live-b2-test-guard.ts
@@ -1,3 +1,5 @@
+import credentialPolicy from "../../scripts/b2-credential-env.json";
+
 type Env = Record<string, string | undefined>;
 
 type TestCase = (name: string, fn: () => unknown | Promise<unknown>, timeout?: number) => unknown;
@@ -6,11 +8,11 @@ interface TestApi extends TestCase {
   skip: TestCase;
 }
 
-export const LIVE_B2_REQUIRED_CREDENTIALS = [
-  "B2_APPLICATION_KEY_ID",
-  "B2_APPLICATION_KEY",
-] as const;
+export const LIVE_B2_REQUIRED_CREDENTIALS = credentialPolicy.liveRequired;
 export const LIVE_B2_REQUIRE_FLAG = "B2_REQUIRE_LIVE_TESTS";
+
+const TRUE_FLAG_VALUES = new Set(["1", "true", "yes"]);
+const FALSE_FLAG_VALUES = new Set(["0", "false", "no"]);
 
 export interface LiveB2GuardState {
   readonly hasCredentials: boolean;
@@ -18,12 +20,27 @@ export interface LiveB2GuardState {
   readonly requireLiveTests: boolean;
 }
 
+function parseRequireLiveTestsFlag(env: Env): boolean {
+  const raw = env[LIVE_B2_REQUIRE_FLAG];
+  const normalized = String(raw ?? "")
+    .trim()
+    .toLowerCase();
+  if (!normalized) return false;
+  if (TRUE_FLAG_VALUES.has(normalized)) return true;
+  if (FALSE_FLAG_VALUES.has(normalized)) return false;
+  throw new Error(
+    `${LIVE_B2_REQUIRE_FLAG} must be one of 1, true, yes, 0, false, or no; got ${JSON.stringify(
+      raw,
+    )}.`,
+  );
+}
+
 export function liveB2GuardState(env: Env = process.env): LiveB2GuardState {
   const missingCredentials = LIVE_B2_REQUIRED_CREDENTIALS.filter((name) => !env[name]);
   return {
     hasCredentials: missingCredentials.length === 0,
     missingCredentials,
-    requireLiveTests: env[LIVE_B2_REQUIRE_FLAG] === "1",
+    requireLiveTests: parseRequireLiveTestsFlag(env),
   };
 }
 

--- a/tests/support/live-b2-test-guard.ts
+++ b/tests/support/live-b2-test-guard.ts
@@ -59,7 +59,7 @@ export function assertLiveB2Runnable(env: Env = process.env): void {
   );
 }
 
-export function selectLiveB2Test(testApi: TestApi, env: Env = process.env): TestCase {
+export function assertAndSelectLiveB2Test(testApi: TestApi, env: Env = process.env): TestCase {
   assertLiveB2Runnable(env);
   return hasLiveB2Credentials(env) ? testApi : testApi.skip;
 }

--- a/tests/support/live-b2-test-guard.ts
+++ b/tests/support/live-b2-test-guard.ts
@@ -1,0 +1,48 @@
+type Env = Record<string, string | undefined>;
+
+type TestCase = (name: string, fn: () => unknown | Promise<unknown>, timeout?: number) => unknown;
+
+interface TestApi extends TestCase {
+  skip: TestCase;
+}
+
+export const LIVE_B2_REQUIRED_CREDENTIALS = [
+  "B2_APPLICATION_KEY_ID",
+  "B2_APPLICATION_KEY",
+] as const;
+export const LIVE_B2_REQUIRE_FLAG = "B2_REQUIRE_LIVE_TESTS";
+
+export interface LiveB2GuardState {
+  readonly hasCredentials: boolean;
+  readonly missingCredentials: string[];
+  readonly requireLiveTests: boolean;
+}
+
+export function liveB2GuardState(env: Env = process.env): LiveB2GuardState {
+  const missingCredentials = LIVE_B2_REQUIRED_CREDENTIALS.filter((name) => !env[name]);
+  return {
+    hasCredentials: missingCredentials.length === 0,
+    missingCredentials,
+    requireLiveTests: env[LIVE_B2_REQUIRE_FLAG] === "1",
+  };
+}
+
+export function hasLiveB2Credentials(env: Env = process.env): boolean {
+  return liveB2GuardState(env).hasCredentials;
+}
+
+export function assertLiveB2Runnable(env: Env = process.env): void {
+  const state = liveB2GuardState(env);
+  if (!state.requireLiveTests || state.hasCredentials) return;
+
+  throw new Error(
+    `${LIVE_B2_REQUIRE_FLAG}=1 requires live Backblaze B2 credentials. Missing: ${state.missingCredentials.join(
+      ", ",
+    )}. Set B2_APPLICATION_KEY_ID and B2_APPLICATION_KEY before running the live B2 suites.`,
+  );
+}
+
+export function selectLiveB2Test(testApi: TestApi, env: Env = process.env): TestCase {
+  assertLiveB2Runnable(env);
+  return hasLiveB2Credentials(env) ? testApi : testApi.skip;
+}

--- a/tests/unit/b2-tools.unit.test.ts
+++ b/tests/unit/b2-tools.unit.test.ts
@@ -601,6 +601,81 @@ describe("b2_list_keys and b2_delete_key", () => {
     );
     expect(deleted.applicationKeyId).toBe(created.applicationKeyId);
   });
+
+  it("omits key secrets from every paginated b2_list_keys page", async () => {
+    invalidateAuthManagerCache();
+    const listKeyBodies: Record<string, unknown>[] = [];
+    installSdkTransport(
+      new RecordingTransport((request) => {
+        const endpoint = b2EndpointName(request);
+        if (endpoint === "b2_authorize_account") {
+          return new StaticHttpResponse(200, authorizeResponse(["listKeys"]));
+        }
+        if (endpoint === "b2_list_keys") {
+          const body = requestJson(request);
+          listKeyBodies.push(body);
+          if (!body.startApplicationKeyId) {
+            return new StaticHttpResponse(200, {
+              keys: [
+                {
+                  keyName: "page-one",
+                  applicationKeyId: "key-page-one",
+                  capabilities: ["readFiles"],
+                  accountId: "test-account-123",
+                  expirationTimestamp: null,
+                  bucketIds: null,
+                  bucketId: null,
+                  namePrefix: null,
+                  options: [],
+                  applicationKey: "secret-page-one",
+                },
+              ],
+              nextApplicationKeyId: "key-page-two",
+            });
+          }
+          return new StaticHttpResponse(200, {
+            keys: [
+              {
+                keyName: "page-two",
+                applicationKeyId: "key-page-two",
+                capabilities: ["listFiles"],
+                accountId: "test-account-123",
+                expirationTimestamp: null,
+                bucketIds: ["bucket-1"],
+                bucketId: "bucket-1",
+                namePrefix: "prefix/",
+                options: [],
+                applicationKey: "secret-page-two",
+              },
+            ],
+            nextApplicationKeyId: null,
+          });
+        }
+        return new StaticHttpResponse(500, { status: 500, code: "unexpected", message: endpoint });
+      }),
+    );
+    server = createServer(testConfig);
+
+    const firstPage = parseResult(await callTool(server, "b2_list_keys", { maxKeyCount: 1 }));
+    const secondPage = parseResult(
+      await callTool(server, "b2_list_keys", {
+        maxKeyCount: 1,
+        startApplicationKeyId: firstPage.nextApplicationKeyId,
+      }),
+    );
+
+    expect(firstPage.nextApplicationKeyId).toBe("key-page-two");
+    expect(secondPage.nextApplicationKeyId).toBeNull();
+    expect(listKeyBodies.map((body) => body.startApplicationKeyId ?? null)).toEqual([
+      null,
+      "key-page-two",
+    ]);
+    expect(JSON.stringify([firstPage, secondPage])).not.toContain("secret-page");
+    for (const key of [...firstPage.keys, ...secondPage.keys]) {
+      expect(key).not.toHaveProperty("applicationKey");
+      expect(key).not.toHaveProperty("masterApplicationKey");
+    }
+  });
 });
 
 describe("native SDK DTO boundaries", () => {

--- a/tests/unit/live-b2-janitor.unit.test.ts
+++ b/tests/unit/live-b2-janitor.unit.test.ts
@@ -1,23 +1,12 @@
 import { join } from "path";
 import { pathToFileURL } from "url";
-import type { CleanupStats } from "../support/live-b2-contract-types";
+import { readFileSync } from "fs";
 
 interface JanitorModule {
   assertExpectedLiveTestAccount(
     authManager: { getAuth(): Promise<{ accountId: string }> },
     expectedAccountId: string,
     options?: { log?: (message: string) => void },
-  ): Promise<void>;
-  cleanupKeys(
-    b2Client: {
-      listKeys(args: { maxKeyCount: number; startApplicationKeyId?: string }): Promise<{
-        keys?: Array<{ applicationKeyId: string; keyName: string }>;
-        nextApplicationKeyId?: string | null;
-      }>;
-      deleteKey(applicationKeyId: string): Promise<void>;
-    },
-    stats: CleanupStats,
-    options: { prefix: string; excludePrefixes?: string[]; dryRun?: boolean },
   ): Promise<void>;
   parseArgs(argv: string[]): {
     prefix: string;
@@ -31,17 +20,6 @@ async function loadJanitor(): Promise<JanitorModule> {
   return import(
     pathToFileURL(join(__dirname, "../../scripts/live-b2-janitor.mjs")).href
   ) as Promise<JanitorModule>;
-}
-
-function stats(): CleanupStats {
-  return {
-    buckets: 0,
-    objectVersions: 0,
-    multipartUploads: 0,
-    keys: 0,
-    errors: 0,
-    leakedBuckets: 0,
-  };
 }
 
 describe("live B2 janitor", () => {
@@ -62,81 +40,13 @@ describe("live B2 janitor", () => {
     ).resolves.toBeUndefined();
   });
 
-  it("deletes run-prefixed keys discovered after the first key page", async () => {
+  it("does not require key-management capabilities for cleanup", async () => {
     const janitor = await loadJanitor();
-    const deleted: string[] = [];
-    const cursors: Array<string | undefined> = [];
-    const b2Client = {
-      async listKeys(args: { maxKeyCount: number; startApplicationKeyId?: string }) {
-        cursors.push(args.startApplicationKeyId);
-        if (!args.startApplicationKeyId) {
-          return {
-            keys: [{ applicationKeyId: "other-key", keyName: "customer-key" }],
-            nextApplicationKeyId: "cursor-1",
-          };
-        }
-        return {
-          keys: [{ applicationKeyId: "run-key", keyName: "mcp-contract-123-key" }],
-          nextApplicationKeyId: null,
-        };
-      },
-      async deleteKey(applicationKeyId: string) {
-        deleted.push(applicationKeyId);
-      },
-    };
-    const cleanupStats = stats();
+    const source = readFileSync(join(__dirname, "../../scripts/live-b2-janitor.mjs"), "utf8");
 
-    await janitor.cleanupKeys(b2Client, cleanupStats, {
-      prefix: "mcp-contract-123",
-      excludePrefixes: [],
-      dryRun: false,
-    });
-
-    expect(cursors).toEqual([undefined, "cursor-1"]);
-    expect(deleted).toEqual(["run-key"]);
-    expect(cleanupStats.keys).toBe(1);
-    expect(cleanupStats.errors).toBe(0);
-  });
-
-  it("applies prefix boundaries and exclusions to key cleanup", async () => {
-    const janitor = await loadJanitor();
-    const deleted: string[] = [];
-    const b2Client = {
-      async listKeys() {
-        return {
-          keys: [
-            { applicationKeyId: "run-key", keyName: "mcp-contract-run1-restricted" },
-            { applicationKeyId: "nearby-key", keyName: "mcp-contract-run10-restricted" },
-            { applicationKeyId: "excluded-key", keyName: "mcp-contract-run2-restricted" },
-          ],
-          nextApplicationKeyId: null,
-        };
-      },
-      async deleteKey(applicationKeyId: string) {
-        deleted.push(applicationKeyId);
-      },
-    };
-    const cleanupStats = stats();
-
-    await janitor.cleanupKeys(b2Client, cleanupStats, {
-      prefix: "mcp-contract-",
-      excludePrefixes: ["mcp-contract-run2"],
-      dryRun: false,
-    });
-
-    expect(deleted).toEqual(["run-key", "nearby-key"]);
-    expect(cleanupStats.keys).toBe(2);
-    expect(cleanupStats.errors).toBe(0);
-
-    deleted.length = 0;
-    const scopedStats = stats();
-    await janitor.cleanupKeys(b2Client, scopedStats, {
-      prefix: "mcp-contract-run1",
-      excludePrefixes: [],
-      dryRun: false,
-    });
-    expect(deleted).toEqual(["run-key"]);
-    expect(scopedStats.keys).toBe(1);
+    expect("cleanupKeys" in janitor).toBe(false);
+    expect(source).not.toMatch(/\.(?:listKeys|deleteKey)\s*\(/);
+    expect(source).not.toContain("keys=");
   });
 
   it("parses best-effort cleanup mode separately from scheduled cleanup", async () => {

--- a/tests/unit/live-b2-test-guard.unit.test.ts
+++ b/tests/unit/live-b2-test-guard.unit.test.ts
@@ -4,7 +4,7 @@ import {
   assertLiveB2Runnable,
   hasLiveB2Credentials,
   liveB2GuardState,
-  selectLiveB2Test,
+  assertAndSelectLiveB2Test,
 } from "../support/live-b2-test-guard";
 import credentialPolicy from "../../scripts/b2-credential-env.json";
 
@@ -26,7 +26,7 @@ describe("live B2 test guard", () => {
   it("fails loudly instead of selecting skip when required live credentials are absent", () => {
     const { skip, testApi } = fakeTestApi();
 
-    expect(() => selectLiveB2Test(testApi, { [LIVE_B2_REQUIRE_FLAG]: "1" })).toThrow(
+    expect(() => assertAndSelectLiveB2Test(testApi, { [LIVE_B2_REQUIRE_FLAG]: "1" })).toThrow(
       /B2_REQUIRE_LIVE_TESTS=1 requires live Backblaze B2 credentials/,
     );
     expect(skip).not.toHaveBeenCalled();
@@ -35,7 +35,7 @@ describe("live B2 test guard", () => {
   it("keeps local no-credential selection skipped when live tests are not required", () => {
     const { skip, testApi } = fakeTestApi();
 
-    const selected = selectLiveB2Test(testApi, {});
+    const selected = assertAndSelectLiveB2Test(testApi, {});
 
     expect(selected).toBe(skip);
   });
@@ -52,9 +52,9 @@ describe("live B2 test guard", () => {
   it("rejects unrecognized non-empty require flag values instead of skipping", () => {
     const { skip, testApi } = fakeTestApi();
 
-    expect(() => selectLiveB2Test(testApi, { [LIVE_B2_REQUIRE_FLAG]: "required" })).toThrow(
-      /B2_REQUIRE_LIVE_TESTS must be one of/,
-    );
+    expect(() =>
+      assertAndSelectLiveB2Test(testApi, { [LIVE_B2_REQUIRE_FLAG]: "required" }),
+    ).toThrow(/B2_REQUIRE_LIVE_TESTS must be one of/);
     expect(skip).not.toHaveBeenCalled();
   });
 

--- a/tests/unit/live-b2-test-guard.unit.test.ts
+++ b/tests/unit/live-b2-test-guard.unit.test.ts
@@ -1,10 +1,12 @@
 import {
+  LIVE_B2_REQUIRED_CREDENTIALS,
   LIVE_B2_REQUIRE_FLAG,
   assertLiveB2Runnable,
   hasLiveB2Credentials,
   liveB2GuardState,
   selectLiveB2Test,
 } from "../support/live-b2-test-guard";
+import credentialPolicy from "../../scripts/b2-credential-env.json";
 
 function fakeTestApi() {
   const run = vi.fn();
@@ -17,6 +19,10 @@ function fakeTestApi() {
 }
 
 describe("live B2 test guard", () => {
+  it("uses the shared live credential policy source", () => {
+    expect(LIVE_B2_REQUIRED_CREDENTIALS).toEqual(credentialPolicy.liveRequired);
+  });
+
   it("fails loudly instead of selecting skip when required live credentials are absent", () => {
     const { skip, testApi } = fakeTestApi();
 
@@ -37,10 +43,19 @@ describe("live B2 test guard", () => {
   it("fails loudly when only part of the credential pair is present", () => {
     expect(() =>
       assertLiveB2Runnable({
-        [LIVE_B2_REQUIRE_FLAG]: "1",
+        [LIVE_B2_REQUIRE_FLAG]: " true ",
         B2_APPLICATION_KEY_ID: "key-id",
       }),
     ).toThrow(/Missing: B2_APPLICATION_KEY/);
+  });
+
+  it("rejects unrecognized non-empty require flag values instead of skipping", () => {
+    const { skip, testApi } = fakeTestApi();
+
+    expect(() => selectLiveB2Test(testApi, { [LIVE_B2_REQUIRE_FLAG]: "required" })).toThrow(
+      /B2_REQUIRE_LIVE_TESTS must be one of/,
+    );
+    expect(skip).not.toHaveBeenCalled();
   });
 
   it("recognizes a complete live credential pair", () => {

--- a/tests/unit/live-b2-test-guard.unit.test.ts
+++ b/tests/unit/live-b2-test-guard.unit.test.ts
@@ -1,0 +1,59 @@
+import {
+  LIVE_B2_REQUIRE_FLAG,
+  assertLiveB2Runnable,
+  hasLiveB2Credentials,
+  liveB2GuardState,
+  selectLiveB2Test,
+} from "../support/live-b2-test-guard";
+
+function fakeTestApi() {
+  const run = vi.fn();
+  const skip = vi.fn();
+  return {
+    run,
+    skip,
+    testApi: Object.assign(run, { skip }),
+  };
+}
+
+describe("live B2 test guard", () => {
+  it("fails loudly instead of selecting skip when required live credentials are absent", () => {
+    const { skip, testApi } = fakeTestApi();
+
+    expect(() => selectLiveB2Test(testApi, { [LIVE_B2_REQUIRE_FLAG]: "1" })).toThrow(
+      /B2_REQUIRE_LIVE_TESTS=1 requires live Backblaze B2 credentials/,
+    );
+    expect(skip).not.toHaveBeenCalled();
+  });
+
+  it("keeps local no-credential selection skipped when live tests are not required", () => {
+    const { skip, testApi } = fakeTestApi();
+
+    const selected = selectLiveB2Test(testApi, {});
+
+    expect(selected).toBe(skip);
+  });
+
+  it("fails loudly when only part of the credential pair is present", () => {
+    expect(() =>
+      assertLiveB2Runnable({
+        [LIVE_B2_REQUIRE_FLAG]: "1",
+        B2_APPLICATION_KEY_ID: "key-id",
+      }),
+    ).toThrow(/Missing: B2_APPLICATION_KEY/);
+  });
+
+  it("recognizes a complete live credential pair", () => {
+    const env = {
+      B2_APPLICATION_KEY_ID: "key-id",
+      B2_APPLICATION_KEY: "application-key",
+    };
+
+    expect(hasLiveB2Credentials(env)).toBe(true);
+    expect(liveB2GuardState(env)).toMatchObject({
+      hasCredentials: true,
+      missingCredentials: [],
+      requireLiveTests: false,
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- Add a shared live B2 test guard that throws when `B2_REQUIRE_LIVE_TESTS` is truthy (`1` / `true` / `yes`) and the primary B2 credential pair is missing or partial, while rejecting unrecognized non-empty flag values.
- Rename the live-suite selector to `assertAndSelectLiveB2Test` so call sites make the collection-time fail-loud behavior explicit.
- Set `B2_REQUIRE_LIVE_TESTS=1` only for the protected Vitest live contract workflow, remove the inert flag from the smoke workflow, and enforce that `B2_REQUIRE_LIVE_TESTS=1` and `B2_INTEGRATION_REQUIRE_CREDENTIALS=1` stay paired for trusted Vitest live runs.
- Centralize the live contract capability list in `scripts/lib/live-b2-capabilities.cjs`, have workflow preflight import it, and align `docs/TESTING.md` with the same list.
- Have workflow preflight fail fast when required capabilities are missing or forbidden key-management capabilities such as `writeKeys` / `deleteKeys` are granted.
- Remove live janitor application-key cleanup so the documented live contract key does not need `deleteKeys`; policy and unit coverage assert the janitor does not call key-management APIs.
- Add policy coverage that maps exercised live-suite and cleanup tool calls to required capabilities, compares that to the shared preflight list, verifies docs match it, and keeps forbidden capabilities out of the live key contract.
- Keep local direct live-suite selection skip-only when the flag is unset, while retaining paginated `b2_list_keys` secret-redaction coverage through a deterministic unit test.

## Linked issue
Closes #156

## Tests run
- `pnpm run typecheck`
- `pnpm run test:unit`
- `pnpm run test:contract`
- `pnpm run format:check`
- `pnpm run verify`
- `pnpm test`
- `B2_REQUIRE_LIVE_TESTS=1` direct `integration-live` Vitest selection without credentials (expected failure at guard)
- direct `integration-live` Vitest selection without credentials and without the flag (expected skip)
- `B2_REQUIRE_LIVE_TESTS=1` direct `contract-live` Vitest selection without credentials (expected failure at guard)
- `B2_REQUIRE_LIVE_TESTS=yes` direct `integration-live` Vitest selection without credentials (expected failure at guard)

## Follow-up notes
- Repository operators still need to remove obsolete repo-level secrets `B2_KEY`, `B2_KEY_ID`, `B2_APP_KEY`, and `B2_APP_KEY_ID` in GitHub.
- The protected `live-b2-contract` and `live-b2-smoke` GitHub Environments still need the documented environment-scoped secrets populated before hosted live evidence can pass.
- Live B2 credentials were not available locally, so hosted live execution with a real key matching the documented capability list remains CI/operator evidence.