### PR TITLE
Verify public TypeScript consumer contract

### DIFF
--- a/README.md
+++ b/README.md
@@ -263,9 +263,12 @@ const start: () => Promise<void> = b2Mcp.startStdio;
 ```
 
 Programmatic TypeScript imports beyond that root entry are not a supported
-public API. Deep imports such as `@backblaze-labs/b2-mcp/dist/server.js` are
-private implementation details and are closed by the package `exports` map. Use
-the CLI/bin entry or the root `startStdio` export instead.
+public API. The supported form is the CommonJS `import = require` interop shown
+above; ESM named imports such as `import { startStdio } from
+"@backblaze-labs/b2-mcp"` are not part of the contract. Deep imports such as
+`@backblaze-labs/b2-mcp/dist/server.js` are private implementation details and
+are closed by the package `exports` map. Use the CLI/bin entry or the root
+`startStdio` export instead.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -251,7 +251,22 @@ recommended.
 
 ## Package API Surface
 
-The npm package intentionally supports only the root CommonJS entry (`require("@backblaze-labs/b2-mcp")`), which exposes `startStdio`, plus `./package.json` for metadata. Deep imports such as `@backblaze-labs/b2-mcp/dist/server.js` are private implementation details and are closed by the package `exports` map before the 0.1 release. Use the CLI/bin entry or the root `startStdio` export instead.
+The npm package intentionally supports only the root CommonJS entry
+(`require("@backblaze-labs/b2-mcp")`), which exposes
+`startStdio(): Promise<void>`, plus `./package.json` for metadata. TypeScript
+consumers may compile against that same root CommonJS surface:
+
+```ts
+import b2Mcp = require("@backblaze-labs/b2-mcp");
+
+const start: () => Promise<void> = b2Mcp.startStdio;
+```
+
+Programmatic TypeScript imports beyond that root entry are not a supported
+public API. Deep imports such as `@backblaze-labs/b2-mcp/dist/server.js` are
+private implementation details and are closed by the package `exports` map
+before the 0.1 release. Use the CLI/bin entry or the root `startStdio` export
+instead.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -264,9 +264,8 @@ const start: () => Promise<void> = b2Mcp.startStdio;
 
 Programmatic TypeScript imports beyond that root entry are not a supported
 public API. Deep imports such as `@backblaze-labs/b2-mcp/dist/server.js` are
-private implementation details and are closed by the package `exports` map
-before the 0.1 release. Use the CLI/bin entry or the root `startStdio` export
-instead.
+private implementation details and are closed by the package `exports` map. Use
+the CLI/bin entry or the root `startStdio` export instead.
 
 ---
 

--- a/tests/package/packed-install.package.test.ts
+++ b/tests/package/packed-install.package.test.ts
@@ -305,17 +305,26 @@ function typescriptResultOutput(result: ReturnType<typeof spawnSync>): string {
 function assertTypescriptCompile(
   appDir: string,
   projectFile: string,
-  options: { expectSuccess: boolean; label: string },
+  options: { expectSuccess: boolean; label: string; expectOutputIncludes?: string },
 ): void {
   const result = runTypescriptCompiler(appDir, projectFile);
-  const passed =
+  const output = typescriptResultOutput(result);
+  const statusPassed =
     !result.error && (options.expectSuccess ? result.status === 0 : result.status !== 0);
-  if (passed) return;
+  // Negative cases assert not just a non-zero exit but that the failure is the
+  // expected module-resolution diagnostic, so an unrelated fixture error cannot
+  // masquerade as a correctly-closed deep import.
+  const outputPassed =
+    options.expectOutputIncludes === undefined || output.includes(options.expectOutputIncludes);
+  if (statusPassed && outputPassed) return;
   throw new Error(
     [
       `${options.label} ${options.expectSuccess ? "failed to compile" : "unexpectedly compiled"} with status ${result.status ?? "unknown"}`,
+      !outputPassed
+        ? `expected diagnostics to include ${JSON.stringify(options.expectOutputIncludes)}`
+        : "",
       result.signal ? `signal: ${result.signal}` : "",
-      typescriptResultOutput(result),
+      output,
     ]
       .filter(Boolean)
       .join("\n"),
@@ -329,8 +338,17 @@ function assertTypescriptCompileSucceeds(appDir: string, projectFile: string): v
   });
 }
 
-function assertTypescriptCompileFails(appDir: string, projectFile: string, label: string): void {
-  assertTypescriptCompile(appDir, projectFile, { expectSuccess: false, label });
+function assertTypescriptCompileFails(
+  appDir: string,
+  projectFile: string,
+  label: string,
+  expectOutputIncludes?: string,
+): void {
+  assertTypescriptCompile(appDir, projectFile, {
+    expectSuccess: false,
+    label,
+    expectOutputIncludes,
+  });
 }
 
 function writeTypescriptConfig(appDir: string, projectFile: string, files: string[]): void {
@@ -361,7 +379,12 @@ function compileDocumentedTypescriptConsumer(appDir: string): void {
 
   writeTypescriptConfig(appDir, "tsconfig.deep.json", ["consumer-deep.ts"]);
   writeFileSync(join(appDir, "consumer-deep.ts"), PRIVATE_DEEP_IMPORT_CONSUMER_SOURCE);
-  assertTypescriptCompileFails(appDir, "tsconfig.deep.json", "private deep TypeScript import");
+  assertTypescriptCompileFails(
+    appDir,
+    "tsconfig.deep.json",
+    "private deep TypeScript import",
+    PRIVATE_DEEP_IMPORT_SPECIFIER,
+  );
 }
 
 const PACKED_INSTALL_TEST_TIMEOUT_MS = process.platform === "win32" ? 360_000 : 180_000;

--- a/tests/package/packed-install.package.test.ts
+++ b/tests/package/packed-install.package.test.ts
@@ -63,6 +63,7 @@ interface PackageJson {
   license?: string;
   bin?: Record<string, string>;
   dependencies?: Record<string, string>;
+  devDependencies?: Record<string, string>;
   engines?: Record<string, string>;
 }
 
@@ -206,7 +207,84 @@ function installPackedConsumer(appDir: string, cacheDir: string): void {
   assertSuccessfulNpmResult(result, "packed consumer npm install");
 }
 
-const PACKED_INSTALL_TEST_TIMEOUT_MS = process.platform === "win32" ? 300_000 : 120_000;
+function installConsumerDevDependencies(appDir: string, cacheDir: string): void {
+  const result = runNpmCommandWithRetries(
+    [
+      "install",
+      "--include=dev",
+      "--ignore-scripts",
+      "--no-audit",
+      "--no-fund",
+      "--fetch-retries=3",
+      "--fetch-retry-factor=2",
+      "--fetch-retry-mintimeout=1000",
+      "--fetch-retry-maxtimeout=10000",
+      "--cache",
+      cacheDir,
+    ],
+    {
+      attempts: 3,
+      retryLabel: "packed consumer npm install dev dependencies",
+      spawnOptions: {
+        cwd: appDir,
+        encoding: "utf8",
+        stdio: "pipe",
+        timeout: 180_000,
+      },
+    },
+  );
+  assertSuccessfulNpmResult(result, "packed consumer npm install dev dependencies");
+}
+
+function compileDocumentedTypescriptConsumer(appDir: string): void {
+  writeFileSync(
+    join(appDir, "tsconfig.json"),
+    JSON.stringify(
+      {
+        compilerOptions: {
+          module: "Node16",
+          moduleResolution: "Node16",
+          noEmit: true,
+          strict: true,
+          target: "ES2022",
+          types: [],
+        },
+        files: ["consumer.ts"],
+      },
+      null,
+      2,
+    ),
+  );
+  writeFileSync(
+    join(appDir, "consumer.ts"),
+    [
+      'import b2Mcp = require("@backblaze-labs/b2-mcp");',
+      "",
+      "const start: () => Promise<void> = b2Mcp.startStdio;",
+      "void start;",
+      "",
+    ].join("\n"),
+  );
+
+  execFileSync(
+    process.execPath,
+    [
+      join(appDir, "node_modules", "typescript", "bin", "tsc"),
+      "--noEmit",
+      "--pretty",
+      "false",
+      "-p",
+      "tsconfig.json",
+    ],
+    {
+      cwd: appDir,
+      stdio: "pipe",
+      timeout: 60_000,
+    },
+  );
+}
+
+const PACKED_INSTALL_TEST_TIMEOUT_MS = process.platform === "win32" ? 360_000 : 180_000;
 
 describe("packed package", () => {
   it(
@@ -238,6 +316,7 @@ describe("packed package", () => {
 
         expect(packedPaths).toEqual(
           expect.arrayContaining([
+            "dist/index.d.ts",
             "dist/index.js",
             "dist/http-server.js",
             "deploy/customer-hosted/Dockerfile",
@@ -256,6 +335,9 @@ describe("packed package", () => {
 
         const tarball = join(packDir, pack.filename);
         const tarballSpec = `file:${relative(appDir, tarball)}`;
+        const typescriptVersion = repoPkg.devDependencies?.typescript;
+        if (!typescriptVersion)
+          throw new Error("package.json must declare devDependencies.typescript");
         writeFileSync(
           join(appDir, "package.json"),
           JSON.stringify(
@@ -263,6 +345,7 @@ describe("packed package", () => {
               name: "b2-mcp-pack-test",
               private: true,
               dependencies: { [repoPkg.name]: tarballSpec },
+              devDependencies: { typescript: typescriptVersion },
               overrides: committedProductionOverrides(repoLock),
             },
             null,
@@ -277,6 +360,8 @@ describe("packed package", () => {
             readNpmLock(join(appDir, "package-lock.json")),
           ),
         ).toEqual([]);
+        installConsumerDevDependencies(appDir, cacheDir);
+        compileDocumentedTypescriptConsumer(appDir);
 
         execFileSync(
           "node",

--- a/tests/package/packed-install.package.test.ts
+++ b/tests/package/packed-install.package.test.ts
@@ -387,7 +387,10 @@ function compileDocumentedTypescriptConsumer(appDir: string): void {
   );
 }
 
-const PACKED_INSTALL_TEST_TIMEOUT_MS = process.platform === "win32" ? 360_000 : 180_000;
+// Two npm installs (production, then dev TypeScript), each with a bounded retry
+// budget, plus pack, the documented-consumer compile, and the runtime smoke.
+// Sized above the worst case so a slow-but-successful CI run cannot trip Vitest.
+const PACKED_INSTALL_TEST_TIMEOUT_MS = process.platform === "win32" ? 600_000 : 360_000;
 
 describe("packed package", () => {
   it("rejects unpinned TypeScript dev dependency resolution before execution", () => {
@@ -505,16 +508,10 @@ describe("packed package", () => {
         expect(
           committedPackageGraphMismatches(repoLock, readNpmLock(join(appDir, "package-lock.json"))),
         ).toEqual([]);
-        installPackedDependencies(appDir, cacheDir, "development");
-        expect(
-          committedPackageGraphMismatches(
-            repoLock,
-            readNpmLock(join(appDir, "package-lock.json")),
-            { checkedDevelopmentPackages: ["typescript"] },
-          ),
-        ).toEqual([]);
-        compileDocumentedTypescriptConsumer(appDir);
 
+        // Runtime and package-contract checks run against the production-only
+        // install (before any dev dependency is present), so a runtime that
+        // accidentally imports a dev dependency cannot pass here.
         execFileSync(
           "node",
           [
@@ -585,6 +582,21 @@ describe("packed package", () => {
         } finally {
           await client.close().catch(() => undefined);
         }
+
+        // Production contract is proven above. Only now install the pinned dev
+        // TypeScript and verify the documented .d.ts consumer contract compiles
+        // (and that deep TypeScript imports do not).
+        installPackedDependencies(appDir, cacheDir, "development");
+        expect(
+          committedPackageGraphMismatches(
+            repoLock,
+            readNpmLock(join(appDir, "package-lock.json")),
+            {
+              checkedDevelopmentPackages: ["typescript"],
+            },
+          ),
+        ).toEqual([]);
+        compileDocumentedTypescriptConsumer(appDir);
       } finally {
         rmSync(tmp, { recursive: true, force: true });
       }

--- a/tests/package/packed-install.package.test.ts
+++ b/tests/package/packed-install.package.test.ts
@@ -1,4 +1,4 @@
-import { execFileSync } from "child_process";
+import { execFileSync, spawnSync } from "child_process";
 import { mkdtempSync, mkdirSync, readFileSync, rmSync, statSync, writeFileSync } from "fs";
 import { createRequire } from "module";
 import { join, relative } from "path";
@@ -33,6 +33,12 @@ const { npmInvocation, runNpmCommandWithRetries } = nodeRequire(
     stdout?: string;
   };
 };
+const { sanitizedEnv } = nodeRequire("../../scripts/lib/sanitized-env.cjs") as {
+  sanitizedEnv: (
+    extra?: Record<string, string>,
+    options?: { nonSecretEnvNames?: string[]; sourceEnv?: NodeJS.ProcessEnv },
+  ) => NodeJS.ProcessEnv;
+};
 
 interface PackFile {
   path: string;
@@ -63,7 +69,6 @@ interface PackageJson {
   license?: string;
   bin?: Record<string, string>;
   dependencies?: Record<string, string>;
-  devDependencies?: Record<string, string>;
   engines?: Record<string, string>;
 }
 
@@ -85,6 +90,16 @@ function packageNameFromNodeModulesPath(lockPath: string): string {
 function productionEntries(lock: PackageLock): Array<[string, LockPackage]> {
   return Object.entries(lock.packages).filter(
     ([path, entry]) => path.startsWith("node_modules/") && !entry.dev && Boolean(entry.version),
+  );
+}
+
+function checkedDevelopmentEntries(
+  lock: PackageLock,
+  packageNames: string[],
+): Array<[string, LockPackage]> {
+  const checkedPaths = new Set(packageNames.map((packageName) => `node_modules/${packageName}`));
+  return Object.entries(lock.packages).filter(
+    ([path, entry]) => checkedPaths.has(path) && entry.dev && Boolean(entry.version),
   );
 }
 
@@ -138,18 +153,23 @@ function committedProductionOverrides(lock: PackageLock): Record<string, unknown
   return overrides;
 }
 
-function committedProductionGraphMismatches(
+function committedPackageGraphMismatches(
   repoLock: PackageLock,
   consumerLock: PackageLock,
+  options: { checkedDevelopmentPackages?: string[] } = {},
 ): string[] {
+  const expectedEntries = [
+    ...productionEntries(repoLock),
+    ...checkedDevelopmentEntries(repoLock, options.checkedDevelopmentPackages ?? []),
+  ];
   const consumerByIdentity = new Map(
-    productionEntries(consumerLock).map(([path, entry]) => [
-      `${packageNameFromNodeModulesPath(path)}@${entry.version}`,
-      entry,
-    ]),
+    [
+      ...productionEntries(consumerLock),
+      ...checkedDevelopmentEntries(consumerLock, options.checkedDevelopmentPackages ?? []),
+    ].map(([path, entry]) => [`${packageNameFromNodeModulesPath(path)}@${entry.version}`, entry]),
   );
 
-  return productionEntries(repoLock).flatMap(([path, entry]) => {
+  return expectedEntries.flatMap(([path, entry]) => {
     const identity = `${packageNameFromNodeModulesPath(path)}@${entry.version}`;
     const installed = consumerByIdentity.get(identity);
     if (!installed) return [`${identity} missing from consumer lock`];
@@ -178,11 +198,32 @@ function assertSuccessfulNpmResult(
   );
 }
 
-function installPackedConsumer(appDir: string, cacheDir: string): void {
+function lockedDevelopmentPackage(lock: PackageLock, packageName: string): LockPackage {
+  const entries = checkedDevelopmentEntries(lock, [packageName]);
+  if (entries.length !== 1) {
+    throw new Error(
+      `Expected exactly one committed lockfile entry for dev dependency ${packageName}, got ${entries.length}`,
+    );
+  }
+  const [, entry] = entries[0];
+  if (!entry.version) throw new Error(`${packageName} lockfile entry is missing a version`);
+  if (!entry.integrity) throw new Error(`${packageName}@${entry.version} is missing integrity`);
+  return entry;
+}
+
+function installPackedDependencies(
+  appDir: string,
+  cacheDir: string,
+  mode: "production" | "development",
+): void {
+  const label =
+    mode === "development"
+      ? "packed consumer npm install dev dependencies"
+      : "packed consumer npm install";
   const result = runNpmCommandWithRetries(
     [
       "install",
-      "--omit=dev",
+      mode === "development" ? "--include=dev" : "--omit=dev",
       "--ignore-scripts",
       "--no-audit",
       "--no-fund",
@@ -195,7 +236,7 @@ function installPackedConsumer(appDir: string, cacheDir: string): void {
     ],
     {
       attempts: 3,
-      retryLabel: "packed consumer npm install",
+      retryLabel: label,
       spawnOptions: {
         cwd: appDir,
         encoding: "utf8",
@@ -204,41 +245,84 @@ function installPackedConsumer(appDir: string, cacheDir: string): void {
       },
     },
   );
-  assertSuccessfulNpmResult(result, "packed consumer npm install");
+  assertSuccessfulNpmResult(result, label);
 }
 
-function installConsumerDevDependencies(appDir: string, cacheDir: string): void {
-  const result = runNpmCommandWithRetries(
+function readReadmeTypescriptConsumerSample(): string {
+  const readme = readFileSync(join(root, "README.md"), "utf8");
+  const packageApi = readme.indexOf("## Package API Surface");
+  const fenceStart = readme.indexOf("```ts\n", packageApi);
+  const sampleStart = fenceStart + "```ts\n".length;
+  const fenceEnd = readme.indexOf("\n```", sampleStart);
+  if (packageApi === -1 || fenceStart === -1 || fenceEnd === -1) {
+    throw new Error("README Package API Surface must include a TypeScript code sample");
+  }
+  return `${readme.slice(sampleStart, fenceEnd).trimEnd()}\n`;
+}
+
+function typescriptEnv(): NodeJS.ProcessEnv {
+  return sanitizedEnv({
+    NODE_ENV: "test",
+    NODE_OPTIONS: `--import ${pathToFileURL(join(root, "scripts/no-network-guard.mjs")).href}`,
+  });
+}
+
+function runTypescriptCompiler(appDir: string, projectFile: string): ReturnType<typeof spawnSync> {
+  return spawnSync(
+    process.execPath,
     [
-      "install",
-      "--include=dev",
-      "--ignore-scripts",
-      "--no-audit",
-      "--no-fund",
-      "--fetch-retries=3",
-      "--fetch-retry-factor=2",
-      "--fetch-retry-mintimeout=1000",
-      "--fetch-retry-maxtimeout=10000",
-      "--cache",
-      cacheDir,
+      join(appDir, "node_modules", "typescript", "bin", "tsc"),
+      "--noEmit",
+      "--pretty",
+      "false",
+      "-p",
+      projectFile,
     ],
     {
-      attempts: 3,
-      retryLabel: "packed consumer npm install dev dependencies",
-      spawnOptions: {
-        cwd: appDir,
-        encoding: "utf8",
-        stdio: "pipe",
-        timeout: 180_000,
-      },
+      cwd: appDir,
+      encoding: "utf8",
+      env: typescriptEnv(),
+      stdio: "pipe",
+      timeout: 60_000,
     },
   );
-  assertSuccessfulNpmResult(result, "packed consumer npm install dev dependencies");
 }
 
