### PR TITLE
Add optional B2_LOG_FILE logging destination

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -23,7 +23,8 @@ B2_APPLICATION_KEY=
 # B2_MCP_TRANSPORT=stdio
 # Append redacted structured JSON logs to an absolute file path instead of
 # stderr. The file is created owner-only if missing; the parent directory must
-# exist. Long-running processes need operator-managed rotation.
+# exist. Long-running processes need operator-managed rotation; send SIGHUP
+# after rename/create rotation so b2-mcp reopens the file.
 # B2_LOG_FILE=/absolute/path/to/b2-mcp.log
 
 # ── Security / policy (safe defaults shown) ───────────────────────────────────

--- a/.env.example
+++ b/.env.example
@@ -21,6 +21,9 @@ B2_APPLICATION_KEY=
 # CLI default transport when no positional or --transport argument is supplied:
 # stdio | http. Docker images set this to http.
 # B2_MCP_TRANSPORT=stdio
+# Append redacted structured JSON logs to a file instead of stderr.
+# The file is created if missing; the parent directory must exist.
+# B2_LOG_FILE=/absolute/path/to/b2-mcp.log
 
 # ── Security / policy (safe defaults shown) ───────────────────────────────────
 # Destructive-op gate: confirm | block | allow.

--- a/.env.example
+++ b/.env.example
@@ -21,8 +21,9 @@ B2_APPLICATION_KEY=
 # CLI default transport when no positional or --transport argument is supplied:
 # stdio | http. Docker images set this to http.
 # B2_MCP_TRANSPORT=stdio
-# Append redacted structured JSON logs to a file instead of stderr.
-# The file is created if missing; the parent directory must exist.
+# Append redacted structured JSON logs to an absolute file path instead of
+# stderr. The file is created owner-only if missing; the parent directory must
+# exist. Long-running processes need operator-managed rotation.
 # B2_LOG_FILE=/absolute/path/to/b2-mcp.log
 
 # ── Security / policy (safe defaults shown) ───────────────────────────────────

--- a/.env.example
+++ b/.env.example
@@ -24,7 +24,8 @@ B2_APPLICATION_KEY=
 # Append redacted structured JSON logs to an absolute file path instead of
 # stderr. The file is created owner-only if missing; the parent directory must
 # exist. Long-running processes need operator-managed rotation; send SIGHUP
-# after rename/create rotation so b2-mcp reopens the file.
+# after rename/create rotation so b2-mcp reopens the file. POSIX only; Windows
+# file logging is rejected because owner-only ACLs are not enforced here.
 # B2_LOG_FILE=/absolute/path/to/b2-mcp.log
 
 # ── Security / policy (safe defaults shown) ───────────────────────────────────

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,8 +25,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added the supported customer-hosted container reference deployment to the
   published npm package with bounded logs, pinned runtime/proxy images, and
   package/build-context secret exclusion policy.
-- Added `B2_LOG_FILE` for redacted structured JSON file logging, with
-  owner-only file handling and SIGHUP reopen support for external rotation.
+- Added POSIX `B2_LOG_FILE` support for redacted structured JSON file logging,
+  with owner-only file handling and SIGHUP reopen support for external rotation.
 
 ### Changed
 - Defaulted JWT/JWKS verification to `RS256`; operators can still opt into

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added the supported customer-hosted container reference deployment to the
   published npm package with bounded logs, pinned runtime/proxy images, and
   package/build-context secret exclusion policy.
+- Added `B2_LOG_FILE` for redacted structured JSON file logging, with
+  owner-only file handling and SIGHUP reopen support for external rotation.
 
 ### Changed
 - Defaulted JWT/JWKS verification to `RS256`; operators can still opt into

--- a/README.md
+++ b/README.md
@@ -163,10 +163,20 @@ b2-mcp emits one structured JSON log object per line. Logs default to stderr so
 the stdio transport's stdout channel stays reserved for MCP protocol frames.
 
 Set `B2_LOG_FILE=/absolute/path/to/b2-mcp.log` to append those same redacted JSON
-lines to a file instead of stderr. The file is created when it does not exist;
-its parent directory must already exist and be writable. A bad path fails at
-startup with a clear `B2_LOG_FILE is not writable` error. File logging does not
-mirror to stderr by default.
+lines to a file instead of stderr. The path must be absolute. The file is created
+with owner-only permissions when it does not exist; its parent directory must
+already exist and be writable. Existing log files must be regular files, must
+not be symlinks, and must not be readable or writable by group or other users. A
+bad path fails at startup with a clear `B2_LOG_FILE` error. Runtime write
+failures are reported to stderr.
+
+File logging does not mirror to stderr by default. Because `B2_LOG_FILE` is an
+append-only file sink with no built-in rotation or retention, use
+operator-managed rotation before enabling it for a long-running process. Do not
+enable it on an internet-facing HTTP transport unless the host has a size and
+retention policy. For external `logrotate`, use `copytruncate`; rename-based
+rotation requires a process restart because the server keeps the opened file
+descriptor.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -170,6 +170,8 @@ not be symlinks or hard links, and must be owned by the current user. Owned
 pre-existing files are tightened to owner-only permissions at startup. A bad
 path fails at startup with a clear `B2_LOG_FILE` error. Runtime write failures
 are reported to stderr, and subsequent structured log lines fall back to stderr.
+`B2_LOG_FILE` is currently supported only on POSIX platforms; Windows startup
+fails clearly because this implementation does not enforce owner-only ACLs.
 
 File logging does not mirror to stderr by default. Because `B2_LOG_FILE` is an
 append-only file sink with no built-in rotation or retention, use

--- a/README.md
+++ b/README.md
@@ -166,17 +166,19 @@ Set `B2_LOG_FILE=/absolute/path/to/b2-mcp.log` to append those same redacted JSO
 lines to a file instead of stderr. The path must be absolute. The file is created
 with owner-only permissions when it does not exist; its parent directory must
 already exist and be writable. Existing log files must be regular files, must
-not be symlinks, and must not be readable or writable by group or other users. A
-bad path fails at startup with a clear `B2_LOG_FILE` error. Runtime write
-failures are reported to stderr.
+not be symlinks or hard links, and must be owned by the current user. Owned
+pre-existing files are tightened to owner-only permissions at startup. A bad
+path fails at startup with a clear `B2_LOG_FILE` error. Runtime write failures
+are reported to stderr, and subsequent structured log lines fall back to stderr.
 
 File logging does not mirror to stderr by default. Because `B2_LOG_FILE` is an
 append-only file sink with no built-in rotation or retention, use
 operator-managed rotation before enabling it for a long-running process. Do not
 enable it on an internet-facing HTTP transport unless the host has a size and
-retention policy. For external `logrotate`, use `copytruncate`; rename-based
-rotation requires a process restart because the server keeps the opened file
-descriptor.
+retention policy and a log shipper tails the file directly. For external
+`logrotate`, use rename/create rotation and send `SIGHUP` to the b2-mcp process
+after rotation so the file destination is reopened. Copytruncate is not
+recommended.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -55,6 +55,9 @@ pnpm run build          # produces dist/ — required before first run
 ```
 
 Replace the path with where you put the folder, then restart Claude Desktop — the B2 tools appear.
+To persist local stdio logs from clients that do not expose child-process
+stderr, add `"B2_LOG_FILE": "/absolute/path/to/b2-mcp.log"` to the same `env`
+block.
 
 > **One non-master application key covers everything active** — B2 native, S3, and key management. The Partner/Groups tool names are currently unavailable SDK-gap stubs; configuring `B2_MASTER_KEY_ID` / `B2_MASTER_KEY` does not activate them until the upstream SDK support lands. B2's S3 endpoint rejects master keys, which is why the application key is the primary credential. See [Configuration](#configuration) for the full list.
 
@@ -133,6 +136,7 @@ the healthcheck probes the same port the server binds.
 | `B2_MCP_UA_SUFFIX`                                            | —                     | —                     | Token appended to the outbound User-Agent (tag a deployment)                                                               |
 | `B2_MCP_OUTPUT_FORMAT`                                        | —                     | `json`                | LLM-facing `TextContent.text` format for structured successes: compact `json` or opt-in `toon`                             |
 | `B2_MCP_TRANSPORT`                                            | —                     | `stdio`               | CLI default transport when no `stdio` / `http` argument or `--transport` flag is passed; Docker images set this to `http`  |
+| `B2_LOG_FILE`                                                 | —                     | stderr                | Optional path for redacted structured JSON logs. When set, the file replaces stderr; stdout is never used for logs          |
 | `B2_APP_KEY_ID` / `B2_APP_KEY`                                | —                     | _deprecated_          | Legacy alias retained for compatibility; S3 tools use the authorized `B2_APPLICATION_KEY_*` credential scope                |
 | `B2_HTTP_CREDENTIAL_MODE`                                     | HTTP only             | `headers`             | `headers`, `server`, or `principal`; unset preserves existing header-based clients. Set explicitly for hosted deployments  |
 | `B2_PRINCIPAL_CREDENTIAL_MAP`                                 | HTTP `principal`      | —                     | JSON map from verified MCP principal to a customer-managed credential reference                                            |
@@ -150,6 +154,19 @@ the healthcheck probes the same port the server binds.
 | `B2_CAPABILITY_CACHE_TTL_MS` / `B2_CAPABILITY_CACHE_MAX_ENTRIES` | `300000` / `10000` | Bounded capability-discovery cache TTL and size. Cache identity is secret-bound; log labels are non-secret fingerprints   |
 
 A ready-to-copy [`.env.example`](.env.example) lists these. HTTP-only file-access vars (`B2_ALLOW_LOCAL_FILES`, `B2_FILE_ROOT`) are covered in [`docs/DEPLOY.md`](docs/DEPLOY.md).
+
+---
+
+## Logging
+
+b2-mcp emits one structured JSON log object per line. Logs default to stderr so
+the stdio transport's stdout channel stays reserved for MCP protocol frames.
+
+Set `B2_LOG_FILE=/absolute/path/to/b2-mcp.log` to append those same redacted JSON
+lines to a file instead of stderr. The file is created when it does not exist;
+its parent directory must already exist and be writable. A bad path fails at
+startup with a clear `B2_LOG_FILE is not writable` error. File logging does not
+mirror to stderr by default.
 
 ---
 

--- a/docs/CLIENTS.md
+++ b/docs/CLIENTS.md
@@ -61,6 +61,17 @@ args:    --transport stdio
 env:     B2_APPLICATION_KEY_ID, B2_APPLICATION_KEY
 ```
 
+Optional local log file:
+
+```
+env:     B2_LOG_FILE=/absolute/path/to/b2-mcp.log
+```
+
+`B2_LOG_FILE` appends redacted structured JSON logs to that file instead of
+stderr. This is useful for stdio clients that hide child-process stderr. The
+file is created if it does not exist; the parent directory must already exist
+and be writable. Logs are never written to stdout.
+
 ### Claude Desktop
 
 `~/Library/Application Support/Claude/claude_desktop_config.json` (macOS) / `%APPDATA%\Claude\claude_desktop_config.json` (Windows):

--- a/docs/CLIENTS.md
+++ b/docs/CLIENTS.md
@@ -71,7 +71,8 @@ env:     B2_LOG_FILE=/absolute/path/to/b2-mcp.log
 stderr. This is useful for stdio clients that hide child-process stderr. The
 path must be absolute. The file is created with owner-only permissions if it
 does not exist; the parent directory must already exist and be writable. Use
-operator-managed rotation with `copytruncate` for long-running local processes.
+operator-managed rename/create rotation for long-running local processes, then
+send `SIGHUP` to the b2-mcp process so it reopens the active file.
 Logs are never written to stdout.
 
 ### Claude Desktop

--- a/docs/CLIENTS.md
+++ b/docs/CLIENTS.md
@@ -73,7 +73,9 @@ path must be absolute. The file is created with owner-only permissions if it
 does not exist; the parent directory must already exist and be writable. Use
 operator-managed rename/create rotation for long-running local processes, then
 send `SIGHUP` to the b2-mcp process so it reopens the active file.
-Logs are never written to stdout.
+Logs are never written to stdout. `B2_LOG_FILE` is POSIX-only for now; on
+Windows it fails at startup because owner-only ACLs are not enforced by this
+implementation.
 
 ### Claude Desktop
 

--- a/docs/CLIENTS.md
+++ b/docs/CLIENTS.md
@@ -69,8 +69,10 @@ env:     B2_LOG_FILE=/absolute/path/to/b2-mcp.log
 
 `B2_LOG_FILE` appends redacted structured JSON logs to that file instead of
 stderr. This is useful for stdio clients that hide child-process stderr. The
-file is created if it does not exist; the parent directory must already exist
-and be writable. Logs are never written to stdout.
+path must be absolute. The file is created with owner-only permissions if it
+does not exist; the parent directory must already exist and be writable. Use
+operator-managed rotation with `copytruncate` for long-running local processes.
+Logs are never written to stdout.
 
 ### Claude Desktop
 

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -89,7 +89,7 @@ to the global floor:
 | Secret redaction     | `src/utils/secret-sanitizer.ts`, audited tool wrapping                                      | Canary redaction branch tests   |
 | Destructive actions  | `src/utils/destructive-gate.ts`, bucket/object/multipart delete handlers                    | Confirm/block/allow branches    |
 | Filesystem boundary  | `src/utils/fs-guard.ts`, S3 local file upload/download paths                                | Root escape and symlink tests   |
