### PR TITLE
fix: harden publish cache access

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -79,16 +79,55 @@ jobs:
             sleep "$attempt"
           done
       - run: pnpm install --frozen-lockfile
+        env:
+          ACTIONS_CACHE_URL: ""
+          ACTIONS_RESULTS_URL: ""
+          ACTIONS_RUNTIME_TOKEN: ""
+          ACTIONS_RUNTIME_URL: ""
       - run: pnpm run verify
+        env:
+          ACTIONS_CACHE_URL: ""
+          ACTIONS_RESULTS_URL: ""
+          ACTIONS_RUNTIME_TOKEN: ""
+          ACTIONS_RUNTIME_URL: ""
       - run: pnpm run typecheck
+        env:
+          ACTIONS_CACHE_URL: ""
+          ACTIONS_RESULTS_URL: ""
+          ACTIONS_RUNTIME_TOKEN: ""
+          ACTIONS_RUNTIME_URL: ""
       - run: pnpm run build
+        env:
+          ACTIONS_CACHE_URL: ""
+          ACTIONS_RESULTS_URL: ""
+          ACTIONS_RUNTIME_TOKEN: ""
+          ACTIONS_RUNTIME_URL: ""
       - run: pnpm run check:package-budget
+        env:
+          ACTIONS_CACHE_URL: ""
+          ACTIONS_RESULTS_URL: ""
+          ACTIONS_RUNTIME_TOKEN: ""
+          ACTIONS_RUNTIME_URL: ""
       - run: pnpm run audit:supply-chain:denylist --ref HEAD --ref origin/main --packlist --expect-pack-file dist/index.js
+        env:
+          ACTIONS_CACHE_URL: ""
+          ACTIONS_RESULTS_URL: ""
+          ACTIONS_RUNTIME_TOKEN: ""
+          ACTIONS_RUNTIME_URL: ""
       - run: pnpm run audit:supply-chain
         env:
+          ACTIONS_CACHE_URL: ""
+          ACTIONS_RESULTS_URL: ""
+          ACTIONS_RUNTIME_TOKEN: ""
+          ACTIONS_RUNTIME_URL: ""
           B2_MCP_AUDIT_EXPIRED_EXCEPTION_MODE: fail
       - name: Run production audit and generate release SBOM
         id: sbom
+        env:
+          ACTIONS_CACHE_URL: ""
+          ACTIONS_RESULTS_URL: ""
+          ACTIONS_RUNTIME_TOKEN: ""
+          ACTIONS_RUNTIME_URL: ""
         run: |
           set -euo pipefail
           mkdir -p "${GITHUB_WORKSPACE}/publish-package"
@@ -99,6 +138,10 @@ jobs:
       - name: Extract release notes
         id: notes
         env:
+          ACTIONS_CACHE_URL: ""
+          ACTIONS_RESULTS_URL: ""
+          ACTIONS_RUNTIME_TOKEN: ""
+          ACTIONS_RUNTIME_URL: ""
           PUBLISH_TAG: ${{ inputs.tag }}
         run: |
           set -euo pipefail
@@ -112,6 +155,11 @@ jobs:
           echo "release_notes_sha256=${notes_sha256}" >> "$GITHUB_OUTPUT"
       - name: Build and scan publish tarball
         id: pack
+        env:
+          ACTIONS_CACHE_URL: ""
+          ACTIONS_RESULTS_URL: ""
+          ACTIONS_RUNTIME_TOKEN: ""
+          ACTIONS_RUNTIME_URL: ""
         run: |
           set -euo pipefail
           mkdir -p publish-package
@@ -131,6 +179,10 @@ jobs:
           echo "tarball_integrity=$(node -e 'const fs = require("fs"); const [pack] = JSON.parse(fs.readFileSync("publish-package/npm-pack.json", "utf8")); process.stdout.write(pack.integrity || "");')" >> "$GITHUB_OUTPUT"
       - name: Dry-run npm publish from verified tarball
         env:
