### PR TITLE
Adopt tag-driven release flow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -3,21 +3,16 @@ name: Publish Package
 # Tag-driven release. Release owners cut a version with `pnpm version
 # <patch|minor|major>` and push the resulting commit and `v*` tag with
 # `git push --follow-tags`. The unprivileged Release Tag Request workflow
-# receives the tag push; this privileged workflow then runs from the default
-# branch through workflow_run, checks out trusted resolver code from `ci-green`,
-# and only then checks out the validated tag.
+# receives the tag push or manual rerun request; this privileged workflow then
+# runs from the default branch through workflow_run, checks out trusted resolver
+# code from `ci-green`, and only then checks out the validated tag.
 on:
   workflow_run:
     workflows: ["Release Tag Request"]
     types: [completed]
-  workflow_dispatch:
-    inputs:
-      tag:
-        description: "Existing vX.Y.Z[-prerelease] tag to publish or re-run"
-        required: true
-        type: string
 
 permissions:
+  actions: read
   contents: read
 
 concurrency:
@@ -26,11 +21,12 @@ concurrency:
 
 jobs:
   prepare:
-    if: github.repository == 'backblaze-labs/b2-mcp' && (github.event_name == 'workflow_dispatch' || github.event.workflow_run.conclusion == 'success')
+    if: github.repository == 'backblaze-labs/b2-mcp' && github.event.workflow_run.conclusion == 'success'
     runs-on: ubuntu-latest
     # This must exceed the ci-green wait below plus verify/build/pack/SBOM time.
     timeout-minutes: 60
     outputs:
+      publish-tag: ${{ steps.request.outputs.tag }}
       checkout-sha: ${{ steps.ref.outputs.checkout_sha }}
       tarball-name: ${{ steps.pack.outputs.tarball_name }}
       tarball-sha256: ${{ steps.pack.outputs.tarball_sha256 }}
@@ -42,6 +38,24 @@ jobs:
       release-notes-name: ${{ steps.notes.outputs.release_notes_name }}
       release-notes-sha256: ${{ steps.notes.outputs.release_notes_sha256 }}
     steps:
+      # actions/download-artifact v6, reviewed 2026-08-06.
+      - uses: actions/download-artifact@018cc2cf5baa6db3ef3c5f8a56943fffe632ef53
+        with:
+          run-id: ${{ github.event.workflow_run.id }}
+          name: release-tag-request
+          path: release-request
+          github-token: ${{ github.token }}
+      - name: Read requested release tag
+        id: request
+        run: |
+          set -euo pipefail
+          PUBLISH_TAG="$(tr -d '\r\n' < release-request/tag.txt)"
+          PUBLISH_TAG="${PUBLISH_TAG#refs/tags/}"
+          if [[ ! "${PUBLISH_TAG}" =~ ^v[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z.-]+)?$ ]]; then
+            echo "::error::Release tag request artifact contains an invalid tag: ${PUBLISH_TAG}"
+            exit 1
+          fi
+          echo "tag=${PUBLISH_TAG}" >> "${GITHUB_OUTPUT}"
       # actions/checkout v6, reviewed 2026-08-06.
       - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803
         with:
@@ -60,7 +74,7 @@ jobs:
       - name: Resolve ci-green protected release ref
         id: ref
         env:
-          PUBLISH_TAG: ${{ github.event_name == 'workflow_run' && github.event.workflow_run.head_branch || inputs.tag }}
+          PUBLISH_TAG: ${{ steps.request.outputs.tag }}
           PUBLISH_REMOTE: ${{ github.server_url }}/${{ github.repository }}.git
         run: |
           PUBLISH_TAG="${PUBLISH_TAG#refs/tags/}"
@@ -81,7 +95,7 @@ jobs:
           ACTIONS_RESULTS_URL: ""
           ACTIONS_RUNTIME_TOKEN: ""
           ACTIONS_RUNTIME_URL: ""
-          PUBLISH_TAG: ${{ github.event_name == 'workflow_run' && github.event.workflow_run.head_branch || inputs.tag }}
+          PUBLISH_TAG: ${{ steps.request.outputs.tag }}
         run: |
           PUBLISH_TAG="${PUBLISH_TAG#refs/tags/}"
           node scripts/verify-release-input.mjs --tag "${PUBLISH_TAG}"
@@ -162,7 +176,7 @@ jobs:
           ACTIONS_RESULTS_URL: ""
           ACTIONS_RUNTIME_TOKEN: ""
           ACTIONS_RUNTIME_URL: ""
-          PUBLISH_TAG: ${{ github.event_name == 'workflow_run' && github.event.workflow_run.head_branch || inputs.tag }}
+          PUBLISH_TAG: ${{ steps.request.outputs.tag }}
         run: |
           set -euo pipefail
           PUBLISH_TAG="${PUBLISH_TAG#refs/tags/}"
@@ -400,7 +414,7 @@ jobs:
           ACTIONS_RUNTIME_URL: ""
           CHECKOUT_SHA: ${{ needs.prepare.outputs.checkout-sha }}
           GHCR_TOKEN: ${{ github.token }}
-          PUBLISH_TAG: ${{ github.event_name == 'workflow_run' && github.event.workflow_run.head_branch || inputs.tag }}
+          PUBLISH_TAG: ${{ needs.prepare.outputs.publish-tag }}
           REGISTRY_IMAGE: ghcr.io/${{ github.repository }}
         run: |
           export PUBLISH_TAG="${PUBLISH_TAG#refs/tags/}"
@@ -482,7 +496,7 @@ jobs:
           EXPECTED_SBOM_NAME: ${{ needs.prepare.outputs.sbom-name }}
           EXPECTED_CHECKSUMS_NAME: ${{ needs.prepare.outputs.checksums-name }}
           EXPECTED_RELEASE_NOTES_NAME: ${{ needs.prepare.outputs.release-notes-name }}
-          PUBLISH_TAG: ${{ github.event_name == 'workflow_run' && github.event.workflow_run.head_branch || inputs.tag }}
+          PUBLISH_TAG: ${{ needs.prepare.outputs.publish-tag }}
         run: |
           set -euo pipefail
           PUBLISH_TAG="${PUBLISH_TAG#refs/tags/}"

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,8 +1,14 @@
 name: Publish Package
 
+# Tag-driven release. Release owners cut a version with
+# `pnpm version <patch|minor|major>` and push the resulting commit and `v*` tag
+# with `git push --follow-tags`. The tag push starts this workflow; the prepare
+# job waits until that tag is reachable from the protected `ci-green` marker
+# before building or publishing anything.
 on:
-  release:
-    types: [published]
+  push:
+    tags:
+      - "v*"
 
 permissions:
   contents: read
@@ -15,7 +21,7 @@ jobs:
   prepare:
     if: github.repository == 'backblaze-labs/b2-mcp'
     runs-on: ubuntu-latest
-    timeout-minutes: 15
+    timeout-minutes: 90
     outputs:
       checkout-sha: ${{ steps.ref.outputs.checkout_sha }}
       tarball-name: ${{ steps.pack.outputs.tarball_name }}
@@ -45,12 +51,14 @@ jobs:
       - name: Resolve ci-green protected release ref
         id: ref
         env:
-          PUBLISH_TAG: ${{ github.event.release.tag_name }}
+          PUBLISH_TAG: ${{ github.ref_name }}
           PUBLISH_REMOTE: ${{ github.server_url }}/${{ github.repository }}.git
         run: |
           node scripts/resolve-publish-ref.mjs \
             --tag "${PUBLISH_TAG}" \
-            --remote "${PUBLISH_REMOTE}"
+            --remote "${PUBLISH_REMOTE}" \
+            --wait-for-ci-green-timeout-ms 2700000 \
+            --wait-for-ci-green-interval-ms 30000
       # actions/checkout v6, reviewed 2026-08-06.
       - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803
         with:
@@ -63,7 +71,7 @@ jobs:
           ACTIONS_RESULTS_URL: ""
           ACTIONS_RUNTIME_TOKEN: ""
           ACTIONS_RUNTIME_URL: ""
-          PUBLISH_TAG: ${{ github.event.release.tag_name }}
+          PUBLISH_TAG: ${{ github.ref_name }}
         run: node scripts/verify-release-input.mjs --tag "${PUBLISH_TAG}"
       - name: Fetch protected refs for denylist scan
         run: |
@@ -142,7 +150,7 @@ jobs:
           ACTIONS_RESULTS_URL: ""
           ACTIONS_RUNTIME_TOKEN: ""
           ACTIONS_RUNTIME_URL: ""
-          PUBLISH_TAG: ${{ github.event.release.tag_name }}
+          PUBLISH_TAG: ${{ github.ref_name }}
         run: |
           set -euo pipefail
           mkdir -p publish-package
@@ -379,7 +387,7 @@ jobs:
           ACTIONS_RUNTIME_URL: ""
           CHECKOUT_SHA: ${{ needs.prepare.outputs.checkout-sha }}
           GHCR_TOKEN: ${{ github.token }}
-          PUBLISH_TAG: ${{ github.event.release.tag_name }}
+          PUBLISH_TAG: ${{ github.ref_name }}
           REGISTRY_IMAGE: ghcr.io/${{ github.repository }}
         run: node scripts/publish-container-image.mjs
 
@@ -459,7 +467,7 @@ jobs:
           EXPECTED_SBOM_NAME: ${{ needs.prepare.outputs.sbom-name }}
           EXPECTED_CHECKSUMS_NAME: ${{ needs.prepare.outputs.checksums-name }}
           EXPECTED_RELEASE_NOTES_NAME: ${{ needs.prepare.outputs.release-notes-name }}
