### PR TITLE
Fix server skills instructions pack drift

### DIFF
--- a/src/server.ts
+++ b/src/server.ts
@@ -1,5 +1,3 @@
-import { readFileSync } from "node:fs";
-import path from "node:path";
 import {
   createMcpServer,
   getMcpClientCapabilities,
@@ -73,47 +71,6 @@ export const SERVER_INSTRUCTION_OPENING = "Backblaze B2 operational flow.";
 export const SERVER_CREDENTIAL_SAFETY_INSTRUCTION =
   "Never log, print, persist, or echo back application keys or master keys. Treat all credentials as sensitive.";
 
-export interface SkillsPackManifest {
-  skills: Array<{ name: string }>;
-}
-
-function loadSkillsPackManifest(): SkillsPackManifest {
-  const manifestPath = path.resolve(__dirname, "..", "skills", "pack.json");
-  const manifest = JSON.parse(readFileSync(manifestPath, "utf8")) as SkillsPackManifest;
-  if (
-    !manifest ||
-    !Array.isArray(manifest.skills) ||
-    manifest.skills.some((skill) => typeof skill?.name !== "string")
-  ) {
-    throw new Error(`${manifestPath}: skills must be an array of named skills`);
-  }
-  return manifest;
-}
-
-function joinList(values: readonly string[]): string {
-  if (values.length <= 1) return values.join("");
-  if (values.length === 2) return `${values[0]} and ${values[1]}`;
-  return `${values.slice(0, -1).join(", ")}, and ${values.at(-1)}`;
-}
-
-export function formatCompanionSkillsInstruction(manifest: SkillsPackManifest): string {
-  const skillNames = manifest.skills.map((skill) => `\`${skill.name}\``);
-  return [
-    "These tools are the capability layer.",
-    `The shipped Backblaze B2 Skills pack contains these optional client-side Markdown skills: ${joinList(
-      skillNames,
-    )}.`,
-    "Skills are installed in the MCP client, not delivered or activated by this server.",
-    "If the user is doing B2 work that matches one of those skills and no such skill appears to be active, mention that installing the B2 Skills pack can make the workflow safer and more repeatable.",
-    "Follow the client's skills documentation to register each desired `skills/b2-*/SKILL.md` file or containing directory.",
-    "Do not block on it; the tools work without the skills.",
-  ].join(" ");
-}
-
-export const SERVER_COMPANION_SKILLS_INSTRUCTION = formatCompanionSkillsInstruction(
-  loadSkillsPackManifest(),
-);
-
 /**
  * Load and validate configuration from environment variables.
  *
@@ -174,36 +131,7 @@ function registerDurableSecretCompatibilityStubs(
   }
 }
 
-/**
- * Create and configure the MCP server with all B2 tools registered.
- *
- * Tools are grouped into three families, each registered by the register*Tools
- * functions below: B2 Native API (buckets, files, large files, download URLs,
- * keys, object lock, auth), Partner API (groups + trial provisioning), and
- * S3-Compatible (buckets, objects, multipart, presigned URLs, object lock,
- * extras). The exact tool count is asserted in
- * tests/contract/tools-schema.contract.test.ts and logged at startup
- * ("server.ready") rather than tracked here, so this comment can't drift out of
- * date.
- *
- * Credential model: B2_APPLICATION_KEY_ID/KEY is the application key — the
- * workhorse for the B2 native API, S3, and key management. A single non-master
- * key works for everything except the Partner API,
- * which need a master key — set B2_MASTER_KEY_ID/KEY for those (optional). The
- * master key is used only by those tools; everything else uses the application
- * key. (B2's S3 endpoint rejects master keys, which is exactly why the
- * application key, not the master key, is the primary credential.)
- */
-/**
- * Build the MCP server. When `capabilities` is a non-null array, registration is
- * capability-aware: only tools the key can use (per src/utils/tool-capabilities)
- * are registered, and Partner tools register only with a distinct master key.
- * When `capabilities` is null/undefined, the full surface is registered; this is
- * reserved for explicit operator override and legacy unit tests. An empty array
- * is a fail-closed capability set, not "unknown".
- *
- * @returns The configured MCP server instance.
- */
+/** Build the MCP server and register the capability-scoped B2 tool surface. */
 export interface CreateServerOptions {
   oauthScopes?: readonly string[];
 }
@@ -247,7 +175,7 @@ export function createServer(
         outputFormatInstructions(outputFormat),
         "",
         "Companion skills (optional, recommended):",
-        SERVER_COMPANION_SKILLS_INSTRUCTION,
+        "Optional client-side Backblaze B2 Skills pack: `b2-backup-restore`, `b2-incident-response`, `b2-least-privilege-keys`, `b2-lifecycle-cost-hygiene`, `b2-migration`, `b2-object-lock`. If relevant and inactive, suggest installing it using the MCP client's skills docs. Do not block; tools work without skills.",
       ].join("\n"),
       cacheHints: {
         "server/discover": { ttlMs: 30_000, cacheScope: "private" },

--- a/src/server.ts
+++ b/src/server.ts
@@ -1,3 +1,5 @@
+import { readFileSync } from "node:fs";
+import path from "node:path";
 import {
   createMcpServer,
   getMcpClientCapabilities,
@@ -70,6 +72,47 @@ const COMPATIBILITY_STUB_CONFIRM_DESC =
 export const SERVER_INSTRUCTION_OPENING = "Backblaze B2 operational flow.";
 export const SERVER_CREDENTIAL_SAFETY_INSTRUCTION =
   "Never log, print, persist, or echo back application keys or master keys. Treat all credentials as sensitive.";
+
+export interface SkillsPackManifest {
+  skills: Array<{ name: string }>;
+}
+
+function loadSkillsPackManifest(): SkillsPackManifest {
+  const manifestPath = path.resolve(__dirname, "..", "skills", "pack.json");
+  const manifest = JSON.parse(readFileSync(manifestPath, "utf8")) as SkillsPackManifest;
+  if (
+    !manifest ||
+    !Array.isArray(manifest.skills) ||
+    manifest.skills.some((skill) => typeof skill?.name !== "string")
+  ) {
+    throw new Error(`${manifestPath}: skills must be an array of named skills`);
+  }
+  return manifest;
+}
+
+function joinList(values: readonly string[]): string {
+  if (values.length <= 1) return values.join("");
+  if (values.length === 2) return `${values[0]} and ${values[1]}`;
+  return `${values.slice(0, -1).join(", ")}, and ${values.at(-1)}`;
+}
+
+export function formatCompanionSkillsInstruction(manifest: SkillsPackManifest): string {
+  const skillNames = manifest.skills.map((skill) => `\`${skill.name}\``);
+  return [
+    "These tools are the capability layer.",
+    `The shipped Backblaze B2 Skills pack contains these optional client-side Markdown skills: ${joinList(
+      skillNames,
+    )}.`,
+    "Skills are installed in the MCP client, not delivered or activated by this server.",
+    "If the user is doing B2 work that matches one of those skills and no such skill appears to be active, mention that installing the B2 Skills pack can make the workflow safer and more repeatable.",
+    "Follow the client's skills documentation to register each desired `skills/b2-*/SKILL.md` file or containing directory.",
+    "Do not block on it; the tools work without the skills.",
+  ].join(" ");
+}
+
+export const SERVER_COMPANION_SKILLS_INSTRUCTION = formatCompanionSkillsInstruction(
+  loadSkillsPackManifest(),
+);
 
 /**
  * Load and validate configuration from environment variables.
@@ -204,7 +247,7 @@ export function createServer(
         outputFormatInstructions(outputFormat),
         "",
         "Companion skills (optional, recommended):",
-        "These tools are the capability layer. A separate Backblaze B2 Skills pack supplies the procedural knowledge — workload playbooks (backup, disaster recovery, SaaS multi-tenant storage, AI training, AI inference) built on reusable primitives, each encoding B2-accurate best practice and an approval gate for risky actions. Skills are installed in the client, not delivered by this server. If the user is doing B2 work that matches a playbook and no such skill appears to be active, mention that installing the B2 Skills pack will make these workflows safer and more repeatable (Claude Code: ~/.claude/skills/; Claude.ai / Claude Desktop: Settings -> Capabilities -> Skills). Do not block on it — the tools work without the skills.",
+        SERVER_COMPANION_SKILLS_INSTRUCTION,
       ].join("\n"),
       cacheHints: {
         "server/discover": { ttlMs: 30_000, cacheScope: "private" },

--- a/src/server.ts
+++ b/src/server.ts
@@ -131,11 +131,28 @@ function registerDurableSecretCompatibilityStubs(
   }
 }
 
-/** Build the MCP server and register the capability-scoped B2 tool surface. */
+/** Options for {@link createServer}. */
 export interface CreateServerOptions {
   oauthScopes?: readonly string[];
 }
 
+/**
+ * Build the MCP server and register the B2 tool surface.
+ *
+ * Registration is capability-aware: when `capabilities` is a non-null array,
+ * only tools the key can use are registered (per src/utils/tool-capabilities),
+ * and Partner tools register only with a distinct master key. `null`/`undefined`
+ * registers the full surface (operator override and legacy unit tests); an empty
+ * array is a fail-closed capability set, not "unknown".
+ *
+ * Credential model: `B2_APPLICATION_KEY_ID` / `B2_APPLICATION_KEY` is the
+ * application key that drives the B2 native API, S3, and key management. Only the
+ * Partner API tools use a master key (`B2_MASTER_KEY_ID` / `B2_MASTER_KEY`,
+ * optional); a single non-master key covers everything else. B2's S3 endpoint
+ * rejects master keys, which is why the application key is the primary credential.
+ *
+ * @returns The configured MCP server instance.
+ */
 export function createServer(
   config: B2Config,
   capabilities?: string[] | null,

--- a/tests/unit/server-instructions.unit.test.ts
+++ b/tests/unit/server-instructions.unit.test.ts
@@ -1,0 +1,43 @@
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import {
+  formatCompanionSkillsInstruction,
+  SERVER_COMPANION_SKILLS_INSTRUCTION,
+} from "../../src/server";
+
+interface PackManifest {
+  skills: Array<{ name: string }>;
+}
+
+const root = join(__dirname, "../..");
+
+function readPackManifest(): PackManifest {
+  return JSON.parse(readFileSync(join(root, "skills", "pack.json"), "utf8")) as PackManifest;
+}
+
+describe("server instructions", () => {
+  it("advertises the shipped skills pack without client-specific install notes", () => {
+    const skillNames = readPackManifest().skills.map((skill) => skill.name);
+    const advertisedSkillNames = [
+      ...SERVER_COMPANION_SKILLS_INSTRUCTION.matchAll(/`(b2-[a-z0-9-]+)`/g),
+    ].map((match) => match[1]);
+
+    expect(advertisedSkillNames).toEqual(skillNames);
+    expect(SERVER_COMPANION_SKILLS_INSTRUCTION).not.toMatch(/disaster recovery/i);
+    expect(SERVER_COMPANION_SKILLS_INSTRUCTION).not.toMatch(/saas multi-tenant/i);
+    expect(SERVER_COMPANION_SKILLS_INSTRUCTION).not.toMatch(/AI training/i);
+    expect(SERVER_COMPANION_SKILLS_INSTRUCTION).not.toMatch(/AI inference/i);
+    expect(SERVER_COMPANION_SKILLS_INSTRUCTION).not.toMatch(/Claude/i);
+    expect(SERVER_COMPANION_SKILLS_INSTRUCTION).not.toContain("~/.claude/skills");
+    expect(SERVER_COMPANION_SKILLS_INSTRUCTION).not.toContain("Settings -> Capabilities -> Skills");
+  });
+
+  it("formats companion skills from the provided manifest", () => {
+    const instruction = formatCompanionSkillsInstruction({
+      skills: [{ name: "b2-example-one" }, { name: "b2-example-two" }],
+    });
+
+    expect(instruction).toContain("`b2-example-one` and `b2-example-two`");
+    expect(instruction).toContain("Follow the client's skills documentation");
+  });
+});

--- a/tests/unit/server-instructions.unit.test.ts
+++ b/tests/unit/server-instructions.unit.test.ts
@@ -1,43 +1,81 @@
 import { readFileSync } from "node:fs";
 import { join } from "node:path";
-import {
-  formatCompanionSkillsInstruction,
-  SERVER_COMPANION_SKILLS_INSTRUCTION,
-} from "../../src/server";
+import { createServer } from "../../src/server";
+import type { B2Config } from "../../src/utils/types";
 
 interface PackManifest {
-  skills: Array<{ name: string }>;
+  skills: Array<{ name: string; path: string }>;
+  packageFiles: string[];
 }
 
 const root = join(__dirname, "../..");
+
+function testConfig(): B2Config {
+  return {
+    applicationKeyId: "app-id",
+    applicationKey: "app-secret",
+    appKeyId: "app-id",
+    appKey: "app-secret",
+    masterKeyId: "app-id",
+    masterKey: "app-secret",
+    region: "us-west-004",
+    allowLocalFiles: false,
+    fileRoot: null,
+    destructivePolicy: "block",
+    outputFormat: "json",
+    transport: "stdio",
+    credentialFingerprint: "credential-fingerprint",
+  };
+}
 
 function readPackManifest(): PackManifest {
   return JSON.parse(readFileSync(join(root, "skills", "pack.json"), "utf8")) as PackManifest;
 }
 
-describe("server instructions", () => {
-  it("advertises the shipped skills pack without client-specific install notes", () => {
-    const skillNames = readPackManifest().skills.map((skill) => skill.name);
-    const advertisedSkillNames = [
-      ...SERVER_COMPANION_SKILLS_INSTRUCTION.matchAll(/`(b2-[a-z0-9-]+)`/g),
-    ].map((match) => match[1]);
+function serverInstructions(): string {
+  const server = createServer(testConfig());
+  return (server as unknown as { server: { _instructions: string } }).server._instructions;
+}
 
-    expect(advertisedSkillNames).toEqual(skillNames);
-    expect(SERVER_COMPANION_SKILLS_INSTRUCTION).not.toMatch(/disaster recovery/i);
-    expect(SERVER_COMPANION_SKILLS_INSTRUCTION).not.toMatch(/saas multi-tenant/i);
-    expect(SERVER_COMPANION_SKILLS_INSTRUCTION).not.toMatch(/AI training/i);
-    expect(SERVER_COMPANION_SKILLS_INSTRUCTION).not.toMatch(/AI inference/i);
-    expect(SERVER_COMPANION_SKILLS_INSTRUCTION).not.toMatch(/Claude/i);
-    expect(SERVER_COMPANION_SKILLS_INSTRUCTION).not.toContain("~/.claude/skills");
-    expect(SERVER_COMPANION_SKILLS_INSTRUCTION).not.toContain("Settings -> Capabilities -> Skills");
+describe("server instructions", () => {
+  let instructions: string;
+
+  beforeAll(() => {
+    instructions = serverInstructions();
   });
 
-  it("formats companion skills from the provided manifest", () => {
-    const instruction = formatCompanionSkillsInstruction({
-      skills: [{ name: "b2-example-one" }, { name: "b2-example-two" }],
-    });
+  it("keeps manifest package files aligned with skill paths", () => {
+    const manifest = readPackManifest();
+    expect(manifest.packageFiles).toEqual([
+      "skills/pack.json",
+      ...manifest.skills.map((skill) => `skills/${skill.path}`),
+    ]);
+  });
 
-    expect(instruction).toContain("`b2-example-one` and `b2-example-two`");
-    expect(instruction).toContain("Follow the client's skills documentation");
+  it("advertises the shipped skills pack without client-specific install notes", () => {
+    const manifest = readPackManifest();
+    const skillNames = manifest.skills.map((skill) => skill.name);
+    const advertisedSkillNames = [...instructions.matchAll(/`(b2-[a-z0-9-]+)`/g)].map(
+      (match) => match[1],
+    );
+
+    expect(advertisedSkillNames).toEqual(skillNames);
+    expect(instructions).not.toMatch(/disaster recovery/i);
+    expect(instructions).not.toMatch(/saas multi-tenant/i);
+    expect(instructions).not.toMatch(/AI training/i);
+    expect(instructions).not.toMatch(/AI inference/i);
+    expect(instructions).not.toMatch(/Claude/i);
+    expect(instructions).not.toContain("~/.claude/skills");
+    expect(instructions).not.toContain("skills/b2-*/SKILL.md");
+    expect(instructions).not.toContain("Settings -> Capabilities -> Skills");
+  });
+
+  it("keeps registration guidance client neutral", () => {
+    const mentionedSkillPaths = [...instructions.matchAll(/skills\/b2-[a-z0-9-]+\/SKILL\.md/g)].map(
+      (match) => match[0],
+    );
+
+    expect(mentionedSkillPaths).toEqual([]);
+    expect(instructions).toContain("MCP client's skills docs");
   });
 });


### PR DESCRIPTION
## Summary
- Replace the stale server-issued skills guidance (fictional backup / disaster-recovery / SaaS multi-tenant / AI-training / AI-inference playbooks, plus Claude-specific install paths) with client-neutral wording that advertises the actual shipped skills pack names.
- Correct the `createServer` doc comment rather than dropping it: remove the stale references to removed native data tools (files / large files / download URLs) and keep the still-accurate credential model and capability-aware registration notes.
- Add unit coverage that reads `skills/pack.json`, asserts the advertised skill names match the manifest (and its package-file paths), and rejects the stale Claude-specific install notes.

## Linked issue
Closes #205

## Tests run
- `pnpm run typecheck`
- `pnpm exec vitest run --project unit tests/unit/server-instructions.unit.test.ts`
- `pnpm run validate:skills`
- `pnpm run verify`
- `pnpm run test:unit`
- `pnpm run test:contract`
- `pnpm run test:protocol`

## Follow-up notes
- `pnpm run lint` exits 0 and still reports the pre-existing `noEmptyBlockStatements` warning in `src/oauth-resource-server.ts`.
