### PR TITLE
fix: align engines.node with supported Node lines

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -135,11 +135,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `backblaze-labs/b2-mcp`.
 - Aligned package metadata on the `0.1.0` Phase 1 release line.
 - Aligned the enforced runtime policy with the official B2 SDK floor:
-  `engines.node` is `^22.3.0 || ^24 || ^26`, CI verifies production
-  dependencies and the full toolchain on Node.js 22.23.1, 24, and 26, local and
-  live 22.x jobs use a patched Node 22 LTS release, the packed-package smoke
-  runs on the Node.js 22.3.0 engine floor, and workflow drift is checked from
-  `runtime-policy.json`.
+  `engines.node` is `>=22.3.0`, CI verifies production dependencies and the full
+  toolchain on Node.js 22.23.1, 24, and 26, local and live 22.x jobs use a
+  patched Node 22 LTS release, the packed-package smoke runs on the Node.js
+  22.3.0 engine floor, and workflow drift is checked from `runtime-policy.json`.
 - Kept coverage, slow lifecycle, package install, runtime floor, package budget,
   and supply-chain checks as independent required CI gates, with CODEOWNER
   review required for protected files.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- Aligned the package `engines.node` range with the supported Node.js 22.3+,
+  24, and 26 lines so it matches the runtime policy and opossum 10 support.
+
 ## [0.1.1] - 2026-08-18
 
 ### Changed
@@ -130,10 +134,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `backblaze-labs/b2-mcp`.
 - Aligned package metadata on the `0.1.0` Phase 1 release line.
 - Aligned the enforced runtime policy with the official B2 SDK floor:
-  `engines.node` is `>=22.3.0`, CI verifies production dependencies and the full
-  toolchain on Node.js 22.23.1, 24, and 26, local and live 22.x jobs use a
-  patched Node 22 LTS release, the packed-package smoke runs on the Node.js
-  22.3.0 engine floor, and workflow drift is checked from `runtime-policy.json`.
+  `engines.node` is `^22.3.0 || ^24 || ^26`, CI verifies production
+  dependencies and the full toolchain on Node.js 22.23.1, 24, and 26, local and
+  live 22.x jobs use a patched Node 22 LTS release, the packed-package smoke
+  runs on the Node.js 22.3.0 engine floor, and workflow drift is checked from
+  `runtime-policy.json`.
 - Kept coverage, slow lifecycle, package install, runtime floor, package budget,
   and supply-chain checks as independent required CI gates, with CODEOWNER
   review required for protected files.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 - Aligned the package `engines.node` range with the supported Node.js 22.3+,