-          PUBLISH_TAG: ${{ github.event.release.tag_name }}
+          PUBLISH_TAG: ${{ github.ref_name }}
         run: |
           set -euo pipefail
           release_flags=(

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,14 +1,21 @@
 name: Publish Package
 
-# Tag-driven release. Release owners cut a version with
-# `pnpm version <patch|minor|major>` and push the resulting commit and `v*` tag
-# with `git push --follow-tags`. The tag push starts this workflow; the prepare
-# job waits until that tag is reachable from the protected `ci-green` marker
-# before building or publishing anything.
+# Tag-driven release. Release owners cut a version with `pnpm version
+# <patch|minor|major>` and push the resulting commit and `v*` tag with
+# `git push --follow-tags`. The unprivileged Release Tag Request workflow
+# receives the tag push; this privileged workflow then runs from the default
+# branch through workflow_run, checks out trusted resolver code from `ci-green`,
+# and only then checks out the validated tag.
 on:
-  push:
-    tags:
-      - "v*"
+  workflow_run:
+    workflows: ["Release Tag Request"]
+    types: [completed]
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: "Existing vX.Y.Z[-prerelease] tag to publish or re-run"
+        required: true
+        type: string
 
 permissions:
   contents: read
@@ -19,9 +26,10 @@ concurrency:
 
 jobs:
   prepare:
-    if: github.repository == 'backblaze-labs/b2-mcp'
+    if: github.repository == 'backblaze-labs/b2-mcp' && (github.event_name == 'workflow_dispatch' || github.event.workflow_run.conclusion == 'success')
     runs-on: ubuntu-latest
-    timeout-minutes: 90
+    # This must exceed the ci-green wait below plus verify/build/pack/SBOM time.
+    timeout-minutes: 60
     outputs:
       checkout-sha: ${{ steps.ref.outputs.checkout_sha }}
       tarball-name: ${{ steps.pack.outputs.tarball_name }}
@@ -37,6 +45,7 @@ jobs:
       # actions/checkout v6, reviewed 2026-08-06.
       - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803
         with:
+          ref: refs/heads/ci-green
           persist-credentials: false
       # pnpm/action-setup v6.0.10, reviewed 2026-08-06.
       - uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86
@@ -51,13 +60,14 @@ jobs:
       - name: Resolve ci-green protected release ref
         id: ref
         env:
-          PUBLISH_TAG: ${{ github.ref_name }}
+          PUBLISH_TAG: ${{ github.event_name == 'workflow_run' && github.event.workflow_run.head_branch || inputs.tag }}
           PUBLISH_REMOTE: ${{ github.server_url }}/${{ github.repository }}.git
         run: |
+          PUBLISH_TAG="${PUBLISH_TAG#refs/tags/}"
           node scripts/resolve-publish-ref.mjs \
             --tag "${PUBLISH_TAG}" \
             --remote "${PUBLISH_REMOTE}" \
-            --wait-for-ci-green-timeout-ms 2700000 \
+            --wait-for-ci-green-timeout-ms 1200000 \
             --wait-for-ci-green-interval-ms 30000
       # actions/checkout v6, reviewed 2026-08-06.
       - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803
@@ -71,8 +81,10 @@ jobs:
           ACTIONS_RESULTS_URL: ""
           ACTIONS_RUNTIME_TOKEN: ""
           ACTIONS_RUNTIME_URL: ""
-          PUBLISH_TAG: ${{ github.ref_name }}
-        run: node scripts/verify-release-input.mjs --tag "${PUBLISH_TAG}"
+          PUBLISH_TAG: ${{ github.event_name == 'workflow_run' && github.event.workflow_run.head_branch || inputs.tag }}
+        run: |
+          PUBLISH_TAG="${PUBLISH_TAG#refs/tags/}"
+          node scripts/verify-release-input.mjs --tag "${PUBLISH_TAG}"
       - name: Fetch protected refs for denylist scan
         run: |
           set -euo pipefail
@@ -150,9 +162,10 @@ jobs:
           ACTIONS_RESULTS_URL: ""
           ACTIONS_RUNTIME_TOKEN: ""
           ACTIONS_RUNTIME_URL: ""
-          PUBLISH_TAG: ${{ github.ref_name }}
+          PUBLISH_TAG: ${{ github.event_name == 'workflow_run' && github.event.workflow_run.head_branch || inputs.tag }}
         run: |
           set -euo pipefail
+          PUBLISH_TAG="${PUBLISH_TAG#refs/tags/}"
           mkdir -p publish-package
           version="${PUBLISH_TAG#v}"
           node scripts/extract-release-notes.mjs \
@@ -387,9 +400,11 @@ jobs:
           ACTIONS_RUNTIME_URL: ""
           CHECKOUT_SHA: ${{ needs.prepare.outputs.checkout-sha }}
           GHCR_TOKEN: ${{ github.token }}
-          PUBLISH_TAG: ${{ github.ref_name }}
+          PUBLISH_TAG: ${{ github.event_name == 'workflow_run' && github.event.workflow_run.head_branch || inputs.tag }}
           REGISTRY_IMAGE: ghcr.io/${{ github.repository }}
-        run: node scripts/publish-container-image.mjs
+        run: |
+          export PUBLISH_TAG="${PUBLISH_TAG#refs/tags/}"
+          node scripts/publish-container-image.mjs
 
   github-release:
     needs: [prepare, publish, container-image]
@@ -467,9 +482,10 @@ jobs:
           EXPECTED_SBOM_NAME: ${{ needs.prepare.outputs.sbom-name }}
           EXPECTED_CHECKSUMS_NAME: ${{ needs.prepare.outputs.checksums-name }}
           EXPECTED_RELEASE_NOTES_NAME: ${{ needs.prepare.outputs.release-notes-name }}
-          PUBLISH_TAG: ${{ github.ref_name }}
+          PUBLISH_TAG: ${{ github.event_name == 'workflow_run' && github.event.workflow_run.head_branch || inputs.tag }}
         run: |
           set -euo pipefail
+          PUBLISH_TAG="${PUBLISH_TAG#refs/tags/}"
           release_flags=(
             --repo "${GITHUB_REPOSITORY}"
             --notes-file "publish-package/${EXPECTED_RELEASE_NOTES_NAME}"

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -7,6 +7,9 @@ name: Publish Package
 # runs from the default branch through workflow_run, checks out trusted resolver
 # code from `ci-green`, and only then checks out the validated tag.
 on:
+  # zizmor: ignore[dangerous-triggers] This workflow_run only consumes an inert
+  # tag artifact, checks out ci-green resolver code, validates protected refs,
+  # and publishes behind protected environments.
   workflow_run:
     workflows: ["Release Tag Request"]
     types: [completed]

--- a/.github/workflows/release-tag.yml
+++ b/.github/workflows/release-tag.yml
@@ -1,12 +1,19 @@
 name: Release Tag Request
 
-# This workflow is intentionally unprivileged. A pushed v* tag only creates a
-# workflow_run signal; Publish Package runs from the default-branch workflow and
-# validates the tag against protected refs before publishing.
+# This workflow is intentionally unprivileged. A pushed or manually requested
+# v* tag only creates a workflow_run signal plus a tag artifact; Publish Package
+# runs from the default-branch workflow and validates the tag against protected
+# refs before publishing.
 on:
   push:
     tags:
       - "v*"
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: "Existing vX.Y.Z[-prerelease] tag to publish or re-run"
+        required: true
+        type: string
 
 permissions:
   contents: read
@@ -17,10 +24,25 @@ jobs:
     timeout-minutes: 2
     steps:
       - name: Record release tag request
+        env:
+          REQUEST_TAG: ${{ github.event_name == 'workflow_dispatch' && inputs.tag || github.ref_name }}
         run: |
           set -euo pipefail
-          if [[ "${GITHUB_REF}" != refs/tags/v* ]]; then
-            echo "::error::Release tag requests must come from v* tags; got ${GITHUB_REF}"
+          REQUEST_TAG="${REQUEST_TAG#refs/tags/}"
+          if [[ ! "${REQUEST_TAG}" =~ ^v[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z.-]+)?$ ]]; then
+            echo "::error::Release tag requests must use a vX.Y.Z[-prerelease] tag; got ${REQUEST_TAG}"
             exit 1
           fi
-          echo "Release publish requested for ${GITHUB_REF_NAME}"
+          if ! git ls-remote --exit-code "${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}.git" "refs/tags/${REQUEST_TAG}" >/dev/null; then
+            echo "::error::Release tag refs/tags/${REQUEST_TAG} does not exist"
+            exit 1
+          fi
+          mkdir -p release-request
+          printf '%s\n' "${REQUEST_TAG}" > release-request/tag.txt
+          echo "Release publish requested for ${REQUEST_TAG}"
+      # actions/upload-artifact v6, reviewed 2026-08-06.
+      - uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f
+        with:
+          name: release-tag-request
+          path: release-request/tag.txt
+          if-no-files-found: error

--- a/.github/workflows/release-tag.yml
+++ b/.github/workflows/release-tag.yml
@@ -1,0 +1,26 @@
+name: Release Tag Request
+
+# This workflow is intentionally unprivileged. A pushed v* tag only creates a
+# workflow_run signal; Publish Package runs from the default-branch workflow and
+# validates the tag against protected refs before publishing.
+on:
+  push:
+    tags:
+      - "v*"
+
+permissions:
+  contents: read
+
+jobs:
+  request:
+    runs-on: ubuntu-latest
+    timeout-minutes: 2
+    steps:
+      - name: Record release tag request
+        run: |
+          set -euo pipefail
+          if [[ "${GITHUB_REF}" != refs/tags/v* ]]; then
+            echo "::error::Release tag requests must come from v* tags; got ${GITHUB_REF}"
+            exit 1
+          fi
+          echo "Release publish requested for ${GITHUB_REF_NAME}"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   with owner-only file handling and SIGHUP reopen support for external rotation.
 
 ### Changed
+- Adopted tag-driven release publishing for issue #187: `pnpm version` now
+  promotes the changelog before `git push --follow-tags` starts the protected
+  publish workflow, while keeping the existing SBOM, live-contract,
+  package-budget, GHCR, and `ci-green` gates.
 - Bumped `@backblaze-labs/b2-sdk` to exact-pinned `0.3.0` and moved
   Partner/Groups read/eject/list tooling onto the SDK `/partner` operations;
   durable-secret Partner create/reserve tool names remain unavailable stubs.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,8 +34,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 - Adopted tag-driven release publishing for issue #187: `pnpm version` now
   promotes the changelog before `git push --follow-tags` starts the protected
-  publish workflow, while keeping the existing SBOM, live-contract,
-  package-budget, GHCR, and `ci-green` gates.
+  publish workflow from trusted `ci-green` resolver code, while keeping the
+  existing SBOM, live-contract, package-budget, GHCR, manual publish guard, and
+  `ci-green` gates.
 - Bumped `@backblaze-labs/b2-sdk` to exact-pinned `0.3.0` and moved
   Partner/Groups read/eject/list tooling onto the SDK `/partner` operations;
   durable-secret Partner create/reserve tool names remain unavailable stubs.

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -76,14 +76,21 @@ Before publishing `v0.1.0`:
    a release-blocking follow-up once the upstream package exists.
 12. Push the release commit and `v*` tag, then publish only from the canonical
     repository through the protected `.github/workflows/publish.yml` workflow.
-    Do not publish from a developer workstation. The publish workflow must prove
-    the `v*` tag is reachable from `ci-green`, build explicitly, enforce the
-    runtime package budget, scan the generated packlist and tarball, generate
-    and verify a CycloneDX production SBOM artifact, call the protected live B2
-    contract workflow as a pre-release gate, verify the tarball SHA-256, publish
-    the already-scanned tarball with lifecycle scripts disabled, publish and
-    verify the GHCR image, and attach the SBOM to the GitHub Release only after
-    npm publish and GHCR publishing succeed.
+    Do not publish from a developer workstation. The tag push first runs the
+    unprivileged `Release Tag Request` workflow; `Publish Package` then runs
+    from the default-branch workflow, checks out trusted resolver code from
+    `ci-green`, and must prove the `v*` tag is reachable from `ci-green`, build
+    explicitly, enforce the runtime package budget, scan the generated packlist
+    and tarball, generate and verify a CycloneDX production SBOM artifact, call
+    the protected live B2 contract workflow as a pre-release gate, verify the
+    tarball SHA-256, publish the already-scanned tarball with lifecycle scripts
+    disabled, publish and verify the GHCR image, and attach the SBOM to the
+    GitHub Release only after npm publish and GHCR publishing succeed.
+13. Confirm the release tag ruleset only allows release owners to create
+    `v*` tags and does not allow force-updating or deleting release tags.
+14. Confirm `refs/heads/ci-green` is treated as an owned protected marker:
+    only the `CI` workflow's `mark-green` job may force-push it after all
+    required `main` checks pass, and humans must not push it directly.
 
 ## First Package Bootstrap
 
@@ -119,18 +126,23 @@ exists. For the first public package only:
 
 1. Start from a clean, up-to-date `main`, confirm the intended release content
    is under `[Unreleased]`, and run the deterministic local gate listed above.
-2. Run `pnpm version patch`, `pnpm version minor`, or `pnpm version major`. The
-   package `version` lifecycle promotes `[Unreleased]` into a dated
+2. Confirm release tags will be signed with `git config --get tag.gpgSign`, then
+   run `pnpm version patch`, `pnpm version minor`, or `pnpm version major`. If
+   `tag.gpgSign` is not enabled in the release checkout, pass
+   `--sign-git-tag` to that `pnpm version` command instead. The package
+   `version` lifecycle promotes `[Unreleased]` into a dated
    `## [x.y.z] - YYYY-MM-DD` changelog section, stages `CHANGELOG.md`, creates
    the version commit, and creates the matching `vX.Y.Z` tag.
+   Release tags are signed.
 3. Push the release commit and tag:
 
    ```bash
    git push --follow-tags
    ```
 
-   The tag push starts `Publish Package`. The workflow waits until the tag is
-   reachable from the protected `ci-green` marker, then verifies
+   The tag push starts `Release Tag Request`, and its successful completion
+   starts `Publish Package` from the default branch. The publish workflow waits
+   until the tag is reachable from the protected `ci-green` marker, then verifies
    tag/package/changelog consistency, runs `pnpm run verify`, requires live
    contract success, builds one tarball, runs an npm dry-run publish, records
    checksums and SBOM, publishes that exact tarball with npm OIDC provenance,
@@ -141,7 +153,12 @@ exists. For the first public package only:
    signature plus provenance and SBOM attestations, and it must not overwrite an
    existing versioned image whose recorded revision differs from the verified
    checkout SHA.
-4. If GHCR has the version/release tags but the retry fails because the digest is
+4. To re-run publishing for an existing tag after a transient external failure,
+   use the `Publish Package` workflow's `workflow_dispatch` input with the
+   existing `vX.Y.Z` tag. Do not delete, force-move, or re-push the tag.
+   Creating or editing a GitHub Release is not a publish trigger; the workflow
+   creates or updates the GitHub Release only after npm and GHCR succeed.
+5. If GHCR has the version/release tags but the retry fails because the digest is
    unsigned or missing trusted attestations, delete that specific GHCR package
    version and rerun the same tag:
 

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -154,10 +154,12 @@ exists. For the first public package only:
    existing versioned image whose recorded revision differs from the verified
    checkout SHA.
 4. To re-run publishing for an existing tag after a transient external failure,
-   use the `Publish Package` workflow's `workflow_dispatch` input with the
-   existing `vX.Y.Z` tag. Do not delete, force-move, or re-push the tag.
-   Creating or editing a GitHub Release is not a publish trigger; the workflow
-   creates or updates the GitHub Release only after npm and GHCR succeed.
+   use the unprivileged `Release Tag Request` workflow's `workflow_dispatch`
+   input with the existing `vX.Y.Z` tag. Its successful completion starts
+   `Publish Package` from the default branch. Do not delete, force-move, or
+   re-push the tag. Creating or editing a GitHub Release is not a publish
+   trigger; the workflow creates or updates the GitHub Release only after npm
+   and GHCR succeed.
 5. If GHCR has the version/release tags but the retry fails because the digest is
    unsigned or missing trusted attestations, delete that specific GHCR package
    version and rerun the same tag:

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -74,16 +74,16 @@ Before publishing `v0.1.0`:
    Node.js 22.23.1, Node.js 24, and Node.js 26.
 11. Confirm any claimed MCP SDK package split is either implemented or tracked as
    a release-blocking follow-up once the upstream package exists.
-12. Create the GitHub Release for the publish tag, then publish only from the
-    canonical repository through the protected
-    `.github/workflows/publish.yml` workflow. Do not publish from a developer
-    workstation. The publish workflow must prove the `v*` tag is reachable from
-    `ci-green`, build explicitly, enforce the runtime package budget, scan the
-    generated packlist and tarball, generate and verify a CycloneDX production
-    SBOM artifact, call the protected live B2 contract workflow as a pre-release
-    gate, verify the tarball SHA-256, publish the already-scanned tarball with
-    lifecycle scripts disabled, and attach the SBOM to the GitHub Release only
-    after npm publish succeeds.
+12. Push the release commit and `v*` tag, then publish only from the canonical
+    repository through the protected `.github/workflows/publish.yml` workflow.
+    Do not publish from a developer workstation. The publish workflow must prove
+    the `v*` tag is reachable from `ci-green`, build explicitly, enforce the
+    runtime package budget, scan the generated packlist and tarball, generate
+    and verify a CycloneDX production SBOM artifact, call the protected live B2
+    contract workflow as a pre-release gate, verify the tarball SHA-256, publish
+    the already-scanned tarball with lifecycle scripts disabled, publish and
+    verify the GHCR image, and attach the SBOM to the GitHub Release only after
+    npm publish and GHCR publishing succeed.
 
 ## First Package Bootstrap
 
@@ -111,17 +111,26 @@ exists. For the first public package only:
    `npm-publish` GitHub environment.
 3. Deprecate the bootstrap version with a note that it is a reserved package
    bootstrap and is not supported for installation.
-4. Run the publish workflow against the signed `v0.1.0` tag. The workflow must
+4. Push the signed `v0.1.0` tag to run the publish workflow. The workflow must
    publish the verified tarball with OIDC provenance; do not publish a different
    local tarball to bootstrap the package.
 
 ## Normal Release
 
-1. Keep `[Unreleased]` for future work and move the release contents into a
-   matching `## [x.y.z] - YYYY-MM-DD` changelog section.
-2. Commit the version and changelog update, wait for `ci-green`, then create the
-   signed `vX.Y.Z` tag at that commit.
-3. Dispatch `Publish Package` with the exact tag. The workflow verifies
+1. Start from a clean, up-to-date `main`, confirm the intended release content
+   is under `[Unreleased]`, and run the deterministic local gate listed above.
+2. Run `pnpm version patch`, `pnpm version minor`, or `pnpm version major`. The
+   package `version` lifecycle promotes `[Unreleased]` into a dated
+   `## [x.y.z] - YYYY-MM-DD` changelog section, stages `CHANGELOG.md`, creates
+   the version commit, and creates the matching `vX.Y.Z` tag.
+3. Push the release commit and tag:
+
+   ```bash
+   git push --follow-tags
+   ```
+
+   The tag push starts `Publish Package`. The workflow waits until the tag is
+   reachable from the protected `ci-green` marker, then verifies
    tag/package/changelog consistency, runs `pnpm run verify`, requires live
    contract success, builds one tarball, runs an npm dry-run publish, records
    checksums and SBOM, publishes that exact tarball with npm OIDC provenance,
@@ -149,8 +158,9 @@ exists. For the first public package only:
 ## Prerelease
 
 Use npm semver prerelease tags such as `v0.2.0-rc.1`. Publish from the same
-workflow and tag shape. Validate install commands against the prerelease tag
-before advertising the release candidate outside the release issue.
+`pnpm version prerelease --preid rc` and `git push --follow-tags` flow. Validate
+install commands against the prerelease tag before advertising the release
+candidate outside the release issue.
 
 ## Rollback
 

--- a/docs/SUPPLY_CHAIN_SECURITY.md
+++ b/docs/SUPPLY_CHAIN_SECURITY.md
@@ -186,8 +186,12 @@ The only repository workflow allowed to publish npm packages is
 
 - runs only in the canonical `backblaze-labs/b2-mcp` repository;
 - pins every marketplace action to a reviewed commit SHA;
-- accepts only a `vMAJOR.MINOR.PATCH[-prerelease]` tag and checks it out only
-  after proving it is reachable from the current `ci-green` history;
+- starts from a successful unprivileged `Release Tag Request` workflow for
+  `vMAJOR.MINOR.PATCH[-prerelease]` tag pushes or from an explicit manual
+  dispatch for an existing tag;
+- checks out the resolver from the trusted `ci-green` marker before running
+  repository scripts, and checks out the tag only after proving it is reachable
+  from the current `ci-green` history;
 - verifies tag/package/changelog consistency, then runs
   `pnpm install --frozen-lockfile` with lifecycle scripts still disabled and
   `pnpm run verify`;
@@ -201,7 +205,9 @@ The only repository workflow allowed to publish npm packages is
   environment approval;
 - runs the protected live B2 contract suite once on the exact publish ref before
   the npm publish job can start;
-- requires a protected `npm-publish` environment only for the final publish job;
+- requires a protected `npm-publish` environment for npm publishing and a
+  protected `ghcr-publish` environment for container publishing, so tag push
+  alone cannot publish release artifacts;
 - verifies the tarball SHA-256 and npm `dist.integrity` before publishing;
 - compares an already-published registry version's integrity to the verified
   local tarball before treating the run as an idempotent success;
@@ -221,10 +227,12 @@ The only repository workflow allowed to publish npm packages is
 - treats an already-published version tag as idempotent only after verifying the
   existing digest's prior cosign signature from this release workflow and
   checking the signed index contains BuildKit provenance and SBOM attestation
-  manifests for each required platform, so the workflow does not sign a digest
-  based only on caller-controlled OCI annotations; if a first publish dies after
-  pushing tags but before signing, delete the unsigned GHCR package version
-  documented in `RELEASE.md` and rerun the same tag;
+  manifests for each required platform; tag-push and manual rerun paths both use
+  the protected `main` workflow identity after the same tag-to-`ci-green`
+  validation, so the workflow does not sign a digest based only on
+  caller-controlled OCI annotations; if a first publish dies after pushing tags
+  but before signing, delete the unsigned GHCR package version documented in
+  `RELEASE.md` and rerun the same tag;
 - verifies the pushed version tag through an anonymous manifest inspection before
   the GitHub Release job can run, so a private first-publish GHCR package fails
   the workflow until an owner sets the package visibility to Public and reruns
@@ -236,7 +244,9 @@ The only repository workflow allowed to publish npm packages is
   `npm publish <tarball> --provenance --access public --ignore-scripts`.
 
 Do not publish from a developer workstation or from a workflow that has not
-first proved the release tag is reachable from `ci-green`.
+first proved the release tag is reachable from `ci-green`. Treat
+`refs/heads/ci-green` as an owned protected marker: only the `CI` workflow's
+green-marker job may advance it after required `main` checks pass.
 
 ## Container Base Image Pinning
 

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -497,5 +497,5 @@ workflow through `workflow_call` before npm publish. The caller passes only the
 reviewed checkout SHA. The called workflow's jobs bind `live-b2-contract` and
 resolve `LIVE_B2_KEY_ID`, `LIVE_B2_KEY`, and `B2_LIVE_TEST_ACCOUNT_ID` there;
 those values must not be duplicated or forwarded from repository or
-`npm-publish` secrets. `release.published` is not a pre-release gate and is not
-used for live contract evidence.
+`npm-publish` secrets. GitHub Release publication events are not pre-release
+gates and are not used for live contract evidence.

--- a/package.json
+++ b/package.json
@@ -70,6 +70,7 @@
     "release:notes": "node scripts/extract-release-notes.mjs",
     "release:sbom": "node scripts/production-security-gate.mjs --sbom publish-package/b2-mcp-production.cdx.json",
     "version": "node scripts/cut-changelog.mjs && git add CHANGELOG.md",
+    "prepublishOnly": "pnpm run build && node scripts/verify-release-input.mjs --tag \"v$(node -p 'require(\"./package.json\").version')\"",
     "probe:500": "pnpm run build && node scripts/probe-b2-500s.mjs",
     "lint": "node scripts/run-biome.mjs lint src tests scripts",
     "lint:fix": "node scripts/run-biome.mjs lint src tests scripts --write",

--- a/package.json
+++ b/package.json
@@ -69,6 +69,7 @@
     "release:verify": "node scripts/verify-release-input.mjs",
     "release:notes": "node scripts/extract-release-notes.mjs",
     "release:sbom": "node scripts/production-security-gate.mjs --sbom publish-package/b2-mcp-production.cdx.json",
+    "version": "node scripts/cut-changelog.mjs && git add CHANGELOG.md",
     "probe:500": "pnpm run build && node scripts/probe-b2-500s.mjs",
     "lint": "node scripts/run-biome.mjs lint src tests scripts",
     "lint:fix": "node scripts/run-biome.mjs lint src tests scripts --write",

--- a/scripts/cut-changelog.mjs
+++ b/scripts/cut-changelog.mjs
@@ -45,6 +45,7 @@ async function main() {
     );
   }
 
