### PR TITLE
fix: publish npm package from staged dir

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -247,12 +247,9 @@ jobs:
             echo "::error::Expected staged package.json is missing"
             exit 1
           fi
-          npm_tag="$(node --input-type=module -e '
-            import { readFileSync } from "node:fs";
-            import { npmDistTag } from "./scripts/lib/release-utils.mjs";
-            const pkg = JSON.parse(readFileSync(process.argv[1], "utf8"));
-            process.stdout.write(npmDistTag(pkg.version));
-          ' "${package_dir}/package.json")"
+          npm_tag="$(node scripts/npm-publish-metadata.mjs \
+            --package-json "${package_dir}/package.json" \
+            --field tag)"
           npm publish "$package_dir" \
             --dry-run \
             --access public \
@@ -272,6 +269,20 @@ jobs:
           checksums_sha256="$(sha256sum SHA256SUMS | awk '{print $1}')"
           echo "checksums_name=SHA256SUMS" >> "$GITHUB_OUTPUT"
           echo "checksums_sha256=${checksums_sha256}" >> "$GITHUB_OUTPUT"
+      - name: Stage publish helper scripts
+        env:
+          ACTIONS_CACHE_URL: ""
+          ACTIONS_RESULTS_URL: ""
+          ACTIONS_RUNTIME_TOKEN: ""
+          ACTIONS_RUNTIME_URL: ""
+        run: |
+          set -euo pipefail
+          mkdir -p publish-package/release-tools/lib
+          cp \
+            scripts/npm-publish-metadata.mjs \
+            scripts/verify-npm-registry-metadata.mjs \
+            publish-package/release-tools/
+          cp scripts/lib/release-utils.mjs publish-package/release-tools/lib/
       # actions/upload-artifact v6, reviewed 2026-08-06.
       - uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f
         with:
@@ -282,6 +293,8 @@ jobs:
             publish-package/SHA256SUMS
             publish-package/release-notes.md
             publish-package/npm-pack.json