-  24, and 26 lines so it matches the runtime policy and opossum 10 support.
+  24, and 26 lines so it matches the runtime policy and opossum 10 support,
+  with drift guards for workflow and deployment documentation claims.
 
 ## [0.1.1] - 2026-08-18
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -7,11 +7,11 @@ By participating you agree to abide by our [Code of Conduct](./CODE_OF_CONDUCT.m
 
 ## Development setup
 
-The package engine floor is `>=22.3.0` because it matches the official B2 SDK.
-For local development and deployed 22.x hosts, use the patched Node 22 LTS
-release pinned in `.nvmrc` (`22.23.1` at the time of writing) or a later patched
-22.x release. The package engine remains `>=22.3.0` for consumer compatibility;
-CI runs the full toolchain on Node.js 22.23.1, 24, and 26.
+The package engine range is `^22.3.0 || ^24 || ^26`: it preserves the official
+B2 SDK's Node 22.3.0 floor and excludes Node.js lines outside opossum's supported
+range. For local development and deployed 22.x hosts, use the patched Node 22
+LTS release pinned in `.nvmrc` (`22.23.1` at the time of writing) or a later
+patched 22.x release. CI runs the full toolchain on Node.js 22.23.1, 24, and 26.
 
 ```bash
 corepack enable pnpm

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 [![npm](https://img.shields.io/npm/v/@backblaze-labs/b2-mcp?color=cb3837)](https://www.npmjs.com/package/@backblaze-labs/b2-mcp)
 [![License: MIT](https://img.shields.io/badge/license-MIT-blue.svg)](LICENSE)
 [![TypeScript](https://img.shields.io/badge/TypeScript-6.x-3178c6?logo=typescript&logoColor=white)](https://www.typescriptlang.org/)
-[![Node.js](https://img.shields.io/badge/Node.js-%E2%89%A522.3-339933?logo=nodedotjs&logoColor=white)](https://nodejs.org/)
+[![Node.js](https://img.shields.io/badge/Node.js-22.3%2B%20%7C%2024%20%7C%2026-339933?logo=nodedotjs&logoColor=white)](https://nodejs.org/)
 [![MCP](https://img.shields.io/badge/MCP-2026--07--28-5b5fc7)](https://modelcontextprotocol.io/specification/2026-07-28)
 [![Coverage floors](https://img.shields.io/badge/coverage-S%2090.5%20%7C%20B%2081.8%20%7C%20F%2094.6%20%7C%20L%2093.8-brightgreen)](docs/TESTING.md)
 [![Runtime dependencies](https://img.shields.io/badge/runtime_dependencies-9-blue)](package-budget.json)
@@ -29,7 +29,7 @@ Destructive actions are gated, durable B2 secrets stay out of the model's contex
 
 ## Quick start
 
-**Prerequisites:** A supported [Node.js](https://nodejs.org) runtime (22.23.1+, or 24 / 26) and a Backblaze B2 [application key](https://www.backblaze.com/docs/cloud-storage-application-keys). A non-master key is all you need. The package engine floor is `>=22.3.0`; CI runs on Node.js 22.23.1, 24, and 26.
+**Prerequisites:** A supported [Node.js](https://nodejs.org) runtime (22.23.1+, or 24 / 26) and a Backblaze B2 [application key](https://www.backblaze.com/docs/cloud-storage-application-keys). A non-master key is all you need. The package engine range is `^22.3.0 || ^24 || ^26`; CI runs on Node.js 22.23.1, 24, and 26.
 
 The canonical package name is `@backblaze-labs/b2-mcp` and the canonical binary is `b2-mcp` (`b2-mcp-server` is a transition alias). The fastest setup runs it with `npx`, no clone or build.
 

--- a/deploy/vercel/README.md
+++ b/deploy/vercel/README.md
@@ -56,13 +56,14 @@ keeps Fluid Compute enabled, sets a bounded function duration, selects `iad1`,
 and rewrites `/mcp` to the API function. The checked-in JavaScript API files are
 thin launchers; the `vercel-build` hook runs repository typecheck/build and
 compiles the typed Vercel adapter sources into `.vercel/build-runtime/` before
-`@vercel/node` traces functions. The package engine range remains `>=22.3.0`
-for consumers, while `vercel.json` explicitly pins the deployed Vercel Function
-runtime to the reviewed `nodejs24.x` line. This intentionally moves the Vercel
-deployment from the older Node 22 function runtime to the reviewed Node 24
-line; CI fails if generated `.vercel/output` runtime configs do not match that
-pin. Change the region only after reviewing latency to your B2 account region;
-Vercel function region selection does not change B2 data residency.
+`@vercel/node` traces functions. The package engine range is
+`^22.3.0 || ^24 || ^26`, while `vercel.json` explicitly pins the deployed
+Vercel Function runtime to the reviewed `nodejs24.x` line. This intentionally
+moves the Vercel deployment from the older Node 22 function runtime to the
+reviewed Node 24 line; CI fails if generated `.vercel/output` runtime configs do
+not match that pin. Change the region only after reviewing latency to your B2
+account region; Vercel function region selection does not change B2 data
+residency.
 
 [![Deploy with Vercel](https://vercel.com/button)](https://vercel.com/new/clone?repository-url=https://github.com/backblaze-labs/b2-mcp&env=B2_HTTP_CREDENTIAL_MODE,B2_APPLICATION_KEY_ID,B2_APPLICATION_KEY,B2_ALLOWED_HOSTS,B2_DESTRUCTIVE_POLICY,B2_REGISTER_ALL_TOOLS,B2_ALLOW_LOCAL_FILES,B2_MCP_OUTPUT_FORMAT,B2_MCP_PUBLIC_URL,B2_OAUTH_ISSUER,B2_OAUTH_AUTHORIZATION_ENDPOINT,B2_OAUTH_TOKEN_ENDPOINT,B2_OAUTH_INTROSPECTION_ENDPOINT,B2_OAUTH_JWKS_URI,B2_OAUTH_JWKS_CACHE_TTL_SECONDS,B2_OAUTH_RESOURCE,B2_OAUTH_AUDIENCE,B2_OAUTH_ALLOWED_SUBJECTS,B2_OAUTH_INTROSPECTION_CLIENT_ID,B2_OAUTH_INTROSPECTION_CLIENT_SECRET&envDescription=Production-only%20B2%20credentials%20and%20OAuth%20resource-server%20settings.%20Never%20put%20secret%20values%20in%20Preview%20or%20URL%20query%20strings.)
 

--- a/docs/DEPLOY.md
+++ b/docs/DEPLOY.md
@@ -12,9 +12,9 @@ Provider guides link back to that file instead of repeating credential,
 rotation, CI secret, teardown, health-check, and smoke-test policy.
 
 Supported Node.js runtimes are the repository runtimes, not provider defaults:
-Node.js `22.23.1`, Node.js `24`, and Node.js `26`. Do not add Node 18 or Node
-20 support. The package engine floor remains `>=22.3.0` for consumer
-compatibility, and release/build examples use
+Node.js `22.23.1`, Node.js `24`, and Node.js `26`. Do not add Node 18, 20, 23,
+or 25 support. The package engine range is `^22.3.0 || ^24 || ^26`, and
+release/build examples use
 `pnpm@11.20.0+sha256.34e198cb1e43237517ecedfd31f9ae26a6c0a3e5366ce58a2d05f4b21fb5f19a`.
 
 ## Support Levels

--- a/docs/V1_SCOPE.md
+++ b/docs/V1_SCOPE.md
@@ -28,10 +28,11 @@ In scope for Phase 1:
 - Customer-operated MCP OAuth resource-server integration.
 - Deterministic tool-profile contracts for the full, default, and read-only
   profiles.
-- A Node.js `>=22.3.0` package engine floor matching the official B2 SDK, with
-  deterministic CI evidence on Node.js 22.23.1, 24, and 26, live B2 evidence on
-  Node.js 22.23.1, 24, and 26, plus packed-package smoke coverage on the Node.js
-  22.3.0 engine floor.
+- A Node.js package engine range of `^22.3.0 || ^24 || ^26`, preserving the
+  official B2 SDK's `>=22.3.0` floor while matching opossum's supported Node.js
+  lines, with deterministic CI evidence on Node.js 22.23.1, 24, and 26, live B2
+  evidence on Node.js 22.23.1, 24, and 26, plus packed-package smoke coverage on
+  the Node.js 22.3.0 engine floor.
 - Release, package, CI, protocol, security, and reference-deployment work needed
   to ship `v0.1.0`.
 
@@ -85,12 +86,13 @@ metadata.
 
 Inherited values from the incoming project must be treated as pre-Phase-1
 history. Release work must keep visible metadata aligned with the canonical
-`@backblaze-labs/b2-mcp`, `0.1.0`, and Node.js `>=22.3.0` contract before `v0.1.0`
-is released.
+`@backblaze-labs/b2-mcp`, `0.1.0`, and Node.js `^22.3.0 || ^24 || ^26` contract
+before `v0.1.0` is released.
 
 ## Runtime
 
-Node.js `>=22.3.0` is the package engine floor for Phase 1.
+Node.js `^22.3.0 || ^24 || ^26` is the package engine range for Phase 1. Node.js
+22.3.0 remains the minimum 22.x engine floor.
 
 CI must continuously verify production dependency installation and the full
 implementation, tests, and package toolchain on Node.js 22.23.1, 24, and 26.

--- a/docs/deployment/vercel.md
+++ b/docs/deployment/vercel.md
@@ -39,9 +39,9 @@ compatibility path, Pino, timers, and shared HTTP code. The checked-in
 `api/*.js` files are thin launchers; the package `vercel-build` hook runs
 repository `typecheck`/`build` and compiles `deploy/vercel/**/*.ts` plus `src/`
 into `.vercel/build-runtime/` before `@vercel/node` traces functions. The
-package engine range remains `>=22.3.0` for consumers; the Vercel builder
-config explicitly pins the deployed Function runtime to `nodejs24.x`. This is
-an intentional move from the previous Vercel Node 22 function runtime to
+package engine range is `^22.3.0 || ^24 || ^26`; the Vercel builder config
+explicitly pins the deployed Function runtime to `nodejs24.x`. This is an
+intentional move from the previous Vercel Node 22 function runtime to
 Vercel's reviewed Node 24 line, and CI fails if the generated `.vercel/output`
 Function runtime changes before the pin and allowed runtime set are reviewed.
 Import the repository into Vercel and keep the project framework setting

--- a/package.json
+++ b/package.json
@@ -127,7 +127,7 @@
     "wrangler": "4.123.0"
   },
   "engines": {
-    "node": ">=22.3.0"
+    "node": "^22.3.0 || ^24 || ^26"
   },
   "files": [
     ".dockerignore",

--- a/runtime-policy.json
+++ b/runtime-policy.json
@@ -1,4 +1,5 @@
 {
+  "engineRange": "^22.3.0 || ^24 || ^26",
   "engineFloor": ">=22.3.0",
   "runtimeInstallNode": "22.23.1",
   "minimumEvidenceNode": "22.23.1",

--- a/scripts/check-runtime-policy.mjs
+++ b/scripts/check-runtime-policy.mjs
@@ -5,7 +5,9 @@ import path from "node:path";
 import { fileURLToPath } from "node:url";
 import workflowYaml from "./lib/workflow-yaml.cjs";
 
-const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
+const root = process.env.B2_MCP_RUNTIME_POLICY_ROOT
+  ? path.resolve(process.env.B2_MCP_RUNTIME_POLICY_ROOT)
+  : path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
 const require = createRequire(import.meta.url);
 const { readPackageManagerLock } = require("./lib/pnpm-lock.cjs");
 const errors = [];
@@ -70,6 +72,25 @@ function parseNodeVersion(value) {
   };
 }
 
+function parseEngineRangeMinimums(value) {
+  return String(value)
+    .split(/\s*\|\|\s*/)
+    .map((part) => {
+      const match = part.match(/^\^(\d+)(?:\.(\d+)\.(\d+))?$/);
+      if (!match) return null;
+      const major = Number(match[1]);
+      const minor = match[2] === undefined ? null : Number(match[2]);
+      const patch = match[3] === undefined ? null : Number(match[3]);
+      return {
+        major,
+        minor,
+        patch,
+        raw: minor === null || patch === null ? String(major) : `${major}.${minor}.${patch}`,
+      };
+    })
+    .filter(Boolean);
+}
+
 function comparePatch(a, b) {
   const left = parseNodeVersion(a);
   const right = parseNodeVersion(b);
@@ -80,6 +101,18 @@ function comparePatch(a, b) {
     if (left[key] !== right[key]) return left[key] - right[key];
   }
   return 0;
+}
+
+function isSupportedWorkflowNodeVersion(version, policy) {
+  const parsed = parseNodeVersion(version);
+  if (!parsed) return true;
+  const minimum = parseEngineRangeMinimums(policy.engineRange).find(
+    (candidate) => candidate.major === parsed.major,
+  );
+  if (!minimum) return false;
+  if (minimum.minor === null || minimum.patch === null) return true;
+  if (parsed.minor === null || parsed.patch === null) return false;
+  return comparePatch(parsed.raw, minimum.raw) >= 0;
 }
 
 function requireNode22LtsPatch(label, version, policy) {
@@ -130,8 +163,7 @@ function parseEnvironmentNodeVersion() {
   return match?.[1] ?? null;
 }
 
-function requireNoLegacyRuntimeJobs(policy) {
-  const unsupported = new Set(policy.unsupportedMajors.map(String));
+function requireSupportedRuntimeJobs(policy) {
   for (const workflow of listFiles(".github/workflows")) {
     const text = read(workflow);
     if (text.includes("node-version-file:")) fail(`${workflow}: node-version-file is not allowed`);
@@ -140,8 +172,10 @@ function requireNoLegacyRuntimeJobs(policy) {
     );
     for (const version of versions) {
       const parsed = parseNodeVersion(version);
-      if (parsed && unsupported.has(String(parsed.major))) {
-        fail(`${workflow}: unsupported Node ${parsed.major} is present`);
+      if (parsed && !isSupportedWorkflowNodeVersion(version, policy)) {
+        fail(
+          `${workflow}: unsupported Node ${parsed.raw} is present; expected ${policy.engineRange}`,
+        );
       }
     }
   }
@@ -243,7 +277,7 @@ requireWorkflowMatrixInJob(
   "node-version",
   policy.liveNodeMatrix,
 );
-requireNoLegacyRuntimeJobs(policy);
+requireSupportedRuntimeJobs(policy);
 
 for (const workflow of [".github/workflows/contract.yml", ".github/workflows/smoke.yml"]) {
   requireWorkflowScalar(workflow, "max-parallel", "1", "live matrix serialization");
@@ -253,6 +287,9 @@ requireContains("docs/V1_SCOPE.md", policy.engineRange, "package engine range");
 requireContains("docs/V1_SCOPE.md", policy.engineFloor, "runtime floor");
 requireContains("README.md", policy.engineRange, "package engine range");
 requireContains("CONTRIBUTING.md", policy.engineRange, "package engine range");
+requireContains("docs/DEPLOY.md", policy.engineRange, "package engine range");
+requireContains("docs/deployment/vercel.md", policy.engineRange, "package engine range");
+requireContains("deploy/vercel/README.md", policy.engineRange, "package engine range");
 requireContains("docs/DEPLOY.md", policy.crossPlatformNode, "patched Node 22 pin");
 requireContains("README.md", policy.crossPlatformNode, "patched Node 22 pin");
 requireContains("CONTRIBUTING.md", policy.crossPlatformNode, "patched Node 22 pin");

--- a/scripts/check-runtime-policy.mjs
+++ b/scripts/check-runtime-policy.mjs
@@ -77,7 +77,14 @@ function parseEngineRangeMinimums(value) {
     .split(/\s*\|\|\s*/)
     .map((part) => {
       const match = part.match(/^\^(\d+)(?:\.(\d+)\.(\d+))?$/);
-      if (!match) return null;
+      if (!match) {
+        // Fail loud rather than silently dropping a comparator: the parser only
+        // understands caret ranges, so any other form must surface as an error
+        // instead of quietly shrinking the supported-major set.
+        throw new Error(
+          `Unsupported engineRange comparator ${JSON.stringify(part)} in ${JSON.stringify(String(value))}; expected caret ranges like "^22.3.0" or "^24"`,
+        );
+      }
       const major = Number(match[1]);
       const minor = match[2] === undefined ? null : Number(match[2]);
       const patch = match[3] === undefined ? null : Number(match[3]);
@@ -87,8 +94,7 @@ function parseEngineRangeMinimums(value) {
         patch,
         raw: minor === null || patch === null ? String(major) : `${major}.${minor}.${patch}`,
       };
-    })
-    .filter(Boolean);
+    });
 }
 
 function comparePatch(a, b) {
@@ -104,8 +110,11 @@ function comparePatch(a, b) {
 }
 
 function isSupportedWorkflowNodeVersion(version, policy) {
+  // Fail closed: callers pre-filter non-literal tokens (e.g. `${{ ... }}`
+  // expressions parse to null and are skipped), so anything that reaches here
+  // and does not parse as a concrete version is treated as unsupported.
   const parsed = parseNodeVersion(version);
-  if (!parsed) return true;
+  if (!parsed) return false;
   const minimum = parseEngineRangeMinimums(policy.engineRange).find(
     (candidate) => candidate.major === parsed.major,
   );

--- a/scripts/check-runtime-policy.mjs
+++ b/scripts/check-runtime-policy.mjs
@@ -151,8 +151,8 @@ const policy = readJson("runtime-policy.json");
 const packageJson = readJson("package.json");
 const lock = readPackageManagerLock(root);
 
-requireEqual("package.json engines.node", packageJson.engines?.node, policy.engineFloor);
-requireEqual("pnpm lock root engines.node", lock.packages?.[""]?.engines?.node, policy.engineFloor);
+requireEqual("package.json engines.node", packageJson.engines?.node, policy.engineRange);
+requireEqual("pnpm lock root engines.node", lock.packages?.[""]?.engines?.node, policy.engineRange);
 requireEqual(
   "Backblaze SDK engine floor",
   lock.packages?.["node_modules/@backblaze-labs/b2-sdk"]?.engines?.node,
@@ -249,7 +249,10 @@ for (const workflow of [".github/workflows/contract.yml", ".github/workflows/smo
   requireWorkflowScalar(workflow, "max-parallel", "1", "live matrix serialization");
 }
 
+requireContains("docs/V1_SCOPE.md", policy.engineRange, "package engine range");
 requireContains("docs/V1_SCOPE.md", policy.engineFloor, "runtime floor");
+requireContains("README.md", policy.engineRange, "package engine range");
+requireContains("CONTRIBUTING.md", policy.engineRange, "package engine range");
 requireContains("docs/DEPLOY.md", policy.crossPlatformNode, "patched Node 22 pin");
 requireContains("README.md", policy.crossPlatformNode, "patched Node 22 pin");
 requireContains("CONTRIBUTING.md", policy.crossPlatformNode, "patched Node 22 pin");

--- a/scripts/packed-consumer-smoke.mjs
+++ b/scripts/packed-consumer-smoke.mjs
@@ -717,7 +717,7 @@ try {
         "  try { require.resolve(legacyPackage, { paths: [packageRoot] }); throw new Error(`${legacyPackage} should not be installed`); }",
         '  catch (err) { if (err.code !== "MODULE_NOT_FOUND") throw err; }',
         "}",
-        `if (meta.engines.node !== ${JSON.stringify(runtimePolicy.engineFloor)}) throw new Error("wrong package engine");`,
+        `if (meta.engines.node !== ${JSON.stringify(runtimePolicy.engineRange)}) throw new Error("wrong package engine");`,
         'if (meta.bin["b2-mcp"] !== "dist/index.js") throw new Error("wrong b2-mcp bin");',
         'if (meta.bin["b2-mcp-server"] !== "dist/index.js") throw new Error("wrong b2-mcp-server bin");',
         'for (const requiredDoc of ["docs/CLIENTS.md", "docs/DEPLOY.md"]) {',

--- a/scripts/verify-release-input.mjs
+++ b/scripts/verify-release-input.mjs
@@ -50,12 +50,13 @@ function parseArgs(argv) {
   return { tag };
 }
 
-function packageJson(root) {
-  return JSON.parse(readFileSync(path.join(root, "package.json"), "utf8"));
+function readJson(root, relativePath) {
+  return JSON.parse(readFileSync(path.join(root, relativePath), "utf8"));
 }
 
 export function verifyReleaseInput(root, tag) {
-  const pkg = packageJson(root);
+  const pkg = readJson(root, "package.json");
+  const runtimePolicy = readJson(root, "runtime-policy.json");
   const expectedTag = `v${pkg.version}`;
 
   assert(tag === expectedTag, `release tag ${tag} does not match package version ${pkg.version}`);
@@ -66,8 +67,8 @@ export function verifyReleaseInput(root, tag) {
   assert(pkg.bugs?.url === canonicalIssues, "package bugs URL is not canonical");
   assert(pkg.homepage === canonicalHomepage, "package homepage is not canonical");
   assert(
-    pkg.engines?.node === "^22.3.0 || ^24 || ^26",
-    "package engine range must be ^22.3.0 || ^24 || ^26",
+    pkg.engines?.node === runtimePolicy.engineRange,
+    `package engine range must be ${runtimePolicy.engineRange}`,
   );
   assert(pkg.bin?.["b2-mcp"] === "dist/index.js", "missing b2-mcp executable");
   assert(pkg.bin?.["b2-mcp-server"] === "dist/index.js", "missing b2-mcp-server alias");

--- a/scripts/verify-release-input.mjs
+++ b/scripts/verify-release-input.mjs
@@ -65,7 +65,10 @@ export function verifyReleaseInput(root, tag) {
   assert(pkg.repository?.url === canonicalRepository, "package repository URL is not canonical");
   assert(pkg.bugs?.url === canonicalIssues, "package bugs URL is not canonical");
   assert(pkg.homepage === canonicalHomepage, "package homepage is not canonical");
-  assert(pkg.engines?.node === ">=22.3.0", "package engine floor must be >=22.3.0");
+  assert(
+    pkg.engines?.node === "^22.3.0 || ^24 || ^26",
+    "package engine range must be ^22.3.0 || ^24 || ^26",
+  );
   assert(pkg.bin?.["b2-mcp"] === "dist/index.js", "missing b2-mcp executable");
   assert(pkg.bin?.["b2-mcp-server"] === "dist/index.js", "missing b2-mcp-server alias");
   for (const file of requiredFiles) {

--- a/tests/contract/readme-drift.contract.test.ts
+++ b/tests/contract/readme-drift.contract.test.ts
@@ -76,7 +76,7 @@ describe("README project badges", () => {
     const dependencyCount = Object.keys(packageMetadata.dependencies).length;
 
     expect(packageMetadata.name).toBe("@backblaze-labs/b2-mcp");
-    expect(packageMetadata.engines.node).toBe(">=22.3.0");
+    expect(packageMetadata.engines.node).toBe("^22.3.0 || ^24 || ^26");
     // Intentional overlap with typescript-7-migration: this guard owns README
     // badge sync, while the migration test owns the 6.0-line deferral record.
     expect(packageMetadata.devDependencies.typescript).toMatch(/^~6\./);
@@ -85,7 +85,7 @@ describe("README project badges", () => {
     expect(readme).toContain("npm/v/@backblaze-labs/b2-mcp");
     expect(readme).toContain(`license-${packageMetadata.license}-blue.svg`);
     expect(readme).toContain("TypeScript-6.x-3178c6");
-    expect(readme).toContain("Node.js-%E2%89%A522.3-339933");
+    expect(readme).toContain("Node.js-22.3%2B%20%7C%2024%20%7C%2026-339933");
     expect(readme).toContain("MCP-2026--07--28-5b5fc7");
     expect(readme).toContain(`runtime_dependencies-${dependencyCount}-blue`);
   });

--- a/tests/contract/sdk-adoption.contract.test.ts
+++ b/tests/contract/sdk-adoption.contract.test.ts
@@ -81,8 +81,8 @@ function matrixRows(
 }
 
 function parseFloor(value: string): [number, number, number] {
-  const match = value.match(/^>=(\d+)\.(\d+)\.(\d+)$/);
-  if (!match) throw new Error(`Unsupported engine floor: ${value}`);
+  const match = value.match(/^(?:>=|\^)(\d+)\.(\d+)\.(\d+)(?:\s|\||$)/);
+  if (!match) throw new Error(`Unsupported engine floor/range: ${value}`);
   return [Number(match[1]), Number(match[2]), Number(match[3])];
 }
 

--- a/tests/contract/sdk-adoption.contract.test.ts
+++ b/tests/contract/sdk-adoption.contract.test.ts
@@ -80,28 +80,12 @@ function matrixRows(
   return rows;
 }
 
-function parseFloor(value: string): [number, number, number] {
-  const match = value.match(/^(?:>=|\^)(\d+)\.(\d+)\.(\d+)(?:\s|\||$)/);
-  if (!match) throw new Error(`Unsupported engine floor/range: ${value}`);
-  return [Number(match[1]), Number(match[2]), Number(match[3])];
-}
-
-function compareFloor(a: string, b: string): number {
-  const left = parseFloor(a);
-  const right = parseFloor(b);
-  for (let i = 0; i < left.length; i++) {
-    if (left[i] !== right[i]) return left[i] - right[i];
-  }
-  return 0;
-}
-
 describe("SDK adoption contract", () => {
   const contract = readFileSync(join(ROOT, "docs/SDK_ADOPTION_CONTRACT.md"), "utf8");
 
   it("pins the reviewed Backblaze SDK package exactly", () => {
     const pkg = readJson<{
       dependencies: Record<string, string>;
-      engines: { node: string };
     }>("package.json");
     const lock = readLock<{
       packages: Record<
@@ -115,7 +99,6 @@ describe("SDK adoption contract", () => {
     expect(sdk?.version).toBe(SDK_VERSION);
     expect(sdk?.resolved).toBe(SDK_RESOLVED);
     expect(sdk?.integrity).toBe(SDK_INTEGRITY);
-    expect(compareFloor(pkg.engines.node, sdk?.engines?.node ?? "")).toBeGreaterThanOrEqual(0);
   });
 
   it("has rows for every registered tool and only approved sink-blocked extras", () => {

--- a/tests/unit/package-surface-policy.unit.test.ts
+++ b/tests/unit/package-surface-policy.unit.test.ts
@@ -409,7 +409,7 @@ describe("package surface policy", () => {
         '      version: "0.1.0",',
         '      main: "dist/index.js",',
         '      bin: { "b2-mcp": "dist/index.js", "b2-mcp-server": "dist/index.js" },',
-        '      engines: { node: ">=22.3.0" }',
+        '      engines: { node: "^22.3.0 || ^24 || ^26" }',
         "    }),",
         "  );",
         '  fs.writeFileSync(path.join(packageRoot, "docs", "CLIENTS.md"), "# Clients\\n");',

--- a/tests/unit/release-scripts.unit.test.ts
+++ b/tests/unit/release-scripts.unit.test.ts
@@ -28,7 +28,7 @@ function withFixture(run: (fixtureRoot: string) => void): void {
           },
           bugs: { url: "https://github.com/backblaze-labs/b2-mcp/issues" },
           homepage: "https://github.com/backblaze-labs/b2-mcp#readme",
-          engines: { node: ">=22.3.0" },
+          engines: { node: "^22.3.0 || ^24 || ^26" },
           bin: { "b2-mcp": "dist/index.js", "b2-mcp-server": "dist/index.js" },
           files: [
             "dist/**/*",

--- a/tests/unit/release-scripts.unit.test.ts
+++ b/tests/unit/release-scripts.unit.test.ts
@@ -65,6 +65,10 @@ function withFixture(run: (fixtureRoot: string) => void): void {
         "",
       ].join("\n"),
     );
+    writeFileSync(
+      join(fixtureRoot, "runtime-policy.json"),
+      JSON.stringify({ engineRange: "^22.3.0 || ^24 || ^26" }, null, 2),
+    );
     run(fixtureRoot);
   } finally {
     rmSync(fixtureRoot, { recursive: true, force: true });

--- a/tests/unit/runtime-policy.unit.test.ts
+++ b/tests/unit/runtime-policy.unit.test.ts
@@ -1,0 +1,202 @@
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "fs";
+import { tmpdir } from "os";
+import { dirname, join } from "path";
+import { spawnSync } from "child_process";
+
+const root = join(__dirname, "../..");
+
+function writeFixtureFile(fixtureRoot: string, relativePath: string, contents: string): void {
+  const absolutePath = join(fixtureRoot, relativePath);
+  mkdirSync(dirname(absolutePath), { recursive: true });
+  writeFileSync(absolutePath, contents);
+}
+
+function withRuntimePolicyFixture(run: (fixtureRoot: string) => void): void {
+  const fixtureRoot = mkdtempSync(join(tmpdir(), "b2-mcp-runtime-policy-"));
+  const packageManager = "pnpm@11.20.0+sha256.test";
+
+  try {
+    writeFixtureFile(
+      fixtureRoot,
+      "package.json",
+      JSON.stringify(
+        {
+          name: "@backblaze-labs/b2-mcp",
+          version: "0.1.0",
+          packageManager,
+          engines: { node: "^22.3.0 || ^24 || ^26" },
+          dependencies: { "@backblaze-labs/b2-sdk": "0.3.0" },
+          devDependencies: { "@types/node": "22.3.0" },
+        },
+        null,
+        2,
+      ),
+    );
+    writeFixtureFile(
+      fixtureRoot,
+      "runtime-policy.json",
+      JSON.stringify(
+        {
+          engineRange: "^22.3.0 || ^24 || ^26",
+          engineFloor: ">=22.3.0",
+          runtimeInstallNode: "22.23.1",
+          minimumEvidenceNode: "22.23.1",
+          node22LtsMinimum: "22.11.0",
+          node22Pinned: "22.23.1",
+          deterministicLinuxMatrix: ["22.23.1", "24", "26"],
+          crossPlatformNode: "22.23.1",
+          liveNodeMatrix: ["22.23.1", "24", "26"],
+          unsupportedMajors: [18, 20],
+          typesNodeVersion: "22.3.0",
+        },
+        null,
+        2,
+      ),
+    );
+    writeFixtureFile(fixtureRoot, ".nvmrc", "22.23.1\n");
+    writeFixtureFile(
+      fixtureRoot,
+      "environment.yml",
+      "name: b2-mcp-test\ndependencies:\n  - nodejs=22.23.1=h35957e4_0\n",
+    );
+    writeFixtureFile(
+      fixtureRoot,
+      "pnpm-lock.yaml",
+      [
+        "lockfileVersion: '9.0'",
+        "",
+        "importers:",
+        "",
+        "  .:",
+        "    dependencies:",
+        "      '@backblaze-labs/b2-sdk':",
+        "        specifier: 0.3.0",
+        "        version: 0.3.0",
+        "    devDependencies:",
+        "      '@types/node':",
+        "        specifier: 22.3.0",
+        "        version: 22.3.0",
+        "",
+        "packages:",
+        "",
+        "  '@backblaze-labs/b2-sdk@0.3.0':",
+        "    resolution: {integrity: sha512-test}",
+        "    engines: {node: '>=22.3.0'}",
+        "",
+        "  '@types/node@22.3.0':",
+        "    resolution: {integrity: sha512-test}",
+        "",
+        "snapshots:",
+        "",
+        "  '@backblaze-labs/b2-sdk@0.3.0': {}",
+        "",
+        "  '@types/node@22.3.0': {}",
+        "",
+      ].join("\n"),
+    );
+    writeFixtureFile(
+      fixtureRoot,
+      ".github/workflows/test.yml",
+      [
+        "jobs:",
+        "  format-lint-typecheck:",
+        "    steps:",
+        "      - with:",
+        "          node-version: 22.23.1",
+        "      - run: pnpm run verify",
+        "  package-install-smoke:",
+        "    steps:",
+        "      - with:",
+        "          node-version: 22.23.1",
+        '      - run: node scripts/packed-consumer-smoke.mjs --tarball "$tarball"',
+        "  runtime-engine-floor:",
+        "    steps:",
+        "      - with:",
+        "          node-version: 22.3.0",
+        "  unit-coverage-matrix:",
+        "    strategy:",
+        "      matrix:",
+        "        node-version: [22.23.1, 24, 26]",
+        "  production-dependency-audit-matrix:",
+        "    strategy:",
+        "      matrix:",
+        "        node-version: [22.23.1, 24, 26]",
+        "  cross-platform-minimum-matrix:",
+        "    strategy:",
+        "      matrix:",
+        "        os: [ubuntu-latest, windows-latest, macos-latest]",
+        "    steps:",
+        "      - with:",
+        "          node-version: 22.23.1",
+        "  unsupported-node-23:",
+        "    steps:",
+        "      - with:",
+        "          node-version: 23",
+        "  unsupported-node-25:",
+        "    steps:",
+        "      - with:",
+        "          node-version: 25.9.0",
+        "",
+      ].join("\n"),
+    );
+    for (const [workflow, jobName] of [
+      [".github/workflows/contract.yml", "contract"],
+      [".github/workflows/smoke.yml", "smoke"],
+    ]) {
+      writeFixtureFile(
+        fixtureRoot,
+        workflow,
+        [
+          "jobs:",
+          `  ${jobName}:`,
+          "    strategy:",
+          "      max-parallel: 1",
+          "      matrix:",
+          "        node-version: [22.23.1, 24, 26]",
+          "",
+        ].join("\n"),
+      );
+    }
+    writeFixtureFile(
+      fixtureRoot,
+      "README.md",
+      `^22.3.0 || ^24 || ^26\n22.23.1\n${packageManager}\n`,
+    );
+    writeFixtureFile(
+      fixtureRoot,
+      "CONTRIBUTING.md",
+      `^22.3.0 || ^24 || ^26\n22.23.1\n${packageManager}\n`,
+    );
+    writeFixtureFile(fixtureRoot, "docs/V1_SCOPE.md", "^22.3.0 || ^24 || ^26\n>=22.3.0\n");
+    writeFixtureFile(
+      fixtureRoot,
+      "docs/DEPLOY.md",
+      `^22.3.0 || ^24 || ^26\n22.23.1\n${packageManager}\n`,
+    );
+    writeFixtureFile(fixtureRoot, "docs/deployment/vercel.md", "^22.3.0 || ^24 || ^26\n");
+    writeFixtureFile(fixtureRoot, "deploy/vercel/README.md", "^22.3.0 || ^24 || ^26\n");
+    writeFixtureFile(fixtureRoot, "RELEASE.md", "22.23.1\n");
+    writeFixtureFile(fixtureRoot, "CHANGELOG.md", "22.23.1\n");
+
+    run(fixtureRoot);
+  } finally {
+    rmSync(fixtureRoot, { recursive: true, force: true });
+  }
+}
+
+describe("runtime policy", () => {
+  it("rejects workflow Node versions outside the supported engine range", () => {
+    withRuntimePolicyFixture((fixtureRoot) => {
+      const result = spawnSync(process.execPath, ["scripts/check-runtime-policy.mjs"], {
+        cwd: root,
+        env: { ...process.env, B2_MCP_RUNTIME_POLICY_ROOT: fixtureRoot },
+        encoding: "utf8",
+      });
+
+      expect(result.status).not.toBe(0);
+      expect(result.stderr).toContain("unsupported Node 23 is present");
+      expect(result.stderr).toContain("unsupported Node 25.9.0 is present");
+      expect(result.stderr).toContain("^22.3.0 || ^24 || ^26");
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- Set `package.json` `engines.node` to `^22.3.0 || ^24 || ^26` so Node 25 is no longer implied as supported.
- Added `runtime-policy.json` `engineRange` and updated runtime, package, release, docs, and drift checks to enforce the supported 22.3+/24/26 lines.
- Tightened workflow and deployment documentation drift checks from review feedback, including fixture coverage for unsupported Node 23 and 25 workflow entries.
- Preserved the released 0.1.0 changelog history while documenting the engine-range correction under Unreleased.

## Linked issue
Closes #204

## Tests run
- `pnpm run check:runtime-policy`
- `pnpm exec vitest run tests/unit/runtime-policy.unit.test.ts tests/unit/release-scripts.unit.test.ts tests/contract/sdk-adoption.contract.test.ts tests/contract/readme-drift.contract.test.ts`
- `pnpm run typecheck`
- `pnpm run test:package`
- `pnpm run format:check`
- `pnpm run lint` (passes with an existing warning in `src/oauth-resource-server.ts`)
- `pnpm run lint:docs`
- `pnpm run spell`

## Follow-up notes
- None.
