### PR TITLE
Ratchet coverage thresholds after coverage push

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -122,7 +122,7 @@ jobs:
         run: |
           echo "## Coverage summary" >> "$GITHUB_STEP_SUMMARY"
           echo "Node.js ${{ matrix.node-version }}" >> "$GITHUB_STEP_SUMMARY"
-          echo "Required: statements 82%, branches 72%, functions 86%, lines 86%." >> "$GITHUB_STEP_SUMMARY"
+          echo "Required: statements 90.5%, branches 81.8%, functions 94.6%, lines 93.8%." >> "$GITHUB_STEP_SUMMARY"
           echo '```' >> "$GITHUB_STEP_SUMMARY"
           if [ -f coverage/coverage-summary.json ]; then
             node -e "

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 [![TypeScript](https://img.shields.io/badge/TypeScript-6.x-3178c6?logo=typescript&logoColor=white)](https://www.typescriptlang.org/)
 [![Node.js](https://img.shields.io/badge/Node.js-%E2%89%A522.3-339933?logo=nodedotjs&logoColor=white)](https://nodejs.org/)
 [![MCP](https://img.shields.io/badge/MCP-2026--07--28-5b5fc7)](https://modelcontextprotocol.io/specification/2026-07-28)
-[![Coverage floors](https://img.shields.io/badge/coverage-S%2082%20%7C%20B%2072%20%7C%20F%2086%20%7C%20L%2086-brightgreen)](docs/TESTING.md)
+[![Coverage floors](https://img.shields.io/badge/coverage-S%2090.5%20%7C%20B%2081.8%20%7C%20F%2094.6%20%7C%20L%2093.8-brightgreen)](docs/TESTING.md)
 [![Runtime dependencies](https://img.shields.io/badge/runtime_dependencies-8-blue)](package-budget.json)
 
 A [Model Context Protocol](https://modelcontextprotocol.io) server for [Backblaze B2 Cloud Storage](https://www.backblaze.com/cloud-storage). It lets any MCP-compatible AI client (Claude, and others) operate B2 through a focused, safe set of tools.

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -69,9 +69,9 @@ The stable required PR check names are:
 - `slow/lifecycle`
 - `cross-platform minimum`
 
-Global V8 coverage must remain at or above 82% statements, 72% branches, 86%
-functions, and 86% lines. Raise these floors as coverage improves; lowering
-them requires explicit review and justification. Coverage collection is source
+Global V8 coverage must remain at or above 90.5% statements, 81.8% branches,
+94.6% functions, and 93.8% lines. Raise these floors as coverage improves;
+lowering them requires explicit review and justification. Coverage collection is source
 only: `src/**/*.ts`, excluding `dist/`, declarations, generated files, and test
 files. The current Phase 1 floor is a ratchet: when `coverage/coverage-summary.json`
 shows every global percentage at least two points above the floor for three

--- a/tests/contract/test-layering.contract.test.ts
+++ b/tests/contract/test-layering.contract.test.ts
@@ -366,14 +366,14 @@ describe("test layer naming", () => {
     const readme = readFileSync(join(root, "README.md"), "utf8");
 
     expect(vitestConfig).toMatch(
-      /thresholds:\s*{\s*statements:\s*82,\s*branches:\s*72,\s*functions:\s*86,\s*lines:\s*86,?\s*}/,
+      /thresholds:\s*{\s*statements:\s*90\.5,\s*branches:\s*81\.8,\s*functions:\s*94\.6,\s*lines:\s*93\.8,?\s*}/,
     );
     expect(vitestConfig).toContain('include: ["src/**/*.ts"]');
     expect(vitestConfig).toContain('"html"');
     expect(vitestConfig).toContain('"lcov"');
     expect(vitestConfig).toContain('"cobertura"');
     expect(readme).toContain(
-      "coverage-S%2082%20%7C%20B%2072%20%7C%20F%2086%20%7C%20L%2086-brightgreen",
+      "coverage-S%2090.5%20%7C%20B%2081.8%20%7C%20F%2094.6%20%7C%20L%2093.8-brightgreen",
     );
   });
 

--- a/tests/contract/test-layering.contract.test.ts
+++ b/tests/contract/test-layering.contract.test.ts
@@ -364,6 +364,8 @@ describe("test layer naming", () => {
   it("enforces the current global coverage floors", () => {
     const vitestConfig = readFileSync(join(root, "vitest.config.mts"), "utf8");
     const readme = readFileSync(join(root, "README.md"), "utf8");
+    const testingGuide = readFileSync(join(root, "docs/TESTING.md"), "utf8");
+    const ciWorkflow = readFileSync(join(root, ".github/workflows/test.yml"), "utf8");
 
     expect(vitestConfig).toMatch(
       /thresholds:\s*{\s*statements:\s*90\.5,\s*branches:\s*81\.8,\s*functions:\s*94\.6,\s*lines:\s*93\.8,?\s*}/,
@@ -374,6 +376,12 @@ describe("test layer naming", () => {
     expect(vitestConfig).toContain('"cobertura"');
     expect(readme).toContain(
       "coverage-S%2090.5%20%7C%20B%2081.8%20%7C%20F%2094.6%20%7C%20L%2093.8-brightgreen",
+    );
+    expect(testingGuide).toMatch(
+      /Global V8 coverage must remain at or above 90\.5% statements,\s*81\.8% branches,\s*94\.6% functions, and 93\.8% lines\./,
+    );
+    expect(ciWorkflow).toContain(
+      "Required: statements 90.5%, branches 81.8%, functions 94.6%, lines 93.8%.",
     );
   });
 

--- a/vitest.config.mts
+++ b/vitest.config.mts
@@ -34,10 +34,10 @@ export default defineConfig({
       include: ["src/**/*.ts"],
       exclude: ["dist/**", "tests/**", "**/*.d.ts", "**/*.test.ts", "**/generated/**"],
       thresholds: {
-        statements: 82,
-        branches: 72,
-        functions: 86,
-        lines: 86,
+        statements: 90.5,
+        branches: 81.8,
+        functions: 94.6,
+        lines: 93.8,
       },
     },
     projects: layerProjectNamesForConfig().map((name) =>


### PR DESCRIPTION
## Summary
- Raises Vitest global coverage thresholds to statements 90.5, branches 81.8, functions 94.6, and lines 93.8.
- Updates the coverage policy contract, README coverage badge, docs/TESTING.md policy prose, and CI step-summary text to match the new floors.
- Records the current measured baseline: statements 90.9% (4080/4488), branches 82.17% (2647/3221), functions 94.94% (957/1008), lines 94.12% (3702/3933).

## Linked issue
Fixes #149

## Tests run
- `pnpm run test:coverage`
- `pnpm run test:contract`
- `pnpm run lint:docs`
- `pnpm run format:check`

## Follow-up notes
- Thresholds intentionally leave a few tenths of buffer below the measured coverage baseline for nondeterministic line accounting.
- Three completed local `pnpm run test:coverage` runs reported the same measured baseline: statements 90.9%, branches 82.17%, functions 94.94%, lines 94.12%.