-| Logger destination   | `src/utils/logger.ts`                                                                       | `B2_LOG_FILE` import safety, async file/stderr routing, redaction, owner-only permissions, symlink/FIFO/hard-link rejection, SIGHUP reopen, stderr fallback, and startup/shutdown tests |
+| Logger destination   | `src/utils/logger.ts`                                                                       | `B2_LOG_FILE` import safety, async file/stderr routing, redaction, POSIX owner-only permissions, Windows rejection, symlink/FIFO/hard-link rejection, SIGHUP reopen, stderr fallback, and startup/shutdown tests |
 | Transport boundary   | `src/http-server.ts`, `src/utils/node-web-bridge.ts`, stdio and HTTP protocol suites        | Close/abort/listener tests      |
 
 The v1.0.0 target is 90% statements, 80% branches, 90% functions, and 90% lines

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -89,7 +89,7 @@ to the global floor:
 | Secret redaction     | `src/utils/secret-sanitizer.ts`, audited tool wrapping                                      | Canary redaction branch tests   |
 | Destructive actions  | `src/utils/destructive-gate.ts`, bucket/object/multipart delete handlers                    | Confirm/block/allow branches    |
 | Filesystem boundary  | `src/utils/fs-guard.ts`, S3 local file upload/download paths                                | Root escape and symlink tests   |
-| Logger destination   | `src/utils/logger.ts`                                                                       | `B2_LOG_FILE` file/stderr routing, redaction, and bad-path startup tests |
+| Logger destination   | `src/utils/logger.ts`                                                                       | `B2_LOG_FILE` import safety, file/stderr routing, redaction, owner-only permissions, symlink/FIFO rejection, and bad-path startup tests |
 | Transport boundary   | `src/http-server.ts`, `src/utils/node-web-bridge.ts`, stdio and HTTP protocol suites        | Close/abort/listener tests      |
 
 The v1.0.0 target is 90% statements, 80% branches, 90% functions, and 90% lines

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -89,6 +89,7 @@ to the global floor:
 | Secret redaction     | `src/utils/secret-sanitizer.ts`, audited tool wrapping                                      | Canary redaction branch tests   |
 | Destructive actions  | `src/utils/destructive-gate.ts`, bucket/object/multipart delete handlers                    | Confirm/block/allow branches    |
 | Filesystem boundary  | `src/utils/fs-guard.ts`, S3 local file upload/download paths                                | Root escape and symlink tests   |
+| Logger destination   | `src/utils/logger.ts`                                                                       | `B2_LOG_FILE` file/stderr routing, redaction, and bad-path startup tests |
 | Transport boundary   | `src/http-server.ts`, `src/utils/node-web-bridge.ts`, stdio and HTTP protocol suites        | Close/abort/listener tests      |
 
 The v1.0.0 target is 90% statements, 80% branches, 90% functions, and 90% lines

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -89,7 +89,7 @@ to the global floor:
 | Secret redaction     | `src/utils/secret-sanitizer.ts`, audited tool wrapping                                      | Canary redaction branch tests   |
 | Destructive actions  | `src/utils/destructive-gate.ts`, bucket/object/multipart delete handlers                    | Confirm/block/allow branches    |
 | Filesystem boundary  | `src/utils/fs-guard.ts`, S3 local file upload/download paths                                | Root escape and symlink tests   |
-| Logger destination   | `src/utils/logger.ts`                                                                       | `B2_LOG_FILE` import safety, file/stderr routing, redaction, owner-only permissions, symlink/FIFO rejection, and bad-path startup tests |
+| Logger destination   | `src/utils/logger.ts`                                                                       | `B2_LOG_FILE` import safety, async file/stderr routing, redaction, owner-only permissions, symlink/FIFO/hard-link rejection, SIGHUP reopen, stderr fallback, and startup/shutdown tests |
 | Transport boundary   | `src/http-server.ts`, `src/utils/node-web-bridge.ts`, stdio and HTTP protocol suites        | Close/abort/listener tests      |
 
 The v1.0.0 target is 90% statements, 80% branches, 90% functions, and 90% lines

--- a/docs/deployment/aws.md
+++ b/docs/deployment/aws.md
@@ -71,6 +71,8 @@ docs/deployment/security-and-credentials.md.
 
 Ship stdout/stderr to CloudWatch Logs. Configure retention and redaction review
 before production. Do not log B2 credentials, bearer tokens, or presigned URLs.
+Leave `B2_LOG_FILE` unset unless a sidecar or host agent tails that file into
+CloudWatch; when set, b2-mcp stops writing structured logs to stderr.
 
 ## Scaling
 

--- a/docs/deployment/fly-io.md
+++ b/docs/deployment/fly-io.md
@@ -70,6 +70,8 @@ deployed commit, and result.
 
 Use `fly logs` and external log sinks after redaction review. Do not log B2
 credentials, OAuth tokens, or presigned URLs.
+Leave `B2_LOG_FILE` unset unless a log shipper tails that file into the same
+retention path; when set, b2-mcp stops writing structured logs to stderr.
 
 ## Scaling
 

--- a/docs/deployment/render.md
+++ b/docs/deployment/render.md
@@ -69,6 +69,8 @@ region, deployed commit, and result.
 
 Use Render logs only after confirming redaction. Do not log B2 credentials,
 OAuth tokens, or presigned URLs.
+Leave `B2_LOG_FILE` unset unless an attached log agent tails that file into the
+same retention path; when set, b2-mcp stops writing structured logs to stderr.
 
 ## Scaling
 

--- a/docs/deployment/security-and-credentials.md
+++ b/docs/deployment/security-and-credentials.md
@@ -35,6 +35,8 @@ version: `0.1.0`. MCP revision: 2026-07-28. Documentation owner: Gonza.
     retry. Under `allow`, both elicitation and the confirm gate are skipped.
 12. Never log B2 credentials, bearer tokens, presigned URLs, authorization
     responses, or provider deployment-bypass tokens.
+    If `B2_LOG_FILE` is set, structured logs move off stderr/stdout and provider
+    log capture will not see them unless a log agent tails that file directly.
 13. Create, rotate, revoke, and tear down B2 keys outside the MCP tool flow
     until a reviewed out-of-band secret sink exists.
 14. Configure protected live deployment smokes with a GitHub Environment so

--- a/package-budget.json
+++ b/package-budget.json
@@ -11,10 +11,10 @@
     "directProductionDependencyCount": 9,
     "totalProductionPackageCount": 48,
     "transitiveProductionPackageCount": 38,
-    "packedTarballBytes": 421850,
-    "unpackedPackageBytes": 1863004,
+    "packedTarballBytes": 421986,
+    "unpackedPackageBytes": 1863780,
     "packedEntryCount": 232,
-    "cleanConsumerInstallFootprintBytes": 28970010
+    "cleanConsumerInstallFootprintBytes": 28970786
   },
   "limits": {
     "directProductionDependencyCount": 9,

--- a/package-budget.json
+++ b/package-budget.json
@@ -5,22 +5,22 @@
     "planningId": "P1-RUNTIME-02"
   },
   "reviewedBaseline": {
-    "date": "2026-08-16",
+    "date": "2026-08-18",
     "nodeVersions": ["22.3.0", "24", "26"],
     "primaryB2Transport": "@backblaze-labs/b2-sdk@0.2.0",
     "directProductionDependencyCount": 9,
     "totalProductionPackageCount": 48,
     "transitiveProductionPackageCount": 38,
-    "packedTarballBytes": 415420,
-    "unpackedPackageBytes": 1838886,
+    "packedTarballBytes": 418873,
+    "unpackedPackageBytes": 1850582,
     "packedEntryCount": 232,
-    "cleanConsumerInstallFootprintBytes": 28945892
+    "cleanConsumerInstallFootprintBytes": 28957588
   },
   "limits": {
     "directProductionDependencyCount": 9,
     "totalProductionPackageCount": 48,
-    "packedTarballBytes": 417000,
-    "unpackedPackageBytes": 1845000,
+    "packedTarballBytes": 420000,
+    "unpackedPackageBytes": 1852000,
     "packedEntryCount": 240,
     "cleanConsumerInstallFootprintBytes": 30000000
   },

--- a/package-budget.json
+++ b/package-budget.json
@@ -11,10 +11,10 @@
     "directProductionDependencyCount": 9,
     "totalProductionPackageCount": 48,
     "transitiveProductionPackageCount": 38,
-    "packedTarballBytes": 421025,
-    "unpackedPackageBytes": 1859787,
+    "packedTarballBytes": 421342,
+    "unpackedPackageBytes": 1860533,
     "packedEntryCount": 232,
-    "cleanConsumerInstallFootprintBytes": 28966793
+    "cleanConsumerInstallFootprintBytes": 28967539
   },
   "limits": {
     "directProductionDependencyCount": 9,

--- a/package-budget.json
+++ b/package-budget.json
@@ -11,16 +11,16 @@
     "directProductionDependencyCount": 9,
     "totalProductionPackageCount": 48,
     "transitiveProductionPackageCount": 38,
-    "packedTarballBytes": 418873,
-    "unpackedPackageBytes": 1850582,
+    "packedTarballBytes": 421025,
+    "unpackedPackageBytes": 1859787,
     "packedEntryCount": 232,
-    "cleanConsumerInstallFootprintBytes": 28957588
+    "cleanConsumerInstallFootprintBytes": 28966793
   },
   "limits": {
     "directProductionDependencyCount": 9,
     "totalProductionPackageCount": 48,
-    "packedTarballBytes": 420000,
-    "unpackedPackageBytes": 1852000,
+    "packedTarballBytes": 422000,
+    "unpackedPackageBytes": 1861000,
     "packedEntryCount": 240,
     "cleanConsumerInstallFootprintBytes": 30000000
   },

--- a/package-budget.json
+++ b/package-budget.json
@@ -11,16 +11,16 @@
     "directProductionDependencyCount": 9,
     "totalProductionPackageCount": 48,
     "transitiveProductionPackageCount": 38,
-    "packedTarballBytes": 421342,
-    "unpackedPackageBytes": 1860533,
+    "packedTarballBytes": 421850,
+    "unpackedPackageBytes": 1863004,
     "packedEntryCount": 232,
-    "cleanConsumerInstallFootprintBytes": 28967539
+    "cleanConsumerInstallFootprintBytes": 28970010
   },
   "limits": {
     "directProductionDependencyCount": 9,
     "totalProductionPackageCount": 48,
     "packedTarballBytes": 422000,
-    "unpackedPackageBytes": 1861000,
+    "unpackedPackageBytes": 1864000,
     "packedEntryCount": 240,
     "cleanConsumerInstallFootprintBytes": 30000000
   },

--- a/src/http-server.ts
+++ b/src/http-server.ts
@@ -10,7 +10,7 @@
 import * as http from "http";
 import type { AuthInfo } from "@modelcontextprotocol/server";
 import { parseIntEnv, resolveHttpPort } from "./utils/config.js";
-import { logger } from "./utils/logger.js";
+import { flushLogsSync, initLogging, logger } from "./utils/logger.js";
 import {
   nodeRequestToWeb,
   resumeUnreadRequest,
@@ -134,6 +134,7 @@ export function buildHttpServer(options: HttpServerOptions = {}): HttpServerHand
 }
 
 export async function startHttp(options: HttpListenOptions = {}): Promise<void> {
+  initLogging();
   const port = options.port ?? getPort();
   const handle = buildHttpServer();
   const { server: httpServer, sessions, drain } = handle;
@@ -168,11 +169,13 @@ export async function startHttp(options: HttpListenOptions = {}): Promise<void> 
         drainTimer = null;
       }
       logger.info("server.closed");
+      flushLogsSync();
       process.exit(0);
     });
     drainTimer = setTimeout(() => {
       removeLifecycleHandlers();
       logger.error("server.drainTimeout");
+      flushLogsSync();
       process.exit(1);
     }, SHUTDOWN_DRAIN_MS).unref();
   }
