### PR TITLE
fix: update tootallnate once dependency

### DIFF
--- a/deploy/customer-hosted/pnpm-lock.yaml
+++ b/deploy/customer-hosted/pnpm-lock.yaml
@@ -13,6 +13,7 @@ overrides:
   '@vercel/express>path-to-regexp': 8.4.0
   '@vercel/fun>path-to-regexp': 8.4.0
   '@vercel/fun>tar': 7.5.21
+  '@vercel/fun>@tootallnate/once': 2.0.1
   '@vercel/hono>path-to-regexp': 8.4.0
   '@vercel/node>path-to-regexp': 6.3.0
   '@vercel/node>undici': 6.28.0
@@ -1647,8 +1648,8 @@ packages:
   '@toon-format/toon@4.1.0':
     resolution: {integrity: sha512-dBB3pkEx9QYvHnHR6rtkaBAh+7x4W/oA5ONur4G0fh7Ow69PbPuM7OFxzNRABqyxC0t6SZ3RixiGbCuaFjPDAQ==}
 
-  '@tootallnate/once@2.0.0':
-    resolution: {integrity: sha512-XCuKFP5PS55gnMVu3dty8KPatLqUoy/ZYzDzAGCQ8JNFCkLXzmI7vNHCR+XpbZaMWQK/vQubr7PkYq8g470J/A==}
+  '@tootallnate/once@2.0.1':
+    resolution: {integrity: sha512-HqmEUIGRJ5fSXchkVgR5F7qn48bDBzv0kWj/Kfu5e6uci4UlEeng4331LnBkWffb++Ei3FOVLxo8JJWMFBDMeQ==}
     engines: {node: '>= 10'}
 
   '@ts-morph/common@0.11.1':
@@ -5395,7 +5396,7 @@ snapshots:
 
   '@toon-format/toon@4.1.0': {}
 
-  '@tootallnate/once@2.0.0': {}
+  '@tootallnate/once@2.0.1': {}
 
   '@ts-morph/common@0.11.1':
     dependencies:
@@ -5678,7 +5679,7 @@ snapshots:
 
   '@vercel/fun@1.3.0(supports-color@10.2.2)':
     dependencies:
-      '@tootallnate/once': 2.0.0
+      '@tootallnate/once': 2.0.1
       async-listen: 1.2.0
       debug: 4.3.4(supports-color@10.2.2)
       generic-pool: 3.4.2

--- a/deploy/customer-hosted/pnpm-workspace.yaml
+++ b/deploy/customer-hosted/pnpm-workspace.yaml
@@ -35,6 +35,7 @@ overrides:
   '@vercel/express>path-to-regexp': 8.4.0
   '@vercel/fun>path-to-regexp': 8.4.0
   '@vercel/fun>tar': 7.5.21
+  '@vercel/fun>@tootallnate/once': 2.0.1
   '@vercel/hono>path-to-regexp': 8.4.0
   '@vercel/node>path-to-regexp': 6.3.0
   '@vercel/node>undici': 6.28.0

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -13,6 +13,7 @@ overrides:
   '@vercel/express>path-to-regexp': 8.4.0
   '@vercel/fun>path-to-regexp': 8.4.0
   '@vercel/fun>tar': 7.5.21
+  '@vercel/fun>@tootallnate/once': 2.0.1
   '@vercel/hono>path-to-regexp': 8.4.0
   '@vercel/node>path-to-regexp': 6.3.0
   '@vercel/node>undici': 6.28.0
@@ -1647,8 +1648,8 @@ packages:
   '@toon-format/toon@4.1.0':
     resolution: {integrity: sha512-dBB3pkEx9QYvHnHR6rtkaBAh+7x4W/oA5ONur4G0fh7Ow69PbPuM7OFxzNRABqyxC0t6SZ3RixiGbCuaFjPDAQ==}
 
-  '@tootallnate/once@2.0.0':
-    resolution: {integrity: sha512-XCuKFP5PS55gnMVu3dty8KPatLqUoy/ZYzDzAGCQ8JNFCkLXzmI7vNHCR+XpbZaMWQK/vQubr7PkYq8g470J/A==}
+  '@tootallnate/once@2.0.1':
+    resolution: {integrity: sha512-HqmEUIGRJ5fSXchkVgR5F7qn48bDBzv0kWj/Kfu5e6uci4UlEeng4331LnBkWffb++Ei3FOVLxo8JJWMFBDMeQ==}
     engines: {node: '>= 10'}
 
   '@ts-morph/common@0.11.1':
@@ -5395,7 +5396,7 @@ snapshots:
 
   '@toon-format/toon@4.1.0': {}
 
-  '@tootallnate/once@2.0.0': {}
+  '@tootallnate/once@2.0.1': {}
 
   '@ts-morph/common@0.11.1':
     dependencies:
@@ -5678,7 +5679,7 @@ snapshots:
 
   '@vercel/fun@1.3.0(supports-color@10.2.2)':
     dependencies:
-      '@tootallnate/once': 2.0.0
+      '@tootallnate/once': 2.0.1
       async-listen: 1.2.0
       debug: 4.3.4(supports-color@10.2.2)
       generic-pool: 3.4.2

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -35,6 +35,7 @@ overrides:
   '@vercel/express>path-to-regexp': 8.4.0
   '@vercel/fun>path-to-regexp': 8.4.0
   '@vercel/fun>tar': 7.5.21
+  '@vercel/fun>@tootallnate/once': 2.0.1
   '@vercel/hono>path-to-regexp': 8.4.0
   '@vercel/node>path-to-regexp': 6.3.0
   '@vercel/node>undici': 6.28.0


### PR DESCRIPTION
## Summary
- Add pnpm overrides in the root and deploy/customer-hosted workspace configs so `@vercel/fun>@tootallnate/once` resolves to patched `2.0.1`.
- Regenerate the root and deploy/customer-hosted pnpm lockfiles so `@tootallnate/once@2.0.0` is no longer resolved.

## Dependabot alerts
- https://github.com/backblaze-labs/b2-mcp/security/dependabot/15
- https://github.com/backblaze-labs/b2-mcp/security/dependabot/16

## Tests run
- `/Users/gpenacastellanos/miniforge3/condabin/mamba run -n b2-mcp-dependabot-once pnpm install --frozen-lockfile`
- `/Users/gpenacastellanos/miniforge3/condabin/mamba run -n b2-mcp-dependabot-once pnpm run audit:supply-chain`

## Follow-up notes
- No follow-up required.