-function compileDocumentedTypescriptConsumer(appDir: string): void {
+function typescriptResultOutput(result: ReturnType<typeof spawnSync>): string {
+  return [result.stdout, result.stderr, result.error?.message].filter(Boolean).join("\n");
+}
+
+function assertTypescriptCompileSucceeds(appDir: string, projectFile: string): void {
+  const result = runTypescriptCompiler(appDir, projectFile);
+  if (!result.error && result.status === 0) return;
+  throw new Error(
+    [
+      `documented TS consumer failed to compile with status ${result.status ?? "unknown"}`,
+      result.signal ? `signal: ${result.signal}` : "",
+      typescriptResultOutput(result),
+    ]
+      .filter(Boolean)
+      .join("\n"),
+  );
+}
+
+function assertTypescriptCompileFails(appDir: string, projectFile: string, label: string): void {
+  const result = runTypescriptCompiler(appDir, projectFile);
+  if (!result.error && result.status !== 0) return;
+  throw new Error(
+    [
+      `${label} unexpectedly compiled with status ${result.status ?? "unknown"}`,
+      result.signal ? `signal: ${result.signal}` : "",
+      typescriptResultOutput(result),
+    ]
+      .filter(Boolean)
+      .join("\n"),
+  );
+}
+
+function writeTypescriptConfig(appDir: string, projectFile: string, files: string[]): void {
   writeFileSync(
-    join(appDir, "tsconfig.json"),
+    join(appDir, projectFile),
     JSON.stringify(
       {
         compilerOptions: {
@@ -249,44 +333,73 @@ function compileDocumentedTypescriptConsumer(appDir: string): void {
           target: "ES2022",
           types: [],
         },
-        files: ["consumer.ts"],
+        files,
       },
       null,
       2,
     ),
   );
-  writeFileSync(
-    join(appDir, "consumer.ts"),
-    [
-      'import b2Mcp = require("@backblaze-labs/b2-mcp");',
-      "",
-      "const start: () => Promise<void> = b2Mcp.startStdio;",
-      "void start;",
-      "",
-    ].join("\n"),
-  );
+}
 
-  execFileSync(
-    process.execPath,
-    [
-      join(appDir, "node_modules", "typescript", "bin", "tsc"),
-      "--noEmit",
-      "--pretty",
-      "false",
-      "-p",
-      "tsconfig.json",
-    ],
-    {
-      cwd: appDir,
-      stdio: "pipe",
-      timeout: 60_000,
-    },
+function compileDocumentedTypescriptConsumer(appDir: string): void {
+  writeTypescriptConfig(appDir, "tsconfig.json", ["consumer.ts"]);
+  writeFileSync(join(appDir, "consumer.ts"), readReadmeTypescriptConsumerSample());
+  assertTypescriptCompileSucceeds(appDir, "tsconfig.json");
+
+  writeTypescriptConfig(appDir, "tsconfig.deep.json", ["consumer-deep.ts"]);
+  writeFileSync(
+    join(appDir, "consumer-deep.ts"),
+    'import server = require("@backblaze-labs/b2-mcp/dist/server.js");\nvoid server;\n',
   );
+  assertTypescriptCompileFails(appDir, "tsconfig.deep.json", "private deep TypeScript import");
 }
 
 const PACKED_INSTALL_TEST_TIMEOUT_MS = process.platform === "win32" ? 360_000 : 180_000;
 
 describe("packed package", () => {
+  it("rejects unpinned TypeScript dev dependency resolution before execution", () => {
+    const repoLock: PackageLock = {
+      packages: {
+        "node_modules/typescript": {
+          dev: true,
+          integrity: "sha512-locked",
+          version: "6.0.3",
+        },
+      },
+    };
+
+    expect(
+      committedPackageGraphMismatches(
+        repoLock,
+        {
+          packages: {
+            "node_modules/typescript": {
+              dev: true,
+              integrity: "sha512-new-patch",
+              version: "6.0.4",
+            },
+          },
+        },
+        { checkedDevelopmentPackages: ["typescript"] },
+      ),
+    ).toEqual(["typescript@6.0.3 missing from consumer lock"]);
+    expect(
+      committedPackageGraphMismatches(
+        repoLock,
+        {
+          packages: {
+            "node_modules/typescript": {
+              dev: true,
+              integrity: "sha512-tampered",
+              version: "6.0.3",
+            },
+          },
+        },
+        { checkedDevelopmentPackages: ["typescript"] },
+      ),
+    ).toEqual(["typescript@6.0.3 integrity mismatch"]);
+  });
+
   it(
     "installs from npm pack and exposes the package entry point",
     async () => {
@@ -335,9 +448,11 @@ describe("packed package", () => {
 
         const tarball = join(packDir, pack.filename);
         const tarballSpec = `file:${relative(appDir, tarball)}`;
-        const typescriptVersion = repoPkg.devDependencies?.typescript;
-        if (!typescriptVersion)
-          throw new Error("package.json must declare devDependencies.typescript");
+        const lockedTypescript = lockedDevelopmentPackage(repoLock, "typescript");
+        const overrides = {
+          ...committedProductionOverrides(repoLock),
+          typescript: lockedTypescript.version,
+        };
         writeFileSync(
           join(appDir, "package.json"),
           JSON.stringify(
@@ -345,22 +460,26 @@ describe("packed package", () => {
               name: "b2-mcp-pack-test",
               private: true,
               dependencies: { [repoPkg.name]: tarballSpec },
-              devDependencies: { typescript: typescriptVersion },
-              overrides: committedProductionOverrides(repoLock),
+              devDependencies: { typescript: lockedTypescript.version },
+              overrides,
             },
             null,
             2,
           ),
         );
-        installPackedConsumer(appDir, cacheDir);
+        installPackedDependencies(appDir, cacheDir, "production");
 
         expect(
-          committedProductionGraphMismatches(
+          committedPackageGraphMismatches(repoLock, readNpmLock(join(appDir, "package-lock.json"))),
+        ).toEqual([]);
+        installPackedDependencies(appDir, cacheDir, "development");
+        expect(
+          committedPackageGraphMismatches(
             repoLock,
             readNpmLock(join(appDir, "package-lock.json")),
+            { checkedDevelopmentPackages: ["typescript"] },
           ),
         ).toEqual([]);
-        installConsumerDevDependencies(appDir, cacheDir);
         compileDocumentedTypescriptConsumer(appDir);
 
         execFileSync(

--- a/tests/package/packed-install.package.test.ts
+++ b/tests/package/packed-install.package.test.ts
@@ -40,6 +40,11 @@ const { sanitizedEnv } = nodeRequire("../../scripts/lib/sanitized-env.cjs") as {
   ) => NodeJS.ProcessEnv;
 };
 
+const PRIVATE_DEEP_IMPORT_SPECIFIER = "@backblaze-labs/b2-mcp/dist/server.js";
+const PRIVATE_DEEP_IMPORT_CONSUMER_SOURCE = `import server = require("${PRIVATE_DEEP_IMPORT_SPECIFIER}");
+void server;
+`;
+
 interface PackFile {
   path: string;
 }
@@ -250,18 +255,19 @@ function installPackedDependencies(
 
 function readReadmeTypescriptConsumerSample(): string {
   const readme = readFileSync(join(root, "README.md"), "utf8");
-  const packageApi = readme.indexOf("## Package API Surface");
-  const packageApiSection = packageApi === -1 ? "" : readme.slice(packageApi);
-  const fenceStart = packageApiSection.match(/```ts\r?\n/);
-  const sampleStart = packageApi + (fenceStart?.index ?? 0) + (fenceStart?.[0].length ?? 0);
-  const fenceEnd = readme.slice(sampleStart).match(/\r?\n```/);
-  if (packageApi === -1 || !fenceStart || !fenceEnd) {
-    throw new Error("README Package API Surface must include a TypeScript code sample");
+  const sectionStart = readme.search(/^## Package API Surface$/m);
+  if (sectionStart === -1) throw new Error("README must include a Package API Surface section");
+  const nextSection = readme.slice(sectionStart + 1).search(/^## /m);
+  const sectionEnd = nextSection === -1 ? readme.length : sectionStart + 1 + nextSection;
+  const packageApiSection = readme.slice(sectionStart, sectionEnd);
+  const samples = [...packageApiSection.matchAll(/```ts\r?\n([\s\S]*?)\r?\n```/g)];
+
+  if (samples.length !== 1) {
+    throw new Error(
+      `README Package API Surface must include exactly one TypeScript code sample, got ${samples.length}`,
+    );
   }
-  return `${readme
-    .slice(sampleStart, sampleStart + (fenceEnd.index ?? 0))
-    .replace(/\r\n/g, "\n")
-    .trimEnd()}\n`;
+  return `${samples[0][1].replace(/\r\n/g, "\n").trimEnd()}\n`;
 }
 
 function typescriptEnv(): NodeJS.ProcessEnv {
@@ -296,12 +302,18 @@ function typescriptResultOutput(result: ReturnType<typeof spawnSync>): string {
   return [result.stdout, result.stderr, result.error?.message].filter(Boolean).join("\n");
 }
 
-function assertTypescriptCompileSucceeds(appDir: string, projectFile: string): void {
+function assertTypescriptCompile(
+  appDir: string,
+  projectFile: string,
+  options: { expectSuccess: boolean; label: string },
+): void {
   const result = runTypescriptCompiler(appDir, projectFile);
-  if (!result.error && result.status === 0) return;
+  const passed =
+    !result.error && (options.expectSuccess ? result.status === 0 : result.status !== 0);
+  if (passed) return;
   throw new Error(
     [
-      `documented TS consumer failed to compile with status ${result.status ?? "unknown"}`,
+      `${options.label} ${options.expectSuccess ? "failed to compile" : "unexpectedly compiled"} with status ${result.status ?? "unknown"}`,
       result.signal ? `signal: ${result.signal}` : "",
       typescriptResultOutput(result),
     ]
@@ -310,18 +322,15 @@ function assertTypescriptCompileSucceeds(appDir: string, projectFile: string): v
   );
 }
 
+function assertTypescriptCompileSucceeds(appDir: string, projectFile: string): void {
+  assertTypescriptCompile(appDir, projectFile, {
+    expectSuccess: true,
+    label: "documented TS consumer",
+  });
+}
+
 function assertTypescriptCompileFails(appDir: string, projectFile: string, label: string): void {
-  const result = runTypescriptCompiler(appDir, projectFile);
-  if (!result.error && result.status !== 0) return;
-  throw new Error(
-    [
-      `${label} unexpectedly compiled with status ${result.status ?? "unknown"}`,
-      result.signal ? `signal: ${result.signal}` : "",
-      typescriptResultOutput(result),
-    ]
-      .filter(Boolean)
-      .join("\n"),
-  );
+  assertTypescriptCompile(appDir, projectFile, { expectSuccess: false, label });
 }
 
 function writeTypescriptConfig(appDir: string, projectFile: string, files: string[]): void {
@@ -351,10 +360,7 @@ function compileDocumentedTypescriptConsumer(appDir: string): void {
   assertTypescriptCompileSucceeds(appDir, "tsconfig.json");
 
   writeTypescriptConfig(appDir, "tsconfig.deep.json", ["consumer-deep.ts"]);
-  writeFileSync(
-    join(appDir, "consumer-deep.ts"),
-    'import server = require("@backblaze-labs/b2-mcp/dist/server.js");\nvoid server;\n',
-  );
+  writeFileSync(join(appDir, "consumer-deep.ts"), PRIVATE_DEEP_IMPORT_CONSUMER_SOURCE);
   assertTypescriptCompileFails(appDir, "tsconfig.deep.json", "private deep TypeScript import");
 }
 

--- a/tests/package/packed-install.package.test.ts
+++ b/tests/package/packed-install.package.test.ts
@@ -251,13 +251,17 @@ function installPackedDependencies(
 function readReadmeTypescriptConsumerSample(): string {
   const readme = readFileSync(join(root, "README.md"), "utf8");
   const packageApi = readme.indexOf("## Package API Surface");
-  const fenceStart = readme.indexOf("```ts\n", packageApi);
-  const sampleStart = fenceStart + "```ts\n".length;
-  const fenceEnd = readme.indexOf("\n```", sampleStart);
-  if (packageApi === -1 || fenceStart === -1 || fenceEnd === -1) {
+  const packageApiSection = packageApi === -1 ? "" : readme.slice(packageApi);
+  const fenceStart = packageApiSection.match(/```ts\r?\n/);
+  const sampleStart = packageApi + (fenceStart?.index ?? 0) + (fenceStart?.[0].length ?? 0);
+  const fenceEnd = readme.slice(sampleStart).match(/\r?\n```/);
+  if (packageApi === -1 || !fenceStart || !fenceEnd) {
     throw new Error("README Package API Surface must include a TypeScript code sample");
   }
-  return `${readme.slice(sampleStart, fenceEnd).trimEnd()}\n`;
+  return `${readme
+    .slice(sampleStart, sampleStart + (fenceEnd.index ?? 0))
+    .replace(/\r\n/g, "\n")
+    .trimEnd()}\n`;
 }
 
 function typescriptEnv(): NodeJS.ProcessEnv {

--- a/tests/unit/package-surface-policy.unit.test.ts
+++ b/tests/unit/package-surface-policy.unit.test.ts
@@ -461,6 +461,7 @@ describe("package surface policy", () => {
     expect(readme).toContain("root CommonJS entry");
     expect(readme).toContain("consumers may compile against that same root CommonJS surface");
     expect(readme).toContain("Programmatic TypeScript imports beyond that root entry");
+    expect(readme).toContain("ESM named imports");
     expect(readme).toContain("startStdio");
     expect(readme).toContain("Deep imports");
     expect(readme).toContain("private implementation details");

--- a/tests/unit/package-surface-policy.unit.test.ts
+++ b/tests/unit/package-surface-policy.unit.test.ts
@@ -459,6 +459,8 @@ describe("package surface policy", () => {
     expect(Object.keys(pkg.exports).sort()).toEqual([".", "./package.json"]);
     expect(readme).toContain("Package API Surface");
     expect(readme).toContain("root CommonJS entry");
+    expect(readme).toContain("consumers may compile against that same root CommonJS surface");
+    expect(readme).toContain("Programmatic TypeScript imports beyond that root entry");
     expect(readme).toContain("startStdio");
     expect(readme).toContain("Deep imports");
     expect(readme).toContain("private implementation details");

--- a/tests/unit/package-surface-policy.unit.test.ts
+++ b/tests/unit/package-surface-policy.unit.test.ts
@@ -464,6 +464,7 @@ describe("package surface policy", () => {
     expect(readme).toContain("startStdio");
     expect(readme).toContain("Deep imports");
     expect(readme).toContain("private implementation details");
+    expect(readme).not.toContain("before the 0.1 release");
   });
 
   it("exact-pins runtime-sensitive lint and typing packages", () => {


### PR DESCRIPTION
## Summary
- Documents the supported public TypeScript consumer contract as the root CommonJS import surface only, with deep imports described as current private/export-map-closed policy.
- Adds packed-tarball consumer coverage that installs the tarball, verifies the README TypeScript sample with `tsc --noEmit`, and asserts deep TypeScript imports fail under Node16 resolution.
- Hardens the fixture so TypeScript is installed at the exact committed lockfile version, covered by integrity checks before execution, and run with a sanitized no-network environment plus visible diagnostics.
- Bounds README sample extraction to the Package API Surface section, centralizes TypeScript compile assertion reporting, and names the private deep-import fixture.
- Keeps the README sample parser cross-platform so Windows CRLF checkouts verify the same documented contract.

## Linked issue
Fixes #195

## Tests run
- `pnpm run test:package`
- `node scripts/run-vitest-layer.mjs unit -- tests/unit/package-surface-policy.unit.test.ts`
- `pnpm run typecheck`
- `pnpm run lint:docs`
- `pnpm run format:check`

## Follow-up notes
- No follow-up required.