### PR TITLE
[b2-mcp] Strengthen Vercel adapter assertions

### DIFF
--- a/src/tool-contract.ts
+++ b/src/tool-contract.ts
@@ -105,6 +105,44 @@ export interface ToolContractPackageJson {
   devDependencies: Record<string, string>;
 }
 
+export interface RawToolPayload {
+  name: string;
+  description?: string;
+  inputSchema?: {
+    required?: string[];
+    properties?: Record<string, unknown>;
+    [key: string]: unknown;
+  };
+  outputSchema?: unknown;
+  annotations?: unknown;
+  _meta?: unknown;
+}
+
+export interface CollectedToolList {
+  tools: RawToolPayload[];
+  list: { tools?: unknown; ttlMs?: number; cacheScope?: string; [key: string]: unknown };
+  protocolVersion: string;
+  discover?: {
+    supportedVersions?: string[];
+    capabilities?: unknown;
+    ttlMs?: number;
+    cacheScope?: string;
+    resultType?: string;
+  };
+}
+
+export interface ToolFixtureFromCollectedOptions {
+  contractVersion: number;
+  issue: number;
+  profile: ProfileName;
+  era: Era;
+  transport: string;
+  mcpRevision: string;
+  sdk: Record<string, string>;
+  capabilities: string[] | null;
+  collected: CollectedToolList;
+}
+
 export const PROFILE_DESCRIPTIONS: Record<ProfileName, string> = {
   full: "Complete tool superset for contract review and regression detection.",
   "phase1-default":
@@ -237,6 +275,75 @@ export function destructiveConfirmToolsFromTools(
 
 export function fixtureHash(fixture: Pick<ToolFixture, "names" | "tools">): string {
   return sha256(JSON.stringify({ names: fixture.names, tools: fixture.tools }));
+}
+
+function numberValue(value: unknown, fallback: number): number {
+  return typeof value === "number" ? value : fallback;
+}
+
+function stringValue(value: unknown, fallback: string): string {
+  return typeof value === "string" ? value : fallback;
+}
+
+function stringArrayValue(value: unknown): string[] {
+  return Array.isArray(value) && value.every((item) => typeof item === "string") ? [...value] : [];
+}
+
+export function toolFixtureFromCollected({
+  contractVersion,
+  issue,
+  profile,
+  era,
+  transport,
+  mcpRevision,
+  sdk,
+  capabilities,
+  collected,
+}: ToolFixtureFromCollectedOptions): ToolFixture {
+  const tools = [...collected.tools].sort((a, b) => a.name.localeCompare(b.name));
+  const names = tools.map((tool) => tool.name);
+  const fixture: ToolFixture = {
+    contractVersion,
+    issue,
+    profile,
+    era,
+    protocolVersion: collected.protocolVersion,
+    transport,
+    mcpRevision,
+    sdk,
+    capabilities,
+    counts: countPrefixes(names),
+    names,
+    requiredFields: requiredFieldsByTool(tools),
+    confirmTools: confirmToolsFrom(tools),
+    tools: tools.map(normalizeTool),
+    hash: "",
+  };
+
+  if (era === "modern") {
+    const discover = collected.discover;
+    fixture.modern = {
+      toolsListCacheHint: {
+        ttlMs: numberValue(collected.list.ttlMs, -1),
+        cacheScope: stringValue(collected.list.cacheScope, ""),
+      },
+      discover: {
+        supportedVersions: stringArrayValue(discover?.supportedVersions),
+        capabilities: stable(discover?.capabilities ?? {}) as JsonObject,
+        ttlMs: numberValue(discover?.ttlMs, -1),
+        cacheScope: stringValue(discover?.cacheScope, ""),
+        resultType: stringValue(discover?.resultType, ""),
+      },
+    };
+  } else {
+    fixture.legacy = {
+      toolsListCacheHint: null,
+      discover: null,
+    };
+  }
+
+  fixture.hash = fixtureHash(fixture);
+  return fixture;
 }
 
 export function renderProfileReference(contract: ContractArtifact): string {

--- a/tests/contract/tool-profile-contract.contract.test.ts
+++ b/tests/contract/tool-profile-contract.contract.test.ts
@@ -16,22 +16,19 @@ import {
   LEGACY_PROTOCOL_VERSION,
   PROFILE_NAMES,
   capabilitiesForProfile,
-  confirmToolsFrom,
   contractSdkVersions,
   countPrefixes,
   destructiveConfirmToolsFromTools,
-  fixtureHash,
-  normalizeTool,
   renderProfileReference,
-  requiredFieldsByTool,
-  stable,
+  toolFixtureFromCollected,
+  type CollectedToolList,
   type ContractArtifact,
   type Era,
   type JsonObject,
   type NormalizedTool,
   type ProfileName,
-  type ToolContractPackageJson,
   type ToolFixture,
+  type ToolContractPackageJson,
 } from "../../src/tool-contract";
 
 const contract = readJson<ContractArtifact>("docs/tool-profile-contract.json");
@@ -40,40 +37,6 @@ const biomeRunner = join(root, "scripts/run-biome.mjs");
 
 const profileNames = Object.keys(contract.profiles) as ProfileName[];
 const eras: Era[] = ["modern", "legacy"];
-
-interface RawToolPayload {
-  name: string;
-  description?: string;
-  inputSchema?: {
-    required?: string[];
-    properties?: Record<string, unknown>;
-    [key: string]: unknown;
-  };
-  outputSchema?: unknown;
-  annotations?: unknown;
-  _meta?: unknown;
-}
-
-interface CollectedToolList {
-  tools: RawToolPayload[];
-  list: { tools?: unknown; ttlMs?: number; cacheScope?: string; [key: string]: unknown };
-  protocolVersion: string;
-  discover?: {
-    supportedVersions?: string[];
-    capabilities?: unknown;
-    ttlMs?: number;
-    cacheScope?: string;
-    resultType?: string;
-  };
-}
-
-function numberValue(value: unknown, fallback: number): number {
-  return typeof value === "number" ? value : fallback;
-}
-
-function stringValue(value: unknown, fallback: string): string {
-  return typeof value === "string" ? value : fallback;
-}
 
 async function listenOnEphemeralPort(handle: HttpServerHandle): Promise<number> {
   await new Promise<void>((resolve) => handle.server.listen(0, "127.0.0.1", resolve));
@@ -129,50 +92,17 @@ async function collectToolsList(profile: ProfileName, era: Era): Promise<Collect
 
 async function collectFixture(profile: ProfileName, era: Era): Promise<ToolFixture> {
   const collected = await collectToolsList(profile, era);
-  const tools = collected.tools;
-  const names = tools.map((tool) => tool.name);
-  const fixture: ToolFixture = {
+  return toolFixtureFromCollected({
     contractVersion: contract.contractVersion,
     issue: contract.issue,
     profile,
     era,
-    protocolVersion: collected.protocolVersion,
     transport: "streamable-http",
     mcpRevision: contract.mcpRevision,
     sdk: contractSdkVersions(packageJson),
     capabilities: contract.profiles[profile].capabilities,
-    counts: countPrefixes(names),
-    names,
-    requiredFields: requiredFieldsByTool(tools),
-    confirmTools: confirmToolsFrom(tools),
-    tools: tools.map(normalizeTool),
-    hash: "",
-  };
-
-  if (era === "modern") {
-    const discover = collected.discover;
-    fixture.modern = {
-      toolsListCacheHint: {
-        ttlMs: numberValue(collected.list.ttlMs, -1),
-        cacheScope: stringValue(collected.list.cacheScope, ""),
-      },
-      discover: {
-        supportedVersions: discover?.supportedVersions ?? [],
-        capabilities: stable(discover?.capabilities ?? {}) as JsonObject,
-        ttlMs: numberValue(discover?.ttlMs, -1),
-        cacheScope: stringValue(discover?.cacheScope, ""),
-        resultType: stringValue(discover?.resultType, ""),
-      },
-    };
-  } else {
-    fixture.legacy = {
-      toolsListCacheHint: null,
-      discover: null,
-    };
-  }
-
-  fixture.hash = fixtureHash(fixture);
-  return fixture;
+    collected,
+  });
 }
 
 function fixtureFor(profile: ProfileName, era: Era): ToolFixture {

--- a/tests/protocol/vercel.modern-protocol.test.ts
+++ b/tests/protocol/vercel.modern-protocol.test.ts
@@ -5,10 +5,22 @@
  * and do not start the standalone Node http.Server.
  */
 
+import { readFileSync } from "fs";
+import { join } from "path";
 import { S3Client } from "@aws-sdk/client-s3";
 import { B2Simulator } from "@backblaze-labs/b2-sdk/simulator";
 import { closeVercelMcpHandlerForTests } from "../../deploy/vercel/adapter";
 import { invalidateAuthManagerCache, invalidateCapabilityCache } from "../../src/server";
+import {
+  confirmToolsFrom,
+  countPrefixes,
+  fixtureHash,
+  normalizeTool,
+  requiredFieldsByTool,
+  stable,
+  type JsonObject,
+  type ToolFixture,
+} from "../../src/tool-contract";
 import { setB2SdkClientFactoryForTests } from "../support/sdk-factory-hook";
 import { installSdkTransport } from "../support/sdk-test-helpers";
 import { closeClient } from "./support/clients";
@@ -19,6 +31,94 @@ import {
 } from "./support/vercel";
 
 const savedEnv = { ...process.env };
+const root = join(__dirname, "../..");
+const fullModernFixture = readJson<ToolFixture>("tests/fixtures/tool-contract/full.modern.json");
+
+interface RawToolPayload {
+  name: string;
+  description?: string;
+  inputSchema?: {
+    required?: string[];
+    properties?: Record<string, unknown>;
+    [key: string]: unknown;
+  };
+  outputSchema?: unknown;
+  annotations?: unknown;
+  _meta?: unknown;
+}
+
+interface CollectedVercelProfile {
+  protocolVersion: string;
+  mcpRevision: string;
+  counts: ToolFixture["counts"];
+  names: string[];
+  requiredFields: Record<string, string[]>;
+  confirmTools: string[];
+  tools: ToolFixture["tools"];
+  modern: NonNullable<ToolFixture["modern"]>;
+}
+
+function readJson<T>(relativePath: string): T {
+  return JSON.parse(readFileSync(join(root, relativePath), "utf8")) as T;
+}
+
+function numberValue(value: unknown, fallback: number): number {
+  return typeof value === "number" ? value : fallback;
+}
+
+function stringValue(value: unknown, fallback: string): string {
+  return typeof value === "string" ? value : fallback;
+}
+
+function sortedTools(tools: unknown): RawToolPayload[] {
+  if (!Array.isArray(tools)) return [];
+  return [...(tools as RawToolPayload[])].sort((a, b) => a.name.localeCompare(b.name));
+}
+
+function collectedVercelProfile(
+  listed: Record<string, unknown>,
+  discover: Record<string, unknown>,
+  protocolVersion: string,
+): CollectedVercelProfile {
+  const tools = sortedTools(listed.tools);
+  const names = tools.map((tool) => tool.name);
+  return {
+    protocolVersion,
+    mcpRevision: MODERN_PROTOCOL_VERSION,
+    counts: countPrefixes(names),
+    names,
+    requiredFields: requiredFieldsByTool(tools),
+    confirmTools: confirmToolsFrom(tools),
+    tools: tools.map(normalizeTool),
+    modern: {
+      toolsListCacheHint: {
+        ttlMs: numberValue(listed.ttlMs, -1),
+        cacheScope: stringValue(listed.cacheScope, ""),
+      },
+      discover: {
+        supportedVersions: Array.isArray(discover.supportedVersions)
+          ? (discover.supportedVersions as string[])
+          : [],
+        capabilities: stable(discover.capabilities ?? {}) as JsonObject,
+        ttlMs: numberValue(discover.ttlMs, -1),
+        cacheScope: stringValue(discover.cacheScope, ""),
+        resultType: stringValue(discover.resultType, ""),
+      },
+    },
+  };
+}
+
+function expectVercelProfileToMatchFrozenFixture(actual: CollectedVercelProfile): void {
+  expect(actual.protocolVersion).toBe(fullModernFixture.protocolVersion);
+  expect(actual.mcpRevision).toBe(fullModernFixture.mcpRevision);
+  expect(actual.counts).toEqual(fullModernFixture.counts);
+  expect(actual.names).toEqual(fullModernFixture.names);
+  expect(actual.requiredFields).toEqual(fullModernFixture.requiredFields);
+  expect(actual.confirmTools).toEqual(fullModernFixture.confirmTools);
+  expect(actual.tools).toEqual(fullModernFixture.tools);
+  expect(actual.modern).toEqual(fullModernFixture.modern);
+  expect(fixtureHash(actual)).toBe(fullModernFixture.hash);
+}
 
 beforeEach(async () => {
   setVercelProtocolEnv(savedEnv);
@@ -59,6 +159,13 @@ describe("Vercel adapter (MCP 2026-07-28)", () => {
       expect(discover.cacheScope).toBe("private");
 
       const listed = await client.listTools(undefined, { cacheMode: "refresh" });
+      expectVercelProfileToMatchFrozenFixture(
+        collectedVercelProfile(
+          listed as Record<string, unknown>,
+          discover as Record<string, unknown>,
+          client.getNegotiatedProtocolVersion() ?? "",
+        ),
+      );
       const toolNames = listed.tools.map((tool) => tool.name);
       expect(toolNames).toContain("b2_list_buckets");
       expect(toolNames).toContain("s3_list_objects_v2");
@@ -72,9 +179,12 @@ describe("Vercel adapter (MCP 2026-07-28)", () => {
           })
         ).isError,
       ).not.toBe(true);
-      expect((await client.callTool({ name: "b2_list_buckets", arguments: {} })).isError).not.toBe(
-        true,
-      );
+      const b2Call = await client.callTool({ name: "b2_list_buckets", arguments: {} });
+      expect(b2Call.isError).not.toBe(true);
+      expect(b2Call.structuredContent).toBeDefined();
+      expect(b2Call.content).toEqual([
+        { type: "text", text: JSON.stringify(b2Call.structuredContent) },
+      ]);
       expect(
         (
           await client.callTool({
@@ -90,6 +200,15 @@ describe("Vercel adapter (MCP 2026-07-28)", () => {
       );
       expect(requests.some((record) => record.headers["mcp-method"] === "tools/list")).toBe(true);
       expect(requests.every((record) => record.headers["mcp-session-id"] === undefined)).toBe(true);
+
+      const schemaFailure = await client.callTool({
+        name: "b2_create_bucket",
+        arguments: { bucketType: "allPrivate" },
+      });
+      expect(schemaFailure.isError).toBe(true);
+      expect(schemaFailure.content).toEqual([
+        expect.objectContaining({ type: "text", text: expect.stringMatching(/validation/i) }),
+      ]);
     } finally {
       await closeClient(client);
     }

--- a/tests/protocol/vercel.modern-protocol.test.ts
+++ b/tests/protocol/vercel.modern-protocol.test.ts
@@ -5,22 +5,19 @@
  * and do not start the standalone Node http.Server.
  */
 
-import { readFileSync } from "fs";
-import { join } from "path";
 import { S3Client } from "@aws-sdk/client-s3";
 import { B2Simulator } from "@backblaze-labs/b2-sdk/simulator";
 import { closeVercelMcpHandlerForTests } from "../../deploy/vercel/adapter";
 import { invalidateAuthManagerCache, invalidateCapabilityCache } from "../../src/server";
 import {
-  confirmToolsFrom,
-  countPrefixes,
-  fixtureHash,
-  normalizeTool,
-  requiredFieldsByTool,
-  stable,
-  type JsonObject,
+  MCP_REVISION,
+  contractSdkVersions,
+  toolFixtureFromCollected,
+  type CollectedToolList,
   type ToolFixture,
+  type ToolContractPackageJson,
 } from "../../src/tool-contract";
+import { readJson } from "../contract/support";
 import { setB2SdkClientFactoryForTests } from "../support/sdk-factory-hook";
 import { installSdkTransport } from "../support/sdk-test-helpers";
 import { closeClient } from "./support/clients";
@@ -31,93 +28,37 @@ import {
 } from "./support/vercel";
 
 const savedEnv = { ...process.env };
-const root = join(__dirname, "../..");
 const fullModernFixture = readJson<ToolFixture>("tests/fixtures/tool-contract/full.modern.json");
+const packageJson = readJson<ToolContractPackageJson>("package.json");
 
-interface RawToolPayload {
-  name: string;
-  description?: string;
-  inputSchema?: {
-    required?: string[];
-    properties?: Record<string, unknown>;
-    [key: string]: unknown;
-  };
-  outputSchema?: unknown;
-  annotations?: unknown;
-  _meta?: unknown;
-}
-
-interface CollectedVercelProfile {
-  protocolVersion: string;
-  mcpRevision: string;
-  counts: ToolFixture["counts"];
-  names: string[];
-  requiredFields: Record<string, string[]>;
-  confirmTools: string[];
-  tools: ToolFixture["tools"];
-  modern: NonNullable<ToolFixture["modern"]>;
-}
-
-function readJson<T>(relativePath: string): T {
-  return JSON.parse(readFileSync(join(root, relativePath), "utf8")) as T;
-}
-
-function numberValue(value: unknown, fallback: number): number {
-  return typeof value === "number" ? value : fallback;
-}
-
-function stringValue(value: unknown, fallback: string): string {
-  return typeof value === "string" ? value : fallback;
-}
-
-function sortedTools(tools: unknown): RawToolPayload[] {
-  if (!Array.isArray(tools)) return [];
-  return [...(tools as RawToolPayload[])].sort((a, b) => a.name.localeCompare(b.name));
-}
-
-function collectedVercelProfile(
+function collectVercelFixture(
   listed: Record<string, unknown>,
   discover: Record<string, unknown>,
   protocolVersion: string,
-): CollectedVercelProfile {
-  const tools = sortedTools(listed.tools);
-  const names = tools.map((tool) => tool.name);
-  return {
-    protocolVersion,
-    mcpRevision: MODERN_PROTOCOL_VERSION,
-    counts: countPrefixes(names),
-    names,
-    requiredFields: requiredFieldsByTool(tools),
-    confirmTools: confirmToolsFrom(tools),
-    tools: tools.map(normalizeTool),
-    modern: {
-      toolsListCacheHint: {
-        ttlMs: numberValue(listed.ttlMs, -1),
-        cacheScope: stringValue(listed.cacheScope, ""),
-      },
-      discover: {
-        supportedVersions: Array.isArray(discover.supportedVersions)
-          ? (discover.supportedVersions as string[])
-          : [],
-        capabilities: stable(discover.capabilities ?? {}) as JsonObject,
-        ttlMs: numberValue(discover.ttlMs, -1),
-        cacheScope: stringValue(discover.cacheScope, ""),
-        resultType: stringValue(discover.resultType, ""),
-      },
+): ToolFixture {
+  return toolFixtureFromCollected({
+    contractVersion: fullModernFixture.contractVersion,
+    issue: fullModernFixture.issue,
+    profile: fullModernFixture.profile,
+    era: fullModernFixture.era,
+    transport: fullModernFixture.transport,
+    mcpRevision: MCP_REVISION,
+    sdk: contractSdkVersions(packageJson),
+    capabilities: fullModernFixture.capabilities,
+    collected: {
+      tools: Array.isArray(listed.tools) ? (listed.tools as CollectedToolList["tools"]) : [],
+      list: listed as CollectedToolList["list"],
+      discover: discover as CollectedToolList["discover"],
+      protocolVersion,
     },
-  };
+  });
 }
 
-function expectVercelProfileToMatchFrozenFixture(actual: CollectedVercelProfile): void {
-  expect(actual.protocolVersion).toBe(fullModernFixture.protocolVersion);
-  expect(actual.mcpRevision).toBe(fullModernFixture.mcpRevision);
-  expect(actual.counts).toEqual(fullModernFixture.counts);
-  expect(actual.names).toEqual(fullModernFixture.names);
-  expect(actual.requiredFields).toEqual(fullModernFixture.requiredFields);
-  expect(actual.confirmTools).toEqual(fullModernFixture.confirmTools);
-  expect(actual.tools).toEqual(fullModernFixture.tools);
-  expect(actual.modern).toEqual(fullModernFixture.modern);
-  expect(fixtureHash(actual)).toBe(fullModernFixture.hash);
+function expectVercelProfileToMatchFrozenFixture(actual: ToolFixture): void {
+  expect(actual).toEqual({
+    ...fullModernFixture,
+    mcpRevision: MCP_REVISION,
+  });
 }
 
 beforeEach(async () => {
@@ -160,7 +101,7 @@ describe("Vercel adapter (MCP 2026-07-28)", () => {
 
       const listed = await client.listTools(undefined, { cacheMode: "refresh" });
       expectVercelProfileToMatchFrozenFixture(
-        collectedVercelProfile(
+        collectVercelFixture(
           listed as Record<string, unknown>,
           discover as Record<string, unknown>,
           client.getNegotiatedProtocolVersion() ?? "",

--- a/tests/protocol/vercel.modern-protocol.test.ts
+++ b/tests/protocol/vercel.modern-protocol.test.ts
@@ -10,12 +10,12 @@ import { B2Simulator } from "@backblaze-labs/b2-sdk/simulator";
 import { closeVercelMcpHandlerForTests } from "../../deploy/vercel/adapter";
 import { invalidateAuthManagerCache, invalidateCapabilityCache } from "../../src/server";
 import {
-  MCP_REVISION,
   contractSdkVersions,
   toolFixtureFromCollected,
   type CollectedToolList,
-  type ToolFixture,
+  type ContractArtifact,
   type ToolContractPackageJson,
+  type ToolFixture,
 } from "../../src/tool-contract";
 import { readJson } from "../contract/support";
 import { setB2SdkClientFactoryForTests } from "../support/sdk-factory-hook";
@@ -28,37 +28,72 @@ import {
 } from "./support/vercel";
 
 const savedEnv = { ...process.env };
-const fullModernFixture = readJson<ToolFixture>("tests/fixtures/tool-contract/full.modern.json");
+const contract = readJson<ContractArtifact>("docs/tool-profile-contract.json");
+const fullModernFixture = readJson<ToolFixture>(contract.profiles.full.fixtures.modern);
 const packageJson = readJson<ToolContractPackageJson>("package.json");
 
-function collectVercelFixture(
+type VercelClient = Awaited<ReturnType<typeof connectVercelClient>>["client"];
+type VercelRequests = Awaited<ReturnType<typeof connectVercelClient>>["requests"];
+
+function collectVercelToolsList(
   listed: Record<string, unknown>,
   discover: Record<string, unknown>,
   protocolVersion: string,
-): ToolFixture {
-  return toolFixtureFromCollected({
-    contractVersion: fullModernFixture.contractVersion,
-    issue: fullModernFixture.issue,
-    profile: fullModernFixture.profile,
-    era: fullModernFixture.era,
-    transport: fullModernFixture.transport,
-    mcpRevision: MCP_REVISION,
-    sdk: contractSdkVersions(packageJson),
-    capabilities: fullModernFixture.capabilities,
-    collected: {
-      tools: Array.isArray(listed.tools) ? (listed.tools as CollectedToolList["tools"]) : [],
-      list: listed as CollectedToolList["list"],
-      discover: discover as CollectedToolList["discover"],
-      protocolVersion,
-    },
-  });
+): CollectedToolList {
+  return {
+    tools: Array.isArray(listed.tools) ? (listed.tools as CollectedToolList["tools"]) : [],
+    list: listed as CollectedToolList["list"],
+    discover: discover as CollectedToolList["discover"],
+    protocolVersion,
+  };
 }
 
-function expectVercelProfileToMatchFrozenFixture(actual: ToolFixture): void {
-  expect(actual).toEqual({
-    ...fullModernFixture,
-    mcpRevision: MCP_REVISION,
-  });
+async function collectModernVercelTools(client: VercelClient): Promise<{
+  discover: Record<string, unknown>;
+  listed: Record<string, unknown>;
+  collected: CollectedToolList;
+}> {
+  const discover = (client.getDiscoverResult() ?? (await client.discover())) as Record<
+    string,
+    unknown
+  >;
+  const listed = (await client.listTools(undefined, { cacheMode: "refresh" })) as Record<
+    string,
+    unknown
+  >;
+
+  return {
+    discover,
+    listed,
+    collected: collectVercelToolsList(
+      listed,
+      discover,
+      client.getNegotiatedProtocolVersion() ?? "",
+    ),
+  };
+}
+
+function expectVercelProfileToMatchFrozenFixture(collected: CollectedToolList): void {
+  expect(
+    toolFixtureFromCollected({
+      contractVersion: contract.contractVersion,
+      issue: contract.issue,
+      profile: "full",
+      era: "modern",
+      transport: fullModernFixture.transport,
+      mcpRevision: contract.mcpRevision,
+      sdk: contractSdkVersions(packageJson),
+      capabilities: contract.profiles.full.capabilities,
+      collected,
+    }),
+  ).toEqual(fullModernFixture);
+}
+
+function expectStatelessModernRequests(requests: VercelRequests): void {
+  expect(requests.every((record) => record.method === "POST")).toBe(true);
+  expect(requests.some((record) => record.headers["mcp-method"] === "server/discover")).toBe(true);
+  expect(requests.some((record) => record.headers["mcp-method"] === "tools/list")).toBe(true);
+  expect(requests.every((record) => record.headers["mcp-session-id"] === undefined)).toBe(true);
 }
 
 beforeEach(async () => {
@@ -89,28 +124,34 @@ afterEach(async () => {
 });
 
 describe("Vercel adapter (MCP 2026-07-28)", () => {
-  it("serves discover, list, and representative calls without listen()", async () => {
-    const { client, requests } = await connectVercelClient("modern");
+  it("matches the frozen modern tool profile through Vercel", async () => {
+    const { client } = await connectVercelClient("modern");
     try {
       expect(client.getProtocolEra()).toBe("modern");
       expect(client.getNegotiatedProtocolVersion()).toBe(MODERN_PROTOCOL_VERSION);
 
-      const discover = client.getDiscoverResult() ?? (await client.discover());
+      const { discover, collected } = await collectModernVercelTools(client);
       expect(discover.supportedVersions).toContain(MODERN_PROTOCOL_VERSION);
       expect(discover.cacheScope).toBe("private");
+      expectVercelProfileToMatchFrozenFixture(collected);
+    } finally {
+      await closeClient(client);
+    }
+  });
 
-      const listed = await client.listTools(undefined, { cacheMode: "refresh" });
-      expectVercelProfileToMatchFrozenFixture(
-        collectVercelFixture(
-          listed as Record<string, unknown>,
-          discover as Record<string, unknown>,
-          client.getNegotiatedProtocolVersion() ?? "",
-        ),
-      );
-      const toolNames = listed.tools.map((tool) => tool.name);
-      expect(toolNames).toContain("b2_list_buckets");
-      expect(toolNames).toContain("s3_list_objects_v2");
+  it("uses stateless POST requests for modern discover and tools/list", async () => {
+    const { client, requests } = await connectVercelClient("modern");
+    try {
+      await collectModernVercelTools(client);
+      expectStatelessModernRequests(requests);
+    } finally {
+      await closeClient(client);
+    }
+  });
 
+  it("returns JSON text for B2 output and supports representative S3 calls", async () => {
+    const { client } = await connectVercelClient("modern");
+    try {
       const bucketName = "protocol-vercel-modern";
       expect(
         (
@@ -120,12 +161,14 @@ describe("Vercel adapter (MCP 2026-07-28)", () => {
           })
         ).isError,
       ).not.toBe(true);
+
       const b2Call = await client.callTool({ name: "b2_list_buckets", arguments: {} });
       expect(b2Call.isError).not.toBe(true);
       expect(b2Call.structuredContent).toBeDefined();
       expect(b2Call.content).toEqual([
         { type: "text", text: JSON.stringify(b2Call.structuredContent) },
       ]);
+
       expect(
         (
           await client.callTool({
@@ -134,14 +177,14 @@ describe("Vercel adapter (MCP 2026-07-28)", () => {
           })
         ).isError,
       ).not.toBe(true);
+    } finally {
+      await closeClient(client);
+    }
+  });
 
-      expect(requests.every((record) => record.method === "POST")).toBe(true);
-      expect(requests.some((record) => record.headers["mcp-method"] === "server/discover")).toBe(
-        true,
-      );
-      expect(requests.some((record) => record.headers["mcp-method"] === "tools/list")).toBe(true);
-      expect(requests.every((record) => record.headers["mcp-session-id"] === undefined)).toBe(true);
-
+  it("returns schema-validation errors through the Vercel path", async () => {
+    const { client } = await connectVercelClient("modern");
+    try {
       const schemaFailure = await client.callTool({
         name: "b2_create_bucket",
         arguments: { bucketType: "allPrivate" },

--- a/tests/support/oauth-introspection.ts
+++ b/tests/support/oauth-introspection.ts
@@ -1,0 +1,24 @@
+export function introspectionClaims(
+  overrides: Record<string, unknown> = {},
+): Record<string, unknown> {
+  return {
+    active: true,
+    iss: "https://issuer.example.com/",
+    sub: "subject",
+    aud: ["https://mcp.example.com/mcp"],
+    resource: ["https://mcp.example.com/mcp"],
+    exp: Math.floor(Date.now() / 1000) + 600,
+    token_type: "bearer",
+    alg: "RS256",
+    scope: "b2:read",
+    client_id: "client",
+    ...overrides,
+  };
+}
+
+export function introspectionResponse(overrides: Record<string, unknown> = {}): Response {
+  return new Response(JSON.stringify(introspectionClaims(overrides)), {
+    status: 200,
+    headers: { "Content-Type": "application/json" },
+  });
+}

--- a/tests/unit/cloudflare-worker-adapter.unit.test.ts
+++ b/tests/unit/cloudflare-worker-adapter.unit.test.ts
@@ -8,6 +8,7 @@ import {
 } from "../../deploy/cloudflare-worker/adapter";
 import { deriveRateKey } from "../../src/http-fetch-handler";
 import { _getBucket, _resetRateLimiter } from "../../src/utils/rate-limiter";
+import { introspectionResponse } from "../support/oauth-introspection";
 
 const savedEnv = { ...process.env };
 
@@ -78,29 +79,6 @@ function modernHeaders(method: string): Record<string, string> {
     "Mcp-Protocol-Version": "2026-07-28",
     "Mcp-Method": method,
   };
-}
-
-function introspectionClaims(overrides: Record<string, unknown> = {}): Record<string, unknown> {
-  return {
-    active: true,
-    iss: "https://issuer.example.com/",
-    sub: "subject",
-    aud: ["https://mcp.example.com/mcp"],
-    resource: ["https://mcp.example.com/mcp"],
-    exp: Math.floor(Date.now() / 1000) + 600,
-    token_type: "bearer",
-    alg: "RS256",
-    scope: "b2:read",
-    client_id: "client",
-    ...overrides,
-  };
-}
-
-function introspectionResponse(overrides: Record<string, unknown> = {}): Response {
-  return new Response(JSON.stringify(introspectionClaims(overrides)), {
-    status: 200,
-    headers: { "Content-Type": "application/json" },
-  });
 }
 
 async function rpcJson(response: Response): Promise<Record<string, any>> {

--- a/tests/unit/vercel-adapter.unit.test.ts
+++ b/tests/unit/vercel-adapter.unit.test.ts
@@ -111,14 +111,6 @@ async function rpcJson(response: Response): Promise<Record<string, any>> {
   return JSON.parse(dataLine ?? text) as Record<string, any>;
 }
 
-function expectAuthenticatedMcpCacheHeader(response: Response): void {
-  const cacheControl = response.headers.get("cache-control");
-  if (!cacheControl) return;
-
-  expect(cacheControl).not.toMatch(/(?:^|,)\s*(?:public|s-maxage)\b/i);
-  expect(cacheControl).toMatch(/(?:^|,)\s*(?:private|no-store|no-cache)\b/i);
-}
-
 describe("Vercel adapter", () => {
   beforeEach(async () => {
     await closeVercelMcpHandlerForTests();
@@ -228,30 +220,37 @@ describe("Vercel adapter", () => {
     expect(fetchMock).not.toHaveBeenCalled();
   });
 
-  it("rejects disallowed token claims despite allowed forged identity headers", async () => {
-    const introspection = vi
-      .fn()
-      .mockResolvedValue(
-        introspectionResponse({ sub: "attacker-subject", client_id: "attacker-client" }),
-      );
+  it("uses verified token claims instead of forged identity headers in principal mode", async () => {
+    process.env.B2_HTTP_CREDENTIAL_MODE = "principal";
+    process.env.B2_PRINCIPAL_CREDENTIAL_MAP = JSON.stringify({
+      "https://issuer.example.com/#subject": "tenant_a",
+    });
+    process.env.B2_CREDENTIAL_TENANT_A_APPLICATION_KEY_ID = "tenant-id";
+    process.env.B2_CREDENTIAL_TENANT_A_APPLICATION_KEY = "tenant-secret";
+    const introspection = vi.fn().mockResolvedValue(introspectionResponse());
     vi.stubGlobal("fetch", introspection);
 
-    const response = await vercelMcpFetch(
-      new Request("https://mcp.example.com/mcp", {
-        method: "POST",
-        headers: {
-          ...modernHeaders("tools/list"),
-          Authorization: "Bearer access-token",
-          "X-Principal": "subject",
-          "X-User": "subject",
-        },
-        body: modernBody("tools/list"),
-      }),
-      { remoteAddress: "203.0.113.42" },
+    const listed = await rpcJson(
+      await vercelMcpFetch(
+        new Request("https://mcp.example.com/mcp", {
+          method: "POST",
+          headers: {
+            ...modernHeaders("tools/list"),
+            Authorization: "Bearer access-token",
+            "X-Principal": "attacker-subject",
+            "X-User": "attacker-user",
+          },
+          body: modernBody("tools/list"),
+        }),
+        { remoteAddress: "203.0.113.42" },
+      ),
+    );
+    const toolNames = new Set(
+      ((listed.result?.tools ?? []) as Array<{ name: string }>).map((tool) => tool.name),
     );
 
-    expect(response.status).toBe(401);
-    expect(response.headers.get("www-authenticate")).toContain("Bearer");
+    expect(toolNames.has("b2_list_buckets")).toBe(true);
+    expect(toolNames.has("b2_create_bucket")).toBe(false);
     expect(introspection).toHaveBeenCalledTimes(1);
   });
 
@@ -278,8 +277,8 @@ describe("Vercel adapter", () => {
       ((listed.result?.tools ?? []) as Array<{ name: string }>).map((tool) => tool.name),
     );
 
-    expectAuthenticatedMcpCacheHeader(discoverResponse);
-    expectAuthenticatedMcpCacheHeader(listedResponse);
+    expect(discoverResponse.headers.get("cache-control")).toBeNull();
+    expect(listedResponse.headers.get("cache-control")).toBeNull();
     expect(discover.result?.supportedVersions).toContain("2026-07-28");
     expect(discover.result?.capabilities?.tools).toBeDefined();
     expect(discover.result?.ttlMs).toBe(30_000);

--- a/tests/unit/vercel-adapter.unit.test.ts
+++ b/tests/unit/vercel-adapter.unit.test.ts
@@ -8,6 +8,7 @@ import {
   vercelProtectedResourceMetadataFetch,
 } from "../../deploy/vercel/adapter";
 import { logger } from "../../src/utils/logger";
+import { introspectionResponse } from "../support/oauth-introspection";
 
 const savedEnv = { ...process.env };
 
@@ -100,29 +101,6 @@ function legacyBody(method: string, params: Record<string, unknown> = {}, id = 2
   return JSON.stringify({ jsonrpc: "2.0", id, method, params });
 }
 
-function introspectionClaims(overrides: Record<string, unknown> = {}): Record<string, unknown> {
-  return {
-    active: true,
-    iss: "https://issuer.example.com/",
-    sub: "subject",
-    aud: ["https://mcp.example.com/mcp"],
-    resource: ["https://mcp.example.com/mcp"],
-    exp: Math.floor(Date.now() / 1000) + 600,
-    token_type: "bearer",
-    alg: "RS256",
-    scope: "b2:read",
-    client_id: "client",
-    ...overrides,
-  };
-}
-
-function introspectionResponse(overrides: Record<string, unknown> = {}): Response {
-  return new Response(JSON.stringify(introspectionClaims(overrides)), {
-    status: 200,
-    headers: { "Content-Type": "application/json" },
-  });
-}
-
 async function rpcJson(response: Response): Promise<Record<string, any>> {
   expect(response.status).toBe(200);
   const text = await response.text();
@@ -131,6 +109,14 @@ async function rpcJson(response: Response): Promise<Record<string, any>> {
     .find((line) => line.startsWith("data: "))
     ?.slice("data: ".length);
   return JSON.parse(dataLine ?? text) as Record<string, any>;
+}
+
+function expectAuthenticatedMcpCacheHeader(response: Response): void {
+  const cacheControl = response.headers.get("cache-control");
+  if (!cacheControl) return;
+
+  expect(cacheControl).not.toMatch(/(?:^|,)\s*(?:public|s-maxage)\b/i);
+  expect(cacheControl).toMatch(/(?:^|,)\s*(?:private|no-store|no-cache)\b/i);
 }
 
 describe("Vercel adapter", () => {
@@ -242,31 +228,30 @@ describe("Vercel adapter", () => {
     expect(fetchMock).not.toHaveBeenCalled();
   });
 
-  it("ignores forged identity headers and uses verified token claims", async () => {
-    const introspection = vi.fn().mockResolvedValue(introspectionResponse());
+  it("rejects disallowed token claims despite allowed forged identity headers", async () => {
+    const introspection = vi
+      .fn()
+      .mockResolvedValue(
+        introspectionResponse({ sub: "attacker-subject", client_id: "attacker-client" }),
+      );
     vi.stubGlobal("fetch", introspection);
 
-    const listed = await rpcJson(
-      await vercelMcpFetch(
-        new Request("https://mcp.example.com/mcp", {
-          method: "POST",
-          headers: {
-            ...modernHeaders("tools/list"),
-            Authorization: "Bearer access-token",
-            "X-Principal": "attacker-subject",
-            "X-User": "attacker-user",
-          },
-          body: modernBody("tools/list"),
-        }),
-        { remoteAddress: "203.0.113.42" },
-      ),
-    );
-    const toolNames = new Set(
-      ((listed.result?.tools ?? []) as Array<{ name: string }>).map((tool) => tool.name),
+    const response = await vercelMcpFetch(
+      new Request("https://mcp.example.com/mcp", {
+        method: "POST",
+        headers: {
+          ...modernHeaders("tools/list"),
+          Authorization: "Bearer access-token",
+          "X-Principal": "subject",
+          "X-User": "subject",
+        },
+        body: modernBody("tools/list"),
+      }),
+      { remoteAddress: "203.0.113.42" },
     );
 
-    expect(toolNames.has("b2_list_buckets")).toBe(true);
-    expect(toolNames.has("b2_create_bucket")).toBe(false);
+    expect(response.status).toBe(401);
+    expect(response.headers.get("www-authenticate")).toContain("Bearer");
     expect(introspection).toHaveBeenCalledTimes(1);
   });
 
@@ -293,8 +278,8 @@ describe("Vercel adapter", () => {
       ((listed.result?.tools ?? []) as Array<{ name: string }>).map((tool) => tool.name),
     );
 
-    expect(discoverResponse.headers.get("cache-control") ?? "").not.toMatch(/\bpublic\b/i);
-    expect(listedResponse.headers.get("cache-control") ?? "").not.toMatch(/\bpublic\b/i);
+    expectAuthenticatedMcpCacheHeader(discoverResponse);
+    expectAuthenticatedMcpCacheHeader(listedResponse);
     expect(discover.result?.supportedVersions).toContain("2026-07-28");
     expect(discover.result?.capabilities?.tools).toBeDefined();
     expect(discover.result?.ttlMs).toBe(30_000);

--- a/tests/unit/vercel-adapter.unit.test.ts
+++ b/tests/unit/vercel-adapter.unit.test.ts
@@ -100,6 +100,29 @@ function legacyBody(method: string, params: Record<string, unknown> = {}, id = 2
   return JSON.stringify({ jsonrpc: "2.0", id, method, params });
 }
 
+function introspectionClaims(overrides: Record<string, unknown> = {}): Record<string, unknown> {
+  return {
+    active: true,
+    iss: "https://issuer.example.com/",
+    sub: "subject",
+    aud: ["https://mcp.example.com/mcp"],
+    resource: ["https://mcp.example.com/mcp"],
+    exp: Math.floor(Date.now() / 1000) + 600,
+    token_type: "bearer",
+    alg: "RS256",
+    scope: "b2:read",
+    client_id: "client",
+    ...overrides,
+  };
+}
+
+function introspectionResponse(overrides: Record<string, unknown> = {}): Response {
+  return new Response(JSON.stringify(introspectionClaims(overrides)), {
+    status: 200,
+    headers: { "Content-Type": "application/json" },
+  });
+}
+
 async function rpcJson(response: Response): Promise<Record<string, any>> {
   expect(response.status).toBe(200);
   const text = await response.text();
@@ -170,15 +193,23 @@ describe("Vercel adapter", () => {
   });
 
   it.each([
-    ["wrong path", "https://mcp.example.com/not-mcp", "POST", jsonHeaders()],
-    ["wrong method", "https://mcp.example.com/mcp", "PUT", jsonHeaders()],
+    ["wrong path", "https://mcp.example.com/not-mcp", "POST", jsonHeaders(), 404],
+    ["wrong method", "https://mcp.example.com/mcp", "PUT", jsonHeaders(), 405],
+    [
+      "wrong host",
+      "https://mcp.example.com/mcp",
+      "POST",
+      jsonHeaders({ host: "evil.example.com" }),
+      403,
+    ],
     [
       "wrong origin",
       "https://mcp.example.com/mcp",
       "POST",
       jsonHeaders({ Origin: "https://evil.example.com" }),
+      403,
     ],
-  ])("rejects %s before OAuth introspection", async (_name, url, method, headers) => {
+  ])("rejects %s before OAuth introspection", async (_name, url, method, headers, status) => {
     const fetchMock = vi.fn();
     vi.stubGlobal("fetch", fetchMock);
 
@@ -190,37 +221,86 @@ describe("Vercel adapter", () => {
       }),
     );
 
-    expect([403, 404, 405]).toContain(response.status);
+    expect(response.status).toBe(status);
     expect(fetchMock).not.toHaveBeenCalled();
   });
 
-  it("serves modern discovery and tools/list through the Vercel adapter", async () => {
-    const discover = await rpcJson(
-      await vercelMcpFetch(
-        new Request("https://mcp.example.com/mcp", {
-          method: "POST",
-          headers: modernHeaders("server/discover"),
-          body: modernBody("server/discover"),
-        }),
-        validAuthInfo,
-      ),
+  it("rejects malformed Authorization headers before OAuth introspection", async () => {
+    const fetchMock = vi.fn();
+    vi.stubGlobal("fetch", fetchMock);
+
+    const response = await vercelMcpFetch(
+      new Request("https://mcp.example.com/mcp", {
+        method: "POST",
+        headers: jsonHeaders({ Authorization: "Basic access-token" }),
+        body: modernBody("tools/list"),
+      }),
     );
+
+    expect(response.status).toBe(401);
+    expect(response.headers.get("www-authenticate")).toContain("Bearer");
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("ignores forged identity headers and uses verified token claims", async () => {
+    const introspection = vi.fn().mockResolvedValue(introspectionResponse());
+    vi.stubGlobal("fetch", introspection);
+
     const listed = await rpcJson(
       await vercelMcpFetch(
         new Request("https://mcp.example.com/mcp", {
           method: "POST",
-          headers: modernHeaders("tools/list"),
-          body: modernBody("tools/list", {}, 2),
+          headers: {
+            ...modernHeaders("tools/list"),
+            Authorization: "Bearer access-token",
+            "X-Principal": "attacker-subject",
+            "X-User": "attacker-user",
+          },
+          body: modernBody("tools/list"),
         }),
-        validAuthInfo,
+        { remoteAddress: "203.0.113.42" },
       ),
     );
     const toolNames = new Set(
       ((listed.result?.tools ?? []) as Array<{ name: string }>).map((tool) => tool.name),
     );
 
+    expect(toolNames.has("b2_list_buckets")).toBe(true);
+    expect(toolNames.has("b2_create_bucket")).toBe(false);
+    expect(introspection).toHaveBeenCalledTimes(1);
+  });
+
+  it("serves modern discovery and tools/list through the Vercel adapter", async () => {
+    const discoverResponse = await vercelMcpFetch(
+      new Request("https://mcp.example.com/mcp", {
+        method: "POST",
+        headers: modernHeaders("server/discover"),
+        body: modernBody("server/discover"),
+      }),
+      validAuthInfo,
+    );
+    const listedResponse = await vercelMcpFetch(
+      new Request("https://mcp.example.com/mcp", {
+        method: "POST",
+        headers: modernHeaders("tools/list"),
+        body: modernBody("tools/list", {}, 2),
+      }),
+      validAuthInfo,
+    );
+    const discover = await rpcJson(discoverResponse);
+    const listed = await rpcJson(listedResponse);
+    const toolNames = new Set(
+      ((listed.result?.tools ?? []) as Array<{ name: string }>).map((tool) => tool.name),
+    );
+
+    expect(discoverResponse.headers.get("cache-control") ?? "").not.toMatch(/\bpublic\b/i);
+    expect(listedResponse.headers.get("cache-control") ?? "").not.toMatch(/\bpublic\b/i);
     expect(discover.result?.supportedVersions).toContain("2026-07-28");
     expect(discover.result?.capabilities?.tools).toBeDefined();
+    expect(discover.result?.ttlMs).toBe(30_000);
+    expect(discover.result?.cacheScope).toBe("private");
+    expect(listed.result?.ttlMs).toBe(30_000);
+    expect(listed.result?.cacheScope).toBe("private");
     expect(toolNames.has("b2_list_buckets")).toBe(true);
     expect(toolNames.has("b2_create_bucket")).toBe(false);
   });

--- a/tests/unit/vercel-adapter.unit.test.ts
+++ b/tests/unit/vercel-adapter.unit.test.ts
@@ -220,37 +220,34 @@ describe("Vercel adapter", () => {
     expect(fetchMock).not.toHaveBeenCalled();
   });
 
-  it("uses verified token claims instead of forged identity headers in principal mode", async () => {
+  it("rejects disallowed token claims despite forged identity headers", async () => {
     process.env.B2_HTTP_CREDENTIAL_MODE = "principal";
     process.env.B2_PRINCIPAL_CREDENTIAL_MAP = JSON.stringify({
       "https://issuer.example.com/#subject": "tenant_a",
     });
     process.env.B2_CREDENTIAL_TENANT_A_APPLICATION_KEY_ID = "tenant-id";
     process.env.B2_CREDENTIAL_TENANT_A_APPLICATION_KEY = "tenant-secret";
-    const introspection = vi.fn().mockResolvedValue(introspectionResponse());
+    const introspection = vi
+      .fn()
+      .mockResolvedValue(introspectionResponse({ sub: "attacker-subject", scope: "b2:admin" }));
     vi.stubGlobal("fetch", introspection);
 
-    const listed = await rpcJson(
-      await vercelMcpFetch(
-        new Request("https://mcp.example.com/mcp", {
-          method: "POST",
-          headers: {
-            ...modernHeaders("tools/list"),
-            Authorization: "Bearer access-token",
-            "X-Principal": "attacker-subject",
-            "X-User": "attacker-user",
-          },
-          body: modernBody("tools/list"),
-        }),
-        { remoteAddress: "203.0.113.42" },
-      ),
-    );
-    const toolNames = new Set(
-      ((listed.result?.tools ?? []) as Array<{ name: string }>).map((tool) => tool.name),
+    const response = await vercelMcpFetch(
+      new Request("https://mcp.example.com/mcp", {
+        method: "POST",
+        headers: {
+          ...modernHeaders("tools/list"),
+          Authorization: "Bearer access-token",
+          "X-Principal": "subject",
+          "X-User": "subject",
+        },
+        body: modernBody("tools/list"),
+      }),
+      { remoteAddress: "203.0.113.42" },
     );
 
-    expect(toolNames.has("b2_list_buckets")).toBe(true);
-    expect(toolNames.has("b2_create_bucket")).toBe(false);
+    expect(response.status).toBe(401);
+    expect(response.headers.get("www-authenticate")).toContain("Bearer");
     expect(introspection).toHaveBeenCalledTimes(1);
   });
 


### PR DESCRIPTION
## Summary
- Added direct Vercel modern `/mcp` parity coverage against the frozen `full.modern.json` tool profile through the shared `toolFixtureFromCollected` contract path, including normalized schemas, annotations, description hashes, protocol metadata, output formats, error shapes, and cache hints.
- Shared the frozen-profile collector and OAuth introspection test helpers so the Vercel, HTTP contract, and serverless-adapter tests use one fixture shape.
- Split the Vercel modern protocol coverage into focused parity, stateless-request, representative-call, and schema-validation tests.
- Added Vercel adapter hardening assertions for disallowed introspection claims despite forged identity headers, malformed `Authorization`, exact unsupported-method `405`, wrong-`Host` rejection, and absent HTTP `Cache-Control` on authenticated discovery/tools-list responses.
- Kept cache validation focused on MCP `ttlMs`/`cacheScope:"private"` protocol hints because the adapter intentionally emits no HTTP cache header for `/mcp`.

## Linked issue
Closes #142

## Tests run
- `pnpm exec node scripts/run-vitest-layer.mjs unit -- tests/unit/vercel-adapter.unit.test.ts`
- `pnpm exec node scripts/run-vitest-layer.mjs protocol-modern -- tests/protocol/vercel.modern-protocol.test.ts`
- `pnpm exec node scripts/run-vitest-layer.mjs contract -- tests/contract/tool-profile-contract.contract.test.ts`
- `pnpm run typecheck`
- `pnpm run verify`

## Follow-up notes
- No production behavior was changed.