### PR TITLE
chore: release 0.1.0 (version bump, changelog, gitignore)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,8 @@ coverage/
 reports/
 *.log
 *.tsbuildinfo
+# Built package tarballs from `npm pack` / `pnpm pack`
+*.tgz
 .DS_Store
 .env
 .env.local

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.0] - 2026-08-18
+
 ### Added
 - Added `docs/AUTHENTICATION.md` plus public-claim drift coverage for OAuth
   resource-server behavior, B2 credential custody, CLI/env references, package
@@ -189,3 +191,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `B2_ALLOW_KEY_MGMT_GRANTS`, `B2_ALLOW_UNSCOPED_KEYS`, and
   `B2_MAX_KEY_DURATION_SECONDS` because the durable-secret-producing handler is
   no longer exposed in Phase 1.
+
+[Unreleased]: https://github.com/backblaze-labs/b2-mcp/compare/v0.1.0...HEAD
+[0.1.0]: https://github.com/backblaze-labs/b2-mcp/releases/tag/v0.1.0

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backblaze-labs/b2-mcp",
-  "version": "0.0.0",
+  "version": "0.1.0",
   "description": "MCP server for Backblaze B2 with frozen Phase 1 B2 and S3-compatible tool profiles",
   "packageManager": "pnpm@11.20.0+sha256.34e198cb1e43237517ecedfd31f9ae26a6c0a3e5366ce58a2d05f4b21fb5f19a",
   "main": "dist/index.js",


### PR DESCRIPTION
Lands the 0.1.0 version bump and promoted changelog on main to match the published npm package, plus a .gitignore rule for built `*.tgz` tarballs. The npm package @backblaze-labs/b2-mcp@0.1.0 and the v0.1.0 tag/release are already published; this reconciles main (which was still 0.0.0). Merge this, then main is ready for a 0.1.1 patch release to test the OIDC publish workflow.