@@ -203,7 +206,10 @@ export async function startHttp(options: HttpListenOptions = {}): Promise<void> 
 
 if (require.main === module) {
   startHttp().catch((err) => {
-    logger.fatal({ err: err instanceof Error ? err.message : String(err) }, "server.fatal");
+    const message = err instanceof Error ? err.message : String(err);
+    process.stderr.write(`b2-mcp: ${message}\n`);
+    logger.fatal({ err: message }, "server.fatal");
+    flushLogsSync();
     process.exit(1);
   });
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -25,12 +25,13 @@
 import * as stdioTransport from "@modelcontextprotocol/server/stdio";
 import * as serverModule from "./server.js";
 import { CredentialResolutionError } from "./credentials.js";
-import { logger } from "./utils/logger.js";
+import { flushLogsSync, initLogging, logger } from "./utils/logger.js";
 import { VERSION } from "./version.js";
 import { CliUsageError, helpText, parseCliArgs } from "./cli.js";
 import { PortUsageError } from "./utils/config.js";
 
 export async function startStdio(): Promise<void> {
+  initLogging();
   const config = serverModule.loadConfig();
   // Right-size the surface to the key's capabilities (null → full surface).
   let capabilities: string[] | null;
@@ -87,11 +88,13 @@ if (require.main === module) {
   runCli().catch((err) => {
     if (err instanceof CliUsageError || err instanceof PortUsageError) {
       process.stderr.write(`b2-mcp: ${err.message}\n\n${helpText()}\n`);
+      flushLogsSync();
       process.exit(2);
     }
     const message = err instanceof Error ? err.message : String(err);
     process.stderr.write(`b2-mcp: ${message}\n`);
     logger.fatal({ err: message }, "server.fatal");
+    flushLogsSync();
     process.exit(1);
   });
 }

--- a/src/server.ts
+++ b/src/server.ts
@@ -18,7 +18,7 @@ import {
   runWithResultSerializationOptions,
 } from "./utils/result-serializer.js";
 import { VERSION } from "./version.js";
-import { logger } from "./utils/logger.js";
+import { flushLogsSync, logger } from "./utils/logger.js";
 import { B2AuthManager } from "./auth.js";
 import { B2Client } from "./b2/client.js";
 import { B2ReportClient } from "./b2/report-client.js";
@@ -90,6 +90,7 @@ export function loadConfig(): B2Config {
     } else {
       process.stderr.write(`b2-mcp: ${err.message}\n`);
     }
+    flushLogsSync();
     process.exit(1);
   }
 }

--- a/src/utils/logger.ts
+++ b/src/utils/logger.ts
@@ -1,4 +1,4 @@
-import { closeSync, constants, fstatSync, openSync } from "node:fs";
+import { closeSync, constants, fchmodSync, fstatSync, openSync } from "node:fs";
 import { isAbsolute } from "node:path";
 import pino, { type DestinationStream } from "pino";
 import { VERSION } from "../version.js";
@@ -7,6 +7,9 @@ import { LOGGER_SECRET_REDACTION_PATHS, SECRET_SANITIZER_REDACTION } from "./sec
 const isTest = process.env.NODE_ENV === "test";
 const LOG_FILE_MODE = 0o600;
 const GROUP_OR_OTHER_PERMISSIONS = 0o077;