+            publish-package/release-tools/*.mjs
+            publish-package/release-tools/lib/*.mjs
           if-no-files-found: error
           retention-days: 7
 
@@ -376,7 +389,6 @@ jobs:
           fi
       - name: Publish staged package directory with trusted provenance
         env:
-          EXPECTED_TARBALL_NAME: ${{ needs.prepare.outputs.tarball-name }}
           EXPECTED_TARBALL_SHA256: ${{ needs.prepare.outputs.tarball-sha256 }}
           EXPECTED_TARBALL_INTEGRITY: ${{ needs.prepare.outputs.tarball-integrity }}
         run: |
@@ -386,34 +398,26 @@ jobs:
             echo "::error::Expected staged package.json is missing"
             exit 1
           fi
-          package_metadata="$(node -e '
-            const { readFileSync } = require("fs");
-            const pkg = JSON.parse(readFileSync(process.argv[1], "utf8"));
-            const prerelease = String(pkg.version).split("-")[1];
-            const channel = prerelease ? prerelease.split(".")[0].toLowerCase() : "";
-            const tag = prerelease && ["alpha", "beta", "canary", "next", "rc"].includes(channel) ? channel : prerelease ? "next" : "latest";
-            process.stdout.write(JSON.stringify({ spec: `${pkg.name}@${pkg.version}`, tag }));
-          ' "${package_dir}/package.json")"
+          package_metadata="$(node publish-package/release-tools/npm-publish-metadata.mjs \
+            --package-json "${package_dir}/package.json")"
           package_spec="$(node -e 'process.stdout.write(JSON.parse(process.argv[1]).spec)' "$package_metadata")"
           npm_tag="$(node -e 'process.stdout.write(JSON.parse(process.argv[1]).tag)' "$package_metadata")"
-          verify_registry_metadata() {
-            local registry_metadata
-            registry_metadata="$(npm view "${package_spec}" _from _resolved --json)"
-            node -e '
-              const raw = String(process.argv[1] || "").trim();
-              const metadata = raw ? JSON.parse(raw) : {};
-              const leaked = ["_from", "_resolved"].filter((key) => metadata?.[key]);
-              if (leaked.length > 0) {
-                console.error(`registry metadata exposes local publish coordinates: ${leaked.join(", ")}`);
-                for (const key of leaked) console.error(`${key}=${metadata[key]}`);
-                process.exit(1);
-              }
-            ' "$registry_metadata"
-          }
+          metadata_verify_args=(
+            --package "$package_spec"
+            --timeout-ms 120000
+            --initial-interval-ms 5000
+            --max-interval-ms 30000
+          )
+          legacy_metadata_args=(
+            --allow-legacy-local-path-metadata "@backblaze-labs/b2-mcp@0.1.0"
+            --allow-legacy-local-path-metadata "@backblaze-labs/b2-mcp@0.1.1"
+          )
           if registry_integrity="$(npm view "${package_spec}" dist.integrity --json 2>/tmp/npm-view-error)"; then
             registry_integrity="$(node -e 'const value = JSON.parse(process.argv[1] || "null"); process.stdout.write(value || "");' "$registry_integrity")"
             if [[ "$registry_integrity" == "$EXPECTED_TARBALL_INTEGRITY" ]]; then
-              verify_registry_metadata
+              node publish-package/release-tools/verify-npm-registry-metadata.mjs \
+                "${metadata_verify_args[@]}" \
+                "${legacy_metadata_args[@]}"
               echo "::notice::${package_spec} already exists on npm with matching integrity; treating as idempotent success"
               exit 0
             fi
@@ -456,7 +460,8 @@ jobs:
             --access public \
             --ignore-scripts \
             --tag "$npm_tag"
-          verify_registry_metadata
+          node publish-package/release-tools/verify-npm-registry-metadata.mjs \
+            "${metadata_verify_args[@]}"
 
   container-image:
     needs: [prepare, publish]

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -228,7 +228,7 @@ jobs:
           echo "tarball_name=$(basename "$tarball")" >> "$GITHUB_OUTPUT"
           echo "tarball_sha256=$(sha256sum "$tarball" | awk '{print $1}')" >> "$GITHUB_OUTPUT"
           echo "tarball_integrity=$(node -e 'const fs = require("fs"); const [pack] = JSON.parse(fs.readFileSync("publish-package/npm-pack.json", "utf8")); process.stdout.write(pack.integrity || "");')" >> "$GITHUB_OUTPUT"
-      - name: Dry-run npm publish from verified tarball
+      - name: Dry-run npm publish from staged package directory
         env:
           ACTIONS_CACHE_URL: ""
           ACTIONS_RESULTS_URL: ""
@@ -237,13 +237,23 @@ jobs:
           EXPECTED_TARBALL_NAME: ${{ steps.pack.outputs.tarball_name }}
         run: |
           set -euo pipefail
+          tarball="./publish-package/${EXPECTED_TARBALL_NAME}"
+          stage_dir="publish-package/dry-run-stage"
+          rm -rf "$stage_dir"
+          mkdir -p "$stage_dir"
+          tar -xzf "$tarball" -C "$stage_dir"
+          package_dir="${stage_dir}/package"
+          if [[ ! -f "${package_dir}/package.json" ]]; then
+            echo "::error::Expected staged package.json is missing"
+            exit 1
+          fi
           npm_tag="$(node --input-type=module -e '
             import { readFileSync } from "node:fs";
             import { npmDistTag } from "./scripts/lib/release-utils.mjs";
-            const [pack] = JSON.parse(readFileSync("publish-package/npm-pack.json", "utf8"));
-            process.stdout.write(npmDistTag(pack.version));
-          ')"
-          npm publish "./publish-package/${EXPECTED_TARBALL_NAME}" \
+            const pkg = JSON.parse(readFileSync(process.argv[1], "utf8"));
+            process.stdout.write(npmDistTag(pkg.version));
+          ' "${package_dir}/package.json")"
+          npm publish "$package_dir" \
             --dry-run \
             --access public \
             --ignore-scripts \
@@ -357,26 +367,53 @@ jobs:
             echo "actual=${local_integrity}"
             exit 1
           fi
-      - name: Publish prebuilt tarball with trusted provenance
+          rm -rf publish-package/staged
+          mkdir -p publish-package/staged
+          tar -xzf "$tarball" -C publish-package/staged
+          if [[ ! -f publish-package/staged/package/package.json ]]; then
+            echo "::error::Expected staged package.json is missing"
+            exit 1
+          fi
+      - name: Publish staged package directory with trusted provenance
         env:
           EXPECTED_TARBALL_NAME: ${{ needs.prepare.outputs.tarball-name }}
+          EXPECTED_TARBALL_SHA256: ${{ needs.prepare.outputs.tarball-sha256 }}
           EXPECTED_TARBALL_INTEGRITY: ${{ needs.prepare.outputs.tarball-integrity }}
         run: |
           set -euo pipefail
-          tarball="./publish-package/${EXPECTED_TARBALL_NAME}"
+          package_dir="./publish-package/staged/package"
+          if [[ ! -f "${package_dir}/package.json" ]]; then
+            echo "::error::Expected staged package.json is missing"
+            exit 1
+          fi
           package_metadata="$(node -e '
-            const cp = require("child_process");
-            const pkg = JSON.parse(cp.execFileSync("tar", ["-xOf", process.argv[1], "package/package.json"], { encoding: "utf8" }));
+            const { readFileSync } = require("fs");
+            const pkg = JSON.parse(readFileSync(process.argv[1], "utf8"));
             const prerelease = String(pkg.version).split("-")[1];
             const channel = prerelease ? prerelease.split(".")[0].toLowerCase() : "";
             const tag = prerelease && ["alpha", "beta", "canary", "next", "rc"].includes(channel) ? channel : prerelease ? "next" : "latest";
             process.stdout.write(JSON.stringify({ spec: `${pkg.name}@${pkg.version}`, tag }));
-          ' "$tarball")"
+          ' "${package_dir}/package.json")"
           package_spec="$(node -e 'process.stdout.write(JSON.parse(process.argv[1]).spec)' "$package_metadata")"
           npm_tag="$(node -e 'process.stdout.write(JSON.parse(process.argv[1]).tag)' "$package_metadata")"
+          verify_registry_metadata() {
+            local registry_metadata
+            registry_metadata="$(npm view "${package_spec}" _from _resolved --json)"
+            node -e '
+              const raw = String(process.argv[1] || "").trim();
+              const metadata = raw ? JSON.parse(raw) : {};
+              const leaked = ["_from", "_resolved"].filter((key) => metadata?.[key]);
+              if (leaked.length > 0) {
+                console.error(`registry metadata exposes local publish coordinates: ${leaked.join(", ")}`);
+                for (const key of leaked) console.error(`${key}=${metadata[key]}`);
+                process.exit(1);
+              }
+            ' "$registry_metadata"
+          }
           if registry_integrity="$(npm view "${package_spec}" dist.integrity --json 2>/tmp/npm-view-error)"; then
             registry_integrity="$(node -e 'const value = JSON.parse(process.argv[1] || "null"); process.stdout.write(value || "");' "$registry_integrity")"
             if [[ "$registry_integrity" == "$EXPECTED_TARBALL_INTEGRITY" ]]; then
+              verify_registry_metadata
               echo "::notice::${package_spec} already exists on npm with matching integrity; treating as idempotent success"
               exit 0
             fi
@@ -389,11 +426,37 @@ jobs:
             cat /tmp/npm-view-error
             exit 1
           fi
-          npm publish "$tarball" \
+          rm -rf publish-package/repacked
+          mkdir -p publish-package/repacked
+          repack_json="$(npm pack "$package_dir" --json --ignore-scripts --pack-destination publish-package/repacked)"
+          printf '%s\n' "$repack_json" > publish-package/repacked/npm-pack.json
+          repacked_tarball="$(find publish-package/repacked -maxdepth 1 -type f -name '*.tgz' | sort | head -n 1)"
+          if [[ -z "$repacked_tarball" ]]; then
+            echo "::error::npm pack did not produce a staged tarball"
+            exit 1
+          fi
+          repacked_sha256="$(sha256sum "$repacked_tarball" | awk '{print $1}')"
+          if [[ "$repacked_sha256" != "$EXPECTED_TARBALL_SHA256" ]]; then
+            echo "::error::Staged package tarball SHA-256 mismatch"
+            echo "expected=${EXPECTED_TARBALL_SHA256}"
+            echo "actual=${repacked_sha256}"
+            exit 1
+          fi
+          repacked_integrity="$(node -e 'const [pack] = JSON.parse(process.argv[1]); process.stdout.write(pack.integrity || "");' "$repack_json")"
+          if [[ "$repacked_integrity" != "$EXPECTED_TARBALL_INTEGRITY" ]]; then
+            echo "::error::Staged package tarball npm integrity mismatch"
+            echo "expected=${EXPECTED_TARBALL_INTEGRITY}"
+            echo "actual=${repacked_integrity}"
+            exit 1
+          fi
+          # Publish from the staged directory; npm records local file coordinates
+          # in registry metadata when the publish target is a .tgz path.
+          npm publish "$package_dir" \
             --provenance \
             --access public \
             --ignore-scripts \
             --tag "$npm_tag"
+          verify_registry_metadata
 
   container-image:
     needs: [prepare, publish]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Aligned the package `engines.node` range with the supported Node.js 22.3+,
   24, and 26 lines so it matches the runtime policy and opossum 10 support,
   with drift guards for workflow and deployment documentation claims.
+- Publish npm releases from a staged package directory so registry metadata does
+  not retain the release runner's local tarball path.
 
 ## [0.1.1] - 2026-08-18
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   24, and 26 lines so it matches the runtime policy and opossum 10 support,
   with drift guards for workflow and deployment documentation claims.
 - Publish npm releases from a staged package directory so registry metadata does
-  not retain the release runner's local tarball path.
+  not retain the release runner's local tarball path, with a bounded
+  post-publish verification retry and legacy rerun allowance for immutable
+  `0.1.0` and `0.1.1` metadata.
 
 ## [0.1.1] - 2026-08-18
 

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -83,9 +83,10 @@ Before publishing `v0.1.0`:
     explicitly, enforce the runtime package budget, scan the generated packlist
     and tarball, generate and verify a CycloneDX production SBOM artifact, call
     the protected live B2 contract workflow as a pre-release gate, verify the
-    tarball SHA-256, publish the already-scanned tarball with lifecycle scripts
-    disabled, publish and verify the GHCR image, and attach the SBOM to the
-    GitHub Release only after npm publish and GHCR publishing succeed.
+    tarball SHA-256, publish the staged package directory only after its
+    repacked tarball matches the scanned artifact, verify registry metadata,
+    publish and verify the GHCR image, and attach the SBOM to the GitHub Release
+    only after npm publish and GHCR publishing succeed.
 13. Confirm the release tag ruleset only allows release owners to create
     `v*` tags and does not allow force-updating or deleting release tags.
 14. Confirm `refs/heads/ci-green` is treated as an owned protected marker:
@@ -138,8 +139,8 @@ exists. For the first public package only:
 3. Deprecate the bootstrap version with a note that it is a reserved package
    bootstrap and is not supported for installation.
 4. Push the signed `v0.1.0` tag to run the publish workflow. The workflow must
-   publish the verified tarball with OIDC provenance; do not publish a different
-   local tarball to bootstrap the package.
+   publish the verified package contents with OIDC provenance; do not publish a
+   different local tarball to bootstrap the package.
 
 ## Normal Release
 
@@ -183,10 +184,12 @@ exists. For the first public package only:
    starts `Publish Package` from the default branch. The publish workflow waits
    until the tag is reachable from the protected `ci-green` marker, then verifies
    tag/package/changelog consistency, runs `pnpm run verify`, requires live
-   contract success, builds one tarball, runs an npm dry-run publish, records
-   checksums and SBOM, publishes that exact tarball with npm OIDC provenance,
-   publishes and anonymously verifies the idempotent GHCR container image from
-   the same verified ref, and then creates or updates the GitHub Release. A
+   contract success, builds one tarball, runs an npm dry-run publish from staged
+   package contents, records checksums and SBOM, repacks the staged package to
+   prove it still matches the tarball, publishes the staged package directory
+   with npm OIDC provenance, publishes and anonymously verifies the idempotent
+   GHCR container image from the same verified ref, and then creates or updates
+   the GitHub Release. A
    Docker/GHCR failure can be retried against the same tag; it must not sign an
    existing digest unless that digest already has this workflow's trusted
    signature plus provenance and SBOM attestations, and it must not overwrite an

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -84,9 +84,9 @@ Before publishing `v0.1.0`:
     and tarball, generate and verify a CycloneDX production SBOM artifact, call
     the protected live B2 contract workflow as a pre-release gate, verify the
     tarball SHA-256, publish the staged package directory only after its
-    repacked tarball matches the scanned artifact, verify registry metadata,
-    publish and verify the GHCR image, and attach the SBOM to the GitHub Release
-    only after npm publish and GHCR publishing succeed.
+    repacked tarball matches the scanned artifact, verify registry metadata with
+    bounded retry, publish and verify the GHCR image, and attach the SBOM to the
+    GitHub Release only after npm publish and GHCR publishing succeed.
 13. Confirm the release tag ruleset only allows release owners to create
     `v*` tags and does not allow force-updating or deleting release tags.
 14. Confirm `refs/heads/ci-green` is treated as an owned protected marker:
@@ -187,9 +187,9 @@ exists. For the first public package only:
    contract success, builds one tarball, runs an npm dry-run publish from staged
    package contents, records checksums and SBOM, repacks the staged package to
    prove it still matches the tarball, publishes the staged package directory
-   with npm OIDC provenance, publishes and anonymously verifies the idempotent
-   GHCR container image from the same verified ref, and then creates or updates
-   the GitHub Release. A
+   with npm OIDC provenance, verifies registry metadata with bounded retry,
+   publishes and anonymously verifies the idempotent GHCR container image from
+   the same verified ref, and then creates or updates the GitHub Release. A
    Docker/GHCR failure can be retried against the same tag; it must not sign an
    existing digest unless that digest already has this workflow's trusted
    signature plus provenance and SBOM attestations, and it must not overwrite an
@@ -201,7 +201,11 @@ exists. For the first public package only:
    `Publish Package` from the default branch. Do not delete, force-move, or
    re-push the tag. Creating or editing a GitHub Release is not a publish
    trigger; the workflow creates or updates the GitHub Release only after npm
-   and GHCR succeed.
+   and GHCR succeed. Existing immutable npm versions `0.1.0` and `0.1.1` may
+   expose local `_from` or `_resolved` registry metadata from the former
+   tarball-publish flow. Matching-integrity reruns for only those versions log a
+   warning and continue so downstream GHCR or GitHub Release recovery remains
+   possible; newer versions fail if that metadata is present.
 6. If GHCR has the version/release tags but the retry fails because the digest is
    unsigned or missing trusted attestations, delete that specific GHCR package
    version and rerun the same tag:

--- a/docs/SUPPLY_CHAIN_SECURITY.md
+++ b/docs/SUPPLY_CHAIN_SECURITY.md
@@ -199,18 +199,21 @@ The only repository workflow allowed to publish npm packages is
   `dist/index.js` in the packlist, runs the npm production audit and CycloneDX
   SBOM flow through `pnpm run release:sbom`, creates an npm tarball with
   lifecycle scripts disabled, scans that exact tarball through the safe denylist
-  extractor, runs an npm dry-run publish against that tarball, writes SHA-256
-  checksums and versioned release notes, and uploads the tarball, SBOM,
-  checksums, pack manifest, and notes as seven-day artifacts for protected
-  environment approval;
+  extractor, runs an npm dry-run publish from the tarball's staged package
+  directory, writes SHA-256 checksums and versioned release notes, and uploads
+  the tarball, SBOM, checksums, pack manifest, and notes as seven-day artifacts
+  for protected environment approval;
 - runs the protected live B2 contract suite once on the exact publish ref before
   the npm publish job can start;
 - requires a protected `npm-publish` environment for npm publishing and a
   protected `ghcr-publish` environment for container publishing, so tag push
   alone cannot publish release artifacts;
-- verifies the tarball SHA-256 and npm `dist.integrity` before publishing;
+- verifies the tarball SHA-256 and npm `dist.integrity` before staging the
+  package directory for publishing;
 - compares an already-published registry version's integrity to the verified
   local tarball before treating the run as an idempotent success;
+- repacks the staged package directory and compares it to the verified tarball
+  before invoking npm publish;
 - verifies checksums and creates or updates the GitHub Release after npm publish
   and the public GHCR manifest check succeed, from a separate job that does not
   hold npm OIDC permission; the GHCR job is idempotent, so a Docker/GHCR retry
@@ -240,8 +243,10 @@ The only repository workflow allowed to publish npm packages is
 - publishes only immutable container tags: the package version without a leading
   `v` and the matching signed release tag; no mutable `latest` tag is produced;
 - uses npm trusted publishing with `id-token: write` and an OIDC preflight;
-- publishes the prebuilt tarball with lifecycle scripts disabled:
-  `npm publish <tarball> --provenance --access public --ignore-scripts`.
+- publishes the staged package directory with lifecycle scripts disabled:
+  `npm publish <staged-package-directory> --provenance --access public --ignore-scripts`;
+- verifies the published npm registry metadata does not include local
+  `_from` or `_resolved` publish coordinates.
 
 Do not publish from a developer workstation or from a workflow that has not
 first proved the release tag is reachable from `ci-green`. Treat

--- a/docs/SUPPLY_CHAIN_SECURITY.md
+++ b/docs/SUPPLY_CHAIN_SECURITY.md
@@ -212,6 +212,9 @@ The only repository workflow allowed to publish npm packages is
   package directory for publishing;
 - compares an already-published registry version's integrity to the verified
   local tarball before treating the run as an idempotent success;
+- allows matching-integrity idempotent reruns for immutable legacy versions
+  `0.1.0` and `0.1.1` with a warning when those versions still expose
+  pre-fix `_from` or `_resolved` registry metadata;
 - repacks the staged package directory and compares it to the verified tarball
   before invoking npm publish;
 - verifies checksums and creates or updates the GitHub Release after npm publish
@@ -246,7 +249,8 @@ The only repository workflow allowed to publish npm packages is
 - publishes the staged package directory with lifecycle scripts disabled:
   `npm publish <staged-package-directory> --provenance --access public --ignore-scripts`;
 - verifies the published npm registry metadata does not include local
-  `_from` or `_resolved` publish coordinates.
+  `_from` or `_resolved` publish coordinates, using bounded retry for transient
+  npm registry errors and short-lived post-publish propagation gaps.
 
 Do not publish from a developer workstation or from a workflow that has not
 first proved the release tag is reachable from `ci-green`. Treat

--- a/scripts/npm-publish-metadata.mjs
+++ b/scripts/npm-publish-metadata.mjs
@@ -1,0 +1,83 @@
+#!/usr/bin/env node
+import { readFileSync } from "node:fs";
+import { pathToFileURL } from "node:url";
+import { npmDistTag } from "./lib/release-utils.mjs";
+
+function usage() {
+  return "Usage: node scripts/npm-publish-metadata.mjs --package-json <path> [--field <spec|tag>]";
+}
+
+function parseArgs(argv) {
+  let packageJson = "";
+  let field = "";
+
+  for (let index = 0; index < argv.length; index += 1) {
+    const arg = argv[index];
+    if (arg === "--help") {
+      console.log(usage());
+      process.exit(0);
+    }
+    if (arg === "--package-json") {
+      const value = argv[index + 1];
+      if (!value) throw new Error("--package-json requires a value");
+      packageJson = value;
+      index += 1;
+      continue;
+    }
+    if (arg.startsWith("--package-json=")) {
+      packageJson = arg.slice("--package-json=".length);
+      continue;
+    }
+    if (arg === "--field") {
+      const value = argv[index + 1];
+      if (!value) throw new Error("--field requires a value");
+      field = value;
+      index += 1;
+      continue;
+    }
+    if (arg.startsWith("--field=")) {
+      field = arg.slice("--field=".length);
+      continue;
+    }
+    throw new Error(`unknown argument ${arg}`);
+  }
+
+  if (!packageJson) throw new Error("--package-json is required");
+  if (field && !["spec", "tag"].includes(field)) {
+    throw new Error("--field must be spec or tag");
+  }
+
+  return { packageJson, field };
+}
+
+export function npmPublishMetadata(pkg) {
+  if (!pkg || typeof pkg !== "object") throw new Error("package.json must be an object");
+  if (typeof pkg.name !== "string" || !pkg.name) throw new Error("package.json name is required");
+  if (typeof pkg.version !== "string" || !pkg.version) {
+    throw new Error("package.json version is required");
+  }
+
+  return {
+    spec: `${pkg.name}@${pkg.version}`,
+    tag: npmDistTag(pkg.version),
+  };
+}
+
+function main() {
+  const options = parseArgs(process.argv.slice(2));
+  const pkg = JSON.parse(readFileSync(options.packageJson, "utf8"));
+  const metadata = npmPublishMetadata(pkg);
+  process.stdout.write(options.field ? metadata[options.field] : JSON.stringify(metadata));
+}
+
+if (import.meta.url === pathToFileURL(process.argv[1]).href) {
+  try {
+    main();
+  } catch (error) {
+    console.error(
+      `npm-publish-metadata: ${error instanceof Error ? error.message : String(error)}`,
+    );
+    console.error(usage());
+    process.exit(2);
+  }
+}

--- a/scripts/verify-npm-registry-metadata.mjs
+++ b/scripts/verify-npm-registry-metadata.mjs
@@ -1,0 +1,242 @@
+#!/usr/bin/env node
+import { spawnSync } from "node:child_process";
+import { setTimeout as sleep } from "node:timers/promises";
+import { pathToFileURL } from "node:url";
+
+const retryableViewFailure = [
+  "E404",
+  "404",
+  "not found",
+  "EAI_AGAIN",
+  "ECONNRESET",
+  "ETIMEDOUT",
+  "ENOTFOUND",
+  "ECONNREFUSED",
+  "EPIPE",
+  "fetch failed",
+  "network socket",
+  "network timeout",
+  "rate limit",
+  "429",
+  "500",
+  "502",
+  "503",
+  "504",
+];
+
+function usage() {
+  return [
+    "Usage: node scripts/verify-npm-registry-metadata.mjs --package <name@version>",
+    "  [--timeout-ms <ms>] [--initial-interval-ms <ms>] [--max-interval-ms <ms>]",
+    "  [--allow-legacy-local-path-metadata <name@version> ...]",
+  ].join("\n");
+}
+
+function parsePositiveInteger(value, optionName) {
+  if (!/^\d+$/.test(String(value))) throw new Error(`${optionName} must be a positive integer`);
+  const parsed = Number(value);
+  if (!Number.isSafeInteger(parsed) || parsed <= 0) {
+    throw new Error(`${optionName} must be a positive integer`);
+  }
+  return parsed;
+}
+
+function parseArgs(argv) {
+  const options = {
+    packageSpec: "",
+    timeoutMs: 120_000,
+    initialIntervalMs: 5_000,
+    maxIntervalMs: 30_000,
+    allowedLegacySpecs: new Set(),
+  };
+
+  for (let index = 0; index < argv.length; index += 1) {
+    const arg = argv[index];
+    if (arg === "--help") {
+      console.log(usage());
+      process.exit(0);
+    }
+
+    const readValue = (optionName) => {
+      const value = argv[index + 1];
+      if (!value) throw new Error(`${optionName} requires a value`);
+      index += 1;
+      return value;
+    };
+
+    if (arg === "--package") {
+      options.packageSpec = readValue(arg);
+      continue;
+    }
+    if (arg.startsWith("--package=")) {
+      options.packageSpec = arg.slice("--package=".length);
+      continue;
+    }
+    if (arg === "--timeout-ms") {
+      options.timeoutMs = parsePositiveInteger(readValue(arg), arg);
+      continue;
+    }
+    if (arg.startsWith("--timeout-ms=")) {
+      options.timeoutMs = parsePositiveInteger(arg.slice("--timeout-ms=".length), "--timeout-ms");
+      continue;
+    }
+    if (arg === "--initial-interval-ms") {
+      options.initialIntervalMs = parsePositiveInteger(readValue(arg), arg);
+      continue;
+    }
+    if (arg.startsWith("--initial-interval-ms=")) {
+      options.initialIntervalMs = parsePositiveInteger(
+        arg.slice("--initial-interval-ms=".length),
+        "--initial-interval-ms",
+      );
+      continue;
+    }
+    if (arg === "--max-interval-ms") {
+      options.maxIntervalMs = parsePositiveInteger(readValue(arg), arg);
+      continue;
+    }
+    if (arg.startsWith("--max-interval-ms=")) {
+      options.maxIntervalMs = parsePositiveInteger(
+        arg.slice("--max-interval-ms=".length),
+        "--max-interval-ms",
+      );
+      continue;
+    }
+    if (arg === "--allow-legacy-local-path-metadata") {
+      options.allowedLegacySpecs.add(readValue(arg));
+      continue;
+    }
+    if (arg.startsWith("--allow-legacy-local-path-metadata=")) {
+      options.allowedLegacySpecs.add(arg.slice("--allow-legacy-local-path-metadata=".length));
+      continue;
+    }
+
+    throw new Error(`unknown argument ${arg}`);
+  }
+
+  if (!options.packageSpec) throw new Error("--package is required");
+  return options;
+}
+
+export function leakedRegistryMetadataKeys(metadata) {
+  if (!metadata || typeof metadata !== "object") return [];
+  return ["_from", "_resolved"].filter((key) => Boolean(metadata[key]));
+}
+
+export function parseRegistryMetadata(raw) {
+  const trimmed = String(raw ?? "").trim();
+  if (!trimmed) return {};
+  return JSON.parse(trimmed);
+}
+
+function compactErrorText(result) {
+  return [result.stderr, result.stdout].filter(Boolean).join("\n").replace(/\s+/g, " ").trim();
+}
+
+export function isRetryableNpmViewFailure(result) {
+  const text = compactErrorText(result);
+  return retryableViewFailure.some((pattern) => text.toLowerCase().includes(pattern.toLowerCase()));
+}
+
+function npmViewMetadata(packageSpec) {
+  return spawnSync("npm", ["view", packageSpec, "_from", "_resolved", "--json"], {
+    encoding: "utf8",
+  });
+}
+
+function retryDelayMs(intervalMs, maxIntervalMs) {
+  return Math.min(intervalMs * 2, maxIntervalMs);
+}
+
+export async function verifyNpmRegistryMetadata({
+  packageSpec,
+  timeoutMs = 120_000,
+  initialIntervalMs = 5_000,
+  maxIntervalMs = 30_000,
+  allowedLegacySpecs = new Set(),
+  viewMetadata = npmViewMetadata,
+  wait = sleep,
+  now = () => Date.now(),
+  log = console,
+}) {
+  const deadline = now() + timeoutMs;
+  let attempt = 1;
+  let intervalMs = initialIntervalMs;
+  let lastRetryableError = "";
+
+  while (true) {
+    const result = viewMetadata(packageSpec);
+
+    if (result.status === 0) {
+      let metadata;
+      try {
+        metadata = parseRegistryMetadata(result.stdout);
+      } catch (error) {
+        lastRetryableError = `invalid npm view JSON: ${
+          error instanceof Error ? error.message : String(error)
+        }`;
+        metadata = null;
+      }
+
+      if (metadata) {
+        const leaked = leakedRegistryMetadataKeys(metadata);
+        if (leaked.length === 0) {
+          log.log(`npm-registry-metadata: verified ${packageSpec} has no _from/_resolved metadata`);
+          return { status: "verified", attempts: attempt };
+        }
+
+        if (allowedLegacySpecs.has(packageSpec)) {
+          log.warn(
+            `::warning::npm-registry-metadata: ${packageSpec} exposes legacy ${leaked.join(
+              ", ",
+            )} metadata; matching-integrity rerun is allowed for this immutable pre-fix version`,
+          );
+          return { status: "legacy-allowed", attempts: attempt, leaked };
+        }
+
+        throw new Error(
+          `registry metadata exposes local publish coordinates for ${packageSpec}: ${leaked.join(
+            ", ",
+          )}`,
+        );
+      }
+    } else {
+      const failureKind = isRetryableNpmViewFailure(result) ? "retryable" : "unexpected";
+      lastRetryableError = `${failureKind} npm view failure: ${
+        compactErrorText(result) || `exit status ${result.status}`
+      }`;
+    }
+
+    const remainingMs = deadline - now();
+    if (remainingMs <= 0) {
+      throw new Error(
+        `registry metadata verification for ${packageSpec} did not complete within ${timeoutMs}ms: ${lastRetryableError}`,
+      );
+    }
+
+    const delayMs = Math.min(intervalMs, remainingMs);
+    log.warn(
+      `npm-registry-metadata: retrying npm view for ${packageSpec} in ${delayMs}ms after attempt ${attempt}: ${lastRetryableError}`,
+    );
+    await wait(delayMs);
+    attempt += 1;
+    intervalMs = retryDelayMs(intervalMs, maxIntervalMs);
+  }
+}
+
+async function main() {
+  const options = parseArgs(process.argv.slice(2));
+  await verifyNpmRegistryMetadata(options);
+}
+
+if (import.meta.url === pathToFileURL(process.argv[1]).href) {
+  try {
+    await main();
+  } catch (error) {
+    console.error(
+      `npm-registry-metadata: ${error instanceof Error ? error.message : String(error)}`,
+    );
+    console.error(usage());
+    process.exit(1);
+  }
+}

--- a/scripts/verify-npm-registry-metadata.mjs
+++ b/scripts/verify-npm-registry-metadata.mjs
@@ -4,24 +4,21 @@ import { setTimeout as sleep } from "node:timers/promises";
 import { pathToFileURL } from "node:url";
 
 const retryableViewFailure = [
-  "E404",
-  "404",
-  "not found",
-  "EAI_AGAIN",
-  "ECONNRESET",
-  "ETIMEDOUT",
-  "ENOTFOUND",
-  "ECONNREFUSED",
-  "EPIPE",
-  "fetch failed",
-  "network socket",
-  "network timeout",
-  "rate limit",
-  "429",
-  "500",
-  "502",
-  "503",
-  "504",
+  /\bE404\b/i,
+  /not found/i,
+  /\bEAI_AGAIN\b/i,
+  /\bECONNRESET\b/i,
+  /\bETIMEDOUT\b/i,
+  /\bENOTFOUND\b/i,
+  /\bECONNREFUSED\b/i,
+  /\bEPIPE\b/i,
+  /fetch failed/i,
+  /network socket/i,
+  /network timeout/i,
+  /rate limit/i,
+  // Transient HTTP statuses, matched only as standalone tokens so an embedded
+  // number (a version like 1.500.0, or 1500) is not misread as a 5xx/404/429.
+  /(?<![\w.])(?:404|429|500|502|503|504)(?![\w.])/,
 ];
 
 function usage() {
@@ -135,7 +132,7 @@ function compactErrorText(result) {
 
 export function isRetryableNpmViewFailure(result) {
   const text = compactErrorText(result);
-  return retryableViewFailure.some((pattern) => text.toLowerCase().includes(pattern.toLowerCase()));
+  return retryableViewFailure.some((pattern) => pattern.test(text));
 }
 
 function npmViewMetadata(packageSpec) {

--- a/tests/package/repack-reproducible.package.test.ts
+++ b/tests/package/repack-reproducible.package.test.ts
@@ -1,0 +1,78 @@
+import { execFileSync } from "child_process";
+import { createHash } from "crypto";
+import { mkdirSync, mkdtempSync, readFileSync, rmSync } from "fs";
+import { createRequire } from "module";
+import { tmpdir } from "os";
+import { join } from "path";
+import { root } from "../contract/support";
+
+const nodeRequire = createRequire(__filename);
+const { npmInvocation } = nodeRequire("../../scripts/lib/retry-utils.cjs") as {
+  npmInvocation: (args: string[]) => { command: string; args: string[] };
+};
+
+interface PackResult {
+  tarball: string;
+  integrity: string;
+}
+
+function sha256(path: string): string {
+  return createHash("sha256")
+    .update(new Uint8Array(readFileSync(path)))
+    .digest("hex");
+}
+
+// Mirrors the publish workflow's pack flags (`npm pack --json --ignore-scripts`)
+// so this reproduces exactly what prepare/publish do.
+function pack(sourceArgs: string[], destDir: string): PackResult {
+  mkdirSync(destDir, { recursive: true });
+  const invocation = npmInvocation([
+    "pack",
+    ...sourceArgs,
+    "--json",
+    "--ignore-scripts",
+    "--pack-destination",
+    destDir,
+  ]);
+  const stdout = execFileSync(invocation.command, invocation.args, {
+    cwd: root,
+    encoding: "utf8",
+    maxBuffer: 64 * 1024 * 1024,
+  });
+  const [meta] = JSON.parse(stdout) as Array<{ filename: string; integrity?: string }>;
+  return { tarball: join(destDir, meta.filename), integrity: String(meta.integrity ?? "") };
+}
+
+const REPACK_TEST_TIMEOUT_MS = process.platform === "win32" ? 300_000 : 120_000;
+
+// The publish job publishes from a staged directory (to avoid leaking the
+// runner's local `.tgz` path into registry `_from`/`_resolved`) but must still
+// prove the staged directory reproduces the exact scanned/attested tarball. That
+// guarantee only runs during a real release, so this test exercises the same
+// pack -> extract -> repack -> compare path in CI. The publish job runs on
+// Linux; reproducibility is asserted there, not for the Windows dev matrix.
+describe.skipIf(process.platform === "win32")("packed package reproducibility", () => {
+  it(
+    "repacking the extracted tarball reproduces identical bytes and integrity",
+    () => {
+      const tmp = mkdtempSync(join(tmpdir(), "b2-mcp-repack-"));
+      try {
+        const first = pack([], join(tmp, "first"));
+        const firstSha256 = sha256(first.tarball);
+
+        const stageDir = join(tmp, "stage");
+        mkdirSync(stageDir, { recursive: true });
+        execFileSync("tar", ["-xzf", first.tarball, "-C", stageDir], { encoding: "utf8" });
+
+        const second = pack([join(stageDir, "package")], join(tmp, "second"));
+        const secondSha256 = sha256(second.tarball);
+
+        expect(secondSha256).toBe(firstSha256);
+        expect(second.integrity).toBe(first.integrity);
+      } finally {
+        rmSync(tmp, { recursive: true, force: true });
+      }
+    },
+    REPACK_TEST_TIMEOUT_MS,
+  );
+});

--- a/tests/support/mjs-modules.d.ts
+++ b/tests/support/mjs-modules.d.ts
@@ -1,0 +1,5 @@
+declare module "*.mjs" {
+  export function verifyNpmRegistryMetadata(
+    options: Record<string, unknown>,
+  ): Promise<Record<string, unknown>>;
+}

--- a/tests/unit/release-scripts.unit.test.ts
+++ b/tests/unit/release-scripts.unit.test.ts
@@ -5,6 +5,16 @@ import { spawnSync } from "child_process";
 
 const root = join(__dirname, "../..");
 
+type RegistryMetadataModule = {
+  verifyNpmRegistryMetadata: (options: Record<string, unknown>) => Promise<Record<string, unknown>>;
+};
+
+async function registryMetadataModule(): Promise<RegistryMetadataModule> {
+  return (await import(
+    "../../scripts/verify-npm-registry-metadata.mjs"
+  )) as unknown as RegistryMetadataModule;
+}
+
 function runGit(cwd: string, args: string[]): string {
   const result = spawnSync("git", args, { cwd, encoding: "utf8" });
   if (result.status !== 0) throw new Error(`git ${args.join(" ")} failed: ${result.stderr}`);
@@ -189,6 +199,118 @@ describe("release scripts", () => {
 
     expect(result.status).toBe(0);
     expect(JSON.parse(result.stdout)).toEqual(["latest", "rc", "next"]);
+  });
+
+  it("prints package publish metadata through the shared helper", () => {
+    withFixture((fixtureRoot) => {
+      const packagePath = join(fixtureRoot, "package.json");
+      const pkg = JSON.parse(readFileSync(packagePath, "utf8"));
+      writeFileSync(packagePath, JSON.stringify({ ...pkg, version: "0.2.0-preview.1" }, null, 2));
+
+      const result = spawnSync(
+        process.execPath,
+        ["scripts/npm-publish-metadata.mjs", "--package-json", packagePath],
+        { cwd: root, encoding: "utf8" },
+      );
+
+      expect(result.status).toBe(0);
+      expect(JSON.parse(result.stdout)).toEqual({
+        spec: "@backblaze-labs/b2-mcp@0.2.0-preview.1",
+        tag: "next",
+      });
+    });
+  });
+
+  it("rejects leaked npm registry _from/_resolved metadata", async () => {
+    const { verifyNpmRegistryMetadata } = await registryMetadataModule();
+
+    await expect(
+      verifyNpmRegistryMetadata({
+        packageSpec: "@backblaze-labs/b2-mcp@9.9.9",
+        viewMetadata: () => ({
+          status: 0,
+          stdout: JSON.stringify({
+            _resolved:
+              "/home/runner/work/b2-mcp/b2-mcp/publish-package/backblaze-labs-b2-mcp-9.9.9.tgz",
+          }),
+          stderr: "",
+        }),
+        wait: async () => undefined,
+        log: { log: () => undefined, warn: () => undefined },
+      }),
+    ).rejects.toThrow("registry metadata exposes local publish coordinates");
+  });
+
+  it("retries not-yet-visible npm registry metadata before passing", async () => {
+    const { verifyNpmRegistryMetadata } = await registryMetadataModule();
+    const warnings: string[] = [];
+    const delays: number[] = [];
+    let attempts = 0;
+
+    const result = await verifyNpmRegistryMetadata({
+      packageSpec: "@backblaze-labs/b2-mcp@9.9.9",
+      timeoutMs: 1_000,
+      initialIntervalMs: 1,
+      maxIntervalMs: 4,
+      viewMetadata: () => {
+        attempts += 1;
+        return attempts === 1
+          ? { status: 1, stdout: "", stderr: "npm ERR! 404 not found" }
+          : { status: 0, stdout: "{}", stderr: "" };
+      },
+      wait: async (delayMs: number) => {
+        delays.push(delayMs);
+      },
+      log: { log: () => undefined, warn: (message: string) => warnings.push(message) },
+    });
+
+    expect(result).toMatchObject({ status: "verified", attempts: 2 });
+    expect(delays).toEqual([1]);
+    expect(warnings.join("\n")).toContain("retrying npm view");
+  });
+
+  it("allows matching-integrity reruns for documented legacy metadata leaks", async () => {
+    const { verifyNpmRegistryMetadata } = await registryMetadataModule();
+    const warnings: string[] = [];
+
+    const result = await verifyNpmRegistryMetadata({
+      packageSpec: "@backblaze-labs/b2-mcp@0.1.1",
+      allowedLegacySpecs: new Set(["@backblaze-labs/b2-mcp@0.1.1"]),
+      viewMetadata: () => ({
+        status: 0,
+        stdout: JSON.stringify({
+          _from: "file:publish-package/backblaze-labs-b2-mcp-0.1.1.tgz",
+          _resolved:
+            "/home/runner/work/b2-mcp/b2-mcp/publish-package/backblaze-labs-b2-mcp-0.1.1.tgz",
+        }),
+        stderr: "",
+      }),
+      wait: async () => undefined,
+      log: { log: () => undefined, warn: (message: string) => warnings.push(message) },
+    });
+
+    expect(result).toMatchObject({ status: "legacy-allowed", leaked: ["_from", "_resolved"] });
+    expect(warnings.join("\n")).toContain("matching-integrity rerun is allowed");
+  });
+
+  it("fails registry metadata verification when the retry deadline expires", async () => {
+    const { verifyNpmRegistryMetadata } = await registryMetadataModule();
+    let nowCalls = 0;
+
+    await expect(
+      verifyNpmRegistryMetadata({
+        packageSpec: "@backblaze-labs/b2-mcp@9.9.9",
+        timeoutMs: 5,
+        initialIntervalMs: 1,
+        viewMetadata: () => ({ status: 1, stdout: "", stderr: "npm ERR! 503 registry busy" }),
+        wait: async () => undefined,
+        now: () => {
+          nowCalls += 1;
+          return nowCalls === 1 ? 0 : 10;
+        },
+        log: { log: () => undefined, warn: () => undefined },
+      }),
+    ).rejects.toThrow("did not complete within 5ms");
   });
 
   it("verifies tag, metadata, package files, and changelog agreement", () => {

--- a/tests/unit/release-scripts.unit.test.ts
+++ b/tests/unit/release-scripts.unit.test.ts
@@ -7,6 +7,13 @@ const root = join(__dirname, "../..");
 
 type RegistryMetadataModule = {
   verifyNpmRegistryMetadata: (options: Record<string, unknown>) => Promise<Record<string, unknown>>;
+  isRetryableNpmViewFailure: (result: {
+    status: number | null;
+    stdout?: string;
+    stderr?: string;
+  }) => boolean;
+  parseRegistryMetadata: (raw: unknown) => Record<string, unknown>;
+  leakedRegistryMetadataKeys: (metadata: unknown) => string[];
 };
 
 async function registryMetadataModule(): Promise<RegistryMetadataModule> {
@@ -239,6 +246,34 @@ describe("release scripts", () => {
         log: { log: () => undefined, warn: () => undefined },
       }),
     ).rejects.toThrow("registry metadata exposes local publish coordinates");
+  });
+
+  it("classifies npm view failures as retryable only for transient signals", async () => {
+    const { isRetryableNpmViewFailure } = await registryMetadataModule();
+    const failing = (stderr: string) =>
+      isRetryableNpmViewFailure({ status: 1, stdout: "", stderr });
+
+    expect(failing("npm error 503 registry busy")).toBe(true);
+    expect(failing("npm error 429 Too Many Requests")).toBe(true);
+    expect(failing("npm error code E404")).toBe(true);
+    expect(failing("npm error network timeout while fetching")).toBe(true);
+    // Non-transient failures must fail fast, not retry to the deadline.
+    expect(failing("npm error code E403 403 Forbidden")).toBe(false);
+    expect(failing("EACCES: permission denied")).toBe(false);
+    // An embedded version/number must not be misread as an HTTP status.
+    expect(failing("cannot find matching version 1.500.0")).toBe(false);
+  });
+
+  it("reads registry metadata without assuming absent _from/_resolved are present", async () => {
+    const { parseRegistryMetadata, leakedRegistryMetadataKeys } = await registryMetadataModule();
+
+    expect(parseRegistryMetadata("")).toEqual({});
+    expect(parseRegistryMetadata("{}")).toEqual({});
+    expect(leakedRegistryMetadataKeys(parseRegistryMetadata("{}"))).toEqual([]);
+    expect(leakedRegistryMetadataKeys({ _resolved: "" })).toEqual([]);
+    expect(
+      leakedRegistryMetadataKeys({ _from: "file:x.tgz", _resolved: "/Users/x/x.tgz" }),
+    ).toEqual(["_from", "_resolved"]);
   });
 
   it("retries not-yet-visible npm registry metadata before passing", async () => {

--- a/tests/unit/supply-chain-policy.unit.test.ts
+++ b/tests/unit/supply-chain-policy.unit.test.ts
@@ -625,7 +625,7 @@ describe("supply-chain audit policy", () => {
     );
     expect(publishWorkflow).toContain("pnpm run release:sbom");
     expect(publishWorkflow).toContain("node scripts/extract-release-notes.mjs");
-    expect(publishWorkflow).toContain("Dry-run npm publish from verified tarball");
+    expect(publishWorkflow).toContain("Dry-run npm publish from staged package directory");
     expect(publishWorkflow).toContain("--dry-run");
     expect(publishWorkflow).toContain("--access public");
     expect(publishWorkflow).toContain("--ignore-scripts");
@@ -674,7 +674,7 @@ describe("supply-chain audit policy", () => {
     expect(publishWorkflow).toContain("--provenance");
     expect(publishWorkflow).toContain('--tag "$npm_tag"');
     expect(publishWorkflow).not.toContain("--ignore-scripts=false");
-    expect(publishWorkflow).not.toContain("tar -xzf");
+    expect(publishWorkflow).toContain('tar -xzf "$tarball" -C publish-package/staged');
   });
 
   it("keeps tsx dev-only and denies esbuild install builds", () => {
@@ -728,7 +728,7 @@ describe("supply-chain audit policy", () => {
     const prepareJob = publishJobBlock("prepare");
     const publishJob = publishJobBlock("publish");
 
-    expect(prepareJob).toContain("npmDistTag(pack.version)");
+    expect(prepareJob).toContain("npmDistTag(pkg.version)");
     expect(prepareJob).toContain('--tag "${npm_tag}"');
     expect(publishJob).toContain('const prerelease = String(pkg.version).split("-")[1]');
     expect(publishJob).toContain(
@@ -859,6 +859,8 @@ describe("supply-chain audit policy", () => {
     expect(prepareJob).toContain("pnpm run build");
     expect(prepareJob).toContain("persist-credentials: false");
     expect(prepareJob).toContain("package-manager-cache: false");
+    expect(prepareJob).toContain("Dry-run npm publish from staged package directory");
+    expect(prepareJob).toContain('stage_dir="publish-package/dry-run-stage"');
     expect(githubReleaseJob).toContain("actions: read");
     expect(githubReleaseJob).toContain("contents: write");
     expect(githubReleaseJob).not.toContain("id-token: write");
@@ -876,6 +878,13 @@ describe("supply-chain audit policy", () => {
     expect(publishJob).not.toContain("--ignore-scripts=false");
     expect(publishJob).toContain("npm publish");
     expect(publishJob).toContain("--ignore-scripts");
+    expect(publishJob).toContain('package_dir="./publish-package/staged/package"');
+    expect(publishJob).toContain('npm publish "$package_dir"');
+    expect(publishJob).not.toContain('npm publish "$tarball"');
+    expect(publishJob).toContain('npm view "${package_spec}" _from _resolved --json');
+    expect(publishJob).toContain("registry metadata exposes local publish coordinates");
+    expect(publishJob).toContain('npm pack "$package_dir" --json --ignore-scripts');
+    expect(publishJob).toContain("Staged package tarball SHA-256 mismatch");
   });
 
   it.each(allWorkflows)("pins every marketplace action used by %s", (_name, workflowText) => {

--- a/tests/unit/supply-chain-policy.unit.test.ts
+++ b/tests/unit/supply-chain-policy.unit.test.ts
@@ -242,6 +242,17 @@ describe("supply-chain audit policy", () => {
     return workflowJobBlock(publishWorkflow, name) ?? "";
   }
 
+  function workflowStepBlock(job: string, stepName: string): string {
+    const escaped = stepName.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+    const match = job.match(
+      new RegExp(
+        `- name: ${escaped}[\\s\\S]*?(?=\\n\\s+- name:|\\n\\s+- uses:|\\n\\n  [A-Za-z0-9_-]+:|\\s*$)`,
+      ),
+    );
+    if (!match) throw new Error(`Missing workflow step ${stepName}`);
+    return match[0];
+  }
+
   function scopedAuditReport(overrides: Record<string, unknown> = {}) {
     return {
       auditReportVersion: 2,
@@ -637,6 +648,10 @@ describe("supply-chain audit policy", () => {
     expect(publishWorkflow).toContain("release-notes.md");
     expect(publishWorkflow).toContain("sbom-sha256");
     expect(publishWorkflow).toContain("EXPECTED_SBOM_SHA256");
+    expect(publishWorkflow).toContain("Stage publish helper scripts");
+    expect(publishWorkflow).toContain("scripts/npm-publish-metadata.mjs");
+    expect(publishWorkflow).toContain("scripts/verify-npm-registry-metadata.mjs");
+    expect(publishWorkflow).toContain("publish-package/release-tools/*.mjs");
     expect(publishWorkflow).toContain("Create GitHub release from verified artifact");
     expect(publishWorkflow).toContain("gh release upload");
     expect(publishWorkflow).toContain("gh release create");
@@ -728,10 +743,11 @@ describe("supply-chain audit policy", () => {
     const prepareJob = publishJobBlock("prepare");
     const publishJob = publishJobBlock("publish");
 
-    expect(prepareJob).toContain("npmDistTag(pkg.version)");
+    expect(prepareJob).toContain("node scripts/npm-publish-metadata.mjs");
     expect(prepareJob).toContain('--tag "${npm_tag}"');
-    expect(publishJob).toContain('const prerelease = String(pkg.version).split("-")[1]');
-    expect(publishJob).toContain(
+    expect(publishJob).toContain("node publish-package/release-tools/npm-publish-metadata.mjs");
+    expect(publishJob).not.toContain('const prerelease = String(pkg.version).split("-")[1]');
+    expect(publishJob).not.toContain(
       'const tag = prerelease && ["alpha", "beta", "canary", "next", "rc"].includes(channel) ? channel : prerelease ? "next" : "latest"',
     );
     expect(publishJob).toContain('--tag "$npm_tag"');
@@ -815,6 +831,10 @@ describe("supply-chain audit policy", () => {
     const githubReleaseJob = publishJobBlock("github-release");
     const containerImageJob = publishJobBlock("container-image");
     const publishJob = publishJobBlock("publish");
+    const publishStep = workflowStepBlock(
+      publishJob,
+      "Publish staged package directory with trusted provenance",
+    );
     const publishOnBlock = yamlBlockForKey(publishWorkflow, "on") ?? "";
     const publishWorkflowRunBlock = yamlBlockForKey(publishOnBlock, "workflow_run") ?? "";
     const releaseTagOnBlock = yamlBlockForKey(releaseTagWorkflow, "on") ?? "";
@@ -879,12 +899,31 @@ describe("supply-chain audit policy", () => {
     expect(publishJob).toContain("npm publish");
     expect(publishJob).toContain("--ignore-scripts");
     expect(publishJob).toContain('package_dir="./publish-package/staged/package"');
-    expect(publishJob).toContain('npm publish "$package_dir"');
-    expect(publishJob).not.toContain('npm publish "$tarball"');
-    expect(publishJob).toContain('npm view "${package_spec}" _from _resolved --json');
-    expect(publishJob).toContain("registry metadata exposes local publish coordinates");
-    expect(publishJob).toContain('npm pack "$package_dir" --json --ignore-scripts');
-    expect(publishJob).toContain("Staged package tarball SHA-256 mismatch");
+    expect(publishStep).toContain("node publish-package/release-tools/npm-publish-metadata.mjs");
+    expect(publishStep).toContain(
+      "node publish-package/release-tools/verify-npm-registry-metadata.mjs",
+    );
+    expect(publishStep).toContain("--timeout-ms 120000");
+    expect(publishStep).toContain("--initial-interval-ms 5000");
+    expect(publishStep).toContain("--max-interval-ms 30000");
+    expect(publishStep).toContain(
+      '--allow-legacy-local-path-metadata "@backblaze-labs/b2-mcp@0.1.0"',
+    );
+    expect(publishStep).toContain(
+      '--allow-legacy-local-path-metadata "@backblaze-labs/b2-mcp@0.1.1"',
+    );
+    expect(publishStep).toContain('"${legacy_metadata_args[@]}"');
+    expect(publishStep).toContain('npm publish "$package_dir"');
+    expect(publishStep).not.toContain('npm publish "$tarball"');
+    expect(publishStep).not.toContain("EXPECTED_TARBALL_NAME");
+    expect(publishStep).toContain('npm pack "$package_dir" --json --ignore-scripts');
+    expect(publishStep).toContain("Staged package tarball SHA-256 mismatch");
+    expect(publishStep.indexOf('npm publish "$package_dir"')).toBeLessThan(
+      publishStep.lastIndexOf("verify-npm-registry-metadata.mjs"),
+    );
+    expect(publishStep.slice(publishStep.lastIndexOf('npm publish "$package_dir"'))).not.toContain(
+      '"${legacy_metadata_args[@]}"',
+    );
   });
 
   it.each(allWorkflows)("pins every marketplace action used by %s", (_name, workflowText) => {


### PR DESCRIPTION
## Summary
- Publish npm releases from a staged package directory instead of passing the `.tgz` path to `npm publish`, avoiding registry `_from`/`_resolved` local file coordinates.
- Repack the staged directory in the trusted publish job and compare SHA-256/integrity to the scanned tarball before publishing.
- Centralize npm package spec/dist-tag derivation in a shared release helper used by dry-run and publish paths.
- Verify published registry metadata with bounded retry/backoff, failing hard on leaked `_from`/`_resolved` for new releases.
- Preserve matching-integrity recovery for documented legacy `0.1.0` and `0.1.1` reruns with a warning-only allowlist, and update release docs/tests.

Closes #207

## Tests
- `pnpm install --frozen-lockfile`
- `pnpm run build`
- `node scripts/run-vitest-layer.mjs unit -- tests/unit/release-scripts.unit.test.ts`
- `node scripts/run-vitest-layer.mjs unit -- tests/unit/supply-chain-policy.unit.test.ts`
- `node scripts/run-vitest-layer.mjs contract -- tests/contract/ci-workflow-policy.contract.test.ts`
- `pnpm run format:check`
- `pnpm run typecheck`
- `pnpm run lint`
- `pnpm run lint:docs`
- `pnpm run lint:links`
- `npm pack` plus `npx npm@11.17.0 pack` staged-repack SHA/integrity comparison

## Follow-up notes
- `0.1.0` and `0.1.1` already expose immutable `_resolved` metadata in npm, so this PR fixes future releases and keeps recovery possible for those known versions only when package integrity matches.
- Post-publish metadata verification now retries transient npm registry read failures and short-lived not-yet-visible responses before failing on deadline expiration.
- `pnpm run lint` passed with the existing `src/oauth-resource-server.ts` `noEmptyBlockStatements` warning.