+          ACTIONS_CACHE_URL: ""
+          ACTIONS_RESULTS_URL: ""
+          ACTIONS_RUNTIME_TOKEN: ""
+          ACTIONS_RUNTIME_URL: ""
           EXPECTED_TARBALL_NAME: ${{ steps.pack.outputs.tarball_name }}
         run: |
           set -euo pipefail
@@ -147,6 +199,11 @@ jobs:
             --tag "${npm_tag}"
       - name: Write artifact checksums
         id: checksums
+        env:
+          ACTIONS_CACHE_URL: ""
+          ACTIONS_RESULTS_URL: ""
+          ACTIONS_RUNTIME_TOKEN: ""
+          ACTIONS_RUNTIME_URL: ""
         run: |
           set -euo pipefail
           cd publish-package
@@ -307,11 +364,19 @@ jobs:
       - uses: sigstore/cosign-installer@d58896d6a1865668819e1d91763c7751a165e159
       - name: Smoke local Docker image
         env:
+          ACTIONS_CACHE_URL: ""
+          ACTIONS_RESULTS_URL: ""
+          ACTIONS_RUNTIME_TOKEN: ""
+          ACTIONS_RUNTIME_URL: ""
           CHECKOUT_SHA: ${{ needs.prepare.outputs.checkout-sha }}
         run: node scripts/smoke-container-image.mjs --build --image "b2-mcp-release-smoke:${CHECKOUT_SHA}"
       - name: Publish signed multi-platform GHCR image
         id: image
         env:
+          ACTIONS_CACHE_URL: ""
+          ACTIONS_RESULTS_URL: ""
+          ACTIONS_RUNTIME_TOKEN: ""
+          ACTIONS_RUNTIME_URL: ""
           CHECKOUT_SHA: ${{ needs.prepare.outputs.checkout-sha }}
           GHCR_TOKEN: ${{ github.token }}
           PUBLISH_TAG: ${{ inputs.tag }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -63,6 +63,10 @@ jobs:
           persist-credentials: false
       - name: Verify release version and changelog
         env:
+          ACTIONS_CACHE_URL: ""
+          ACTIONS_RESULTS_URL: ""
+          ACTIONS_RUNTIME_TOKEN: ""
+          ACTIONS_RUNTIME_URL: ""
           PUBLISH_TAG: ${{ inputs.tag }}
         run: node scripts/verify-release-input.mjs --tag "${PUBLISH_TAG}"
       - name: Fetch protected refs for denylist scan


### PR DESCRIPTION
## Summary
- Clears GitHub Actions cache/runtime service variables for publish workflow shell steps that execute after the protected release SHA checkout.
- Applies the same guard to later container image shell steps that use the resolved release checkout SHA.
- Keeps artifact upload/download and trusted publishing steps able to use their required GitHub runtime and OIDC variables.

## Linked alerts
- https://github.com/backblaze-labs/b2-mcp/security/code-scanning/23
- https://github.com/backblaze-labs/b2-mcp/security/code-scanning/24
- https://github.com/backblaze-labs/b2-mcp/security/code-scanning/25
- https://github.com/backblaze-labs/b2-mcp/security/code-scanning/26
- https://github.com/backblaze-labs/b2-mcp/security/code-scanning/27
- https://github.com/backblaze-labs/b2-mcp/security/code-scanning/28
- https://github.com/backblaze-labs/b2-mcp/security/code-scanning/29
- https://github.com/backblaze-labs/b2-mcp/security/code-scanning/30
- https://github.com/backblaze-labs/b2-mcp/security/code-scanning/31
- https://github.com/backblaze-labs/b2-mcp/security/code-scanning/32

## Tests run
- `pnpm install --frozen-lockfile`
- `pnpm run format:check`
- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/publish.yml"); puts "publish.yml parsed"'`
- `node -e 'const fs=require("fs"); const text=fs.readFileSync(".github/workflows/publish.yml","utf8"); if (!text.includes("ACTIONS_CACHE_URL: \"\"")) process.exit(1); console.log("publish workflow cache env guards present")'`
- `git diff --check`

## Follow-up notes
- No alert milestone was provided in the workflow payload.
- No issue labels were provided in the workflow payload.