### PR TITLE
fix: disable publish package manager cache

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -45,6 +45,7 @@ jobs:
         with:
           node-version: 22.23.1
           registry-url: https://registry.npmjs.org
+          package-manager-cache: false
       - name: Resolve protected release ref
         id: ref
         env:
@@ -196,6 +197,7 @@ jobs:
         with:
           node-version: 24.19.0
           registry-url: https://registry.npmjs.org
+          package-manager-cache: false
       - name: Preflight trusted publishing
         run: |
           set -euo pipefail

--- a/tests/unit/supply-chain-policy.unit.test.ts
+++ b/tests/unit/supply-chain-policy.unit.test.ts
@@ -770,6 +770,7 @@ describe("supply-chain audit policy", () => {
     expect(prepareJob).toContain("pnpm run typecheck");
     expect(prepareJob).toContain("pnpm run build");
     expect(prepareJob).toContain("persist-credentials: false");
+    expect(prepareJob).toContain("package-manager-cache: false");
     expect(githubReleaseJob).toContain("actions: read");
     expect(githubReleaseJob).toContain("contents: write");
     expect(githubReleaseJob).not.toContain("id-token: write");
@@ -778,6 +779,7 @@ describe("supply-chain audit policy", () => {
     expect(publishJob).toContain("id-token: write");
     expect(publishJob).toContain("actions: read");
     expect(publishJob).toContain("contents: read");
+    expect(publishJob).toContain("package-manager-cache: false");
     expect(publishJob).not.toContain("contents: write");
     expect(publishJob).not.toContain("actions/checkout");
     expect(publishJob).not.toContain("pnpm install");


### PR DESCRIPTION
## Summary
- Disable setup-node package manager auto-cache in the publish workflow's prepare job so release validation steps cannot save dependency caches after running checked-out release code.
- Disable setup-node package manager auto-cache in the trusted npm publish job.
- Add supply-chain policy assertions that both publish paths keep package-manager caching disabled.

## Linked Dependabot alerts
- https://github.com/backblaze-labs/b2-mcp/security/code-scanning/23
- https://github.com/backblaze-labs/b2-mcp/security/code-scanning/24
- https://github.com/backblaze-labs/b2-mcp/security/code-scanning/25
- https://github.com/backblaze-labs/b2-mcp/security/code-scanning/26
- https://github.com/backblaze-labs/b2-mcp/security/code-scanning/27
- https://github.com/backblaze-labs/b2-mcp/security/code-scanning/28
- https://github.com/backblaze-labs/b2-mcp/security/code-scanning/29
- https://github.com/backblaze-labs/b2-mcp/security/code-scanning/30
- https://github.com/backblaze-labs/b2-mcp/security/code-scanning/31
- https://github.com/backblaze-labs/b2-mcp/security/code-scanning/32

## Tests run
- `/Users/gpenacastellanos/miniforge3/condabin/conda run -n b2-mcp-cache-poisoning pnpm exec vitest run tests/unit/supply-chain-policy.unit.test.ts tests/contract/ci-workflow-policy.contract.test.ts tests/unit/workflow-yaml.unit.test.ts`
- `/Users/gpenacastellanos/miniforge3/condabin/conda run -n b2-mcp-cache-poisoning pnpm run verify`

## Follow-up notes
- No milestone was set because the linked code-scanning alerts do not provide milestone metadata.
