### PR TITLE
Add workerd JWKS fetch smoke

### DIFF
--- a/.cspell/project-words.txt
+++ b/.cspell/project-words.txt
@@ -69,8 +69,10 @@ unparseable
 unreviewed
 
 # Test fixture tokens and identifier fragments
+AQAB
 dontMock
 eddsa
 ghijkl
 klass
 pathb
+Xhsm

--- a/deploy/cloudflare-worker/adapter.ts
+++ b/deploy/cloudflare-worker/adapter.ts
@@ -15,7 +15,9 @@ import { sanitizeForMcpOutput, sanitizeText } from "../../src/utils/secret-sanit
 
 const ALLOW_HEADER_MODE_FLAG = "B2_CLOUDFLARE_ALLOW_HEADER_CREDENTIAL_MODE";
 const ALLOW_SHARED_SERVER_CREDENTIAL_FLAG = "B2_CLOUDFLARE_ALLOW_SHARED_SERVER_CREDENTIAL";
-const JWKS_SERVICE_BINDING = "B2_OAUTH_JWKS_SERVICE";
+const WORKER_SMOKE_FLAG = "B2_CLOUDFLARE_WORKER_SMOKE";
+const WORKER_SMOKE_JWKS_SERVICE_BINDING = "B2_CLOUDFLARE_WORKER_SMOKE_JWKS_SERVICE";
+const workerSmokeJwksWarnings = new Set<string>();
 
 export type CloudflareWorkerEnv = Record<string, unknown>;
 
@@ -58,23 +60,59 @@ function requestWithHostHeader(request: Request): Request {
   return new Request(request, { headers });
 }
 