+  // Use UTC so release dates are stable across local workstations and CI reruns.
   const date = new Date().toISOString().slice(0, 10);
   const before = text.slice(0, unreleasedMatch.index);
   const promoted = unreleasedBody ? `${unreleasedBody}\n\n` : "";
@@ -59,6 +60,8 @@ async function main() {
   if (/^\[Unreleased\]:.*$/m.test(text)) {
     text = text.replace(/^\[Unreleased\]:.*$/m, `${unreleasedLink}\n${versionLink}`);
   } else {
+    // The inherited changelog has reference-less historical headings. Seed link
+    // references from this release forward without inventing links for old tags.
     text = `${text.replace(/\s*$/, "")}\n\n${unreleasedLink}\n${versionLink}\n`;
   }
 

--- a/scripts/cut-changelog.mjs
+++ b/scripts/cut-changelog.mjs
@@ -1,0 +1,74 @@
+#!/usr/bin/env node
+import { promises as fs } from "node:fs";
+import path from "node:path";
+import { releaseRoot } from "./lib/release-utils.mjs";
+
+function escapeRegExp(value) {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
+function normalizeRepositoryUrl(value) {
+  return String(value ?? "")
+    .replace(/^git\+/, "")
+    .replace(/\.git$/, "")
+    .replace(/\/$/, "");
+}
+
+async function main() {
+  const root = releaseRoot();
+  const changelogPath = path.join(root, "CHANGELOG.md");
+  const pkg = JSON.parse(await fs.readFile(path.join(root, "package.json"), "utf8"));
+  const version = String(pkg.version ?? "");
+  const repoUrl = normalizeRepositoryUrl(pkg.repository?.url);
+
+  if (!version) throw new Error("package.json version is missing");
+  if (!repoUrl) throw new Error("package.json repository.url is missing");
+
+  let text = await fs.readFile(changelogPath, "utf8");
+  if (new RegExp(`^## \\[${escapeRegExp(version)}\\]`, "m").test(text)) {
+    throw new Error(`CHANGELOG.md already has a "## [${version}]" section`);
+  }
+
+  const unreleasedMatch = /^## \[Unreleased\]\s*$/m.exec(text);
+  if (!unreleasedMatch) throw new Error('CHANGELOG.md is missing "## [Unreleased]"');
+
+  const sectionStart = unreleasedMatch.index + unreleasedMatch[0].length;
+  const rest = text.slice(sectionStart);
+  const nextHeadingOffset = rest.search(/^## \[/m);
+  const sectionEnd = nextHeadingOffset === -1 ? text.length : sectionStart + nextHeadingOffset;
+  const unreleasedBody = text.slice(sectionStart, sectionEnd).trim();
+  const previousVersion = /^## \[(\d+\.\d+\.\d+(?:-[^\]]+)?)\]/m.exec(rest)?.[1] ?? "";
+
+  if (!unreleasedBody) {
+    console.warn(
+      `cut-changelog: WARNING - [Unreleased] is empty; releasing v${version} with no notes.`,
+    );
+  }
+
+  const date = new Date().toISOString().slice(0, 10);
+  const before = text.slice(0, unreleasedMatch.index);
+  const promoted = unreleasedBody ? `${unreleasedBody}\n\n` : "";
+  const after = text.slice(sectionEnd);
+  text = `${before}## [Unreleased]\n\n## [${version}] - ${date}\n\n${promoted}${after}`;
+
+  const unreleasedLink = `[Unreleased]: ${repoUrl}/compare/v${version}...HEAD`;
+  const versionLink = previousVersion
+    ? `[${version}]: ${repoUrl}/compare/v${previousVersion}...v${version}`
+    : `[${version}]: ${repoUrl}/releases/tag/v${version}`;
+
+  if (/^\[Unreleased\]:.*$/m.test(text)) {
+    text = text.replace(/^\[Unreleased\]:.*$/m, `${unreleasedLink}\n${versionLink}`);
+  } else {
+    text = `${text.replace(/\s*$/, "")}\n\n${unreleasedLink}\n${versionLink}\n`;
+  }
+
+  await fs.writeFile(changelogPath, text);
+  console.log(`cut-changelog: promoted [Unreleased] to [${version}] - ${date}`);
+}
+
+try {
+  await main();
+} catch (error) {
+  console.error(`cut-changelog: ${error instanceof Error ? error.message : String(error)}`);
+  process.exit(1);
+}

--- a/scripts/publish-container-image.mjs
+++ b/scripts/publish-container-image.mjs
@@ -228,7 +228,8 @@ function escapeRegex(value) {
 }
 
 function trustArgs(githubServerUrl, githubRepository) {
-  const identity = `^${escapeRegex(githubServerUrl.replace(/\/$/, ""))}/${escapeRegex(githubRepository)}/\\.github/workflows/publish\\.yml@refs/tags/v`;
+  const workflow = `${escapeRegex(githubServerUrl.replace(/\/$/, ""))}/${escapeRegex(githubRepository)}/\\.github/workflows/publish\\.yml`;
+  const identity = `^${workflow}@refs/heads/main$`;
   return [
     "--certificate-identity-regexp",
     identity,

--- a/scripts/resolve-publish-ref.mjs
+++ b/scripts/resolve-publish-ref.mjs
@@ -6,10 +6,11 @@ import { spawnSync } from "node:child_process";
 
 function usage() {
   return [
-    "Usage: node scripts/resolve-publish-ref.mjs --tag <vX.Y.Z[-prerelease]> --remote <url> [--output <path>] [--wait-for-ci-green-timeout-ms <ms>]",
+    "Usage: node scripts/resolve-publish-ref.mjs --tag <vX.Y.Z[-prerelease]> --remote <url> [--output <path>] [--wait-for-ci-green-timeout-ms <ms>] [--wait-for-ci-green-interval-ms <ms>]",
     "",
-    "Validates that the requested release tag is reachable from refs/heads/ci-green and",
-    "writes checkout_sha=<sha> to the GitHub Actions output file when provided.",
+    "Validates that the requested release tag is reachable from refs/heads/ci-green.",
+    "During a nonzero wait, the tag must at least be reachable from refs/heads/main.",
+    "Writes checkout_sha=<sha> to the GitHub Actions output file when provided.",
   ].join("\n");
 }
 
@@ -83,6 +84,10 @@ function sleep(ms) {
   Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, ms);
 }
 
+function errorMessage(error) {
+  return error instanceof Error ? error.message : String(error);
+}
+
 function runGit(args, { cwd = process.cwd(), timeout = 30_000, retries = 3 } = {}) {
   let lastResult;
   for (let attempt = 1; attempt <= retries; attempt += 1) {
@@ -130,35 +135,64 @@ function lsRemoteTagCommit(remote, tag) {
   return refs.get(peeledRef) ?? refs.get(tagRef) ?? "";
 }
 
-function fetchReleaseRefs(remote, tag) {
+function initReleaseRefsWorkDir() {
   const workDir = mkdtempSync(path.join(tmpdir(), "b2-mcp-publish-ref-"));
-  try {
-    runGit(["init", "-b", "verify"], { cwd: workDir });
-    runGit(
-      [
-        "fetch",
-        "--no-tags",
-        remote,
-        "+refs/heads/ci-green:refs/remotes/origin/ci-green",
-        `+refs/tags/${tag}:refs/tags/${tag}`,
-      ],
-      { cwd: workDir, timeout: 120_000 },
-    );
-    const tagSha = runGit(["rev-parse", `refs/tags/${tag}^{}`], { cwd: workDir }).stdout.trim();
-    const ciGreenSha = runGit(["rev-parse", "refs/remotes/origin/ci-green"], {
+  runGit(["init", "-b", "verify"], { cwd: workDir });
+  return workDir;
+}
+
+function fetchReleaseRefs(remote, tag, workDir) {
+  runGit(
+    [
+      "fetch",
+      "--no-tags",
+      remote,
+      "+refs/heads/main:refs/remotes/origin/main",
+      "+refs/heads/ci-green:refs/remotes/origin/ci-green",
+      `+refs/tags/${tag}:refs/tags/${tag}`,
+    ],
+    { cwd: workDir, timeout: 120_000 },
+  );
+  const tagSha = runGit(["rev-parse", `refs/tags/${tag}^{}`], { cwd: workDir }).stdout.trim();
+  const mainSha = runGit(["rev-parse", "refs/remotes/origin/main"], {
+    cwd: workDir,
+  }).stdout.trim();
+  const ciGreenSha = runGit(["rev-parse", "refs/remotes/origin/ci-green"], {
+    cwd: workDir,
+  }).stdout.trim();
+  const ciGreenAncestor = spawnSync(
+    "git",
+    ["merge-base", "--is-ancestor", tagSha, "refs/remotes/origin/ci-green"],
+    {
       cwd: workDir,
-    }).stdout.trim();
-    const ancestor = spawnSync(
-      "git",
-      ["merge-base", "--is-ancestor", tagSha, "refs/remotes/origin/ci-green"],
-      {
-        cwd: workDir,
-        encoding: "utf8",
-        stdio: ["ignore", "pipe", "pipe"],
-        timeout: 30_000,
-      },
-    );
-    return { tagSha, ciGreenSha, isAncestor: ancestor.status === 0 };
+      encoding: "utf8",
+      stdio: ["ignore", "pipe", "pipe"],
+      timeout: 30_000,
+    },
+  );
+  const mainAncestor = spawnSync(
+    "git",
+    ["merge-base", "--is-ancestor", tagSha, "refs/remotes/origin/main"],
+    {
+      cwd: workDir,
+      encoding: "utf8",
+      stdio: ["ignore", "pipe", "pipe"],
+      timeout: 30_000,
+    },
+  );
+  return {
+    tagSha,
+    mainSha,
+    ciGreenSha,
+    isCiGreenAncestor: ciGreenAncestor.status === 0,
+    isMainAncestor: mainAncestor.status === 0,
+  };
+}
+
+function withReleaseRefsWorkDir(run) {
+  const workDir = initReleaseRefsWorkDir();
+  try {
+    return run(workDir);
   } finally {
     rmSync(workDir, { recursive: true, force: true });
   }
@@ -174,32 +208,83 @@ function failUnreachable(tag, tagSha, ciGreenSha, waited) {
   process.exit(1);
 }
 
-function waitForReachableTag(options, tagSha) {
-  const startedAt = Date.now();
-  const deadline = startedAt + options.waitForCiGreenTimeoutMs;
+function failUntrustedPendingTag(tag, tagSha, mainSha, ciGreenSha) {
+  console.error(
+    `::error::refs/tags/${tag} is not reachable from refs/heads/main or refs/heads/ci-green`,
+  );
+  console.error(`main_sha=${mainSha}`);
+  console.error(`ci_green_sha=${ciGreenSha}`);
+  console.error(`tag_sha=${tagSha}`);
+  process.exit(1);
+}
+
+function sleepUntilNextPoll(deadline, intervalMs, message) {
+  if (Date.now() >= deadline) return false;
+  const sleepMs = Math.min(intervalMs, Math.max(0, deadline - Date.now()));
+  console.warn(`${message}; waiting ${Math.ceil(sleepMs / 1000)}s before retrying`);
+  sleep(sleepMs);
+  return true;
+}
+
+function sleepAfterRetryableError(options, deadline, context, error) {
+  if (options.waitForCiGreenTimeoutMs <= 0) throw error;
+  if (
+    !sleepUntilNextPoll(
+      deadline,
+      options.waitForCiGreenIntervalMs,
+      `::warning::publish-ref: retryable ${context} failure: ${errorMessage(error)}`,
+    )
+  ) {
+    console.error(
+      `::error::Timed out waiting for refs/tags/${options.tag} to reach refs/heads/ci-green`,
+    );
+    console.error(`::error::last retryable ${context} failure: ${errorMessage(error)}`);
+    process.exit(1);
+  }
+}
+
+function resolveInitialTagSha(options, deadline) {
+  for (;;) {
+    try {
+      const tagSha = lsRemoteTagCommit(options.remote, options.tag);
+      if (!tagSha) {
+        console.error(`::error::refs/tags/${options.tag} is missing`);
+        process.exit(1);
+      }
+      return tagSha;
+    } catch (error) {
+      sleepAfterRetryableError(options, deadline, "tag lookup", error);
+    }
+  }
+}
+
+function waitForReachableTag(options, tagSha, workDir, deadline) {
   let lastCiGreenSha = "";
 
   for (;;) {
-    const ciGreenSha = lsRemote(options.remote, "refs/heads/ci-green");
+    let ciGreenSha = "";
+    let currentTagSha = "";
+    try {
+      ciGreenSha = lsRemote(options.remote, "refs/heads/ci-green");
+      currentTagSha = lsRemoteTagCommit(options.remote, options.tag);
+    } catch (error) {
+      sleepAfterRetryableError(options, deadline, "remote ref lookup", error);
+      continue;
+    }
+
     if (!ciGreenSha) {
       if (Date.now() >= deadline) {
         console.error("::error::refs/heads/ci-green is missing");
         process.exit(1);
       }
-      const sleepMs = Math.min(
+      sleepUntilNextPoll(
+        deadline,
         options.waitForCiGreenIntervalMs,
-        Math.max(0, deadline - Date.now()),
+        "::warning::publish-ref: refs/heads/ci-green is missing",
       );
-      console.warn(
-        `publish-ref: refs/heads/ci-green is missing; waiting ${Math.ceil(
-          sleepMs / 1000,
-        )}s before retrying`,
-      );
-      sleep(sleepMs);
       continue;
     }
 
-    const currentTagSha = lsRemoteTagCommit(options.remote, options.tag);
     if (!currentTagSha) {
       console.error(`::error::refs/tags/${options.tag} is missing`);
       process.exit(1);
@@ -209,25 +294,33 @@ function waitForReachableTag(options, tagSha) {
       process.exit(1);
     }
 
-    const fetched = fetchReleaseRefs(options.remote, options.tag);
+    let fetched;
+    try {
+      fetched = fetchReleaseRefs(options.remote, options.tag, workDir);
+    } catch (error) {
+      sleepAfterRetryableError(options, deadline, "remote ref verification", error);
+      continue;
+    }
+
     if (fetched.tagSha !== tagSha) {
       console.error(`::error::refs/tags/${options.tag} changed while resolving release tag`);
       process.exit(1);
     }
-    if (fetched.isAncestor) return fetched;
+    if (fetched.isCiGreenAncestor) return fetched;
+    if (!fetched.isMainAncestor) {
+      failUntrustedPendingTag(options.tag, tagSha, fetched.mainSha, fetched.ciGreenSha);
+    }
 
     lastCiGreenSha = fetched.ciGreenSha || ciGreenSha;
     if (Date.now() >= deadline) {
       failUnreachable(options.tag, tagSha, lastCiGreenSha, options.waitForCiGreenTimeoutMs > 0);
     }
 
-    const sleepMs = Math.min(options.waitForCiGreenIntervalMs, Math.max(0, deadline - Date.now()));
-    console.warn(
-      `publish-ref: refs/tags/${options.tag} is not yet reachable from ci-green ${lastCiGreenSha}; waiting ${Math.ceil(
-        sleepMs / 1000,
-      )}s before retrying`,
+    sleepUntilNextPoll(
+      deadline,
+      options.waitForCiGreenIntervalMs,
+      `::warning::publish-ref: refs/tags/${options.tag} is not yet reachable from ci-green ${lastCiGreenSha}`,
     );
-    sleep(sleepMs);
   }
 }
 
@@ -246,14 +339,11 @@ if (!publishTagPattern.test(options.tag)) {
   process.exit(1);
 }
 
-const tagSha = lsRemoteTagCommit(options.remote, options.tag);
-
-if (!tagSha) {
-  console.error(`::error::refs/tags/${options.tag} is missing`);
-  process.exit(1);
-}
-
-const fetched = waitForReachableTag(options, tagSha);
+const deadline = Date.now() + options.waitForCiGreenTimeoutMs;
+const tagSha = resolveInitialTagSha(options, deadline);
+const fetched = withReleaseRefsWorkDir((workDir) =>
+  waitForReachableTag(options, tagSha, workDir, deadline),
+);
 
 if (options.output) appendFileSync(options.output, `checkout_sha=${tagSha}\n`);
 console.log(

--- a/scripts/resolve-publish-ref.mjs
+++ b/scripts/resolve-publish-ref.mjs
@@ -6,11 +6,19 @@ import { spawnSync } from "node:child_process";
 
 function usage() {
   return [
-    "Usage: node scripts/resolve-publish-ref.mjs --tag <vX.Y.Z[-prerelease]> --remote <url> [--output <path>]",
+    "Usage: node scripts/resolve-publish-ref.mjs --tag <vX.Y.Z[-prerelease]> --remote <url> [--output <path>] [--wait-for-ci-green-timeout-ms <ms>]",
     "",
     "Validates that the requested release tag is reachable from refs/heads/ci-green and",
     "writes checkout_sha=<sha> to the GitHub Actions output file when provided.",
   ].join("\n");
+}
+
+function parseNonNegativeInteger(value, optionName) {
+  if (!/^(0|[1-9]\d*)$/.test(String(value))) {
+    console.error(`publish-ref: ${optionName} must be a non-negative integer`);
+    process.exit(2);
+  }
+  return Number(value);
 }
 
 function parseArgs(argv) {
@@ -18,6 +26,8 @@ function parseArgs(argv) {
     tag: "",
     remote: "",
     output: process.env.GITHUB_OUTPUT ?? "",
+    waitForCiGreenTimeoutMs: 0,
+    waitForCiGreenIntervalMs: 30_000,
   };
 
   for (let index = 0; index < argv.length; index += 1) {
@@ -26,7 +36,13 @@ function parseArgs(argv) {
       console.log(usage());
       process.exit(0);
     }
-    if (arg === "--tag" || arg === "--remote" || arg === "--output") {
+    if (
+      arg === "--tag" ||
+      arg === "--remote" ||
+      arg === "--output" ||
+      arg === "--wait-for-ci-green-timeout-ms" ||
+      arg === "--wait-for-ci-green-interval-ms"
+    ) {
       const value = argv[index + 1];
       if (!value) {
         console.error(`publish-ref: ${arg} requires a value`);
@@ -35,7 +51,12 @@ function parseArgs(argv) {
       index += 1;
       if (arg === "--tag") options.tag = value;
       else if (arg === "--remote") options.remote = value;
-      else options.output = value;
+      else if (arg === "--output") options.output = value;
+      else if (arg === "--wait-for-ci-green-timeout-ms") {
+        options.waitForCiGreenTimeoutMs = parseNonNegativeInteger(value, arg);
+      } else {
+        options.waitForCiGreenIntervalMs = parseNonNegativeInteger(value, arg);
+      }
       continue;
     }
     console.error(`publish-ref: unknown option ${arg}`);
@@ -49,6 +70,10 @@ function parseArgs(argv) {
   }
   if (!options.remote) {
     console.error("publish-ref: --remote is required");
+    process.exit(2);
+  }
+  if (options.waitForCiGreenTimeoutMs > 0 && options.waitForCiGreenIntervalMs === 0) {
+    console.error("publish-ref: --wait-for-ci-green-interval-ms must be greater than zero");
     process.exit(2);
   }
   return options;
@@ -139,6 +164,73 @@ function fetchReleaseRefs(remote, tag) {
   }
 }
 
+function failUnreachable(tag, tagSha, ciGreenSha, waited) {
+  if (waited) {
+    console.error(`::error::Timed out waiting for refs/tags/${tag} to reach refs/heads/ci-green`);
+  }
+  console.error(`::error::refs/tags/${tag} must be reachable from refs/heads/ci-green`);
+  console.error(`ci_green_sha=${ciGreenSha}`);
+  console.error(`tag_sha=${tagSha}`);
+  process.exit(1);
+}
+
+function waitForReachableTag(options, tagSha) {
+  const startedAt = Date.now();
+  const deadline = startedAt + options.waitForCiGreenTimeoutMs;
+  let lastCiGreenSha = "";
+
+  for (;;) {
+    const ciGreenSha = lsRemote(options.remote, "refs/heads/ci-green");
+    if (!ciGreenSha) {
+      if (Date.now() >= deadline) {
+        console.error("::error::refs/heads/ci-green is missing");
+        process.exit(1);
+      }
+      const sleepMs = Math.min(
+        options.waitForCiGreenIntervalMs,
+        Math.max(0, deadline - Date.now()),
+      );
+      console.warn(
+        `publish-ref: refs/heads/ci-green is missing; waiting ${Math.ceil(
+          sleepMs / 1000,
+        )}s before retrying`,
+      );
+      sleep(sleepMs);
+      continue;
+    }
+
+    const currentTagSha = lsRemoteTagCommit(options.remote, options.tag);
+    if (!currentTagSha) {
+      console.error(`::error::refs/tags/${options.tag} is missing`);
+      process.exit(1);
+    }
+    if (currentTagSha !== tagSha) {
+      console.error(`::error::refs/tags/${options.tag} changed while resolving release tag`);
+      process.exit(1);
+    }
+
+    const fetched = fetchReleaseRefs(options.remote, options.tag);
+    if (fetched.tagSha !== tagSha) {
+      console.error(`::error::refs/tags/${options.tag} changed while resolving release tag`);
+      process.exit(1);
+    }
+    if (fetched.isAncestor) return fetched;
+
+    lastCiGreenSha = fetched.ciGreenSha || ciGreenSha;
+    if (Date.now() >= deadline) {
+      failUnreachable(options.tag, tagSha, lastCiGreenSha, options.waitForCiGreenTimeoutMs > 0);
+    }
+
+    const sleepMs = Math.min(options.waitForCiGreenIntervalMs, Math.max(0, deadline - Date.now()));
+    console.warn(
+      `publish-ref: refs/tags/${options.tag} is not yet reachable from ci-green ${lastCiGreenSha}; waiting ${Math.ceil(
+        sleepMs / 1000,
+      )}s before retrying`,
+    );
+    sleep(sleepMs);
+  }
+}
+
 const options = parseArgs(process.argv.slice(2));
 
 const numericIdentifier = "(?:0|[1-9]\\d*)";
@@ -154,35 +246,16 @@ if (!publishTagPattern.test(options.tag)) {
   process.exit(1);
 }
 
-const ciGreenSha = lsRemote(options.remote, "refs/heads/ci-green");
 const tagSha = lsRemoteTagCommit(options.remote, options.tag);
 
-if (!ciGreenSha) {
-  console.error("::error::refs/heads/ci-green is missing");
-  process.exit(1);
-}
 if (!tagSha) {
   console.error(`::error::refs/tags/${options.tag} is missing`);
   process.exit(1);
 }
 
-const fetched = fetchReleaseRefs(options.remote, options.tag);
-if (lsRemote(options.remote, "refs/heads/ci-green") !== ciGreenSha) {
-  console.error("::error::refs/heads/ci-green changed while resolving release tag");
-  process.exit(1);
-}
-if (fetched.tagSha !== tagSha) {
-  console.error(`::error::refs/tags/${options.tag} changed while resolving release tag`);
-  process.exit(1);
-}
-if (!fetched.isAncestor) {
-  console.error(`::error::refs/tags/${options.tag} must be reachable from refs/heads/ci-green`);
-  console.error(`ci_green_sha=${ciGreenSha}`);
-  console.error(`tag_sha=${tagSha}`);
-  process.exit(1);
-}
+const fetched = waitForReachableTag(options, tagSha);
 
 if (options.output) appendFileSync(options.output, `checkout_sha=${tagSha}\n`);
 console.log(
-  `publish-ref: ${options.tag} resolves to ${tagSha}, reachable from ci-green ${ciGreenSha}`,
+  `publish-ref: ${options.tag} resolves to ${tagSha}, reachable from ci-green ${fetched.ciGreenSha}`,
 );

--- a/tests/unit/container-image.unit.test.ts
+++ b/tests/unit/container-image.unit.test.ts
@@ -114,6 +114,8 @@ describe("container image policy", () => {
     expect(publishScript).toContain("DOCKER_CONFIG");
     expect(publishScript).toContain("cosign");
     expect(publishScript).toContain("signDigest");
+    expect(publishScript).toContain("refs/heads/main");
+    expect(publishScript).not.toContain("refs/tags/v.*|refs/heads/main");
     expect(publishScript.indexOf("signDigest(registryImage, digest);")).toBeLessThan(
       publishScript.indexOf("verifyAnonymousManifestPull(versionRef);"),
     );

--- a/tests/unit/package-budget-policy.unit.test.ts
+++ b/tests/unit/package-budget-policy.unit.test.ts
@@ -525,7 +525,8 @@ describe("package budget policy gate", () => {
     const packageBudgetStep = publishWorkflow.indexOf("- run: pnpm run check:package-budget");
     const packStep = publishWorkflow.indexOf("- name: Build and scan publish tarball");
 
-    expect(pkg.scripts.prepublishOnly).toBeUndefined();
+    expect(pkg.scripts.prepublishOnly).toContain("pnpm run build");
+    expect(pkg.scripts.prepublishOnly).toContain("scripts/verify-release-input.mjs");
     expect(packageBudgetStep).toBeGreaterThan(-1);
     expect(packageBudgetStep).toBeLessThan(packStep);
   });

--- a/tests/unit/publish-ref.unit.test.ts
+++ b/tests/unit/publish-ref.unit.test.ts
@@ -21,9 +21,10 @@ function runGit(cwd: string, args: string[]) {
   return result.stdout.trim();
 }
 
-function runResolver(remote: string, tag: string, outputPath?: string) {
+function runResolver(remote: string, tag: string, outputPath?: string, extraArgs: string[] = []) {
   const args = [script, "--tag", tag, "--remote", remote];
   if (outputPath) args.push("--output", outputPath);
+  args.push(...extraArgs);
   return spawnSync(process.execPath, args, { cwd: root, encoding: "utf8" });
 }
 
@@ -133,6 +134,32 @@ describe("publish ref resolver", () => {
 
       expect(result.status).toBe(1);
       expect(result.stderr).toContain("must be reachable from refs/heads/ci-green");
+      expect(result.stderr).toContain(`ci_green_sha=${ciGreenSha}`);
+      expect(result.stderr).toContain(`tag_sha=${tagSha}`);
+    });
+  });
+
+  it("times out while waiting for a tag that never reaches ci-green", () => {
+    withTempDir((dir) => {
+      const ciGreenSha = createRepo(dir);
+      runGit(dir, ["branch", "ci-green", ciGreenSha]);
+      writeFileSync(join(dir, "README.md"), "changed\n");
+      runGit(dir, ["add", "README.md"]);
+      runGit(dir, ["commit", "-m", "changed"]);
+      const tagSha = runGit(dir, ["rev-parse", "HEAD"]);
+      runGit(dir, ["tag", "--no-sign", "v0.2.0", tagSha]);
+
+      const result = runResolver(dir, "v0.2.0", undefined, [
+        "--wait-for-ci-green-timeout-ms",
+        "1",
+        "--wait-for-ci-green-interval-ms",
+        "1",
+      ]);
+
+      expect(result.status).toBe(1);
+      expect(result.stderr).toContain(
+        "Timed out waiting for refs/tags/v0.2.0 to reach refs/heads/ci-green",
+      );
       expect(result.stderr).toContain(`ci_green_sha=${ciGreenSha}`);
       expect(result.stderr).toContain(`tag_sha=${tagSha}`);
     });

--- a/tests/unit/publish-ref.unit.test.ts
+++ b/tests/unit/publish-ref.unit.test.ts
@@ -1,7 +1,7 @@
-import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "fs";
+import { chmodSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "fs";
 import { tmpdir } from "os";
 import { join } from "path";
-import { spawnSync } from "child_process";
+import { spawn, spawnSync } from "child_process";
 
 const root = join(__dirname, "../..");
 const script = join(root, "scripts/resolve-publish-ref.mjs");
@@ -10,6 +10,15 @@ function withTempDir(run: (dir: string) => void): void {
   const dir = mkdtempSync(join(tmpdir(), "b2-mcp-publish-ref-"));
   try {
     run(dir);
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+}
+
+async function withTempDirAsync(run: (dir: string) => Promise<void>): Promise<void> {
+  const dir = mkdtempSync(join(tmpdir(), "b2-mcp-publish-ref-"));
+  try {
+    await run(dir);
   } finally {
     rmSync(dir, { recursive: true, force: true });
   }
@@ -28,6 +37,31 @@ function runResolver(remote: string, tag: string, outputPath?: string, extraArgs
   return spawnSync(process.execPath, args, { cwd: root, encoding: "utf8" });
 }
 
+function runResolverAsync(
+  remote: string,
+  tag: string,
+  outputPath: string,
+  extraArgs: string[],
+  env: NodeJS.ProcessEnv = process.env,
+): Promise<{ status: number | null; stderr: string; stdout: string }> {
+  const args = [script, "--tag", tag, "--remote", remote, "--output", outputPath, ...extraArgs];
+  const child = spawn(process.execPath, args, { cwd: root, env });
+  let stdout = "";
+  let stderr = "";
+  child.stdout.setEncoding("utf8");
+  child.stderr.setEncoding("utf8");
+  child.stdout.on("data", (chunk) => {
+    stdout += chunk;
+  });
+  child.stderr.on("data", (chunk) => {
+    stderr += chunk;
+  });
+  return new Promise((resolve, reject) => {
+    child.on("error", reject);
+    child.on("close", (status) => resolve({ status, stdout, stderr }));
+  });
+}
+
 function createRepo(dir: string) {
   runGit(dir, ["init", "-b", "main"]);
   runGit(dir, ["config", "user.email", "test@example.com"]);
@@ -38,7 +72,53 @@ function createRepo(dir: string) {
   return runGit(dir, ["rev-parse", "HEAD"]);
 }
 
+function realGitPath() {
+  const result = spawnSync("which", ["git"], { encoding: "utf8" });
+  if (result.status !== 0) throw new Error(`which git failed: ${result.stderr}`);
+  return result.stdout.trim();
+}
+
+function fakeGitFetchFailsOnceEnv(dir: string): NodeJS.ProcessEnv {
+  const fakeGit = join(dir, "git");
+  const state = join(dir, "fake-git-state");
+  writeFileSync(
+    fakeGit,
+    [
+      "#!/usr/bin/env node",
+      'const fs = require("node:fs");',
+      'const cp = require("node:child_process");',
+      "const args = process.argv.slice(2);",
+      "const attempts = fs.existsSync(process.env.B2_MCP_FAKE_GIT_STATE)",
+      "  ? Number(fs.readFileSync(process.env.B2_MCP_FAKE_GIT_STATE, 'utf8'))",
+      "  : 0;",
+      "if (args[0] === 'fetch' && attempts < 3) {",
+      "  fs.writeFileSync(process.env.B2_MCP_FAKE_GIT_STATE, String(attempts + 1));",
+      "  console.error('fake transient git fetch failure');",
+      "  process.exit(128);",
+      "}",
+      "const result = cp.spawnSync(process.env.B2_MCP_REAL_GIT, args, { stdio: 'inherit' });",
+      "process.exit(result.status ?? 1);",
+      "",
+    ].join("\n"),
+  );
+  chmodSync(fakeGit, 0o755);
+  return {
+    ...process.env,
+    B2_MCP_FAKE_GIT_STATE: state,
+    B2_MCP_REAL_GIT: realGitPath(),
+    PATH: `${dir}${process.platform === "win32" ? ";" : ":"}${process.env.PATH ?? ""}`,
+  };
+}
+
 describe("publish ref resolver", () => {
+  it("documents every accepted wait option in help output", () => {
+    const result = spawnSync(process.execPath, [script, "--help"], { cwd: root, encoding: "utf8" });
+
+    expect(result.status).toBe(0);
+    expect(result.stdout).toContain("--wait-for-ci-green-timeout-ms");
+    expect(result.stdout).toContain("--wait-for-ci-green-interval-ms");
+  });
+
   it.each(["v0.1.0", "v1.2.3-rc.1"])("accepts release tag %s at ci-green", (tag) => {
     withTempDir((dir) => {
       const sha = createRepo(dir);
@@ -159,6 +239,92 @@ describe("publish ref resolver", () => {
       expect(result.status).toBe(1);
       expect(result.stderr).toContain(
         "Timed out waiting for refs/tags/v0.2.0 to reach refs/heads/ci-green",
+      );
+      expect(result.stderr).toContain(`ci_green_sha=${ciGreenSha}`);
+      expect(result.stderr).toContain(`tag_sha=${tagSha}`);
+    });
+  });
+
+  it("succeeds when a pending main tag reaches ci-green during the wait", async () => {
+    await withTempDirAsync(async (dir) => {
+      const ciGreenSha = createRepo(dir);
+      runGit(dir, ["branch", "ci-green", ciGreenSha]);
+      writeFileSync(join(dir, "README.md"), "release commit\n");
+      runGit(dir, ["add", "README.md"]);
+      runGit(dir, ["commit", "-m", "release"]);
+      const tagSha = runGit(dir, ["rev-parse", "HEAD"]);
+      runGit(dir, ["tag", "--no-sign", "v0.2.0", tagSha]);
+      const output = join(dir, "github-output");
+      const resultPromise = runResolverAsync(dir, "v0.2.0", output, [
+        "--wait-for-ci-green-timeout-ms",
+        "5000",
+        "--wait-for-ci-green-interval-ms",
+        "100",
+      ]);
+
+      setTimeout(() => {
+        runGit(dir, ["branch", "-f", "ci-green", tagSha]);
+      }, 250);
+
+      const result = await resultPromise;
+      expect(result.status).toBe(0);
+      expect(readFileSync(output, "utf8")).toBe(`checkout_sha=${tagSha}\n`);
+      expect(result.stdout).toContain(`reachable from ci-green ${tagSha}`);
+    });
+  });
+
+  it("keeps waiting after a transient git fetch failure", async () => {
+    await withTempDirAsync(async (dir) => {
+      const ciGreenSha = createRepo(dir);
+      runGit(dir, ["branch", "ci-green", ciGreenSha]);
+      writeFileSync(join(dir, "README.md"), "release commit\n");
+      runGit(dir, ["add", "README.md"]);
+      runGit(dir, ["commit", "-m", "release"]);
+      const tagSha = runGit(dir, ["rev-parse", "HEAD"]);
+      runGit(dir, ["tag", "--no-sign", "v0.2.0", tagSha]);
+      const output = join(dir, "github-output");
+      const resultPromise = runResolverAsync(
+        dir,
+        "v0.2.0",
+        output,
+        ["--wait-for-ci-green-timeout-ms", "5000", "--wait-for-ci-green-interval-ms", "100"],
+        fakeGitFetchFailsOnceEnv(dir),
+      );
+
+      setTimeout(() => {
+        runGit(dir, ["branch", "-f", "ci-green", tagSha]);
+      }, 250);
+
+      const result = await resultPromise;
+      expect(result.status).toBe(0);
+      expect(readFileSync(output, "utf8")).toBe(`checkout_sha=${tagSha}\n`);
+      expect(result.stderr).toContain("retryable remote ref verification failure");
+      expect(result.stdout).toContain(`reachable from ci-green ${tagSha}`);
+    });
+  });
+
+  it("fails fast when a pending tag is not reachable from main", () => {
+    withTempDir((dir) => {
+      const ciGreenSha = createRepo(dir);
+      runGit(dir, ["branch", "ci-green", ciGreenSha]);
+      runGit(dir, ["checkout", "-b", "attacker"]);
+      writeFileSync(join(dir, "README.md"), "unreviewed tag commit\n");
+      runGit(dir, ["add", "README.md"]);
+      runGit(dir, ["commit", "-m", "unreviewed"]);
+      const tagSha = runGit(dir, ["rev-parse", "HEAD"]);
+      runGit(dir, ["tag", "--no-sign", "v9.9.9", tagSha]);
+      runGit(dir, ["checkout", "main"]);
+
+      const result = runResolver(dir, "v9.9.9", undefined, [
+        "--wait-for-ci-green-timeout-ms",
+        "5000",
+        "--wait-for-ci-green-interval-ms",
+        "100",
+      ]);
+
+      expect(result.status).toBe(1);
+      expect(result.stderr).toContain(
+        "refs/tags/v9.9.9 is not reachable from refs/heads/main or refs/heads/ci-green",
       );
       expect(result.stderr).toContain(`ci_green_sha=${ciGreenSha}`);
       expect(result.stderr).toContain(`tag_sha=${tagSha}`);

--- a/tests/unit/release-scripts.unit.test.ts
+++ b/tests/unit/release-scripts.unit.test.ts
@@ -5,6 +5,12 @@ import { spawnSync } from "child_process";
 
 const root = join(__dirname, "../..");
 
+function runGit(cwd: string, args: string[]): string {
+  const result = spawnSync("git", args, { cwd, encoding: "utf8" });
+  if (result.status !== 0) throw new Error(`git ${args.join(" ")} failed: ${result.stderr}`);
+  return result.stdout.trim();
+}
+
 function withFixture(run: (fixtureRoot: string) => void): void {
   const fixtureRoot = mkdtempSync(join(tmpdir(), "b2-mcp-release-scripts-"));
   try {
@@ -108,6 +114,47 @@ describe("release scripts", () => {
       expect(changelog).toContain(
         "[0.2.0]: https://github.com/backblaze-labs/b2-mcp/compare/v0.1.0...v0.2.0",
       );
+    });
+  });
+
+  it("runs the pnpm version changelog lifecycle with install scripts disabled", () => {
+    withFixture((fixtureRoot) => {
+      const packagePath = join(fixtureRoot, "package.json");
+      const pkg = JSON.parse(readFileSync(packagePath, "utf8"));
+      writeFileSync(
+        packagePath,
+        JSON.stringify(
+          {
+            ...pkg,
+            scripts: {
+              version: `node ${join(root, "scripts/cut-changelog.mjs")} && git add CHANGELOG.md`,
+            },
+          },
+          null,
+          2,
+        ),
+      );
+      writeFileSync(join(fixtureRoot, ".npmrc"), "ignore-scripts=true\n");
+      runGit(fixtureRoot, ["init", "-b", "main"]);
+      runGit(fixtureRoot, ["config", "user.email", "release@example.com"]);
+      runGit(fixtureRoot, ["config", "user.name", "Release Test"]);
+      runGit(fixtureRoot, ["add", "."]);
+      runGit(fixtureRoot, ["commit", "-m", "initial"]);
+
+      const result = spawnSync(
+        "pnpm",
+        ["version", "patch", "--no-git-tag-version", "--no-commit-hooks"],
+        { cwd: fixtureRoot, env: scriptEnv(fixtureRoot), encoding: "utf8" },
+      );
+      const changelog = readFileSync(join(fixtureRoot, "CHANGELOG.md"), "utf8");
+      const bumpedPackage = JSON.parse(readFileSync(packagePath, "utf8"));
+      const stagedFiles = runGit(fixtureRoot, ["diff", "--cached", "--name-only"]);
+
+      expect(result.status).toBe(0);
+      expect(result.stdout).toContain("cut-changelog: promoted [Unreleased] to [0.1.1]");
+      expect(bumpedPackage.version).toBe("0.1.1");
+      expect(changelog).toMatch(/^## \[Unreleased\]\n\n## \[0\.1\.1\] - \d{4}-\d{2}-\d{2}/m);
+      expect(stagedFiles.split(/\r?\n/)).toContain("CHANGELOG.md");
     });
   });
 

--- a/tests/unit/release-scripts.unit.test.ts
+++ b/tests/unit/release-scripts.unit.test.ts
@@ -85,6 +85,32 @@ describe("release scripts", () => {
     });
   });
 
+  it("promotes Unreleased notes into the bumped version changelog section", () => {
+    withFixture((fixtureRoot) => {
+      const packagePath = join(fixtureRoot, "package.json");
+      const pkg = JSON.parse(readFileSync(packagePath, "utf8"));
+      writeFileSync(packagePath, JSON.stringify({ ...pkg, version: "0.2.0" }, null, 2));
+
+      const result = spawnSync(process.execPath, ["scripts/cut-changelog.mjs"], {
+        cwd: root,
+        env: scriptEnv(fixtureRoot),
+        encoding: "utf8",
+      });
+
+      const changelog = readFileSync(join(fixtureRoot, "CHANGELOG.md"), "utf8");
+      expect(result.status).toBe(0);
+      expect(result.stdout).toContain("cut-changelog: promoted [Unreleased] to [0.2.0]");
+      expect(changelog).toMatch(/^## \[Unreleased\]\n\n## \[0\.2\.0\] - \d{4}-\d{2}-\d{2}/m);
+      expect(changelog).toContain("Future change.");
+      expect(changelog).toContain(
+        "[Unreleased]: https://github.com/backblaze-labs/b2-mcp/compare/v0.2.0...HEAD",
+      );
+      expect(changelog).toContain(
+        "[0.2.0]: https://github.com/backblaze-labs/b2-mcp/compare/v0.1.0...v0.2.0",
+      );
+    });
+  });
+
   it("includes the issue 64 release automation entry in v0.1.0 notes", () => {
     const result = spawnSync(
       process.execPath,

--- a/tests/unit/supply-chain-policy.unit.test.ts
+++ b/tests/unit/supply-chain-policy.unit.test.ts
@@ -600,6 +600,9 @@ describe("supply-chain audit policy", () => {
     expect(packageJson.scripts["release:sbom"]).toBe(
       "node scripts/production-security-gate.mjs --sbom publish-package/b2-mcp-production.cdx.json",
     );
+    expect(packageJson.scripts.version).toBe(
+      "node scripts/cut-changelog.mjs && git add CHANGELOG.md",
+    );
     expect(packageJson.scripts.test).toBe("pnpm run typecheck && pnpm run test:unit");
     expect(packageJson.scripts.pretest).toBeUndefined();
     expect(packageJson.scripts.prepublishOnly).toBeUndefined();
@@ -804,15 +807,14 @@ describe("supply-chain audit policy", () => {
     const containerImageJob = publishJobBlock("container-image");
     const publishJob = publishJobBlock("publish");
 
-    expect(publishWorkflow).toContain("release:");
-    expect(publishWorkflow).toContain("types: [published]");
-    expect(publishWorkflow).not.toContain("push:");
-    expect(publishWorkflow).not.toContain("tags:");
-    expect(publishWorkflow).not.toContain("workflow_dispatch");
+    expect(publishWorkflow).toMatch(/^ {2}push:\n {4}tags:\n {6}- "v\*"$/m);
+    expect(publishWorkflow).not.toMatch(/^ {2}release:/m);
+    expect(publishWorkflow).not.toMatch(/^ {2}workflow_dispatch:/m);
     expect(publishWorkflow).not.toContain("inputs.tag");
-    expect(publishWorkflow).not.toContain("${{ github.ref_name }}");
-    expect(publishWorkflow).toContain("${{ github.event.release.tag_name }}");
+    expect(publishWorkflow).toContain("${{ github.ref_name }}");
+    expect(publishWorkflow).not.toContain("${{ github.event.release.tag_name }}");
     expect(prepareJob).not.toContain("id-token: write");
+    expect(prepareJob).toContain("--wait-for-ci-green-timeout-ms");
     expect(prepareJob).toContain("pnpm run verify");
     expect(prepareJob).not.toContain("actions/setup-python");
     expect(prepareJob).toContain("pnpm run typecheck");

--- a/tests/unit/supply-chain-policy.unit.test.ts
+++ b/tests/unit/supply-chain-policy.unit.test.ts
@@ -817,14 +817,18 @@ describe("supply-chain audit policy", () => {
     const publishJob = publishJobBlock("publish");
     const publishOnBlock = yamlBlockForKey(publishWorkflow, "on") ?? "";
     const publishWorkflowRunBlock = yamlBlockForKey(publishOnBlock, "workflow_run") ?? "";
-    const publishDispatchBlock = yamlBlockForKey(publishOnBlock, "workflow_dispatch") ?? "";
     const releaseTagOnBlock = yamlBlockForKey(releaseTagWorkflow, "on") ?? "";
     const releaseTagPushBlock = yamlBlockForKey(releaseTagOnBlock, "push") ?? "";
+    const releaseTagDispatchBlock = yamlBlockForKey(releaseTagOnBlock, "workflow_dispatch") ?? "";
     const releaseTagPushTags = yamlValuesForKey(releaseTagPushBlock, "tags");
 
     expect(
       releaseTagPushTags.some((value) => Array.isArray(value) && valuesEqual(value, ["v*"])),
     ).toBe(true);
+    expect(releaseTagDispatchBlock).toContain("tag:");
+    expect(releaseTagWorkflow).toContain("REQUEST_TAG:");
+    expect(releaseTagWorkflow).toContain("actions/upload-artifact@");
+    expect(releaseTagWorkflow).toContain("release-tag-request");
     expect(releaseTagWorkflow).toContain("permissions:\n  contents: read");
     expect(releaseTagWorkflow).not.toContain("id-token: write");
     expect(releaseTagWorkflow).not.toContain("actions/checkout");
@@ -833,11 +837,16 @@ describe("supply-chain audit policy", () => {
     expect(publishWorkflowRunBlock).toContain("Release Tag Request");
     expect(yamlBlockForKey(publishOnBlock, "release")).toBeNull();
     expect(yamlBlockForKey(publishOnBlock, "push")).toBeNull();
-    expect(publishDispatchBlock).toContain("tag:");
-    expect(publishWorkflow).toContain("inputs.tag");
-    expect(publishWorkflow).toContain("github.event.workflow_run.head_branch");
+    expect(yamlBlockForKey(publishOnBlock, "workflow_dispatch")).toBeNull();
+    expect(publishWorkflow).not.toContain("inputs.tag");
+    expect(publishWorkflow).not.toContain("github.event.workflow_run.head_branch");
     expect(publishWorkflow).not.toContain("${{ github.event.release.tag_name }}");
     expect(prepareJob).not.toContain("id-token: write");
+    expect(prepareJob).toContain("actions/download-artifact@");
+    expect(prepareJob).toContain("github.event.workflow_run.id");
+    expect(prepareJob).toContain("release-request/tag.txt");
+    expect(prepareJob).toContain("steps.request.outputs.tag");
+    expect(publishWorkflow).toContain("needs.prepare.outputs.publish-tag");
     expect(prepareJob).toContain("ref: refs/heads/ci-green");
     expect(prepareJob).toContain("--wait-for-ci-green-timeout-ms 1200000");
     expect(prepareJob).toContain("--wait-for-ci-green-interval-ms");

--- a/tests/unit/supply-chain-policy.unit.test.ts
+++ b/tests/unit/supply-chain-policy.unit.test.ts
@@ -834,6 +834,9 @@ describe("supply-chain audit policy", () => {
     expect(releaseTagWorkflow).not.toContain("actions/checkout");
     expect(releaseTagWorkflow).not.toContain("npm publish");
     expect(releaseTagWorkflow).not.toContain("GHCR_TOKEN");
+    expect(publishWorkflow).toContain("zizmor: ignore[dangerous-triggers]");
+    expect(publishWorkflow).toContain("tag artifact");
+    expect(publishWorkflow).toContain("validates protected refs");
     expect(publishWorkflowRunBlock).toContain("Release Tag Request");
     expect(yamlBlockForKey(publishOnBlock, "release")).toBeNull();
     expect(yamlBlockForKey(publishOnBlock, "push")).toBeNull();

--- a/tests/unit/supply-chain-policy.unit.test.ts
+++ b/tests/unit/supply-chain-policy.unit.test.ts
@@ -21,6 +21,13 @@ const nodeRequire = createRequire(__filename);
 const { workflowJobBlock } = nodeRequire("../../scripts/lib/workflow-yaml.cjs") as {
   workflowJobBlock: (text: string, jobName: string) => string | null;
 };
+const { valuesEqual, yamlBlockForKey, yamlValuesForKey } = nodeRequire(
+  "../../scripts/lib/workflow-yaml.cjs",
+) as {
+  valuesEqual: (actual: unknown[], expected: unknown[]) => boolean;
+  yamlBlockForKey: (text: string, key: string) => string | null;
+  yamlValuesForKey: (text: string, key: string) => unknown[];
+};
 const { parseYaml, readPackageManagerLock } = nodeRequire("../../scripts/lib/pnpm-lock.cjs") as {
   parseYaml: (text: string) => unknown;
   readPackageManagerLock: (root: string) => unknown;
@@ -32,6 +39,7 @@ const semver = nodeRequire("semver") as {
 describe("supply-chain audit policy", () => {
   const workflow = readFileSync(join(root, ".github/workflows/test.yml"), "utf8");
   const publishWorkflow = readFileSync(join(root, ".github/workflows/publish.yml"), "utf8");
+  const releaseTagWorkflow = readFileSync(join(root, ".github/workflows/release-tag.yml"), "utf8");
   const rawPnpmLock = parseYaml(readFileSync(join(root, "pnpm-lock.yaml"), "utf8")) as {
     importers?: Record<
       string,
@@ -603,9 +611,10 @@ describe("supply-chain audit policy", () => {
     expect(packageJson.scripts.version).toBe(
       "node scripts/cut-changelog.mjs && git add CHANGELOG.md",
     );
+    expect(packageJson.scripts.prepublishOnly).toContain("pnpm run build");
+    expect(packageJson.scripts.prepublishOnly).toContain("scripts/verify-release-input.mjs");
     expect(packageJson.scripts.test).toBe("pnpm run typecheck && pnpm run test:unit");
     expect(packageJson.scripts.pretest).toBeUndefined();
-    expect(packageJson.scripts.prepublishOnly).toBeUndefined();
     expect(publishWorkflow).toContain("permissions:");
     expect(publishWorkflow).toContain("id-token: write");
     expect(publishWorkflow).toContain("environment: npm-publish");
@@ -806,15 +815,32 @@ describe("supply-chain audit policy", () => {
     const githubReleaseJob = publishJobBlock("github-release");
     const containerImageJob = publishJobBlock("container-image");
     const publishJob = publishJobBlock("publish");
+    const publishOnBlock = yamlBlockForKey(publishWorkflow, "on") ?? "";
+    const publishWorkflowRunBlock = yamlBlockForKey(publishOnBlock, "workflow_run") ?? "";
+    const publishDispatchBlock = yamlBlockForKey(publishOnBlock, "workflow_dispatch") ?? "";
+    const releaseTagOnBlock = yamlBlockForKey(releaseTagWorkflow, "on") ?? "";
+    const releaseTagPushBlock = yamlBlockForKey(releaseTagOnBlock, "push") ?? "";
+    const releaseTagPushTags = yamlValuesForKey(releaseTagPushBlock, "tags");
 
-    expect(publishWorkflow).toMatch(/^ {2}push:\n {4}tags:\n {6}- "v\*"$/m);
-    expect(publishWorkflow).not.toMatch(/^ {2}release:/m);
-    expect(publishWorkflow).not.toMatch(/^ {2}workflow_dispatch:/m);
-    expect(publishWorkflow).not.toContain("inputs.tag");
-    expect(publishWorkflow).toContain("${{ github.ref_name }}");
+    expect(
+      releaseTagPushTags.some((value) => Array.isArray(value) && valuesEqual(value, ["v*"])),
+    ).toBe(true);
+    expect(releaseTagWorkflow).toContain("permissions:\n  contents: read");
+    expect(releaseTagWorkflow).not.toContain("id-token: write");
+    expect(releaseTagWorkflow).not.toContain("actions/checkout");
+    expect(releaseTagWorkflow).not.toContain("npm publish");
+    expect(releaseTagWorkflow).not.toContain("GHCR_TOKEN");
+    expect(publishWorkflowRunBlock).toContain("Release Tag Request");
+    expect(yamlBlockForKey(publishOnBlock, "release")).toBeNull();
+    expect(yamlBlockForKey(publishOnBlock, "push")).toBeNull();
+    expect(publishDispatchBlock).toContain("tag:");
+    expect(publishWorkflow).toContain("inputs.tag");
+    expect(publishWorkflow).toContain("github.event.workflow_run.head_branch");
     expect(publishWorkflow).not.toContain("${{ github.event.release.tag_name }}");
     expect(prepareJob).not.toContain("id-token: write");
-    expect(prepareJob).toContain("--wait-for-ci-green-timeout-ms");
+    expect(prepareJob).toContain("ref: refs/heads/ci-green");
+    expect(prepareJob).toContain("--wait-for-ci-green-timeout-ms 1200000");
+    expect(prepareJob).toContain("--wait-for-ci-green-interval-ms");
     expect(prepareJob).toContain("pnpm run verify");
     expect(prepareJob).not.toContain("actions/setup-python");
     expect(prepareJob).toContain("pnpm run typecheck");


### PR DESCRIPTION
## Summary
- Adopts the tag-driven release flow for #187 while moving privileged publish work behind a default-branch `workflow_run`/manual-dispatch workflow that first checks out trusted `ci-green` resolver code.
- Adds a manual `workflow_dispatch` rerun path, a manual `prepublishOnly` guard, a shorter retryable `ci-green` wait with fail-fast main ancestry checks, and hardened GHCR signature identity validation.
- Updates release docs, supply-chain docs, changelog handling notes, and policy/unit coverage for the tag request workflow, hostile/unreviewed tags, retryable git failures, wait-then-succeed behavior, and manual publish guards.

## Linked Issue
Closes #187

## Tests Run
- `pnpm run prepublishOnly`
- `pnpm publish --dry-run --no-git-checks`
- `pnpm exec vitest run tests/unit/publish-ref.unit.test.ts tests/unit/supply-chain-policy.unit.test.ts tests/unit/container-image.unit.test.ts tests/unit/package-budget-policy.unit.test.ts tests/unit/release-scripts.unit.test.ts`
- `pnpm exec vitest run tests/unit/container-image.unit.test.ts tests/unit/supply-chain-policy.unit.test.ts`
- `pnpm run typecheck`
- `pnpm run lint`
- `pnpm run lint:docs`
- `pnpm run lint:links`
- `pnpm run spell`
- `pnpm run format:check`
- `pnpm run check:runtime-policy`
- `pnpm run test:unit`
- `pnpm run verify`

## Follow-up Notes
- `pnpm run lint` and `pnpm run verify` pass with the existing `src/oauth-resource-server.ts` warning unchanged.
