### PR TITLE
fix: disable publish dependency cache

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -44,7 +44,6 @@ jobs:
       - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020
         with:
           node-version: 22.23.1
-          cache: pnpm
           registry-url: https://registry.npmjs.org
       - name: Resolve protected release ref
         id: ref


### PR DESCRIPTION
## Summary
- Disable setup-node pnpm dependency caching in the publish prepare job to remove the CodeQL cache-poisoning path before release verification and artifact upload steps.
- Keep the existing protected tag resolution, pinned actions, release checks, and artifact verification flow unchanged.

## Linked Dependabot alerts
- https://github.com/backblaze-labs/b2-mcp/security/code-scanning/23
- https://github.com/backblaze-labs/b2-mcp/security/code-scanning/24
- https://github.com/backblaze-labs/b2-mcp/security/code-scanning/25
- https://github.com/backblaze-labs/b2-mcp/security/code-scanning/26
- https://github.com/backblaze-labs/b2-mcp/security/code-scanning/27
- https://github.com/backblaze-labs/b2-mcp/security/code-scanning/28
- https://github.com/backblaze-labs/b2-mcp/security/code-scanning/29
- https://github.com/backblaze-labs/b2-mcp/security/code-scanning/30
- https://github.com/backblaze-labs/b2-mcp/security/code-scanning/31
- https://github.com/backblaze-labs/b2-mcp/security/code-scanning/32

## Tests run
- /Users/gpenacastellanos/miniforge3/condabin/conda run -n b2-mcp-cache-poisoning pnpm run format:check
- /Users/gpenacastellanos/miniforge3/condabin/conda run -n b2-mcp-cache-poisoning node -e "const fs=require("fs"); const yaml=require("yaml"); yaml.parse(fs.readFileSync(".github/workflows/publish.yml","utf8")); console.log("publish workflow YAML parsed")"

## Follow-up notes
- Publish runs may spend extra time reinstalling dependencies because this removes the pnpm cache from the release prepare job.