### PR TITLE
fix: harden publish release trigger

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,12 +1,8 @@
 name: Publish Package
 
 on:
-  workflow_dispatch:
-    inputs:
-      tag:
-        description: vMAJOR.MINOR.PATCH[-prerelease] tag; must be reachable from ci-green
-        required: true
-        type: string
+  release:
+    types: [published]
 
 permissions:
   contents: read
@@ -46,10 +42,10 @@ jobs:
           node-version: 22.23.1
           registry-url: https://registry.npmjs.org
           package-manager-cache: false
-      - name: Resolve protected release ref
+      - name: Resolve ci-green protected release ref
         id: ref
         env:
-          PUBLISH_TAG: ${{ inputs.tag }}
+          PUBLISH_TAG: ${{ github.event.release.tag_name }}
           PUBLISH_REMOTE: ${{ github.server_url }}/${{ github.repository }}.git
         run: |
           node scripts/resolve-publish-ref.mjs \
@@ -67,7 +63,7 @@ jobs:
           ACTIONS_RESULTS_URL: ""
           ACTIONS_RUNTIME_TOKEN: ""
           ACTIONS_RUNTIME_URL: ""
-          PUBLISH_TAG: ${{ inputs.tag }}
+          PUBLISH_TAG: ${{ github.event.release.tag_name }}
         run: node scripts/verify-release-input.mjs --tag "${PUBLISH_TAG}"
       - name: Fetch protected refs for denylist scan
         run: |
@@ -146,7 +142,7 @@ jobs:
           ACTIONS_RESULTS_URL: ""
           ACTIONS_RUNTIME_TOKEN: ""
           ACTIONS_RUNTIME_URL: ""
-          PUBLISH_TAG: ${{ inputs.tag }}
+          PUBLISH_TAG: ${{ github.event.release.tag_name }}
         run: |
           set -euo pipefail
           mkdir -p publish-package
@@ -383,7 +379,7 @@ jobs:
           ACTIONS_RUNTIME_URL: ""
           CHECKOUT_SHA: ${{ needs.prepare.outputs.checkout-sha }}
           GHCR_TOKEN: ${{ github.token }}
-          PUBLISH_TAG: ${{ inputs.tag }}
+          PUBLISH_TAG: ${{ github.event.release.tag_name }}
           REGISTRY_IMAGE: ghcr.io/${{ github.repository }}
         run: node scripts/publish-container-image.mjs
 
@@ -463,7 +459,7 @@ jobs:
           EXPECTED_SBOM_NAME: ${{ needs.prepare.outputs.sbom-name }}
           EXPECTED_CHECKSUMS_NAME: ${{ needs.prepare.outputs.checksums-name }}
           EXPECTED_RELEASE_NOTES_NAME: ${{ needs.prepare.outputs.release-notes-name }}
-          PUBLISH_TAG: ${{ inputs.tag }}
+          PUBLISH_TAG: ${{ github.event.release.tag_name }}
         run: |
           set -euo pipefail
           release_flags=(

--- a/tests/unit/supply-chain-policy.unit.test.ts
+++ b/tests/unit/supply-chain-policy.unit.test.ts
@@ -765,6 +765,14 @@ describe("supply-chain audit policy", () => {
     const containerImageJob = publishJobBlock("container-image");
     const publishJob = publishJobBlock("publish");
 
+    expect(publishWorkflow).toContain("release:");
+    expect(publishWorkflow).toContain("types: [published]");
+    expect(publishWorkflow).not.toContain("push:");
+    expect(publishWorkflow).not.toContain("tags:");
+    expect(publishWorkflow).not.toContain("workflow_dispatch");
+    expect(publishWorkflow).not.toContain("inputs.tag");
+    expect(publishWorkflow).not.toContain("${{ github.ref_name }}");
+    expect(publishWorkflow).toContain("${{ github.event.release.tag_name }}");
     expect(prepareJob).not.toContain("id-token: write");
     expect(prepareJob).toContain("pnpm run verify");
     expect(prepareJob).toContain("pnpm run typecheck");


### PR DESCRIPTION
## Summary
- Switch the publish workflow from manual workflow_dispatch tag input to the GitHub release published event so the privileged workflow definition is loaded from the default branch.
- Derive PUBLISH_TAG from github.event.release.tag_name while still resolving and validating the release tag against ci-green before checkout and publish.
- Add a supply-chain policy assertion preventing workflow_dispatch, tag-push triggers, inputs.tag, and github.ref_name from returning to publish.yml.

## Linked dependabot alerts
- https://github.com/backblaze-labs/b2-mcp/security/code-scanning/23
- https://github.com/backblaze-labs/b2-mcp/security/code-scanning/24
- https://github.com/backblaze-labs/b2-mcp/security/code-scanning/25
- https://github.com/backblaze-labs/b2-mcp/security/code-scanning/26
- https://github.com/backblaze-labs/b2-mcp/security/code-scanning/27
- https://github.com/backblaze-labs/b2-mcp/security/code-scanning/28
- https://github.com/backblaze-labs/b2-mcp/security/code-scanning/29
- https://github.com/backblaze-labs/b2-mcp/security/code-scanning/30
- https://github.com/backblaze-labs/b2-mcp/security/code-scanning/31
- https://github.com/backblaze-labs/b2-mcp/security/code-scanning/32

## Tests run
- pnpm exec biome format .github/workflows/publish.yml tests/unit/supply-chain-policy.unit.test.ts --write
- pnpm exec vitest run tests/unit/supply-chain-policy.unit.test.ts tests/contract/ci-workflow-policy.contract.test.ts
- git diff --check

## Follow-up notes
- No alert milestone metadata was provided, so no milestone was set.