-function cloudflareOAuthFetch(env: CloudflareWorkerEnv): typeof fetch | undefined {
-  const jwksService = env[JWKS_SERVICE_BINDING];
-  const jwksUri = process.env.B2_OAUTH_JWKS_URI;
-  if (!jwksUri || !isCloudflareFetchBinding(jwksService)) return undefined;
+function warnWorkerSmokeJwksOnce(reason: string, fields: Record<string, unknown> = {}): void {
+  if (workerSmokeJwksWarnings.has(reason)) return;
+  workerSmokeJwksWarnings.add(reason);
+  cloudflareWarn(
+    {
+      binding: WORKER_SMOKE_JWKS_SERVICE_BINDING,
+      reason,
+      ...fields,
+    },
+    "cloudflare_worker.oauth.test_jwks_service_binding_inactive",
+  );
+}
 
-  let expectedJwksUrl: string;
-  try {
-    expectedJwksUrl = new URL(jwksUri).href;
-  } catch {
+function cloudflareWorkerSmokeOAuthFetch(env: CloudflareWorkerEnv): typeof fetch | undefined {
+  const jwksService = env[WORKER_SMOKE_JWKS_SERVICE_BINDING];
+  if (jwksService === undefined) return undefined;
+  if (process.env[WORKER_SMOKE_FLAG] !== "true") {
+    warnWorkerSmokeJwksOnce("smoke_flag_disabled", { flag: WORKER_SMOKE_FLAG });
+    return undefined;
+  }
+  if (!isCloudflareFetchBinding(jwksService)) {
+    warnWorkerSmokeJwksOnce("invalid_service_binding");
     return undefined;
   }
 
+  const jwksUri = process.env.B2_OAUTH_JWKS_URI;
+  if (!jwksUri) {
+    warnWorkerSmokeJwksOnce("missing_jwks_uri");
+    return undefined;
+  }
+
+  let expectedJwksUrl: URL;
+  try {
+    expectedJwksUrl = new URL(jwksUri);
+  } catch {
+    warnWorkerSmokeJwksOnce("invalid_jwks_uri");
+    return undefined;
+  }
+
+  // Test-only seam for the workerd JWKS smoke: this is intentionally gated by
+  // B2_CLOUDFLARE_WORKER_SMOKE and is not a supported operator service binding.
   return (input, init) => {
     const request = new Request(input, init);
-    if (new URL(request.url).href === expectedJwksUrl) {
+    const requestUrl = new URL(request.url);
+    if (requestUrl.href === expectedJwksUrl.href) {
       return jwksService.fetch(request);
     }
+    warnWorkerSmokeJwksOnce("jwks_url_mismatch", {
+      expectedEndpointHost: expectedJwksUrl.host,
+      expectedEndpointPath: expectedJwksUrl.pathname,
+      requestEndpointHost: requestUrl.host,
+      requestEndpointPath: requestUrl.pathname,
+    });
     return fetch(request);
   };
 }
@@ -115,14 +153,6 @@ export function validateCloudflareWorkerStaticConfiguration(): OAuthResourceServ
   return oauthConfig;
 }
 
-function isCloudflareMcpFetchContext(
-  input: AuthInfo | CloudflareMcpFetchContext,
-): input is CloudflareMcpFetchContext {
-  return (
-    "authInfo" in input || "oauthFetch" in input || "remoteAddress" in input || !("token" in input)
-  );
-}
-
 function cloudflareClientAddress(context: CloudflareMcpFetchContext): string {
   return context.remoteAddress?.trim() || "unknown";
 }
@@ -156,10 +186,7 @@ export async function cloudflareMcpFetch(
   input?: AuthInfo | CloudflareMcpFetchContext,
 ): Promise<Response> {
   const normalizedRequest = requestWithHostHeader(request);
-  return runtime.mcpFetch(
-    normalizedRequest,
-    normalizeServerlessMcpContext(input, isCloudflareMcpFetchContext),
-  );
+  return runtime.mcpFetch(normalizedRequest, normalizeServerlessMcpContext(input));
 }
 
 export async function cloudflareHealthFetch(request: Request): Promise<Response> {
@@ -185,7 +212,7 @@ export async function cloudflareWorkerFetch(
   if (url.pathname === "/mcp" || url.pathname === "/api/mcp") {
     return cloudflareMcpFetch(normalizedRequest, {
       ...context,
-      oauthFetch: cloudflareOAuthFetch(env),
+      oauthFetch: cloudflareWorkerSmokeOAuthFetch(env),
     });
   }
   if (url.pathname === "/health") return cloudflareHealthFetch(normalizedRequest);

--- a/deploy/cloudflare-worker/adapter.ts
+++ b/deploy/cloudflare-worker/adapter.ts
@@ -15,15 +15,29 @@ import { sanitizeForMcpOutput, sanitizeText } from "../../src/utils/secret-sanit
 
 const ALLOW_HEADER_MODE_FLAG = "B2_CLOUDFLARE_ALLOW_HEADER_CREDENTIAL_MODE";
 const ALLOW_SHARED_SERVER_CREDENTIAL_FLAG = "B2_CLOUDFLARE_ALLOW_SHARED_SERVER_CREDENTIAL";
+const JWKS_SERVICE_BINDING = "B2_OAUTH_JWKS_SERVICE";
 
 export type CloudflareWorkerEnv = Record<string, unknown>;
 
 export interface CloudflareMcpFetchContext extends ServerlessMcpFetchContext {}
 
+interface CloudflareFetchBinding {
+  fetch(input: Parameters<typeof fetch>[0], init?: Parameters<typeof fetch>[1]): Promise<Response>;
+}
+
 function envBindingToString(value: unknown): string | undefined {
   if (typeof value === "string") return value;
   if (typeof value === "number" || typeof value === "boolean") return String(value);
   return undefined;
+}
+
+function isCloudflareFetchBinding(value: unknown): value is CloudflareFetchBinding {
+  return (
+    typeof value === "object" &&
+    value !== null &&
+    "fetch" in value &&
+    typeof (value as { fetch?: unknown }).fetch === "function"
+  );
 }
 
 export function installCloudflareEnvironment(env: CloudflareWorkerEnv): void {
@@ -42,6 +56,27 @@ function requestWithHostHeader(request: Request): Request {
   const headers = new Headers(request.headers);
   headers.set("host", new URL(request.url).host);
   return new Request(request, { headers });
+}
+
+function cloudflareOAuthFetch(env: CloudflareWorkerEnv): typeof fetch | undefined {
+  const jwksService = env[JWKS_SERVICE_BINDING];
+  const jwksUri = process.env.B2_OAUTH_JWKS_URI;
+  if (!jwksUri || !isCloudflareFetchBinding(jwksService)) return undefined;
+
+  let expectedJwksUrl: string;
+  try {
+    expectedJwksUrl = new URL(jwksUri).href;
+  } catch {
+    return undefined;
+  }
+
+  return (input, init) => {
+    const request = new Request(input, init);
+    if (new URL(request.url).href === expectedJwksUrl) {
+      return jwksService.fetch(request);
+    }
+    return fetch(request);
+  };
 }
 
 function validateCloudflareWorkerCredentialMode(): void {
@@ -83,7 +118,9 @@ export function validateCloudflareWorkerStaticConfiguration(): OAuthResourceServ
 function isCloudflareMcpFetchContext(
   input: AuthInfo | CloudflareMcpFetchContext,
 ): input is CloudflareMcpFetchContext {
-  return "authInfo" in input || "remoteAddress" in input || !("token" in input);
+  return (
+    "authInfo" in input || "oauthFetch" in input || "remoteAddress" in input || !("token" in input)
+  );
 }
 
 function cloudflareClientAddress(context: CloudflareMcpFetchContext): string {
@@ -146,7 +183,10 @@ export async function cloudflareWorkerFetch(
   const normalizedRequest = requestWithHostHeader(request);
   const url = new URL(normalizedRequest.url);
   if (url.pathname === "/mcp" || url.pathname === "/api/mcp") {
-    return cloudflareMcpFetch(normalizedRequest, context);
+    return cloudflareMcpFetch(normalizedRequest, {
+      ...context,
+      oauthFetch: cloudflareOAuthFetch(env),
+    });
   }
   if (url.pathname === "/health") return cloudflareHealthFetch(normalizedRequest);
   if (

--- a/deploy/customer-hosted/pnpm-lock.yaml
+++ b/deploy/customer-hosted/pnpm-lock.yaml
@@ -101,6 +101,9 @@ importers:
       eslint-plugin-tsdoc:
         specifier: 0.5.2
         version: 0.5.2(eslint@9.39.1(supports-color@7.2.0))(supports-color@7.2.0)(typescript@6.0.3)
+      miniflare:
+        specifier: 5.20260811.1-alpha
+        version: 5.20260811.1-alpha
       semver:
         specifier: 7.8.5
         version: 7.8.5

--- a/package.json
+++ b/package.json
@@ -115,6 +115,7 @@
     "eslint": "9.39.1",
     "eslint-plugin-jsdoc": "50.8.0",
     "eslint-plugin-tsdoc": "0.5.2",
+    "miniflare": "5.20260811.1-alpha",
     "semver": "7.8.5",
     "tsx": "4.23.11",
     "typescript": "~6.0.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -101,6 +101,9 @@ importers:
       eslint-plugin-tsdoc:
         specifier: 0.5.2
         version: 0.5.2(eslint@9.39.1(supports-color@7.2.0))(supports-color@7.2.0)(typescript@6.0.3)
+      miniflare:
+        specifier: 5.20260811.1-alpha
+        version: 5.20260811.1-alpha
       semver:
         specifier: 7.8.5
         version: 7.8.5

--- a/scripts/check-cloudflare-worker-bundle.mjs
+++ b/scripts/check-cloudflare-worker-bundle.mjs
@@ -10,13 +10,17 @@ import {
   statSync,
   writeFileSync,
 } from "fs";
-import { Log, LogLevel, Miniflare, convertV4MiniflareOptions } from "miniflare";
 import { createRequire } from "module";
 import { createServer } from "net";
 import os from "os";
 import path from "path";
 import { fileURLToPath } from "url";
 import { gzipSync } from "zlib";
+import {
+  WORKER_SMOKE_PUBLIC_URL,
+  runMiniflareJwksSmoke,
+  workerJwksSmokeVars,
+} from "./lib/cloudflare-worker-jwks-smoke.mjs";
 
 const require = createRequire(import.meta.url);
 const {
@@ -36,18 +40,6 @@ const wranglerConfigPath = path.join(root, "deploy/cloudflare-worker/wrangler.js
 const entrypoints = ["deploy/cloudflare-worker/worker.ts"];
 const WORKER_SMOKE_TIMEOUT_MS = 30_000;
 const WORKER_SMOKE_PROBE_TIMEOUT_MS = 1_000;
-const WORKER_SMOKE_PUBLIC_URL = "https://mcp.example.com/mcp";
-const WORKER_SMOKE_JWKS_URI = "https://issuer.example.com/.well-known/jwks.json";
-const WORKER_SMOKE_JWKS_SERVICE_BINDING = "B2_OAUTH_JWKS_SERVICE";
-const WORKER_SMOKE_RSA_PUBLIC_JWK = {
-  kty: "RSA",
-  n: "pFW3ni6ZrJmRFlXFVaSgTKa18nbzaUZ1O1McAgPosEdrxBKp_j5_l34oGXiA2h-zdr78a1aXhsmIk0mNW_N-D6wCC56yCYVsEjgLEhId-zmrpKd9tcSn5uDWLR5EYrkFbN9qSb2En7Sdvh2xziG2JsL8pu20UufHVGQF5VJ7__wsGl7fPuEalGmadbDobs7XeN7iu_YQjTuHp0FE5nSsTUJkWmSNEgJ4YgrdCa-yv0-S4szRdQNSTUtKFcY7SIHbzlkaEK3TEW-hHDXlc1eI9QEG7ZIjp9QBi7bKvTe5m3Yi4EAUiKHyC-Di9cXUPQl1vfBtPVSfCQLBgxBXqHvSDQ",
-  e: "AQAB",
-  kid: "worker-smoke-rsa-key",
-  alg: "RS256",
-  use: "sig",
-  key_ops: ["verify"],
-};
 // biome-ignore lint/suspicious/noControlCharactersInRegex: Wrangler may emit ANSI colors.
 const ansiEscapePattern = /\u001B\[[0-9;]*m/g;
 
@@ -113,18 +105,6 @@ function workerSmokeVars(port) {
   };
 }
 
-function workerJwksSmokeVars() {
-  return {
-    ...workerBaseSmokeVars("mcp.example.com,127.0.0.1,localhost"),
-    B2_OAUTH_ALLOWED_ALGORITHMS: "RS256",
-    B2_OAUTH_ALLOWED_TOKEN_TYPES: "bearer",
-    B2_OAUTH_JWKS_CACHE_TTL_SECONDS: "300",
-    B2_OAUTH_JWKS_RETRIES: "0",
-    B2_OAUTH_JWKS_TIMEOUT_MS: "2000",
-    B2_OAUTH_JWKS_URI: WORKER_SMOKE_JWKS_URI,
-  };
-}
-
 function workerRuntimeConfig(config, port) {
   const runtimeConfig = { ...config };
   delete runtimeConfig.secrets;
@@ -163,191 +143,72 @@ function stripAnsi(text) {
 
 function runWranglerDryRun(config) {
   const workspace = mkdtempSync(path.join(os.tmpdir(), "b2-mcp-worker-dry-run-"));
-  const outdir = path.join(workspace, "out");
-  const configPath = writeWorkerRuntimeConfig(config, workspace, 8787);
-  const args = [
-    "exec",
-    "wrangler",
-    "deploy",
-    "--config",
-    configPath,
-    "--dry-run",
-    "--outdir",
-    outdir,
-    "--metafile",
-    path.join(outdir, "bundle-meta.json"),
-    "--containers-rollout=none",
-    "--keep-vars",
-  ];
-
-  const result = spawnSync("pnpm", args, {
-    cwd: root,
-    env: wranglerEnv(process.env),
-    encoding: "utf8",
-    maxBuffer: 10 * 1024 * 1024,
-  });
-  const output = `${result.stdout ?? ""}${result.stderr ?? ""}`;
-  if (result.status !== 0) {
-    fail(`wrangler deploy --dry-run failed\n${output.trim()}`);
-  }
-
-  if (!existsSync(outdir)) fail("wrangler deploy --dry-run did not create an output directory");
-  const files = collectFiles(outdir).sort();
-  if (files.length === 0) fail("wrangler deploy --dry-run emitted no bundle files");
-  const workerScript = files.find((file) => path.basename(file) === "worker.js");
-  if (!workerScript) fail("wrangler deploy --dry-run did not emit worker.js");
-
-  const emittedFiles = files.map((file) => ({
-    path: path.relative(outdir, file),
-    bytes: statSync(file).size,
-  }));
-  const emittedTotalBytes = emittedFiles.reduce((sum, file) => sum + file.bytes, 0);
-  const workerScriptBytes = statSync(workerScript).size;
-  const workerScriptGzipBytes = gzipSync(readFileSync(workerScript)).byteLength;
-  const uploadLine = output.split(/\r?\n/).find((line) => stripAnsi(line).includes("Total Upload"));
-
-  return {
-    emittedFiles,
-    emittedTotalBytes,
-    outdir,
-    uploadLine: uploadLine ? stripAnsi(uploadLine).trim() : undefined,
-    workerScript,
-    workerScriptBytes,
-    workerScriptGzipBytes,
-    workspace,
-  };
-}
-
-function base64UrlJson(value) {
-  return Buffer.from(JSON.stringify(value)).toString("base64url");
-}
-
-function workerSmokeJwt() {
-  const now = Math.floor(Date.now() / 1000);
-  return [
-    base64UrlJson({
-      alg: "RS256",
-      typ: "at+jwt",
-      kid: WORKER_SMOKE_RSA_PUBLIC_JWK.kid,
-    }),
-    base64UrlJson({
-      iss: "https://issuer.example.com/",
-      sub: "worker-smoke-subject",
-      aud: WORKER_SMOKE_PUBLIC_URL,
-      resource: WORKER_SMOKE_PUBLIC_URL,
-      scope: "b2:read",
-      client_id: "worker-smoke-client",
-      iat: now,
-      exp: now + 300,
-    }),
-    Buffer.from("invalid worker smoke signature").toString("base64url"),
-  ].join(".");
-}
-
-function workerSmokeMcpBody() {
-  return JSON.stringify({
-    jsonrpc: "2.0",
-    id: 1,
-    method: "initialize",
-    params: {
-      protocolVersion: "2026-07-28",
-      capabilities: {},
-      clientInfo: {
-        name: "cloudflare-worker-jwks-smoke",
-        version: "0.0.0",
-      },
-    },
-  });
-}
-
-function jwksMockWorkerScript() {
-  return `
-let jwksHits = 0;
-const jwk = ${JSON.stringify(WORKER_SMOKE_RSA_PUBLIC_JWK)};
-
-export default {
-  fetch(request) {
-    const url = new URL(request.url);
-    if (url.pathname === "/.well-known/jwks.json") {
-      jwksHits += 1;
-      return Response.json({ keys: [jwk] }, { headers: { "Cache-Control": "no-store" } });
-    }
-    if (url.pathname === "/__jwks-hits") {
-      return Response.json({ jwksHits });
-    }
-    return Response.json({ error: "not found" }, { status: 404 });
-  },
-};
-`;
-}
-
-async function runMiniflareJwksSmoke(config, workerScript) {
-  const mf = new Miniflare(
-    convertV4MiniflareOptions({
-      log: new Log(LogLevel.ERROR),
-      logRequests: false,
-      workers: [
-        {
-          name: "b2-mcp-worker-smoke",
-          rootPath: path.dirname(workerScript),
-          scriptPath: path.basename(workerScript),
-          modules: true,
-          compatibilityDate: config.compatibility_date,
-          compatibilityFlags: config.compatibility_flags,
-          bindings: workerJwksSmokeVars(),
-          serviceBindings: {
-            [WORKER_SMOKE_JWKS_SERVICE_BINDING]: "jwks-mock",
-          },
-        },
-        {
-          name: "jwks-mock",
-          script: jwksMockWorkerScript(),
-          modules: true,
-          compatibilityDate: config.compatibility_date,
-        },
-      ],
-    }),
-  );
-  let failure;
-  let result;
-
+  let failureMessage;
+  let workspaceTransferred = false;
   try {
-    const response = await mf.dispatchFetch(WORKER_SMOKE_PUBLIC_URL, {
-      method: "POST",
-      headers: {
-        Accept: "application/json, text/event-stream",
-        Authorization: `Bearer ${workerSmokeJwt()}`,
-        "Content-Type": "application/json",
-      },
-      body: workerSmokeMcpBody(),
+    const outdir = path.join(workspace, "out");
+    const configPath = writeWorkerRuntimeConfig(config, workspace, 8787);
+    const args = [
+      "exec",
+      "wrangler",
+      "deploy",
+      "--config",
+      configPath,
+      "--dry-run",
+      "--outdir",
+      outdir,
+      "--metafile",
+      path.join(outdir, "bundle-meta.json"),
+      "--containers-rollout=none",
+      "--keep-vars",
+    ];
+
+    const result = spawnSync("pnpm", args, {
+      cwd: root,
+      env: wranglerEnv(process.env),
+      encoding: "utf8",
+      maxBuffer: 10 * 1024 * 1024,
     });
-    const responseBody = await response.text();
-    const mockWorker = await mf.getWorker("jwks-mock");
-    const hitsResponse = await mockWorker.fetch("https://issuer.example.com/__jwks-hits");
-    const hitsBody = await hitsResponse.json();
-    const jwksHits = hitsBody?.jwksHits;
-
-    if (jwksHits !== 1) {
-      failure = `JWKS smoke expected the mock to receive 1 request, got ${JSON.stringify(
-        hitsBody,
-      )}; /mcp returned ${response.status}: ${responseBody}`;
-    } else if (response.status !== 401) {
-      failure = `JWKS smoke expected /mcp to fail closed with 401 after JWKS, got ${response.status}: ${responseBody}`;
-    } else if (!response.headers.get("www-authenticate")?.includes('error="invalid_token"')) {
-      failure = `JWKS smoke expected an invalid_token challenge, got ${response.headers.get(
-        "www-authenticate",
-      )}`;
-    } else {
-      result = { mcpStatus: response.status, jwksHits };
+    const output = `${result.stdout ?? ""}${result.stderr ?? ""}`;
+    if (result.status !== 0) {
+      throw new Error(`wrangler deploy --dry-run failed\n${output.trim()}`);
     }
-  } catch (error) {
-    failure = error instanceof Error ? error.message : String(error);
-  } finally {
-    await mf.dispose();
-  }
 
-  if (failure) fail(failure);
-  return result;
+    if (!existsSync(outdir))
+      throw new Error("wrangler deploy --dry-run did not create an output directory");
+    const files = collectFiles(outdir).sort();
+    if (files.length === 0) throw new Error("wrangler deploy --dry-run emitted no bundle files");
+    const workerScript = files.find((file) => path.basename(file) === "worker.js");
+    if (!workerScript) throw new Error("wrangler deploy --dry-run did not emit worker.js");
+
+    const emittedFiles = files.map((file) => ({
+      path: path.relative(outdir, file),
+      bytes: statSync(file).size,
+    }));
+    const emittedTotalBytes = emittedFiles.reduce((sum, file) => sum + file.bytes, 0);
+    const workerScriptBytes = statSync(workerScript).size;
+    const workerScriptGzipBytes = gzipSync(readFileSync(workerScript)).byteLength;
+    const uploadLine = output
+      .split(/\r?\n/)
+      .find((line) => stripAnsi(line).includes("Total Upload"));
+
+    workspaceTransferred = true;
+    return {
+      emittedFiles,
+      emittedTotalBytes,
+      outdir,
+      uploadLine: uploadLine ? stripAnsi(uploadLine).trim() : undefined,
+      workerScript,
+      workerScriptBytes,
+      workerScriptGzipBytes,
+      workspace,
+    };
+  } catch (error) {
+    failureMessage = error instanceof Error ? error.message : String(error);
+  } finally {
+    if (!workspaceTransferred) rmSync(workspace, { recursive: true, force: true });
+  }
+  fail(failureMessage ?? "wrangler deploy --dry-run failed");
 }
 
 async function runWranglerStartupSmoke(config) {
@@ -467,7 +328,17 @@ try {
   }
 
   const smoke = await runWranglerStartupSmoke(wranglerConfig);
-  const jwksSmoke = await runMiniflareJwksSmoke(wranglerConfig, dryRun.workerScript);
+  let jwksSmoke;
+  try {
+    jwksSmoke = await runMiniflareJwksSmoke(
+      wranglerConfig,
+      dryRun.workerScript,
+      workerJwksSmokeVars(workerBaseSmokeVars("mcp.example.com,127.0.0.1,localhost")),
+      WORKER_SMOKE_TIMEOUT_MS,
+    );
+  } catch (error) {
+    fail(error instanceof Error ? error.message : String(error));
+  }
   const dryRunMetrics = {
     emittedFiles: dryRun.emittedFiles,
     emittedTotalBytes: dryRun.emittedTotalBytes,

--- a/scripts/check-cloudflare-worker-bundle.mjs
+++ b/scripts/check-cloudflare-worker-bundle.mjs
@@ -10,6 +10,7 @@ import {
   statSync,
   writeFileSync,
 } from "fs";
+import { Log, LogLevel, Miniflare, convertV4MiniflareOptions } from "miniflare";
 import { createRequire } from "module";
 import { createServer } from "net";
 import os from "os";
@@ -35,6 +36,18 @@ const wranglerConfigPath = path.join(root, "deploy/cloudflare-worker/wrangler.js
 const entrypoints = ["deploy/cloudflare-worker/worker.ts"];
 const WORKER_SMOKE_TIMEOUT_MS = 30_000;
 const WORKER_SMOKE_PROBE_TIMEOUT_MS = 1_000;
+const WORKER_SMOKE_PUBLIC_URL = "https://mcp.example.com/mcp";
+const WORKER_SMOKE_JWKS_URI = "https://issuer.example.com/.well-known/jwks.json";
+const WORKER_SMOKE_JWKS_SERVICE_BINDING = "B2_OAUTH_JWKS_SERVICE";
+const WORKER_SMOKE_RSA_PUBLIC_JWK = {
+  kty: "RSA",
+  n: "pFW3ni6ZrJmRFlXFVaSgTKa18nbzaUZ1O1McAgPosEdrxBKp_j5_l34oGXiA2h-zdr78a1aXhsmIk0mNW_N-D6wCC56yCYVsEjgLEhId-zmrpKd9tcSn5uDWLR5EYrkFbN9qSb2En7Sdvh2xziG2JsL8pu20UufHVGQF5VJ7__wsGl7fPuEalGmadbDobs7XeN7iu_YQjTuHp0FE5nSsTUJkWmSNEgJ4YgrdCa-yv0-S4szRdQNSTUtKFcY7SIHbzlkaEK3TEW-hHDXlc1eI9QEG7ZIjp9QBi7bKvTe5m3Yi4EAUiKHyC-Di9cXUPQl1vfBtPVSfCQLBgxBXqHvSDQ",
+  e: "AQAB",
+  kid: "worker-smoke-rsa-key",
+  alg: "RS256",
+  use: "sig",
+  key_ops: ["verify"],
+};
 // biome-ignore lint/suspicious/noControlCharactersInRegex: Wrangler may emit ANSI colors.
 const ansiEscapePattern = /\u001B\[[0-9;]*m/g;
 
@@ -72,26 +85,43 @@ function freePort() {
   });
 }
 
-function workerSmokeVars(port) {
-  const publicUrl = `https://mcp.example.com/mcp`;
+function workerBaseSmokeVars(allowedHosts) {
   return {
     B2_HTTP_CREDENTIAL_MODE: "server",
     B2_APPLICATION_KEY_ID: "worker-smoke-key-id",
     B2_APPLICATION_KEY: "worker-smoke-application-key",
-    B2_ALLOWED_HOSTS: `127.0.0.1:${port},127.0.0.1,localhost,mcp.example.com`,
+    B2_ALLOWED_HOSTS: allowedHosts,
     B2_DESTRUCTIVE_POLICY: "block",
     B2_REGISTER_ALL_TOOLS: "false",
     B2_ALLOW_LOCAL_FILES: "false",
-    B2_MCP_PUBLIC_URL: publicUrl,
+    B2_MCP_PUBLIC_URL: WORKER_SMOKE_PUBLIC_URL,
     B2_OAUTH_ISSUER: "https://issuer.example.com/",
     B2_OAUTH_AUTHORIZATION_ENDPOINT: "https://issuer.example.com/oauth2/authorize",
     B2_OAUTH_TOKEN_ENDPOINT: "https://issuer.example.com/oauth2/token",
+    B2_OAUTH_RESOURCE: WORKER_SMOKE_PUBLIC_URL,
+    B2_OAUTH_AUDIENCE: WORKER_SMOKE_PUBLIC_URL,
+    B2_OAUTH_ALLOWED_SUBJECTS: "worker-smoke-subject",
+  };
+}
+
+function workerSmokeVars(port) {
+  return {
+    ...workerBaseSmokeVars(`127.0.0.1:${port},127.0.0.1,localhost,mcp.example.com`),
     B2_OAUTH_INTROSPECTION_ENDPOINT: "https://issuer.example.com/oauth2/introspect",
     B2_OAUTH_INTROSPECTION_CLIENT_ID: "worker-smoke-client",
     B2_OAUTH_INTROSPECTION_CLIENT_SECRET: "worker-smoke-secret",
-    B2_OAUTH_RESOURCE: publicUrl,
-    B2_OAUTH_AUDIENCE: publicUrl,
-    B2_OAUTH_ALLOWED_SUBJECTS: "worker-smoke-subject",
+  };
+}
+
+function workerJwksSmokeVars() {
+  return {
+    ...workerBaseSmokeVars("mcp.example.com,127.0.0.1,localhost"),
+    B2_OAUTH_ALLOWED_ALGORITHMS: "RS256",
+    B2_OAUTH_ALLOWED_TOKEN_TYPES: "bearer",
+    B2_OAUTH_JWKS_CACHE_TTL_SECONDS: "300",
+    B2_OAUTH_JWKS_RETRIES: "0",
+    B2_OAUTH_JWKS_TIMEOUT_MS: "2000",
+    B2_OAUTH_JWKS_URI: WORKER_SMOKE_JWKS_URI,
   };
 }
 
@@ -150,45 +180,174 @@ function runWranglerDryRun(config) {
     "--keep-vars",
   ];
 
-  try {
-    const result = spawnSync("pnpm", args, {
-      cwd: root,
-      env: wranglerEnv(process.env),
-      encoding: "utf8",
-      maxBuffer: 10 * 1024 * 1024,
-    });
-    const output = `${result.stdout ?? ""}${result.stderr ?? ""}`;
-    if (result.status !== 0) {
-      fail(`wrangler deploy --dry-run failed\n${output.trim()}`);
-    }
-
-    if (!existsSync(outdir)) fail("wrangler deploy --dry-run did not create an output directory");
-    const files = collectFiles(outdir).sort();
-    if (files.length === 0) fail("wrangler deploy --dry-run emitted no bundle files");
-    const workerScript = files.find((file) => path.basename(file) === "worker.js");
-    if (!workerScript) fail("wrangler deploy --dry-run did not emit worker.js");
-
-    const emittedFiles = files.map((file) => ({
-      path: path.relative(outdir, file),
-      bytes: statSync(file).size,
-    }));
-    const emittedTotalBytes = emittedFiles.reduce((sum, file) => sum + file.bytes, 0);
-    const workerScriptBytes = statSync(workerScript).size;
-    const workerScriptGzipBytes = gzipSync(readFileSync(workerScript)).byteLength;
-    const uploadLine = output
-      .split(/\r?\n/)
-      .find((line) => stripAnsi(line).includes("Total Upload"));
-
-    return {
-      emittedFiles,
-      emittedTotalBytes,
-      uploadLine: uploadLine ? stripAnsi(uploadLine).trim() : undefined,
-      workerScriptBytes,
-      workerScriptGzipBytes,
-    };
-  } finally {
-    rmSync(workspace, { recursive: true, force: true });
+  const result = spawnSync("pnpm", args, {
+    cwd: root,
+    env: wranglerEnv(process.env),
+    encoding: "utf8",
+    maxBuffer: 10 * 1024 * 1024,
+  });
+  const output = `${result.stdout ?? ""}${result.stderr ?? ""}`;
+  if (result.status !== 0) {
+    fail(`wrangler deploy --dry-run failed\n${output.trim()}`);
   }
+
+  if (!existsSync(outdir)) fail("wrangler deploy --dry-run did not create an output directory");
+  const files = collectFiles(outdir).sort();
+  if (files.length === 0) fail("wrangler deploy --dry-run emitted no bundle files");
+  const workerScript = files.find((file) => path.basename(file) === "worker.js");
+  if (!workerScript) fail("wrangler deploy --dry-run did not emit worker.js");
+
+  const emittedFiles = files.map((file) => ({
+    path: path.relative(outdir, file),
+    bytes: statSync(file).size,
+  }));
+  const emittedTotalBytes = emittedFiles.reduce((sum, file) => sum + file.bytes, 0);
+  const workerScriptBytes = statSync(workerScript).size;
+  const workerScriptGzipBytes = gzipSync(readFileSync(workerScript)).byteLength;
+  const uploadLine = output.split(/\r?\n/).find((line) => stripAnsi(line).includes("Total Upload"));
+
+  return {
+    emittedFiles,
+    emittedTotalBytes,
+    outdir,
+    uploadLine: uploadLine ? stripAnsi(uploadLine).trim() : undefined,
+    workerScript,
+    workerScriptBytes,
+    workerScriptGzipBytes,
+    workspace,
+  };
+}
+
+function base64UrlJson(value) {
+  return Buffer.from(JSON.stringify(value)).toString("base64url");
+}
+
+function workerSmokeJwt() {
+  const now = Math.floor(Date.now() / 1000);
+  return [
+    base64UrlJson({
+      alg: "RS256",
+      typ: "at+jwt",
+      kid: WORKER_SMOKE_RSA_PUBLIC_JWK.kid,
+    }),
+    base64UrlJson({
+      iss: "https://issuer.example.com/",
+      sub: "worker-smoke-subject",
+      aud: WORKER_SMOKE_PUBLIC_URL,
+      resource: WORKER_SMOKE_PUBLIC_URL,
+      scope: "b2:read",
+      client_id: "worker-smoke-client",
+      iat: now,
+      exp: now + 300,
+    }),
+    Buffer.from("invalid worker smoke signature").toString("base64url"),
+  ].join(".");
+}
+
+function workerSmokeMcpBody() {
+  return JSON.stringify({
+    jsonrpc: "2.0",
+    id: 1,
+    method: "initialize",
+    params: {
+      protocolVersion: "2026-07-28",
+      capabilities: {},
+      clientInfo: {
+        name: "cloudflare-worker-jwks-smoke",
+        version: "0.0.0",
+      },
+    },
+  });
+}
+
+function jwksMockWorkerScript() {
+  return `
+let jwksHits = 0;
+const jwk = ${JSON.stringify(WORKER_SMOKE_RSA_PUBLIC_JWK)};
+
+export default {
+  fetch(request) {
+    const url = new URL(request.url);
+    if (url.pathname === "/.well-known/jwks.json") {
+      jwksHits += 1;
+      return Response.json({ keys: [jwk] }, { headers: { "Cache-Control": "no-store" } });
+    }
+    if (url.pathname === "/__jwks-hits") {
+      return Response.json({ jwksHits });
+    }
+    return Response.json({ error: "not found" }, { status: 404 });
+  },
+};
+`;
+}
+
+async function runMiniflareJwksSmoke(config, workerScript) {
+  const mf = new Miniflare(
+    convertV4MiniflareOptions({
+      log: new Log(LogLevel.ERROR),
+      logRequests: false,
+      workers: [
+        {
+          name: "b2-mcp-worker-smoke",
+          rootPath: path.dirname(workerScript),
+          scriptPath: path.basename(workerScript),
+          modules: true,
+          compatibilityDate: config.compatibility_date,
+          compatibilityFlags: config.compatibility_flags,
+          bindings: workerJwksSmokeVars(),
+          serviceBindings: {
+            [WORKER_SMOKE_JWKS_SERVICE_BINDING]: "jwks-mock",
+          },
+        },
+        {
+          name: "jwks-mock",
+          script: jwksMockWorkerScript(),
+          modules: true,
+          compatibilityDate: config.compatibility_date,
+        },
+      ],
+    }),
+  );
+  let failure;
+  let result;
+
+  try {
+    const response = await mf.dispatchFetch(WORKER_SMOKE_PUBLIC_URL, {
+      method: "POST",
+      headers: {
+        Accept: "application/json, text/event-stream",
+        Authorization: `Bearer ${workerSmokeJwt()}`,
+        "Content-Type": "application/json",
+      },
+      body: workerSmokeMcpBody(),
+    });
+    const responseBody = await response.text();
+    const mockWorker = await mf.getWorker("jwks-mock");
+    const hitsResponse = await mockWorker.fetch("https://issuer.example.com/__jwks-hits");
+    const hitsBody = await hitsResponse.json();
+    const jwksHits = hitsBody?.jwksHits;
+
+    if (jwksHits !== 1) {
+      failure = `JWKS smoke expected the mock to receive 1 request, got ${JSON.stringify(
+        hitsBody,
+      )}; /mcp returned ${response.status}: ${responseBody}`;
+    } else if (response.status !== 401) {
+      failure = `JWKS smoke expected /mcp to fail closed with 401 after JWKS, got ${response.status}: ${responseBody}`;
+    } else if (!response.headers.get("www-authenticate")?.includes('error="invalid_token"')) {
+      failure = `JWKS smoke expected an invalid_token challenge, got ${response.headers.get(
+        "www-authenticate",
+      )}`;
+    } else {
+      result = { mcpStatus: response.status, jwksHits };
+    }
+  } catch (error) {
+    failure = error instanceof Error ? error.message : String(error);
+  } finally {
+    await mf.dispose();
+  }
+
+  if (failure) fail(failure);
+  return result;
 }
 
 async function runWranglerStartupSmoke(config) {
@@ -285,64 +444,78 @@ if (sourceBytes > WORKER_SOURCE_GRAPH_BYTES_BUDGET) {
 }
 
 const dryRun = runWranglerDryRun(wranglerConfig);
-if (dryRun.emittedFiles.length > WORKER_EMITTED_FILES_BUDGET) {
-  fail(
-    `emitted bundle file count exceeded budget: ${dryRun.emittedFiles.length} > ${WORKER_EMITTED_FILES_BUDGET}`,
-  );
-}
-if (dryRun.emittedTotalBytes > WORKER_EMITTED_TOTAL_BYTES_BUDGET) {
-  fail(
-    `emitted bundle bytes exceeded budget: ${dryRun.emittedTotalBytes} > ${WORKER_EMITTED_TOTAL_BYTES_BUDGET}`,
-  );
-}
-if (dryRun.workerScriptBytes > WORKER_UPLOAD_SCRIPT_BYTES_BUDGET) {
-  fail(
-    `Worker upload script bytes exceeded budget: ${dryRun.workerScriptBytes} > ${WORKER_UPLOAD_SCRIPT_BYTES_BUDGET}`,
-  );
-}
-if (dryRun.workerScriptGzipBytes > WORKER_UPLOAD_SCRIPT_GZIP_BYTES_BUDGET) {
-  fail(
-    `Worker upload gzip bytes exceeded budget: ${dryRun.workerScriptGzipBytes} > ${WORKER_UPLOAD_SCRIPT_GZIP_BYTES_BUDGET}`,
-  );
-}
+try {
+  if (dryRun.emittedFiles.length > WORKER_EMITTED_FILES_BUDGET) {
+    fail(
+      `emitted bundle file count exceeded budget: ${dryRun.emittedFiles.length} > ${WORKER_EMITTED_FILES_BUDGET}`,
+    );
+  }
+  if (dryRun.emittedTotalBytes > WORKER_EMITTED_TOTAL_BYTES_BUDGET) {
+    fail(
+      `emitted bundle bytes exceeded budget: ${dryRun.emittedTotalBytes} > ${WORKER_EMITTED_TOTAL_BYTES_BUDGET}`,
+    );
+  }
+  if (dryRun.workerScriptBytes > WORKER_UPLOAD_SCRIPT_BYTES_BUDGET) {
+    fail(
+      `Worker upload script bytes exceeded budget: ${dryRun.workerScriptBytes} > ${WORKER_UPLOAD_SCRIPT_BYTES_BUDGET}`,
+    );
+  }
+  if (dryRun.workerScriptGzipBytes > WORKER_UPLOAD_SCRIPT_GZIP_BYTES_BUDGET) {
+    fail(
+      `Worker upload gzip bytes exceeded budget: ${dryRun.workerScriptGzipBytes} > ${WORKER_UPLOAD_SCRIPT_GZIP_BYTES_BUDGET}`,
+    );
+  }
 
-const smoke = await runWranglerStartupSmoke(wranglerConfig);
+  const smoke = await runWranglerStartupSmoke(wranglerConfig);
+  const jwksSmoke = await runMiniflareJwksSmoke(wranglerConfig, dryRun.workerScript);
+  const dryRunMetrics = {
+    emittedFiles: dryRun.emittedFiles,
+    emittedTotalBytes: dryRun.emittedTotalBytes,
+    uploadLine: dryRun.uploadLine,
+    workerScriptBytes: dryRun.workerScriptBytes,
+    workerScriptGzipBytes: dryRun.workerScriptGzipBytes,
+  };
 
-mkdirSync(reportDir, { recursive: true });
-const metrics = {
-  ...compatibility,
-  wranglerDryRun: dryRun,
-  sourceGraphFiles: files.size,
-  sourceGraphBytes: sourceBytes,
-  workerRuntimeSmoke: smoke,
-  limits: {
-    emittedFiles: WORKER_EMITTED_FILES_BUDGET,
-    emittedTotalBytes: WORKER_EMITTED_TOTAL_BYTES_BUDGET,
-    sourceGraphFiles: WORKER_SOURCE_GRAPH_FILES_BUDGET,
-    sourceGraphBytes: WORKER_SOURCE_GRAPH_BYTES_BUDGET,
-    workerScriptBytes: WORKER_UPLOAD_SCRIPT_BYTES_BUDGET,
-    workerScriptGzipBytes: WORKER_UPLOAD_SCRIPT_GZIP_BYTES_BUDGET,
-  },
-};
-writeFileSync(path.join(reportDir, "metrics.json"), `${JSON.stringify(metrics, null, 2)}\n`);
-writeFileSync(
-  path.join(reportDir, "summary.md"),
-  [
-    "# Cloudflare Worker Bundle Budget",
-    "",
-    "| Metric | Current | Budget |",
-    "| --- | ---: | ---: |",
-    `| Emitted bundle files | ${dryRun.emittedFiles.length} | ${WORKER_EMITTED_FILES_BUDGET} |`,
-    `| Emitted bundle bytes | ${dryRun.emittedTotalBytes} | ${WORKER_EMITTED_TOTAL_BYTES_BUDGET} |`,
-    `| Worker upload script bytes | ${dryRun.workerScriptBytes} | ${WORKER_UPLOAD_SCRIPT_BYTES_BUDGET} |`,
-    `| Worker upload gzip bytes | ${dryRun.workerScriptGzipBytes} | ${WORKER_UPLOAD_SCRIPT_GZIP_BYTES_BUDGET} |`,
-    `| Source graph files | ${files.size} | ${WORKER_SOURCE_GRAPH_FILES_BUDGET} |`,
-    `| Source graph bytes | ${sourceBytes} | ${WORKER_SOURCE_GRAPH_BYTES_BUDGET} |`,
-    `| Runtime smoke /health | ${smoke.healthStatus} | 200 |`,
-    "",
-  ].join("\n"),
-);
+  mkdirSync(reportDir, { recursive: true });
+  const metrics = {
+    ...compatibility,
+    wranglerDryRun: dryRunMetrics,
+    sourceGraphFiles: files.size,
+    sourceGraphBytes: sourceBytes,
+    workerRuntimeSmoke: smoke,
+    workerJwksRuntimeSmoke: jwksSmoke,
+    limits: {
+      emittedFiles: WORKER_EMITTED_FILES_BUDGET,
+      emittedTotalBytes: WORKER_EMITTED_TOTAL_BYTES_BUDGET,
+      sourceGraphFiles: WORKER_SOURCE_GRAPH_FILES_BUDGET,
+      sourceGraphBytes: WORKER_SOURCE_GRAPH_BYTES_BUDGET,
+      workerScriptBytes: WORKER_UPLOAD_SCRIPT_BYTES_BUDGET,
+      workerScriptGzipBytes: WORKER_UPLOAD_SCRIPT_GZIP_BYTES_BUDGET,
+    },
+  };
+  writeFileSync(path.join(reportDir, "metrics.json"), `${JSON.stringify(metrics, null, 2)}\n`);
+  writeFileSync(
+    path.join(reportDir, "summary.md"),
+    [
+      "# Cloudflare Worker Bundle Budget",
+      "",
+      "| Metric | Current | Budget |",
+      "| --- | ---: | ---: |",
+      `| Emitted bundle files | ${dryRun.emittedFiles.length} | ${WORKER_EMITTED_FILES_BUDGET} |`,
+      `| Emitted bundle bytes | ${dryRun.emittedTotalBytes} | ${WORKER_EMITTED_TOTAL_BYTES_BUDGET} |`,
+      `| Worker upload script bytes | ${dryRun.workerScriptBytes} | ${WORKER_UPLOAD_SCRIPT_BYTES_BUDGET} |`,
+      `| Worker upload gzip bytes | ${dryRun.workerScriptGzipBytes} | ${WORKER_UPLOAD_SCRIPT_GZIP_BYTES_BUDGET} |`,
+      `| Source graph files | ${files.size} | ${WORKER_SOURCE_GRAPH_FILES_BUDGET} |`,
+      `| Source graph bytes | ${sourceBytes} | ${WORKER_SOURCE_GRAPH_BYTES_BUDGET} |`,
+      `| Runtime smoke /health | ${smoke.healthStatus} | 200 |`,
+      `| Runtime smoke JWKS /mcp | ${jwksSmoke.jwksHits} JWKS fetch, ${jwksSmoke.mcpStatus} response | 1 fetch, 401 response |`,
+      "",
+    ].join("\n"),
+  );
 
-console.log(
-  `cloudflare-worker-bundle: ${dryRun.workerScriptBytes} upload bytes, ${dryRun.workerScriptGzipBytes} gzip bytes, and workerd health smoke passed`,
-);
+  console.log(
+    `cloudflare-worker-bundle: ${dryRun.workerScriptBytes} upload bytes, ${dryRun.workerScriptGzipBytes} gzip bytes, workerd health smoke passed, and JWKS smoke reached ${jwksSmoke.jwksHits} mock fetch`,
+  );
+} finally {
+  rmSync(dryRun.workspace, { recursive: true, force: true });
+}

--- a/scripts/lib/cloudflare-worker-jwks-smoke.mjs
+++ b/scripts/lib/cloudflare-worker-jwks-smoke.mjs
@@ -1,0 +1,214 @@
+import path from "path";
+
+// Keep the direct Miniflare devDependency pinned to Wrangler's transitive
+// workerd release. The current 5.x package is alpha-only; review the pin on
+// each Wrangler upgrade and move to stable Miniflare once it exposes this API.
+import { Log, LogLevel, Miniflare, convertV4MiniflareOptions } from "miniflare";
+
+export const WORKER_SMOKE_PUBLIC_URL = "https://mcp.example.com/mcp";
+export const WORKER_SMOKE_JWKS_URI = "https://issuer.example.com/.well-known/jwks.json";
+export const WORKER_SMOKE_JWKS_SERVICE_BINDING = "B2_CLOUDFLARE_WORKER_SMOKE_JWKS_SERVICE";
+export const WORKER_SMOKE_FLAG = "B2_CLOUDFLARE_WORKER_SMOKE";
+
+const WORKER_SMOKE_RSA_PUBLIC_JWK = {
+  kty: "RSA",
+  n: "pFW3ni6ZrJmRFlXFVaSgTKa18nbzaUZ1O1McAgPosEdrxBKp_j5_l34oGXiA2h-zdr78a1aXhsmIk0mNW_N-D6wCC56yCYVsEjgLEhId-zmrpKd9tcSn5uDWLR5EYrkFbN9qSb2En7Sdvh2xziG2JsL8pu20UufHVGQF5VJ7__wsGl7fPuEalGmadbDobs7XeN7iu_YQjTuHp0FE5nSsTUJkWmSNEgJ4YgrdCa-yv0-S4szRdQNSTUtKFcY7SIHbzlkaEK3TEW-hHDXlc1eI9QEG7ZIjp9QBi7bKvTe5m3Yi4EAUiKHyC-Di9cXUPQl1vfBtPVSfCQLBgxBXqHvSDQ",
+  e: "AQAB",
+  kid: "worker-smoke-rsa-key",
+  alg: "RS256",
+  use: "sig",
+  key_ops: ["verify"],
+};
+
+function base64UrlJson(value) {
+  return Buffer.from(JSON.stringify(value)).toString("base64url");
+}
+
+function workerSmokeJwt() {
+  const now = Math.floor(Date.now() / 1000);
+  return [
+    base64UrlJson({
+      alg: "RS256",
+      typ: "at+jwt",
+      kid: WORKER_SMOKE_RSA_PUBLIC_JWK.kid,
+    }),
+    base64UrlJson({
+      iss: "https://issuer.example.com/",
+      sub: "worker-smoke-subject",
+      aud: WORKER_SMOKE_PUBLIC_URL,
+      resource: WORKER_SMOKE_PUBLIC_URL,
+      scope: "b2:read",
+      client_id: "worker-smoke-client",
+      iat: now,
+      exp: now + 300,
+    }),
+    Buffer.from("invalid worker smoke signature").toString("base64url"),
+  ].join(".");
+}
+
+function workerSmokeMcpBody() {
+  return JSON.stringify({
+    jsonrpc: "2.0",
+    id: 1,
+    method: "initialize",
+    params: {
+      protocolVersion: "2026-07-28",
+      capabilities: {},
+      clientInfo: {
+        name: "cloudflare-worker-jwks-smoke",
+        version: "0.0.0",
+      },
+    },
+  });
+}
+
+function jwksMockWorkerScript() {
+  return `
+let jwksHits = 0;
+const jwk = ${JSON.stringify(WORKER_SMOKE_RSA_PUBLIC_JWK)};
+
+export default {
+  fetch(request) {
+    const url = new URL(request.url);
+    if (url.pathname === "/.well-known/jwks.json") {
+      jwksHits += 1;
+      return Response.json({ keys: [jwk] }, { headers: { "Cache-Control": "no-store" } });
+    }
+    if (url.pathname === "/__jwks-hits") {
+      return Response.json({ jwksHits });
+    }
+    return Response.json({ error: "not found" }, { status: 404 });
+  },
+};
+`;
+}
+
+async function withTimeout(label, timeoutMs, operation) {
+  let timeout;
+  const timeoutPromise = new Promise((_, reject) => {
+    timeout = setTimeout(() => {
+      reject(new Error(`${label} timed out after ${timeoutMs}ms`));
+    }, timeoutMs);
+  });
+
+  try {
+    return await Promise.race([operation(), timeoutPromise]);
+  } finally {
+    clearTimeout(timeout);
+  }
+}
+
+function createDeadline(label, timeoutMs) {
+  const expiresAt = Date.now() + timeoutMs;
+  return {
+    remaining(step) {
+      const remainingMs = expiresAt - Date.now();
+      if (remainingMs <= 0) {
+        throw new Error(`${label} timed out after ${timeoutMs}ms before ${step}`);
+      }
+      return remainingMs;
+    },
+  };
+}
+
+async function withDeadline(deadline, label, operation) {
+  return withTimeout(label, deadline.remaining(label), operation);
+}
+
+export function workerJwksSmokeVars(baseVars) {
+  return {
+    ...baseVars,
+    [WORKER_SMOKE_FLAG]: "true",
+    B2_OAUTH_ALLOWED_ALGORITHMS: "RS256",
+    B2_OAUTH_ALLOWED_TOKEN_TYPES: "bearer",
+    B2_OAUTH_JWKS_CACHE_TTL_SECONDS: "300",
+    B2_OAUTH_JWKS_RETRIES: "0",
+    B2_OAUTH_JWKS_TIMEOUT_MS: "2000",
+    B2_OAUTH_JWKS_URI: WORKER_SMOKE_JWKS_URI,
+  };
+}
+
+export async function runMiniflareJwksSmoke(config, workerScript, bindings, timeoutMs) {
+  const mf = new Miniflare(
+    convertV4MiniflareOptions({
+      log: new Log(LogLevel.ERROR),
+      logRequests: false,
+      workers: [
+        {
+          name: "b2-mcp-worker-smoke",
+          rootPath: path.dirname(workerScript),
+          scriptPath: path.basename(workerScript),
+          modules: true,
+          compatibilityDate: config.compatibility_date,
+          compatibilityFlags: config.compatibility_flags,
+          bindings,
+          serviceBindings: {
+            [WORKER_SMOKE_JWKS_SERVICE_BINDING]: "jwks-mock",
+          },
+        },
+        {
+          name: "jwks-mock",
+          script: jwksMockWorkerScript(),
+          modules: true,
+          compatibilityDate: config.compatibility_date,
+        },
+      ],
+    }),
+  );
+  let failure;
+  let result;
+  const deadline = createDeadline("JWKS smoke", timeoutMs);
+
+  try {
+    const response = await withDeadline(deadline, "JWKS smoke /mcp dispatchFetch", () =>
+      mf.dispatchFetch(WORKER_SMOKE_PUBLIC_URL, {
+        method: "POST",
+        headers: {
+          Accept: "application/json, text/event-stream",
+          Authorization: `Bearer ${workerSmokeJwt()}`,
+          "Content-Type": "application/json",
+        },
+        body: workerSmokeMcpBody(),
+      }),
+    );
+    const responseBody = await withDeadline(deadline, "JWKS smoke /mcp response body", () =>
+      response.text(),
+    );
+    const mockWorker = await withDeadline(deadline, "JWKS smoke mock worker lookup", () =>
+      mf.getWorker("jwks-mock"),
+    );
+    const hitsResponse = await withDeadline(deadline, "JWKS smoke mock fetch inspection", () =>
+      mockWorker.fetch("https://issuer.example.com/__jwks-hits"),
+    );
+    const hitsBody = await withDeadline(deadline, "JWKS smoke mock hit JSON", () =>
+      hitsResponse.json(),
+    );
+    const jwksHits = hitsBody?.jwksHits;
+
+    if (jwksHits !== 1) {
+      failure = `JWKS smoke expected the mock to receive 1 request, got ${JSON.stringify(
+        hitsBody,
+      )}; /mcp returned ${response.status}: ${responseBody}`;
+    } else if (response.status !== 401) {
+      failure = `JWKS smoke expected /mcp to fail closed with 401 after JWKS, got ${response.status}: ${responseBody}`;
+    } else if (!response.headers.get("www-authenticate")?.includes('error="invalid_token"')) {
+      failure = `JWKS smoke expected an invalid_token challenge, got ${response.headers.get(
+        "www-authenticate",
+      )}`;
+    } else {
+      result = { mcpStatus: response.status, jwksHits };
+    }
+  } catch (error) {
+    failure = error instanceof Error ? error.message : String(error);
+  } finally {
+    try {
+      await withTimeout("JWKS smoke Miniflare dispose", timeoutMs, () => mf.dispose());
+    } catch (error) {
+      const disposeFailure = error instanceof Error ? error.message : String(error);
+      failure = failure ? `${failure}; ${disposeFailure}` : disposeFailure;
+    }
+  }
+
+  if (failure) throw new Error(failure);
+  return result;
+}

--- a/src/serverless-adapter-runtime.ts
+++ b/src/serverless-adapter-runtime.ts
@@ -34,6 +34,8 @@ export interface NormalizedServerlessMcpFetchContext {
   remoteAddress?: string;
 }
 
+const SERVERLESS_MCP_CONTEXT_KEYS = ["authInfo", "oauthFetch", "remoteAddress"] as const;
+
 export type ServerlessWarnLogger = (fields: Record<string, unknown>, message: string) => void;
 
 export interface ServerlessAdapterRuntimeOptions<Context extends ServerlessMcpFetchContext> {
@@ -82,7 +84,7 @@ export function normalizeServerlessMcpContext<Context extends ServerlessMcpFetch
   isContext?: (input: AuthInfo | Context) => input is Context,
 ): NormalizedServerlessMcpFetchContext {
   if (!input) return { authInfo: null };
-  if (isContext?.(input) ?? ("authInfo" in input || "remoteAddress" in input)) {
+  if (isContext?.(input) ?? isServerlessMcpFetchContext(input)) {
     const context = input as Context;
     return {
       authInfo: context.authInfo ?? null,
@@ -91,6 +93,12 @@ export function normalizeServerlessMcpContext<Context extends ServerlessMcpFetch
     };
   }
   return { authInfo: input as AuthInfo };
+}
+
+export function isServerlessMcpFetchContext(
+  input: AuthInfo | ServerlessMcpFetchContext,
+): input is ServerlessMcpFetchContext {
+  return SERVERLESS_MCP_CONTEXT_KEYS.some((key) => key in input) || !("token" in input);
 }
 
 export function serverlessMcpPreflight(request: Request): Response | null {

--- a/src/serverless-adapter-runtime.ts
+++ b/src/serverless-adapter-runtime.ts
@@ -24,11 +24,13 @@ import { readCappedBodyBytes } from "./utils/http-body-limit.js";
 
 export interface ServerlessMcpFetchContext {
   authInfo?: AuthInfo | null;
+  oauthFetch?: typeof fetch;
   remoteAddress?: string;
 }
 
 export interface NormalizedServerlessMcpFetchContext {
   authInfo: AuthInfo | null;
+  oauthFetch?: typeof fetch;
   remoteAddress?: string;
 }
 
@@ -84,6 +86,7 @@ export function normalizeServerlessMcpContext<Context extends ServerlessMcpFetch
     const context = input as Context;
     return {
       authInfo: context.authInfo ?? null,
+      oauthFetch: context.oauthFetch,
       remoteAddress: context.remoteAddress,
     };
   }
@@ -240,7 +243,9 @@ export function createServerlessAdapterRuntime<Context extends ServerlessMcpFetc
     const prepared = await runWithAdmissionLimit(request, context, async () => {
       const boundedRequest = await requestWithCappedBody(request);
       if (boundedRequest instanceof Response) return boundedRequest;
-      const auth = await authenticateOAuthRequest(boundedRequest, oauthConfig);
+      const auth = await authenticateOAuthRequest(boundedRequest, oauthConfig, {
+        fetch: context.oauthFetch,
+      });
       if (auth instanceof Response) return auth;
       return { auth, boundedRequest };
     });

--- a/tests/unit/cloudflare-worker-adapter.unit.test.ts
+++ b/tests/unit/cloudflare-worker-adapter.unit.test.ts
@@ -248,7 +248,8 @@ describe("Cloudflare Worker adapter", () => {
       B2_OAUTH_INTROSPECTION_CLIENT_ID: undefined,
       B2_OAUTH_INTROSPECTION_CLIENT_SECRET: undefined,
       B2_OAUTH_JWKS_URI: "https://issuer.example.com/oauth2/jwks",
-      B2_OAUTH_JWKS_SERVICE: jwksService,
+      B2_CLOUDFLARE_WORKER_SMOKE: "true",
+      B2_CLOUDFLARE_WORKER_SMOKE_JWKS_SERVICE: jwksService,
     };
 
     const discover = await rpcJson(
@@ -265,6 +266,44 @@ describe("Cloudflare Worker adapter", () => {
     expect(discover.result?.supportedVersions).toContain("2026-07-28");
     expect(jwksService.fetch).toHaveBeenCalledTimes(1);
     expect(globalFetch).not.toHaveBeenCalled();
+  });
+
+  it("keeps the JWKS service binding smoke-only", async () => {
+    process.env = { ...savedEnv };
+    const globalFetch = vi.fn(async () => jwksResponse());
+    const jwksService = {
+      fetch: vi.fn(async () => {
+        throw new Error("smoke-only JWKS binding should not be used");
+      }),
+    };
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => undefined);
+    vi.stubGlobal("fetch", globalFetch);
+    const env = {
+      ...cloudflareEnv(),
+      B2_OAUTH_INTROSPECTION_ENDPOINT: undefined,
+      B2_OAUTH_INTROSPECTION_CLIENT_ID: undefined,
+      B2_OAUTH_INTROSPECTION_CLIENT_SECRET: undefined,
+      B2_OAUTH_JWKS_URI: "https://issuer.example.com/oauth2/jwks",
+      B2_CLOUDFLARE_WORKER_SMOKE_JWKS_SERVICE: jwksService,
+    };
+
+    const discover = await rpcJson(
+      await cloudflareWorkerFetch(
+        new Request("https://mcp.example.com/mcp", {
+          method: "POST",
+          headers: { ...modernHeaders("server/discover"), Authorization: `Bearer ${signedJwt()}` },
+          body: modernBody("server/discover"),
+        }),
+        env,
+      ),
+    );
+
+    expect(discover.result?.supportedVersions).toContain("2026-07-28");
+    expect(globalFetch).toHaveBeenCalledTimes(1);
+    expect(jwksService.fetch).not.toHaveBeenCalled();
+    expect(warn).toHaveBeenCalledWith(
+      expect.stringContaining("cloudflare_worker.oauth.test_jwks_service_binding_inactive"),
+    );
   });
 
   it("rejects bearer tokens whose subject is outside the local allowlist", async () => {

--- a/tests/unit/cloudflare-worker-adapter.unit.test.ts
+++ b/tests/unit/cloudflare-worker-adapter.unit.test.ts
@@ -228,6 +228,45 @@ describe("Cloudflare Worker adapter", () => {
     expect(jwksFetch).toHaveBeenCalledTimes(1);
   });
 
+  it("routes Worker JWKS fetches through a service binding when present", async () => {
+    process.env = { ...savedEnv };
+    const globalFetch = vi.fn(async () => {
+      throw new Error("global fetch should not be used for JWKS");
+    });
+    const jwksService = {
+      fetch: vi.fn(async (request: Request) => {
+        expect(request.method).toBe("GET");
+        expect(request.redirect).toBe("manual");
+        expect(request.url).toBe("https://issuer.example.com/oauth2/jwks");
+        return jwksResponse();
+      }),
+    };
+    vi.stubGlobal("fetch", globalFetch);
+    const env = {
+      ...cloudflareEnv(),
+      B2_OAUTH_INTROSPECTION_ENDPOINT: undefined,
+      B2_OAUTH_INTROSPECTION_CLIENT_ID: undefined,
+      B2_OAUTH_INTROSPECTION_CLIENT_SECRET: undefined,
+      B2_OAUTH_JWKS_URI: "https://issuer.example.com/oauth2/jwks",
+      B2_OAUTH_JWKS_SERVICE: jwksService,
+    };
+
+    const discover = await rpcJson(
+      await cloudflareWorkerFetch(
+        new Request("https://mcp.example.com/mcp", {
+          method: "POST",
+          headers: { ...modernHeaders("server/discover"), Authorization: `Bearer ${signedJwt()}` },
+          body: modernBody("server/discover"),
+        }),
+        env,
+      ),
+    );
+
+    expect(discover.result?.supportedVersions).toContain("2026-07-28");
+    expect(jwksService.fetch).toHaveBeenCalledTimes(1);
+    expect(globalFetch).not.toHaveBeenCalled();
+  });
+
   it("rejects bearer tokens whose subject is outside the local allowlist", async () => {
     process.env = { ...savedEnv };
     const introspection = vi


### PR DESCRIPTION
## Summary
- Adds a JWKS-only workerd smoke to the Cloudflare Worker bundle check using Miniflare and the generated worker bundle.
- Extracts the JWKS smoke fixture/runner, adds explicit timeouts around Miniflare operations and cleanup, and cleans dry-run workspaces on early failures.
- Keeps the JWKS service binding as a smoke-only test hook gated by B2_CLOUDFLARE_WORKER_SMOKE, centralizes oauthFetch context detection in the shared serverless normalizer, and allows JWKS fixture fragments in the project spelling dictionary.

## Linked issue
Closes #174

## Tests run
- pnpm run typecheck
- pnpm exec vitest run tests/unit/cloudflare-worker-adapter.unit.test.ts
- pnpm run check:cloudflare-worker-bundle
- pnpm run lint
- pnpm run test:unit
- pnpm run format:check
- pnpm run spell
- pnpm run test:contract
- pnpm run test:coverage
- git diff --check

## Follow-up notes
- Miniflare remains pinned to Wrangler's transitive 5.x alpha workerd release for this smoke; review on each Wrangler bump and move to stable Miniflare once the needed service-binding API is available.