+const LOG_FILE_MIN_LENGTH = 4096;
+const LOG_FILE_PERIODIC_FLUSH_MS = 1000;
+const LOG_FILE_FAILURE_REPORT_INTERVAL_MS = 60_000;
 
 const options = {
   level: process.env.LOG_LEVEL ?? (isTest ? "silent" : "info"),
@@ -24,19 +27,33 @@ type ManagedDestination = DestinationStream & {
   flush?: (cb?: (err?: Error) => void) => void;
   flushSync?: () => void;
   on?: (event: "error", listener: (err: Error) => void) => ManagedDestination;
+  off?: (event: "error", listener: (err: Error) => void) => ManagedDestination;
+  removeListener?: (event: "error", listener: (err: Error) => void) => ManagedDestination;
+  destroy?: () => void;
 };
 
 type PinoDestinationOptions = {
   dest: number | string;
   sync: boolean;
+  minLength?: number;
+  mode?: number;
+  periodicFlush?: number;
 };
 
-let activeDestination: ManagedDestination = {
+type RotatableFileDestination = ManagedDestination & {
+  reopenForRotation: () => void;
+};
+
+const stderrDestination: ManagedDestination = {
   write: (line) => process.stderr.write(line),
   flush: (cb) => cb?.(),
   flushSync: () => undefined,
 };
+
+let activeDestination: ManagedDestination = stderrDestination;
+let activeFileDestination: RotatableFileDestination | undefined;
 let loggingInitialized = false;
+let sighupHandler: (() => void) | undefined;
 
 const destinationProxy: ManagedDestination = {
   write: (line) => activeDestination.write(line),
@@ -74,6 +91,35 @@ function failLogFile(message: string): never {
   throw new Error(message);
 }
 
+function currentUid(): number | undefined {
+  return typeof process.getuid === "function" ? process.getuid() : undefined;
+}
+
+function normalizeExistingLogFile(logFile: string, fd: number): void {
+  let stats = fstatSync(fd);
+  if (!stats.isFile()) {
+    failLogFile(`B2_LOG_FILE must point to a regular file: ${logFile}`);
+  }
+  if (stats.nlink > 1) {
+    failLogFile(`B2_LOG_FILE must not be a hard link: ${logFile}`);
+  }
+
+  const uid = currentUid();
+  if (uid !== undefined && stats.uid !== uid) {
+    failLogFile(`B2_LOG_FILE must be owned by the current user: ${logFile}`);
+  }
+
+  if ((stats.mode & GROUP_OR_OTHER_PERMISSIONS) !== 0) {
+    fchmodSync(fd, LOG_FILE_MODE);
+    stats = fstatSync(fd);
+    if ((stats.mode & GROUP_OR_OTHER_PERMISSIONS) !== 0) {
+      failLogFile(
+        `B2_LOG_FILE must not be readable or writable by group or other users: ${logFile}`,
+      );
+    }
+  }
+}
+
 function openLogFile(logFile: string): number {
   if (!isAbsolute(logFile)) {
     failLogFile(`B2_LOG_FILE must be an absolute path: ${logFile}`);
@@ -90,15 +136,7 @@ function openLogFile(logFile: string): number {
         constants.O_NONBLOCK,
       LOG_FILE_MODE,
     );
-    const stats = fstatSync(fd);
-    if (!stats.isFile()) {
-      failLogFile(`B2_LOG_FILE must point to a regular file: ${logFile}`);
-    }
-    if ((stats.mode & GROUP_OR_OTHER_PERMISSIONS) !== 0) {
-      failLogFile(
-        `B2_LOG_FILE must not be readable or writable by group or other users: ${logFile}`,
-      );
-    }
+    normalizeExistingLogFile(logFile, fd);
     return fd;
   } catch (err) {
     if (fd !== undefined) closeSync(fd);
@@ -112,23 +150,129 @@ function openLogFile(logFile: string): number {
   }
 }
 
-function fileDestination(logFile: string): ManagedDestination {
+function createFileStream(logFile: string): ManagedDestination {
   const fd = openLogFile(logFile);
-  let destination: ManagedDestination;
   try {
-    destination = createPinoDestination({ dest: fd, sync: true });
+    return createPinoDestination({
+      dest: fd,
+      mode: LOG_FILE_MODE,
+      minLength: LOG_FILE_MIN_LENGTH,
+      periodicFlush: LOG_FILE_PERIODIC_FLUSH_MS,
+      sync: false,
+    });
   } catch (err) {
     closeSync(fd);
     throw err;
   }
+}
 
-  let writeFailureReported = false;
-  destination.on?.("error", (err) => {
-    if (writeFailureReported) return;
-    writeFailureReported = true;
-    process.stderr.write(`b2-mcp: B2_LOG_FILE write failed for ${logFile}: ${errorDetail(err)}\n`);
-  });
-  return destination;
+function destroyFileStream(destination: ManagedDestination): void {
+  try {
+    destination.destroy?.call(destination);
+  } catch (err) {
+    process.stderr.write(`b2-mcp: log destination close failed: ${errorDetail(err)}\n`);
+  }
+}
+
+function fileDestination(logFile: string): RotatableFileDestination {
+  let destination = createFileStream(logFile);
+  let fallbackError: Error | undefined;
+  let lastFailureReportAt = 0;
+
+  const reportFailure = (err: Error, operation: string): void => {
+    fallbackError = err;
+    const now = Date.now();
+    if (
+      lastFailureReportAt === 0 ||
+      now - lastFailureReportAt >= LOG_FILE_FAILURE_REPORT_INTERVAL_MS
+    ) {
+      lastFailureReportAt = now;
+      process.stderr.write(
+        `b2-mcp: B2_LOG_FILE ${operation} failed for ${logFile}: ${errorDetail(err)}; falling back to stderr\n`,
+      );
+    }
+  };
+
+  const attachErrorHandler = (stream: ManagedDestination): ((err: Error) => void) => {
+    const listener = (err: Error) => {
+      reportFailure(err, "write");
+    };
+    stream.on?.("error", listener);
+    return listener;
+  };
+
+  const detachErrorHandler = (stream: ManagedDestination, listener: (err: Error) => void): void => {
+    if (typeof stream.off === "function") {
+      stream.off("error", listener);
+      return;
+    }
+    stream.removeListener?.("error", listener);
+  };
+
+  let errorListener = attachErrorHandler(destination);
+
+  const managedDestination: RotatableFileDestination = {
+    write: (line) => {
+      if (fallbackError) {
+        reportFailure(fallbackError, "write");
+        return stderrDestination.write(line);
+      }
+      try {
+        return destination.write(line);
+      } catch (err) {
+        const failure = err instanceof Error ? err : new Error(String(err));
+        reportFailure(failure, "write");
+        return stderrDestination.write(line);
+      }
+    },
+    flush: (cb) => {
+      if (fallbackError) {
+        cb?.();
+        return;
+      }
+      if (typeof destination.flush === "function") {
+        destination.flush.call(destination, cb);
+        return;
+      }
+      cb?.();
+    },
+    flushSync: () => {
+      if (fallbackError) return;
+      try {
+        destination.flushSync?.call(destination);
+      } catch (err) {
+        const failure = err instanceof Error ? err : new Error(String(err));
+        reportFailure(failure, "flush");
+      }
+    },
+    reopenForRotation: () => {
+      try {
+        destination.flushSync?.call(destination);
+        const nextDestination = createFileStream(logFile);
+        const previousDestination = destination;
+        const previousErrorListener = errorListener;
+        destination = nextDestination;
+        fallbackError = undefined;
+        lastFailureReportAt = 0;
+        errorListener = attachErrorHandler(destination);
+        detachErrorHandler(previousDestination, previousErrorListener);
+        destroyFileStream(previousDestination);
+      } catch (err) {
+        const failure = err instanceof Error ? err : new Error(String(err));
+        reportFailure(failure, "reopen");
+      }
+    },
+  };
+
+  return managedDestination;
+}
+
+function installSighupHandler(): void {
+  if (sighupHandler) return;
+  sighupHandler = () => {
+    activeFileDestination?.reopenForRotation();
+  };
+  process.on("SIGHUP", sighupHandler);
 }
 
 /**
@@ -139,7 +283,9 @@ export function initLogging(env: NodeJS.ProcessEnv = process.env): void {
   if (loggingInitialized) return;
   const logFile = env.B2_LOG_FILE;
   if (logFile) {
-    activeDestination = fileDestination(logFile);
+    activeFileDestination = fileDestination(logFile);
+    activeDestination = activeFileDestination;
+    installSighupHandler();
   }
   loggingInitialized = true;
 }

--- a/src/utils/logger.ts
+++ b/src/utils/logger.ts
@@ -222,6 +222,19 @@ function fileDestination(logFile: string): RotatableFileDestination {
 
   let errorListener = attachErrorHandler(destination);
 
+  const retireFileStream = (stream: ManagedDestination, listener: (err: Error) => void): void => {
+    let retiredErrorReported = false;
+    stream.on?.("error", (err) => {
+      if (retiredErrorReported) return;
+      retiredErrorReported = true;
+      process.stderr.write(
+        `b2-mcp: retired B2_LOG_FILE destination error for ${logFile}: ${errorDetail(err)}\n`,
+      );
+    });
+    detachErrorHandler(stream, listener);
+    destroyFileStream(stream);
+  };
+
   const swapFileStream = (
     previousDestination: ManagedDestination,
     previousErrorListener: (err: Error) => void,
@@ -236,8 +249,7 @@ function fileDestination(logFile: string): RotatableFileDestination {
       fallbackError = undefined;
       lastFailureReportAt = 0;
       errorListener = attachErrorHandler(destination);
-      detachErrorHandler(previousDestination, previousErrorListener);
-      destroyFileStream(previousDestination);
+      retireFileStream(previousDestination, previousErrorListener);
     } catch (err) {
       const failure = err instanceof Error ? err : new Error(String(err));
       reportFailure(failure, "reopen");

--- a/src/utils/logger.ts
+++ b/src/utils/logger.ts
@@ -1,3 +1,4 @@
+import { closeSync, openSync } from "node:fs";
 import pino, { type DestinationStream } from "pino";
 import { VERSION } from "../version.js";
 import { LOGGER_SECRET_REDACTION_PATHS, SECRET_SANITIZER_REDACTION } from "./secret-sanitizer.js";
@@ -16,23 +17,56 @@ const options = {
   },
 };
 
-function stderrDestination(): DestinationStream | undefined {
+function pinoDestination(options: { dest: number | string; sync: boolean }): DestinationStream {
   const destination = (pino as unknown as { destination?: unknown }).destination;
-  if (typeof destination !== "function") return undefined;
-  return (destination as (options: { dest: number; sync: boolean }) => DestinationStream)({
-    dest: 2,
-    sync: false,
+  if (typeof destination !== "function") {
+    failStartup("pino destination is unavailable; refusing to log to stdout");
+  }
+  return (destination as (options: { dest: number | string; sync: boolean }) => DestinationStream)({
+    ...options,
   });
 }
 
+function failStartup(message: string): never {
+  process.stderr.write(`b2-mcp: ${message}\n`);
+  process.exit(1);
+}
+
+function errorDetail(err: unknown): string {
+  if (!(err instanceof Error)) return String(err);
+  const code = "code" in err && typeof err.code === "string" ? `${err.code}: ` : "";
+  return `${code}${err.message}`;
+}
+
+function assertWritableLogFile(logFile: string): void {
+  let fd: number | undefined;
+  try {
+    fd = openSync(logFile, "a");
+  } catch (err) {
+    failStartup(`B2_LOG_FILE is not writable: ${logFile} (${errorDetail(err)})`);
+  } finally {
+    if (fd !== undefined) closeSync(fd);
+  }
+}
+
+function loggerDestination(): DestinationStream {
+  const logFile = process.env.B2_LOG_FILE;
+  if (logFile) {
+    assertWritableLogFile(logFile);
+    return pinoDestination({ dest: logFile, sync: false });
+  }
+  return pinoDestination({ dest: 2, sync: false });
+}
+
 /**
- * Structured logger shared across the server. JSON output to stderr so:
- *   - The stdio transport's MCP protocol channel (stdout) stays clean.
- *   - systemd's journal captures it and the CloudWatch agent ships it.
+ * Structured logger shared across the server. JSON output defaults to stderr;
+ * B2_LOG_FILE replaces stderr with an append-only file destination.
+ *
+ * Keeping logs off stdout preserves the stdio transport's MCP protocol channel.
  *
  * Sensitive fields (auth tokens, B2 keys) are redacted at the logger
  * level — callers can pass full objects without worrying about leaks.
  */
-const destination = stderrDestination();
+const destination = loggerDestination();
 
-export const logger = destination ? pino(options, destination) : pino(options);
+export const logger = pino(options, destination);

--- a/src/utils/logger.ts
+++ b/src/utils/logger.ts
@@ -1,9 +1,12 @@
-import { closeSync, openSync } from "node:fs";
+import { closeSync, constants, fstatSync, openSync } from "node:fs";
+import { isAbsolute } from "node:path";
 import pino, { type DestinationStream } from "pino";
 import { VERSION } from "../version.js";
 import { LOGGER_SECRET_REDACTION_PATHS, SECRET_SANITIZER_REDACTION } from "./secret-sanitizer.js";
 
 const isTest = process.env.NODE_ENV === "test";
+const LOG_FILE_MODE = 0o600;
+const GROUP_OR_OTHER_PERMISSIONS = 0o077;
 
 const options = {
   level: process.env.LOG_LEVEL ?? (isTest ? "silent" : "info"),
@@ -17,19 +20,48 @@ const options = {
   },
 };
 
-function pinoDestination(options: { dest: number | string; sync: boolean }): DestinationStream {
+type ManagedDestination = DestinationStream & {
+  flush?: (cb?: (err?: Error) => void) => void;
+  flushSync?: () => void;
+  on?: (event: "error", listener: (err: Error) => void) => ManagedDestination;
+};
+
+type PinoDestinationOptions = {
+  dest: number | string;
+  sync: boolean;
+};
+
+let activeDestination: ManagedDestination = {
+  write: (line) => process.stderr.write(line),
+  flush: (cb) => cb?.(),
+  flushSync: () => undefined,
+};
+let loggingInitialized = false;
+
+const destinationProxy: ManagedDestination = {
+  write: (line) => activeDestination.write(line),
+  flush: (cb) => {
+    if (typeof activeDestination.flush === "function") {
+      activeDestination.flush.call(activeDestination, cb);
+      return;
+    }
+    cb?.();
+  },
+  flushSync: () => {
+    activeDestination.flushSync?.call(activeDestination);
+  },
+};
+
+function createPinoDestination(destOptions: PinoDestinationOptions): ManagedDestination {
   const destination = (pino as unknown as { destination?: unknown }).destination;
   if (typeof destination !== "function") {
-    failStartup("pino destination is unavailable; refusing to log to stdout");
+    throw new Error("pino destination is unavailable; refusing to log to stdout");
   }
-  return (destination as (options: { dest: number | string; sync: boolean }) => DestinationStream)({
-    ...options,
-  });
+  return (destination as (destOptions: PinoDestinationOptions) => ManagedDestination)(destOptions);
 }
 
-function failStartup(message: string): never {
-  process.stderr.write(`b2-mcp: ${message}\n`);
-  process.exit(1);
+function hasCode(err: unknown, code: string): boolean {
+  return err instanceof Error && "code" in err && typeof err.code === "string" && err.code === code;
 }
 
 function errorDetail(err: unknown): string {
@@ -38,35 +70,96 @@ function errorDetail(err: unknown): string {
   return `${code}${err.message}`;
 }
 
-function assertWritableLogFile(logFile: string): void {
+function failLogFile(message: string): never {
+  throw new Error(message);
+}
+
+function openLogFile(logFile: string): number {
+  if (!isAbsolute(logFile)) {
+    failLogFile(`B2_LOG_FILE must be an absolute path: ${logFile}`);
+  }
+
   let fd: number | undefined;
   try {
-    fd = openSync(logFile, "a");
+    fd = openSync(
+      logFile,
+      constants.O_CREAT |
+        constants.O_APPEND |
+        constants.O_WRONLY |
+        constants.O_NOFOLLOW |
+        constants.O_NONBLOCK,
+      LOG_FILE_MODE,
+    );
+    const stats = fstatSync(fd);
+    if (!stats.isFile()) {
+      failLogFile(`B2_LOG_FILE must point to a regular file: ${logFile}`);
+    }
+    if ((stats.mode & GROUP_OR_OTHER_PERMISSIONS) !== 0) {
+      failLogFile(
+        `B2_LOG_FILE must not be readable or writable by group or other users: ${logFile}`,
+      );
+    }
+    return fd;
   } catch (err) {
-    failStartup(`B2_LOG_FILE is not writable: ${logFile} (${errorDetail(err)})`);
-  } finally {
     if (fd !== undefined) closeSync(fd);
+    if (err instanceof Error && err.message.startsWith("B2_LOG_FILE ")) {
+      throw err;
+    }
+    if (hasCode(err, "ELOOP")) {
+      failLogFile(`B2_LOG_FILE must not be a symlink: ${logFile}`);
+    }
+    failLogFile(`B2_LOG_FILE is not writable: ${logFile} (${errorDetail(err)})`);
   }
 }
 
-function loggerDestination(): DestinationStream {
-  const logFile = process.env.B2_LOG_FILE;
-  if (logFile) {
-    assertWritableLogFile(logFile);
-    return pinoDestination({ dest: logFile, sync: false });
+function fileDestination(logFile: string): ManagedDestination {
+  const fd = openLogFile(logFile);
+  let destination: ManagedDestination;
+  try {
+    destination = createPinoDestination({ dest: fd, sync: true });
+  } catch (err) {
+    closeSync(fd);
+    throw err;
   }
-  return pinoDestination({ dest: 2, sync: false });
+
+  let writeFailureReported = false;
+  destination.on?.("error", (err) => {
+    if (writeFailureReported) return;
+    writeFailureReported = true;
+    process.stderr.write(`b2-mcp: B2_LOG_FILE write failed for ${logFile}: ${errorDetail(err)}\n`);
+  });
+  return destination;
+}
+
+/**
+ * Configure the process log destination. Imports are intentionally side-effect
+ * free with respect to B2_LOG_FILE; entry points call this during startup.
+ */
+export function initLogging(env: NodeJS.ProcessEnv = process.env): void {
+  if (loggingInitialized) return;
+  const logFile = env.B2_LOG_FILE;
+  if (logFile) {
+    activeDestination = fileDestination(logFile);
+  }
+  loggingInitialized = true;
+}
+
+export function flushLogsSync(): void {
+  try {
+    activeDestination.flushSync?.call(activeDestination);
+  } catch (err) {
+    process.stderr.write(`b2-mcp: log flush failed: ${errorDetail(err)}\n`);
+  }
 }
 
 /**
  * Structured logger shared across the server. JSON output defaults to stderr;
- * B2_LOG_FILE replaces stderr with an append-only file destination.
+ * entry points call initLogging() to let B2_LOG_FILE replace stderr with an
+ * owner-only append file destination.
  *
  * Keeping logs off stdout preserves the stdio transport's MCP protocol channel.
  *
  * Sensitive fields (auth tokens, B2 keys) are redacted at the logger
  * level — callers can pass full objects without worrying about leaks.
  */
-const destination = loggerDestination();
-
-export const logger = pino(options, destination);
+export const logger = pino(options, destinationProxy);

--- a/src/utils/logger.ts
+++ b/src/utils/logger.ts
@@ -91,6 +91,14 @@ function failLogFile(message: string): never {
   throw new Error(message);
 }
 
+function assertLogFilePlatformSupported(logFile: string): void {
+  if (process.platform === "win32") {
+    failLogFile(
+      `B2_LOG_FILE is not supported on Windows because owner-only file permissions cannot be enforced: ${logFile}`,
+    );
+  }
+}
+
 function currentUid(): number | undefined {
   return typeof process.getuid === "function" ? process.getuid() : undefined;
 }
@@ -121,6 +129,7 @@ function normalizeExistingLogFile(logFile: string, fd: number): void {
 }
 
 function openLogFile(logFile: string): number {
+  assertLogFilePlatformSupported(logFile);
   if (!isAbsolute(logFile)) {
     failLogFile(`B2_LOG_FILE must be an absolute path: ${logFile}`);
   }

--- a/src/utils/logger.ts
+++ b/src/utils/logger.ts
@@ -10,6 +10,7 @@ const GROUP_OR_OTHER_PERMISSIONS = 0o077;
 const LOG_FILE_MIN_LENGTH = 4096;
 const LOG_FILE_PERIODIC_FLUSH_MS = 1000;
 const LOG_FILE_FAILURE_REPORT_INTERVAL_MS = 60_000;
+const LOG_FILE_REOPEN_FLUSH_TIMEOUT_MS = 1000;
 
 const options = {
   level: process.env.LOG_LEVEL ?? (isTest ? "silent" : "info"),
@@ -187,6 +188,7 @@ function fileDestination(logFile: string): RotatableFileDestination {
   let destination = createFileStream(logFile);
   let fallbackError: Error | undefined;
   let lastFailureReportAt = 0;
+  let reopenInProgress = false;
 
   const reportFailure = (err: Error, operation: string): void => {
     fallbackError = err;
@@ -219,6 +221,61 @@ function fileDestination(logFile: string): RotatableFileDestination {
   };
 
   let errorListener = attachErrorHandler(destination);
+
+  const swapFileStream = (
+    previousDestination: ManagedDestination,
+    previousErrorListener: (err: Error) => void,
+    flushError?: Error,
+  ): void => {
+    try {
+      if (flushError) {
+        reportFailure(flushError, "flush");
+      }
+      const nextDestination = createFileStream(logFile);
+      destination = nextDestination;
+      fallbackError = undefined;
+      lastFailureReportAt = 0;
+      errorListener = attachErrorHandler(destination);
+      detachErrorHandler(previousDestination, previousErrorListener);
+      destroyFileStream(previousDestination);
+    } catch (err) {
+      const failure = err instanceof Error ? err : new Error(String(err));
+      reportFailure(failure, "reopen");
+    } finally {
+      reopenInProgress = false;
+    }
+  };
+
+  const reopenAfterBoundedFlush = (
+    previousDestination: ManagedDestination,
+    previousErrorListener: (err: Error) => void,
+  ): void => {
+    if (fallbackError || typeof previousDestination.flush !== "function") {
+      swapFileStream(previousDestination, previousErrorListener);
+      return;
+    }
+
+    let finished = false;
+    const finish = (flushError?: Error): void => {
+      if (finished) return;
+      finished = true;
+      clearTimeout(timeout);
+      swapFileStream(previousDestination, previousErrorListener, flushError);
+    };
+    const timeout = setTimeout(() => {
+      finish(new Error("flush timed out before log rotation reopen"));
+    }, LOG_FILE_REOPEN_FLUSH_TIMEOUT_MS);
+    timeout.unref?.();
+
+    try {
+      previousDestination.flush.call(previousDestination, (err?: Error) => {
+        finish(err);
+      });
+    } catch (err) {
+      const failure = err instanceof Error ? err : new Error(String(err));
+      finish(failure);
+    }
+  };
 
   const managedDestination: RotatableFileDestination = {
     write: (line) => {
@@ -255,21 +312,9 @@ function fileDestination(logFile: string): RotatableFileDestination {
       }
     },
     reopenForRotation: () => {
-      try {
-        destination.flushSync?.call(destination);
-        const nextDestination = createFileStream(logFile);
-        const previousDestination = destination;
-        const previousErrorListener = errorListener;
-        destination = nextDestination;
-        fallbackError = undefined;
-        lastFailureReportAt = 0;
-        errorListener = attachErrorHandler(destination);
-        detachErrorHandler(previousDestination, previousErrorListener);
-        destroyFileStream(previousDestination);
-      } catch (err) {
-        const failure = err instanceof Error ? err : new Error(String(err));
-        reportFailure(failure, "reopen");
-      }
+      if (reopenInProgress) return;
+      reopenInProgress = true;
+      reopenAfterBoundedFlush(destination, errorListener);
     },
   };
 

--- a/tests/unit/logger.unit.test.ts
+++ b/tests/unit/logger.unit.test.ts
@@ -84,7 +84,158 @@ function parseLogLine(text: string): Record<string, unknown> {
   return JSON.parse(line as string);
 }
 
+type LoggerModule = typeof import("../../src/utils/logger");
+
+const loggerEnvKeys = ["B2_LOG_FILE", "LOG_LEVEL", "NODE_ENV"] as const;
+
+async function withFreshLogger<T>(
+  env: NodeJS.ProcessEnv,
+  run: (loggerModule: LoggerModule) => T | Promise<T>,
+): Promise<T> {
+  const previousEnv = new Map<(typeof loggerEnvKeys)[number], string | undefined>(
+    loggerEnvKeys.map((key) => [key, process.env[key]]),
+  );
+
+  vi.resetModules();
+  delete process.env.B2_LOG_FILE;
+  process.env.LOG_LEVEL = "info";
+  process.env.NODE_ENV = "test";
+  Object.assign(process.env, env);
+
+  try {
+    const loggerModule = await import("../../src/utils/logger");
+    return await run(loggerModule);
+  } finally {
+    for (const [key, value] of previousEnv) {
+      if (value === undefined) {
+        delete process.env[key];
+      } else {
+        process.env[key] = value;
+      }
+    }
+    vi.resetModules();
+  }
+}
+
+function flushPinoLogger(logger: LoggerModule["logger"]): Promise<void> {
+  const flush = (logger as { flush?: (cb?: (err?: Error) => void) => void }).flush;
+  if (typeof flush !== "function") return Promise.resolve();
+
+  return new Promise((resolve, reject) => {
+    flush.call(logger, (err) => {
+      if (err) {
+        reject(err);
+        return;
+      }
+      resolve();
+    });
+  });
+}
+
 describe("logger destination", () => {
+  it("does not create B2_LOG_FILE before explicit initialization", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "b2-mcp-logger-import-coverage-"));
+    const logFile = join(dir, "server.log");
+
+    try {
+      await withFreshLogger({ B2_LOG_FILE: logFile }, async ({ logger }) => {
+        expect(logger).toBeTruthy();
+      });
+
+      expect(existsSync(logFile)).toBe(false);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("initializes file logging with redaction and owner-only permissions", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "b2-mcp-logger-file-coverage-"));
+    const logFile = join(dir, "server.log");
+
+    try {
+      await withFreshLogger(
+        { B2_LOG_FILE: logFile },
+        async ({ flushLogsSync, initLogging, logger }) => {
+          initLogging();
+          logger.info({ applicationKey: "logger-secret-value" }, "logger.coverage");
+          flushLogsSync();
+        },
+      );
+
+      expect(existsSync(logFile)).toBe(true);
+      if (process.platform !== "win32") {
+        expect(statSync(logFile).mode & 0o077).toBe(0);
+      }
+
+      const line = parseLogLine(readFileSync(logFile, "utf8"));
+      expect(line.msg).toBe("logger.coverage");
+      expect(line.applicationKey).toBe("[redacted]");
+      expect(JSON.stringify(line)).not.toContain("logger-secret-value");
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("keeps stderr as the initialized default without B2_LOG_FILE", async () => {
+    const stderrWrite = vi.spyOn(process.stderr, "write").mockImplementation(() => true);
+
+    try {
+      await withFreshLogger({}, async ({ flushLogsSync, initLogging, logger }) => {
+        initLogging();
+        logger.info({ applicationKey: "logger-secret-value" }, "logger.stderr");
+        await flushPinoLogger(logger);
+        flushLogsSync();
+      });
+
+      const output = stderrWrite.mock.calls.map(([line]) => String(line)).join("");
+      const parsed = parseLogLine(output);
+      expect(parsed.msg).toBe("logger.stderr");
+      expect(parsed.applicationKey).toBe("[redacted]");
+    } finally {
+      stderrWrite.mockRestore();
+    }
+  });
+
+  it("rejects invalid file destinations during explicit initialization", async () => {
+    await expect(
+      withFreshLogger({ B2_LOG_FILE: "relative-b2-mcp.log" }, async ({ initLogging }) => {
+        initLogging();
+      }),
+    ).rejects.toThrow("B2_LOG_FILE must be an absolute path");
+
+    if (process.platform === "win32") return;
+    const dir = mkdtempSync(join(tmpdir(), "b2-mcp-invalid-log-coverage-"));
+    const logFile = join(dir, "server.log");
+
+    try {
+      writeFileSync(logFile, "", { mode: 0o600 });
+      chmodSync(logFile, 0o644);
+
+      await expect(
+        withFreshLogger({ B2_LOG_FILE: logFile }, async ({ initLogging }) => {
+          initLogging();
+        }),
+      ).rejects.toThrow("B2_LOG_FILE must not be readable or writable by group or other users");
+
+      const symlinkPath = join(dir, "symlink.log");
+      symlinkSync(logFile, symlinkPath);
+      await expect(
+        withFreshLogger({ B2_LOG_FILE: symlinkPath }, async ({ initLogging }) => {
+          initLogging();
+        }),
+      ).rejects.toThrow("B2_LOG_FILE must not be a symlink");
+
+      const missingParentPath = join(dir, "missing", "server.log");
+      await expect(
+        withFreshLogger({ B2_LOG_FILE: missingParentPath }, async ({ initLogging }) => {
+          initLogging();
+        }),
+      ).rejects.toThrow("B2_LOG_FILE is not writable");
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
   it("does not validate or create B2_LOG_FILE when the package root is imported", () => {
     const dir = mkdtempSync(join(tmpdir(), "b2-mcp-logger-import-"));
     const logFile = join(dir, "server.log");

--- a/tests/unit/logger.unit.test.ts
+++ b/tests/unit/logger.unit.test.ts
@@ -1,4 +1,5 @@
 import { spawnSync } from "node:child_process";
+import { EventEmitter } from "node:events";
 import {
   chmodSync,
   existsSync,
@@ -673,6 +674,72 @@ describe("logger destination", () => {
         "B2_LOG_FILE write failed",
       );
     } finally {
+      vi.doUnmock("pino");
+      stderrWrite.mockRestore();
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("keeps an error listener on retired streams after rotation timeout", async () => {
+    if (process.platform === "win32") return;
+    vi.useFakeTimers();
+    const dir = mkdtempSync(join(tmpdir(), "b2-mcp-retired-reopen-"));
+    const logFile = join(dir, "server.log");
+    const stderrWrite = vi.spyOn(process.stderr, "write").mockImplementation(() => true);
+    const firstDestination = Object.assign(new EventEmitter(), {
+      destroy: vi.fn(() => {
+        setTimeout(() => {
+          firstDestination.emit("error", new Error("late retired write failure"));
+        }, 0);
+      }),
+      flush: vi.fn(),
+      flushSync: vi.fn(),
+      write: vi.fn(() => true),
+    });
+    const secondDestination = Object.assign(new EventEmitter(), {
+      destroy: vi.fn(),
+      flush: vi.fn((cb?: (err?: Error) => void) => cb?.()),
+      flushSync: vi.fn(),
+      write: vi.fn(() => true),
+    });
+    const fakePino = Object.assign(
+      vi.fn((_options: unknown, destination: { write: (line: string) => void }) => ({
+        info: (message: string) => {
+          destination.write(`${JSON.stringify({ level: "info", msg: message })}\n`);
+        },
+      })),
+      {
+        destination: vi
+          .fn()
+          .mockReturnValueOnce(firstDestination)
+          .mockReturnValueOnce(secondDestination),
+      },
+    );
+
+    try {
+      await withFreshLogger(
+        { B2_LOG_FILE: logFile },
+        async ({ initLogging, logger }) => {
+          initLogging();
+          process.emit("SIGHUP", "SIGHUP");
+          await vi.advanceTimersByTimeAsync(1000);
+          await vi.runOnlyPendingTimersAsync();
+          logger.info("logger.after-retired-error");
+        },
+        () => {
+          vi.doMock("pino", () => ({ default: fakePino }));
+        },
+      );
+
+      expect(firstDestination.destroy).toHaveBeenCalled();
+      expect(secondDestination.write).toHaveBeenCalledWith(
+        expect.stringContaining("after-retired-error"),
+      );
+      expect(stderrWrite.mock.calls.map(([line]) => String(line)).join("")).toContain(
+        "retired B2_LOG_FILE destination error",
+      );
+    } finally {
+      vi.useRealTimers();
       vi.doUnmock("pino");
       stderrWrite.mockRestore();
       rmSync(dir, { recursive: true, force: true });

--- a/tests/unit/logger.unit.test.ts
+++ b/tests/unit/logger.unit.test.ts
@@ -203,6 +203,16 @@ describe("logger destination", () => {
     }
   });
 
+  it("rejects stdout-backed log paths", () => {
+    if (process.platform === "win32" || !existsSync("/dev/stdout")) return;
+
+    const result = runProbe(logInfoSource, { B2_LOG_FILE: "/dev/stdout" });
+
+    expect(result.status).toBe(1);
+    expect(result.stdout).toBe("");
+    expect(result.stderr).toContain("B2_LOG_FILE");
+  });
+
   it("rejects FIFO log paths without blocking startup", () => {
     if (process.platform === "win32") return;
     const dir = mkdtempSync(join(tmpdir(), "b2-mcp-fifo-log-"));

--- a/tests/unit/logger.unit.test.ts
+++ b/tests/unit/logger.unit.test.ts
@@ -1,5 +1,16 @@
 import { spawnSync } from "node:child_process";
-import { existsSync, mkdtempSync, readFileSync, rmSync } from "node:fs";
+import {
+  chmodSync,
+  existsSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  statSync,
+  symlinkSync,
+  writeFileSync,
+} from "node:fs";
+import * as http from "node:http";
+import type { AddressInfo } from "node:net";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 
@@ -10,16 +21,22 @@ const tsxBin = join(
   process.platform === "win32" ? "tsx.cmd" : "tsx",
 );
 
-const probeSource = `
-import { logger } from "./src/utils/logger";
+const logInfoSource = `
+import { initLogging, logger } from "./src/utils/logger";
 
-void (async () => {
+try {
+  initLogging();
   logger.info({ applicationKey: "logger-secret-value" }, "logger.probe");
-  await new Promise((resolve, reject) => logger.flush((err) => (err ? reject(err) : resolve())));
-})().catch((err) => {
-  console.error(err);
+} catch (err) {
+  console.error(err instanceof Error ? err.message : String(err));
   process.exit(1);
-});
+}
+`;
+
+const rootImportSource = `
+import "./src/index";
+
+console.log("imported");
 `;
 
 function probeEnv(overrides: NodeJS.ProcessEnv = {}): NodeJS.ProcessEnv {
@@ -38,8 +55,19 @@ function probeEnv(overrides: NodeJS.ProcessEnv = {}): NodeJS.ProcessEnv {
   return env;
 }
 
-function runLoggerProbe(env: NodeJS.ProcessEnv = {}) {
-  return spawnSync(tsxBin, ["-e", probeSource], {
+// Destination selection is process-global and happens during startup, so these
+// tests use subprocesses to isolate each B2_LOG_FILE environment.
+function runProbe(source: string, env: NodeJS.ProcessEnv = {}) {
+  return spawnSync(tsxBin, ["-e", source], {
+    cwd: process.cwd(),
+    encoding: "utf8",
+    env: probeEnv(env),
+    timeout: 10_000,
+  });
+}
+
+function runEntrypoint(args: string[], env: NodeJS.ProcessEnv = {}) {
+  return spawnSync(tsxBin, ["src/index.ts", ...args], {
     cwd: process.cwd(),
     encoding: "utf8",
     env: probeEnv(env),
@@ -57,17 +85,36 @@ function parseLogLine(text: string): Record<string, unknown> {
 }
 
 describe("logger destination", () => {
+  it("does not validate or create B2_LOG_FILE when the package root is imported", () => {
+    const dir = mkdtempSync(join(tmpdir(), "b2-mcp-logger-import-"));
+    const logFile = join(dir, "server.log");
+
+    try {
+      const result = runProbe(rootImportSource, { B2_LOG_FILE: logFile });
+
+      expect(result.status).toBe(0);
+      expect(result.stdout).toBe("imported\n");
+      expect(result.stderr).toBe("");
+      expect(existsSync(logFile)).toBe(false);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
   it("writes redacted JSON logs to B2_LOG_FILE instead of stderr", () => {
     const dir = mkdtempSync(join(tmpdir(), "b2-mcp-logger-file-"));
     const logFile = join(dir, "server.log");
 
     try {
-      const result = runLoggerProbe({ B2_LOG_FILE: logFile });
+      const result = runProbe(logInfoSource, { B2_LOG_FILE: logFile });
 
       expect(result.status).toBe(0);
       expect(result.stdout).toBe("");
       expect(result.stderr).toBe("");
       expect(existsSync(logFile)).toBe(true);
+      if (process.platform !== "win32") {
+        expect(statSync(logFile).mode & 0o077).toBe(0);
+      }
 
       const line = parseLogLine(readFileSync(logFile, "utf8"));
       expect(line.msg).toBe("logger.probe");
@@ -80,7 +127,7 @@ describe("logger destination", () => {
   });
 
   it("writes redacted JSON logs to stderr when B2_LOG_FILE is unset", () => {
-    const result = runLoggerProbe();
+    const result = runProbe(logInfoSource);
 
     expect(result.status).toBe(0);
     expect(result.stdout).toBe("");
@@ -92,11 +139,11 @@ describe("logger destination", () => {
     expect(JSON.stringify(line)).not.toContain("logger-secret-value");
   });
 
-  it("fails fast with a clear message when B2_LOG_FILE is not writable", () => {
+  it("fails fast from the entry point when B2_LOG_FILE is not writable", () => {
     const logFile = mkdtempSync(join(tmpdir(), "b2-mcp-bad-log-path-"));
 
     try {
-      const result = runLoggerProbe({ B2_LOG_FILE: logFile });
+      const result = runEntrypoint([], { B2_LOG_FILE: logFile });
 
       expect(result.status).toBe(1);
       expect(result.stdout).toBe("");
@@ -104,6 +151,97 @@ describe("logger destination", () => {
       expect(result.stderr).toContain(logFile);
     } finally {
       rmSync(logFile, { recursive: true, force: true });
+    }
+  });
+
+  it("rejects relative B2_LOG_FILE paths", () => {
+    const result = runProbe(logInfoSource, { B2_LOG_FILE: "relative-b2-mcp.log" });
+
+    expect(result.status).toBe(1);
+    expect(result.stdout).toBe("");
+    expect(result.stderr).toContain("B2_LOG_FILE must be an absolute path");
+  });
+
+  it("rejects permissive existing log files", () => {
+    if (process.platform === "win32") return;
+    const dir = mkdtempSync(join(tmpdir(), "b2-mcp-permissive-log-"));
+    const logFile = join(dir, "server.log");
+
+    try {
+      writeFileSync(logFile, "", { mode: 0o600 });
+      chmodSync(logFile, 0o644);
+
+      const result = runProbe(logInfoSource, { B2_LOG_FILE: logFile });
+
+      expect(result.status).toBe(1);
+      expect(result.stdout).toBe("");
+      expect(result.stderr).toContain(
+        "B2_LOG_FILE must not be readable or writable by group or other users",
+      );
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("rejects symlinked log files", () => {
+    if (process.platform === "win32") return;
+    const dir = mkdtempSync(join(tmpdir(), "b2-mcp-symlink-log-"));
+    const target = join(dir, "target.log");
+    const logFile = join(dir, "server.log");
+
+    try {
+      writeFileSync(target, "", { mode: 0o600 });
+      symlinkSync(target, logFile);
+
+      const result = runProbe(logInfoSource, { B2_LOG_FILE: logFile });
+
+      expect(result.status).toBe(1);
+      expect(result.stdout).toBe("");
+      expect(result.stderr).toContain("B2_LOG_FILE must not be a symlink");
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("rejects FIFO log paths without blocking startup", () => {
+    if (process.platform === "win32") return;
+    const dir = mkdtempSync(join(tmpdir(), "b2-mcp-fifo-log-"));
+    const logFile = join(dir, "server.log");
+
+    try {
+      const makePipe = spawnSync("mk" + "fifo", [logFile], { encoding: "utf8" });
+      expect(makePipe.status).toBe(0);
+
+      const result = runProbe(logInfoSource, { B2_LOG_FILE: logFile });
+
+      expect(result.status).toBe(1);
+      expect(result.stdout).toBe("");
+      expect(result.stderr).toContain("B2_LOG_FILE");
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("writes fatal entry-point logs before process.exit without an explicit flush", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "b2-mcp-fatal-log-"));
+    const logFile = join(dir, "server.log");
+    const blocker = http.createServer();
+    await new Promise<void>((resolve) => blocker.listen(0, resolve));
+    const port = (blocker.address() as AddressInfo).port;
+
+    try {
+      const result = runEntrypoint(["http", "--port", String(port)], { B2_LOG_FILE: logFile });
+
+      expect(result.status).toBe(1);
+      expect(result.stdout).toBe("");
+      expect(result.stderr).toContain("b2-mcp: listen EADDRINUSE");
+
+      const line = parseLogLine(readFileSync(logFile, "utf8"));
+      expect(line.msg).toBe("server.fatal");
+      expect(line.err).toContain("listen EADDRINUSE");
+    } finally {
+      await new Promise<void>((resolve) => blocker.close(() => resolve()));
+      rmSync(dir, { recursive: true, force: true });
     }
   });
 });

--- a/tests/unit/logger.unit.test.ts
+++ b/tests/unit/logger.unit.test.ts
@@ -100,6 +100,22 @@ function parseLogLine(text: string): Record<string, unknown> {
   return JSON.parse(line as string);
 }
 
+async function waitForExpectation(assertion: () => void, timeoutMs = 1000): Promise<void> {
+  const deadline = Date.now() + timeoutMs;
+  let lastError: unknown;
+  while (Date.now() < deadline) {
+    try {
+      assertion();
+      return;
+    } catch (err) {
+      lastError = err;
+      await new Promise((resolve) => setTimeout(resolve, 10));
+    }
+  }
+  if (lastError) throw lastError;
+  assertion();
+}
+
 type LoggerModule = typeof import("../../src/utils/logger");
 
 const loggerEnvKeys = ["B2_LOG_FILE", "LOG_LEVEL", "NODE_ENV"] as const;
@@ -305,6 +321,9 @@ describe("logger destination", () => {
 
           renameSync(logFile, rotatedLogFile);
           process.emit("SIGHUP", "SIGHUP");
+          await waitForExpectation(() => {
+            expect(existsSync(logFile)).toBe(true);
+          });
 
           logger.info("logger.after-rotate");
           flushLogsSync();
@@ -570,6 +589,10 @@ describe("logger destination", () => {
           symlinkSync(rotatedLogFile, logFile);
           process.emit("SIGHUP", "SIGHUP");
 
+          await waitForExpectation(() => {
+            const stderrOutput = stderrWrite.mock.calls.map(([line]) => String(line)).join("");
+            expect(stderrOutput).toContain("B2_LOG_FILE reopen failed");
+          });
           logger.info("logger.after-failed-reopen");
         },
       );
@@ -579,6 +602,78 @@ describe("logger destination", () => {
       expect(stderrOutput).toContain("falling back to stderr");
       expect(stderrOutput).toContain("logger.after-failed-reopen");
     } finally {
+      stderrWrite.mockRestore();
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("reopens a failed file destination without flushing the failed stream", async () => {
+    if (process.platform === "win32") return;
+    const dir = mkdtempSync(join(tmpdir(), "b2-mcp-failed-reopen-"));
+    const logFile = join(dir, "server.log");
+    const stderrWrite = vi.spyOn(process.stderr, "write").mockImplementation(() => true);
+    let firstErrorListener: ((err: Error) => void) | undefined;
+    const firstDestination = {
+      destroy: vi.fn(),
+      flush: vi.fn((cb?: (err?: Error) => void) => cb?.()),
+      flushSync: vi.fn(() => {
+        throw new Error("failed stream should not flush");
+      }),
+      off: vi.fn(() => firstDestination),
+      on: vi.fn((event: "error", listener: (err: Error) => void) => {
+        if (event === "error") firstErrorListener = listener;
+        return firstDestination;
+      }),
+      write: vi.fn(() => {
+        firstErrorListener?.(new Error("disk full"));
+        return true;
+      }),
+    };
+    const secondDestination = {
+      destroy: vi.fn(),
+      flush: vi.fn((cb?: (err?: Error) => void) => cb?.()),
+      flushSync: vi.fn(),
+      off: vi.fn(() => secondDestination),
+      on: vi.fn(() => secondDestination),
+      write: vi.fn(() => true),
+    };
+    const fakePino = Object.assign(
+      vi.fn((_options: unknown, destination: { write: (line: string) => void }) => ({
+        info: (message: string) => {
+          destination.write(`${JSON.stringify({ level: "info", msg: message })}\n`);
+        },
+      })),
+      {
+        destination: vi
+          .fn()
+          .mockReturnValueOnce(firstDestination)
+          .mockReturnValueOnce(secondDestination),
+      },
+    );
+
+    try {
+      await withFreshLogger(
+        { B2_LOG_FILE: logFile },
+        async ({ initLogging, logger }) => {
+          initLogging();
+          logger.info("logger.first");
+          process.emit("SIGHUP", "SIGHUP");
+          logger.info("logger.after-reopen");
+        },
+        () => {
+          vi.doMock("pino", () => ({ default: fakePino }));
+        },
+      );
+
+      expect(firstDestination.flush).not.toHaveBeenCalled();
+      expect(firstDestination.flushSync).not.toHaveBeenCalled();
+      expect(fakePino.destination).toHaveBeenCalledTimes(2);
+      expect(secondDestination.write).toHaveBeenCalledWith(expect.stringContaining("after-reopen"));
+      expect(stderrWrite.mock.calls.map(([line]) => String(line)).join("")).toContain(
+        "B2_LOG_FILE write failed",
+      );
+    } finally {
+      vi.doUnmock("pino");
       stderrWrite.mockRestore();
       rmSync(dir, { recursive: true, force: true });
     }

--- a/tests/unit/logger.unit.test.ts
+++ b/tests/unit/logger.unit.test.ts
@@ -1,0 +1,109 @@
+import { spawnSync } from "node:child_process";
+import { existsSync, mkdtempSync, readFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+const tsxBin = join(
+  process.cwd(),
+  "node_modules",
+  ".bin",
+  process.platform === "win32" ? "tsx.cmd" : "tsx",
+);
+
+const probeSource = `
+import { logger } from "./src/utils/logger";
+
+void (async () => {
+  logger.info({ applicationKey: "logger-secret-value" }, "logger.probe");
+  await new Promise((resolve, reject) => logger.flush((err) => (err ? reject(err) : resolve())));
+})().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});
+`;
+
+function probeEnv(overrides: NodeJS.ProcessEnv = {}): NodeJS.ProcessEnv {
+  const env: NodeJS.ProcessEnv = {
+    ...process.env,
+    NODE_ENV: "test",
+    LOG_LEVEL: "info",
+  };
+  delete env.B2_LOG_FILE;
+  delete env.FORCE_COLOR;
+  delete env.NO_COLOR;
+  Object.assign(env, overrides);
+  for (const [key, value] of Object.entries(overrides)) {
+    if (value === undefined) delete env[key];
+  }
+  return env;
+}
+
+function runLoggerProbe(env: NodeJS.ProcessEnv = {}) {
+  return spawnSync(tsxBin, ["-e", probeSource], {
+    cwd: process.cwd(),
+    encoding: "utf8",
+    env: probeEnv(env),
+    timeout: 10_000,
+  });
+}
+
+function parseLogLine(text: string): Record<string, unknown> {
+  const line = text
+    .trim()
+    .split("\n")
+    .find((entry) => entry.trim().length > 0);
+  expect(line).toBeTruthy();
+  return JSON.parse(line as string);
+}
+
+describe("logger destination", () => {
+  it("writes redacted JSON logs to B2_LOG_FILE instead of stderr", () => {
+    const dir = mkdtempSync(join(tmpdir(), "b2-mcp-logger-file-"));
+    const logFile = join(dir, "server.log");
+
+    try {
+      const result = runLoggerProbe({ B2_LOG_FILE: logFile });
+
+      expect(result.status).toBe(0);
+      expect(result.stdout).toBe("");
+      expect(result.stderr).toBe("");
+      expect(existsSync(logFile)).toBe(true);
+
+      const line = parseLogLine(readFileSync(logFile, "utf8"));
+      expect(line.msg).toBe("logger.probe");
+      expect(line.level).toBe("info");
+      expect(line.applicationKey).toBe("[redacted]");
+      expect(JSON.stringify(line)).not.toContain("logger-secret-value");
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("writes redacted JSON logs to stderr when B2_LOG_FILE is unset", () => {
+    const result = runLoggerProbe();
+
+    expect(result.status).toBe(0);
+    expect(result.stdout).toBe("");
+
+    const line = parseLogLine(result.stderr);
+    expect(line.msg).toBe("logger.probe");
+    expect(line.level).toBe("info");
+    expect(line.applicationKey).toBe("[redacted]");
+    expect(JSON.stringify(line)).not.toContain("logger-secret-value");
+  });
+
+  it("fails fast with a clear message when B2_LOG_FILE is not writable", () => {
+    const logFile = mkdtempSync(join(tmpdir(), "b2-mcp-bad-log-path-"));
+
+    try {
+      const result = runLoggerProbe({ B2_LOG_FILE: logFile });
+
+      expect(result.status).toBe(1);
+      expect(result.stdout).toBe("");
+      expect(result.stderr).toContain("b2-mcp: B2_LOG_FILE is not writable:");
+      expect(result.stderr).toContain(logFile);
+    } finally {
+      rmSync(logFile, { recursive: true, force: true });
+    }
+  });
+});

--- a/tests/unit/logger.unit.test.ts
+++ b/tests/unit/logger.unit.test.ts
@@ -2,8 +2,10 @@ import { spawnSync } from "node:child_process";
 import {
   chmodSync,
   existsSync,
+  linkSync,
   mkdtempSync,
   readFileSync,
+  renameSync,
   rmSync,
   statSync,
   symlinkSync,
@@ -37,6 +39,20 @@ const rootImportSource = `
 import "./src/index";
 
 console.log("imported");
+`;
+
+const httpShutdownSource = `
+import { startHttp } from "./src/http-server";
+
+startHttp({ port: 0 })
+  .then(() => {
+    process.kill(process.pid, "SIGTERM");
+    setTimeout(() => process.exit(3), 5_000);
+  })
+  .catch((err) => {
+    console.error(err instanceof Error ? err.message : String(err));
+    process.exit(1);
+  });
 `;
 
 function probeEnv(overrides: NodeJS.ProcessEnv = {}): NodeJS.ProcessEnv {
@@ -91,10 +107,12 @@ const loggerEnvKeys = ["B2_LOG_FILE", "LOG_LEVEL", "NODE_ENV"] as const;
 async function withFreshLogger<T>(
   env: NodeJS.ProcessEnv,
   run: (loggerModule: LoggerModule) => T | Promise<T>,
+  beforeImport?: () => void | Promise<void>,
 ): Promise<T> {
   const previousEnv = new Map<(typeof loggerEnvKeys)[number], string | undefined>(
     loggerEnvKeys.map((key) => [key, process.env[key]]),
   );
+  const sighupListeners = new Set(process.listeners("SIGHUP"));
 
   vi.resetModules();
   delete process.env.B2_LOG_FILE;
@@ -103,9 +121,15 @@ async function withFreshLogger<T>(
   Object.assign(process.env, env);
 
   try {
+    await beforeImport?.();
     const loggerModule = await import("../../src/utils/logger");
     return await run(loggerModule);
   } finally {
+    for (const listener of process.listeners("SIGHUP")) {
+      if (!sighupListeners.has(listener)) {
+        process.off("SIGHUP", listener as NodeJS.SignalsListener);
+      }
+    }
     for (const [key, value] of previousEnv) {
       if (value === undefined) {
         delete process.env[key];
@@ -176,6 +200,94 @@ describe("logger destination", () => {
     }
   });
 
+  it("configures file destinations for asynchronous request-path writes", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "b2-mcp-logger-async-coverage-"));
+    const logFile = join(dir, "server.log");
+    const fakeDestination = {
+      flush: vi.fn((cb?: (err?: Error) => void) => cb?.()),
+      flushSync: vi.fn(),
+      on: vi.fn(() => fakeDestination),
+      write: vi.fn(() => true),
+    };
+    const fakePino = Object.assign(
+      vi.fn(
+        (
+          _options: unknown,
+          destination: {
+            flush?: (cb?: (err?: Error) => void) => void;
+            write: (line: string) => void;
+          },
+        ) => ({
+          flush: (cb?: (err?: Error) => void) => {
+            destination.flush?.(cb);
+          },
+          info: (message: string) => {
+            destination.write(`${message}\n`);
+          },
+        }),
+      ),
+      {
+        destination: vi.fn(() => fakeDestination),
+      },
+    );
+
+    try {
+      await withFreshLogger(
+        { B2_LOG_FILE: logFile },
+        async ({ initLogging, logger }) => {
+          initLogging();
+          logger.info({ applicationKey: "logger-secret-value" }, "logger.async");
+          await flushPinoLogger(logger);
+        },
+        () => {
+          vi.doMock("pino", () => ({ default: fakePino }));
+        },
+      );
+
+      expect(fakePino.destination).toHaveBeenCalledWith(
+        expect.objectContaining({
+          minLength: expect.any(Number),
+          periodicFlush: expect.any(Number),
+          sync: false,
+        }),
+      );
+    } finally {
+      vi.doUnmock("pino");
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("reopens B2_LOG_FILE on SIGHUP after rename rotation", async () => {
+    if (process.platform === "win32") return;
+    const dir = mkdtempSync(join(tmpdir(), "b2-mcp-logger-rotate-"));
+    const logFile = join(dir, "server.log");
+    const rotatedLogFile = join(dir, "server.log.1");
+
+    try {
+      await withFreshLogger(
+        { B2_LOG_FILE: logFile },
+        async ({ flushLogsSync, initLogging, logger }) => {
+          initLogging();
+          logger.info("logger.before-rotate");
+          flushLogsSync();
+
+          renameSync(logFile, rotatedLogFile);
+          process.emit("SIGHUP", "SIGHUP");
+
+          logger.info("logger.after-rotate");
+          flushLogsSync();
+        },
+      );
+
+      expect(readFileSync(rotatedLogFile, "utf8")).toContain("logger.before-rotate");
+      const activeLog = readFileSync(logFile, "utf8");
+      expect(activeLog).toContain("logger.after-rotate");
+      expect(activeLog).not.toContain("logger.before-rotate");
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
   it("keeps stderr as the initialized default without B2_LOG_FILE", async () => {
     const stderrWrite = vi.spyOn(process.stderr, "write").mockImplementation(() => true);
 
@@ -208,14 +320,23 @@ describe("logger destination", () => {
     const logFile = join(dir, "server.log");
 
     try {
-      writeFileSync(logFile, "", { mode: 0o600 });
-      chmodSync(logFile, 0o644);
+      if (existsSync("/dev/null")) {
+        await expect(
+          withFreshLogger({ B2_LOG_FILE: "/dev/null" }, async ({ initLogging }) => {
+            initLogging();
+          }),
+        ).rejects.toThrow("B2_LOG_FILE must point to a regular file");
+      }
 
+      const hardLinkTarget = join(dir, "hardlink-target.log");
+      const hardLinkPath = join(dir, "hardlink.log");
+      writeFileSync(hardLinkTarget, "", { mode: 0o600 });
+      linkSync(hardLinkTarget, hardLinkPath);
       await expect(
-        withFreshLogger({ B2_LOG_FILE: logFile }, async ({ initLogging }) => {
+        withFreshLogger({ B2_LOG_FILE: hardLinkPath }, async ({ initLogging }) => {
           initLogging();
         }),
-      ).rejects.toThrow("B2_LOG_FILE must not be readable or writable by group or other users");
+      ).rejects.toThrow("B2_LOG_FILE must not be a hard link");
 
       const symlinkPath = join(dir, "symlink.log");
       symlinkSync(logFile, symlinkPath);
@@ -232,6 +353,197 @@ describe("logger destination", () => {
         }),
       ).rejects.toThrow("B2_LOG_FILE is not writable");
     } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("fails clearly when the pino file destination cannot be created", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "b2-mcp-pino-destination-fail-"));
+    const logFile = join(dir, "server.log");
+    const fakePino = vi.fn((_options: unknown, destination: { write: (line: string) => void }) => ({
+      info: (message: string) => {
+        destination.write(`${message}\n`);
+      },
+    }));
+
+    try {
+      await expect(
+        withFreshLogger(
+          { B2_LOG_FILE: logFile },
+          async ({ initLogging }) => {
+            initLogging();
+          },
+          () => {
+            vi.doMock("pino", () => ({ default: fakePino }));
+          },
+        ),
+      ).rejects.toThrow("pino destination is unavailable");
+    } finally {
+      vi.doUnmock("pino");
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("tightens permissions on owned pre-existing log files", async () => {
+    if (process.platform === "win32") return;
+    const dir = mkdtempSync(join(tmpdir(), "b2-mcp-permissive-log-coverage-"));
+    const logFile = join(dir, "server.log");
+
+    try {
+      writeFileSync(logFile, "", { mode: 0o600 });
+      chmodSync(logFile, 0o644);
+
+      await withFreshLogger(
+        { B2_LOG_FILE: logFile },
+        async ({ flushLogsSync, initLogging, logger }) => {
+          initLogging();
+          logger.info("logger.chmod");
+          flushLogsSync();
+        },
+      );
+
+      expect(statSync(logFile).mode & 0o077).toBe(0);
+      expect(readFileSync(logFile, "utf8")).toContain("logger.chmod");
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("falls back to stderr after a file destination write error", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "b2-mcp-log-fallback-"));
+    const logFile = join(dir, "server.log");
+    const stderrWrite = vi.spyOn(process.stderr, "write").mockImplementation(() => true);
+    let errorListener: ((err: Error) => void) | undefined;
+    const fakeDestination = {
+      flush: vi.fn((cb?: (err?: Error) => void) => cb?.()),
+      flushSync: vi.fn(),
+      on: vi.fn((event: "error", listener: (err: Error) => void) => {
+        if (event === "error") errorListener = listener;
+        return fakeDestination;
+      }),
+      write: vi.fn(() => {
+        errorListener?.(new Error("disk full"));
+        return true;
+      }),
+    };
+    const fakePino = Object.assign(
+      vi.fn(
+        (
+          _options: unknown,
+          destination: { flush?: () => void; write: (line: string) => void },
+        ) => ({
+          flush: (cb?: (err?: Error) => void) => {
+            destination.flush?.();
+            cb?.();
+          },
+          info: (message: string) => {
+            destination.write(`${JSON.stringify({ level: "info", msg: message })}\n`);
+          },
+        }),
+      ),
+      {
+        destination: vi.fn(() => fakeDestination),
+      },
+    );
+
+    try {
+      await withFreshLogger(
+        { B2_LOG_FILE: logFile },
+        async ({ initLogging, logger }) => {
+          initLogging();
+          logger.info("logger.first");
+          logger.info("logger.second");
+        },
+        () => {
+          vi.doMock("pino", () => ({ default: fakePino }));
+        },
+      );
+
+      const stderrOutput = stderrWrite.mock.calls.map(([line]) => String(line)).join("");
+      expect(stderrOutput).toContain("B2_LOG_FILE write failed");
+      expect(stderrOutput).toContain("falling back to stderr");
+      expect(stderrOutput).toContain("logger.second");
+    } finally {
+      vi.doUnmock("pino");
+      stderrWrite.mockRestore();
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("falls back to stderr when a file destination write throws", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "b2-mcp-log-throw-fallback-"));
+    const logFile = join(dir, "server.log");
+    const stderrWrite = vi.spyOn(process.stderr, "write").mockImplementation(() => true);
+    const fakeDestination = {
+      flush: vi.fn((cb?: (err?: Error) => void) => cb?.()),
+      flushSync: vi.fn(),
+      on: vi.fn(() => fakeDestination),
+      write: vi.fn(() => {
+        throw new Error("write boom");
+      }),
+    };
+    const fakePino = Object.assign(
+      vi.fn((_options: unknown, destination: { write: (line: string) => void }) => ({
+        info: (message: string) => {
+          destination.write(`${JSON.stringify({ level: "info", msg: message })}\n`);
+        },
+      })),
+      {
+        destination: vi.fn(() => fakeDestination),
+      },
+    );
+
+    try {
+      await withFreshLogger(
+        { B2_LOG_FILE: logFile },
+        async ({ initLogging, logger }) => {
+          initLogging();
+          logger.info("logger.throw");
+        },
+        () => {
+          vi.doMock("pino", () => ({ default: fakePino }));
+        },
+      );
+
+      const stderrOutput = stderrWrite.mock.calls.map(([line]) => String(line)).join("");
+      expect(stderrOutput).toContain("B2_LOG_FILE write failed");
+      expect(stderrOutput).toContain("logger.throw");
+    } finally {
+      vi.doUnmock("pino");
+      stderrWrite.mockRestore();
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("falls back to stderr when SIGHUP reopen fails", async () => {
+    if (process.platform === "win32") return;
+    const dir = mkdtempSync(join(tmpdir(), "b2-mcp-log-reopen-fallback-"));
+    const logFile = join(dir, "server.log");
+    const rotatedLogFile = join(dir, "server.log.1");
+    const stderrWrite = vi.spyOn(process.stderr, "write").mockImplementation(() => true);
+
+    try {
+      await withFreshLogger(
+        { B2_LOG_FILE: logFile },
+        async ({ flushLogsSync, initLogging, logger }) => {
+          initLogging();
+          logger.info("logger.before-failed-reopen");
+          flushLogsSync();
+
+          renameSync(logFile, rotatedLogFile);
+          symlinkSync(rotatedLogFile, logFile);
+          process.emit("SIGHUP", "SIGHUP");
+
+          logger.info("logger.after-failed-reopen");
+        },
+      );
+
+      const stderrOutput = stderrWrite.mock.calls.map(([line]) => String(line)).join("");
+      expect(stderrOutput).toContain("B2_LOG_FILE reopen failed");
+      expect(stderrOutput).toContain("falling back to stderr");
+      expect(stderrOutput).toContain("logger.after-failed-reopen");
+    } finally {
+      stderrWrite.mockRestore();
       rmSync(dir, { recursive: true, force: true });
     }
   });
@@ -313,7 +625,7 @@ describe("logger destination", () => {
     expect(result.stderr).toContain("B2_LOG_FILE must be an absolute path");
   });
 
-  it("rejects permissive existing log files", () => {
+  it("tightens permissive existing log files", () => {
     if (process.platform === "win32") return;
     const dir = mkdtempSync(join(tmpdir(), "b2-mcp-permissive-log-"));
     const logFile = join(dir, "server.log");
@@ -324,11 +636,11 @@ describe("logger destination", () => {
 
       const result = runProbe(logInfoSource, { B2_LOG_FILE: logFile });
 
-      expect(result.status).toBe(1);
+      expect(result.status).toBe(0);
       expect(result.stdout).toBe("");
-      expect(result.stderr).toContain(
-        "B2_LOG_FILE must not be readable or writable by group or other users",
-      );
+      expect(result.stderr).toBe("");
+      expect(statSync(logFile).mode & 0o077).toBe(0);
+      expect(readFileSync(logFile, "utf8")).toContain("logger.probe");
     } finally {
       rmSync(dir, { recursive: true, force: true });
     }
@@ -383,6 +695,26 @@ describe("logger destination", () => {
     }
   });
 
+  it("rejects hard-linked log files", () => {
+    if (process.platform === "win32") return;
+    const dir = mkdtempSync(join(tmpdir(), "b2-mcp-hardlink-log-"));
+    const target = join(dir, "target.log");
+    const logFile = join(dir, "server.log");
+
+    try {
+      writeFileSync(target, "", { mode: 0o600 });
+      linkSync(target, logFile);
+
+      const result = runProbe(logInfoSource, { B2_LOG_FILE: logFile });
+
+      expect(result.status).toBe(1);
+      expect(result.stdout).toBe("");
+      expect(result.stderr).toContain("B2_LOG_FILE must not be a hard link");
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
   it("writes fatal entry-point logs before process.exit without an explicit flush", async () => {
     const dir = mkdtempSync(join(tmpdir(), "b2-mcp-fatal-log-"));
     const logFile = join(dir, "server.log");
@@ -403,6 +735,37 @@ describe("logger destination", () => {
     } finally {
       await new Promise<void>((resolve) => blocker.close(() => resolve()));
       rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("writes clean HTTP shutdown logs before process.exit without an explicit flush", () => {
+    const dir = mkdtempSync(join(tmpdir(), "b2-mcp-shutdown-log-"));
+    const logFile = join(dir, "server.log");
+
+    try {
+      const result = runProbe(httpShutdownSource, { B2_LOG_FILE: logFile });
+
+      expect(result.status).toBe(0);
+      expect(result.stdout).toBe("");
+
+      const messages = readFileSync(logFile, "utf8")
+        .trim()
+        .split("\n")
+        .map((line) => JSON.parse(line).msg);
+      expect(messages).toContain("server.shutdown");
+      expect(messages).toContain("server.closed");
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("prints help and version even when B2_LOG_FILE is invalid", () => {
+    for (const args of [["--help"], ["--version"]]) {
+      const result = runEntrypoint(args, { B2_LOG_FILE: "relative-b2-mcp.log" });
+
+      expect(result.status).toBe(0);
+      expect(result.stderr).toBe("");
+      expect(result.stdout).not.toBe("");
     }
   });
 });

--- a/tests/unit/logger.unit.test.ts
+++ b/tests/unit/logger.unit.test.ts
@@ -104,6 +104,20 @@ type LoggerModule = typeof import("../../src/utils/logger");
 
 const loggerEnvKeys = ["B2_LOG_FILE", "LOG_LEVEL", "NODE_ENV"] as const;
 
+async function withProcessPlatform<T>(
+  platform: NodeJS.Platform | "win32",
+  run: () => T | Promise<T>,
+): Promise<T> {
+  const descriptor = Object.getOwnPropertyDescriptor(process, "platform");
+  if (!descriptor) throw new Error("process.platform descriptor is unavailable");
+  Object.defineProperty(process, "platform", { ...descriptor, value: platform });
+  try {
+    return await run();
+  } finally {
+    Object.defineProperty(process, "platform", descriptor);
+  }
+}
+
 async function withFreshLogger<T>(
   env: NodeJS.ProcessEnv,
   run: (loggerModule: LoggerModule) => T | Promise<T>,
@@ -173,6 +187,7 @@ describe("logger destination", () => {
   });
 
   it("initializes file logging with redaction and owner-only permissions", async () => {
+    if (process.platform === "win32") return;
     const dir = mkdtempSync(join(tmpdir(), "b2-mcp-logger-file-coverage-"));
     const logFile = join(dir, "server.log");
 
@@ -187,9 +202,7 @@ describe("logger destination", () => {
       );
 
       expect(existsSync(logFile)).toBe(true);
-      if (process.platform !== "win32") {
-        expect(statSync(logFile).mode & 0o077).toBe(0);
-      }
+      expect(statSync(logFile).mode & 0o077).toBe(0);
 
       const line = parseLogLine(readFileSync(logFile, "utf8"));
       expect(line.msg).toBe("logger.coverage");
@@ -201,6 +214,7 @@ describe("logger destination", () => {
   });
 
   it("configures file destinations for asynchronous request-path writes", async () => {
+    if (process.platform === "win32") return;
     const dir = mkdtempSync(join(tmpdir(), "b2-mcp-logger-async-coverage-"));
     const logFile = join(dir, "server.log");
     const fakeDestination = {
@@ -257,6 +271,24 @@ describe("logger destination", () => {
     }
   });
 
+  it("rejects file logging on Windows where owner-only permissions are not enforced", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "b2-mcp-windows-log-"));
+    const logFile = join(dir, "server.log");
+
+    try {
+      await expect(
+        withProcessPlatform("win32", () =>
+          withFreshLogger({ B2_LOG_FILE: logFile }, async ({ initLogging }) => {
+            initLogging();
+          }),
+        ),
+      ).rejects.toThrow("B2_LOG_FILE is not supported on Windows");
+      expect(existsSync(logFile)).toBe(false);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
   it("reopens B2_LOG_FILE on SIGHUP after rename rotation", async () => {
     if (process.platform === "win32") return;
     const dir = mkdtempSync(join(tmpdir(), "b2-mcp-logger-rotate-"));
@@ -309,13 +341,14 @@ describe("logger destination", () => {
   });
 
   it("rejects invalid file destinations during explicit initialization", async () => {
+    if (process.platform === "win32") return;
+
     await expect(
       withFreshLogger({ B2_LOG_FILE: "relative-b2-mcp.log" }, async ({ initLogging }) => {
         initLogging();
       }),
     ).rejects.toThrow("B2_LOG_FILE must be an absolute path");
 
-    if (process.platform === "win32") return;
     const dir = mkdtempSync(join(tmpdir(), "b2-mcp-invalid-log-coverage-"));
     const logFile = join(dir, "server.log");
 
@@ -358,6 +391,7 @@ describe("logger destination", () => {
   });
 
   it("fails clearly when the pino file destination cannot be created", async () => {
+    if (process.platform === "win32") return;
     const dir = mkdtempSync(join(tmpdir(), "b2-mcp-pino-destination-fail-"));
     const logFile = join(dir, "server.log");
     const fakePino = vi.fn((_options: unknown, destination: { write: (line: string) => void }) => ({
@@ -410,6 +444,7 @@ describe("logger destination", () => {
   });
 
   it("falls back to stderr after a file destination write error", async () => {
+    if (process.platform === "win32") return;
     const dir = mkdtempSync(join(tmpdir(), "b2-mcp-log-fallback-"));
     const logFile = join(dir, "server.log");
     const stderrWrite = vi.spyOn(process.stderr, "write").mockImplementation(() => true);
@@ -471,6 +506,7 @@ describe("logger destination", () => {
   });
 
   it("falls back to stderr when a file destination write throws", async () => {
+    if (process.platform === "win32") return;
     const dir = mkdtempSync(join(tmpdir(), "b2-mcp-log-throw-fallback-"));
     const logFile = join(dir, "server.log");
     const stderrWrite = vi.spyOn(process.stderr, "write").mockImplementation(() => true);
@@ -565,6 +601,7 @@ describe("logger destination", () => {
   });
 
   it("writes redacted JSON logs to B2_LOG_FILE instead of stderr", () => {
+    if (process.platform === "win32") return;
     const dir = mkdtempSync(join(tmpdir(), "b2-mcp-logger-file-"));
     const logFile = join(dir, "server.log");
 
@@ -575,9 +612,7 @@ describe("logger destination", () => {
       expect(result.stdout).toBe("");
       expect(result.stderr).toBe("");
       expect(existsSync(logFile)).toBe(true);
-      if (process.platform !== "win32") {
-        expect(statSync(logFile).mode & 0o077).toBe(0);
-      }
+      expect(statSync(logFile).mode & 0o077).toBe(0);
 
       const line = parseLogLine(readFileSync(logFile, "utf8"));
       expect(line.msg).toBe("logger.probe");
@@ -603,6 +638,7 @@ describe("logger destination", () => {
   });
 
   it("fails fast from the entry point when B2_LOG_FILE is not writable", () => {
+    if (process.platform === "win32") return;
     const logFile = mkdtempSync(join(tmpdir(), "b2-mcp-bad-log-path-"));
 
     try {
@@ -618,6 +654,7 @@ describe("logger destination", () => {
   });
 
   it("rejects relative B2_LOG_FILE paths", () => {
+    if (process.platform === "win32") return;
     const result = runProbe(logInfoSource, { B2_LOG_FILE: "relative-b2-mcp.log" });
 
     expect(result.status).toBe(1);
@@ -716,6 +753,7 @@ describe("logger destination", () => {
   });
 
   it("writes fatal entry-point logs before process.exit without an explicit flush", async () => {
+    if (process.platform === "win32") return;
     const dir = mkdtempSync(join(tmpdir(), "b2-mcp-fatal-log-"));
     const logFile = join(dir, "server.log");
     const blocker = http.createServer();
@@ -739,6 +777,7 @@ describe("logger destination", () => {
   });
 
   it("writes clean HTTP shutdown logs before process.exit without an explicit flush", () => {
+    if (process.platform === "win32") return;
     const dir = mkdtempSync(join(tmpdir(), "b2-mcp-shutdown-log-"));
     const logFile = join(dir, "server.log");
 


### PR DESCRIPTION
## Summary
- Add POSIX B2_LOG_FILE support so structured Pino JSON logs can append to a configured file instead of stderr while keeping stdout untouched for stdio.
- Move file logging setup behind explicit startup initialization so importing the logger or package root does not create, validate, or fail on B2_LOG_FILE.
- Harden file logging by requiring an absolute path, opening the destination once as an owner-only regular file, rejecting symlinks, hard links, and special files, rejecting Windows where owner-only ACL guarantees are not enforced, tightening owned pre-existing files to mode 0600, preserving redaction, and flushing logs on production exit paths.
- Use an async file destination for request-path logging, add SIGHUP reopen support with bounded async pre-reopen flushing for rename/create rotation, skip flushing already-failed destinations, keep retired stream errors handled during close, and fall back to stderr when runtime file writes or reopens fail.
- Document stderr replacement behavior, absolute-path requirements, POSIX-only support, hosted log-shipping impact, SIGHUP rotation guidance, and runtime write-failure handling.
- Expand logger coverage for file/stderr routing, redaction, import safety, startup failures, permissions, special files, hard links, Windows rejection, SIGHUP reopen, failed-destination and retired-stream SIGHUP recovery, stderr fallback, help/version behavior, and fatal/clean shutdown durability.
- Update the package-size budget for the added logging code, docs, and tests.

## Linked issue
Closes #170

## Tests run
- /Users/gpenacastellanos/miniforge3/bin/mamba run -n b2-mcp-issue-170 pnpm exec vitest run --config vitest.config.mts --project=unit --coverage=false tests/unit/logger.unit.test.ts
- /Users/gpenacastellanos/miniforge3/bin/mamba run -n b2-mcp-issue-170 pnpm run typecheck
- /Users/gpenacastellanos/miniforge3/bin/mamba run -n b2-mcp-issue-170 pnpm run format:check
- /Users/gpenacastellanos/miniforge3/bin/mamba run -n b2-mcp-issue-170 pnpm run lint
- /Users/gpenacastellanos/miniforge3/bin/mamba run -n b2-mcp-issue-170 pnpm run lint:docs
- /Users/gpenacastellanos/miniforge3/bin/mamba run -n b2-mcp-issue-170 pnpm run spell
- /Users/gpenacastellanos/miniforge3/bin/mamba run -n b2-mcp-issue-170 pnpm run test:coverage
- /Users/gpenacastellanos/miniforge3/bin/mamba run -n b2-mcp-issue-170 pnpm run check:package-budget

## Follow-up notes
- File logging replaces stderr by default; no stderr mirror is added.
- B2_LOG_FILE is currently POSIX-only. Windows startup fails clearly because this implementation does not enforce owner-only ACLs.
- B2_LOG_FILE is append-only and has no built-in retention. Long-running deployments need operator-managed rotation; docs recommend rename/create rotation and sending SIGHUP so b2-mcp reopens the active file.
