### PR TITLE
fix: validate bucket info and CORS naming constraints

### DIFF
--- a/docs/TOOL_PROFILES.md
+++ b/docs/TOOL_PROFILES.md
@@ -8,15 +8,15 @@ Approved modern cache hint: `ttlMs=30000`, `cacheScope=private`
 
 | Profile | Total | `b2_*` | `s3_*` | `bz_*` | Hash prefix |
 | --- | ---: | ---: | ---: | ---: | --- |
-| `full` | 40 | 21 | 19 | 0 | `3c8c3a50d2fc` |
-| `phase1-default` | 37 | 18 | 19 | 0 | `8668c4d39cf4` |
+| `full` | 40 | 21 | 19 | 0 | `6cf6387cb398` |
+| `phase1-default` | 37 | 18 | 19 | 0 | `d5bdcd66faa5` |
 | `read-only` | 20 | 11 | 9 | 0 | `d65932946c67` |
 
 ## `full`
 
 Complete tool superset for contract review and regression detection across all backing categories; durable-secret producers are sink-backed when a secret sink is active and otherwise remain availability-annotated stubs.
 
-Profile hash: `3c8c3a50d2fc751662cb6f41d894fae16871ac021da013381044aeac515e6a00`
+Profile hash: `6cf6387cb398b095081f9379e3c8c9610ebc6ee8cdb103c9c5dff02f53733dd8`
 
 ### Capability Input
 
@@ -78,7 +78,7 @@ Profile hash: `3c8c3a50d2fc751662cb6f41d894fae16871ac021da013381044aeac515e6a00`
 
 Default customer-hosted Phase 1 profile: standard B2 application key, no distinct Partner/master credential, and durable-secret producers exposed as sink-backed tools on local stdio or unavailable stubs when the sink is off.
 
-Profile hash: `8668c4d39cf4d058fe39899979c91ee5b64bfa0001caf9ab2deedb62738ed935`
+Profile hash: `d5bdcd66faa57a0aac0bb73599c0d16b72d5bee2e02de4cbeacbbba6af1da971`
 
 ### Capability Input
 

--- a/docs/TOOL_PROFILES.md
+++ b/docs/TOOL_PROFILES.md
@@ -8,15 +8,15 @@ Approved modern cache hint: `ttlMs=30000`, `cacheScope=private`
 
 | Profile | Total | `b2_*` | `s3_*` | `bz_*` | Hash prefix |
 | --- | ---: | ---: | ---: | ---: | --- |
-| `full` | 40 | 21 | 19 | 0 | `0514a29fe155` |
-| `phase1-default` | 37 | 18 | 19 | 0 | `69e5ecbb1a8c` |
+| `full` | 40 | 21 | 19 | 0 | `bb370ed3c3de` |
+| `phase1-default` | 37 | 18 | 19 | 0 | `f217d8a6a68f` |
 | `read-only` | 20 | 11 | 9 | 0 | `d65932946c67` |
 
 ## `full`
 
 Complete tool superset for contract review and regression detection across all backing categories; durable-secret producers are sink-backed when a secret sink is active and otherwise remain availability-annotated stubs.
 
-Profile hash: `0514a29fe155fd62b718351a65d7e41a079638cfbc7981241f89cfc6f93e8c94`
+Profile hash: `bb370ed3c3de5796a66fcfe3fb7925234eda4c9f2b3374199a1a9eb6fbda0079`
 
 ### Capability Input
 
@@ -78,7 +78,7 @@ Profile hash: `0514a29fe155fd62b718351a65d7e41a079638cfbc7981241f89cfc6f93e8c94`
 
 Default customer-hosted Phase 1 profile: standard B2 application key, no distinct Partner/master credential, and durable-secret producers exposed as sink-backed tools on local stdio or unavailable stubs when the sink is off.
 
-Profile hash: `69e5ecbb1a8cadb95d5928d10813bfe7c869938b3821543cb85100064005c850`
+Profile hash: `f217d8a6a68f4a60ef506ab87604f260169987eb6d75357d061a8613c30fa1db`
 
 ### Capability Input
 

--- a/docs/TOOL_PROFILES.md
+++ b/docs/TOOL_PROFILES.md
@@ -8,15 +8,15 @@ Approved modern cache hint: `ttlMs=30000`, `cacheScope=private`
 
 | Profile | Total | `b2_*` | `s3_*` | `bz_*` | Hash prefix |
 | --- | ---: | ---: | ---: | ---: | --- |
-| `full` | 40 | 21 | 19 | 0 | `bb370ed3c3de` |
-| `phase1-default` | 37 | 18 | 19 | 0 | `f217d8a6a68f` |
+| `full` | 40 | 21 | 19 | 0 | `3c8c3a50d2fc` |
+| `phase1-default` | 37 | 18 | 19 | 0 | `8668c4d39cf4` |
 | `read-only` | 20 | 11 | 9 | 0 | `d65932946c67` |
 
 ## `full`
 
 Complete tool superset for contract review and regression detection across all backing categories; durable-secret producers are sink-backed when a secret sink is active and otherwise remain availability-annotated stubs.
 
-Profile hash: `bb370ed3c3de5796a66fcfe3fb7925234eda4c9f2b3374199a1a9eb6fbda0079`
+Profile hash: `3c8c3a50d2fc751662cb6f41d894fae16871ac021da013381044aeac515e6a00`
 
 ### Capability Input
 
@@ -78,7 +78,7 @@ Profile hash: `bb370ed3c3de5796a66fcfe3fb7925234eda4c9f2b3374199a1a9eb6fbda0079`
 
 Default customer-hosted Phase 1 profile: standard B2 application key, no distinct Partner/master credential, and durable-secret producers exposed as sink-backed tools on local stdio or unavailable stubs when the sink is off.
 
-Profile hash: `f217d8a6a68f4a60ef506ab87604f260169987eb6d75357d061a8613c30fa1db`
+Profile hash: `8668c4d39cf4d058fe39899979c91ee5b64bfa0001caf9ab2deedb62738ed935`
 
 ### Capability Input
 

--- a/docs/tool-profile-contract.json
+++ b/docs/tool-profile-contract.json
@@ -204,7 +204,7 @@
         "s3_get_presigned_url",
         "s3_put_bucket_lifecycle"
       ],
-      "hash": "bb370ed3c3de5796a66fcfe3fb7925234eda4c9f2b3374199a1a9eb6fbda0079",
+      "hash": "3c8c3a50d2fc751662cb6f41d894fae16871ac021da013381044aeac515e6a00",
       "fixtures": {
         "modern": "tests/fixtures/tool-contract/full.modern.json",
         "legacy": "tests/fixtures/tool-contract/full.legacy.json"
@@ -348,7 +348,7 @@
         "s3_get_presigned_url",
         "s3_put_bucket_lifecycle"
       ],
-      "hash": "f217d8a6a68f4a60ef506ab87604f260169987eb6d75357d061a8613c30fa1db",
+      "hash": "8668c4d39cf4d058fe39899979c91ee5b64bfa0001caf9ab2deedb62738ed935",
       "fixtures": {
         "modern": "tests/fixtures/tool-contract/phase1-default.modern.json",
         "legacy": "tests/fixtures/tool-contract/phase1-default.legacy.json"

--- a/docs/tool-profile-contract.json
+++ b/docs/tool-profile-contract.json
@@ -204,7 +204,7 @@
         "s3_get_presigned_url",
         "s3_put_bucket_lifecycle"
       ],
-      "hash": "3c8c3a50d2fc751662cb6f41d894fae16871ac021da013381044aeac515e6a00",
+      "hash": "6cf6387cb398b095081f9379e3c8c9610ebc6ee8cdb103c9c5dff02f53733dd8",
       "fixtures": {
         "modern": "tests/fixtures/tool-contract/full.modern.json",
         "legacy": "tests/fixtures/tool-contract/full.legacy.json"
@@ -348,7 +348,7 @@
         "s3_get_presigned_url",
         "s3_put_bucket_lifecycle"
       ],
-      "hash": "8668c4d39cf4d058fe39899979c91ee5b64bfa0001caf9ab2deedb62738ed935",
+      "hash": "d5bdcd66faa57a0aac0bb73599c0d16b72d5bee2e02de4cbeacbbba6af1da971",
       "fixtures": {
         "modern": "tests/fixtures/tool-contract/phase1-default.modern.json",
         "legacy": "tests/fixtures/tool-contract/phase1-default.legacy.json"

--- a/docs/tool-profile-contract.json
+++ b/docs/tool-profile-contract.json
@@ -204,7 +204,7 @@
         "s3_get_presigned_url",
         "s3_put_bucket_lifecycle"
       ],
-      "hash": "0514a29fe155fd62b718351a65d7e41a079638cfbc7981241f89cfc6f93e8c94",
+      "hash": "bb370ed3c3de5796a66fcfe3fb7925234eda4c9f2b3374199a1a9eb6fbda0079",
       "fixtures": {
         "modern": "tests/fixtures/tool-contract/full.modern.json",
         "legacy": "tests/fixtures/tool-contract/full.legacy.json"
@@ -348,7 +348,7 @@
         "s3_get_presigned_url",
         "s3_put_bucket_lifecycle"
       ],
-      "hash": "69e5ecbb1a8cadb95d5928d10813bfe7c869938b3821543cb85100064005c850",
+      "hash": "f217d8a6a68f4a60ef506ab87604f260169987eb6d75357d061a8613c30fa1db",
       "fixtures": {
         "modern": "tests/fixtures/tool-contract/phase1-default.modern.json",
         "legacy": "tests/fixtures/tool-contract/phase1-default.legacy.json"

--- a/src/b2/buckets.ts
+++ b/src/b2/buckets.ts
@@ -98,15 +98,19 @@ const BUCKET_INFO_DESCRIPTION =
 
 const CORS_RULES_MAX_COUNT = 100;
 const CORS_RULE_MAX_BYTES = 1_000;
+const CORS_FIELD_MAX_ITEMS = 100;
+const CORS_STRING_MAX_CHARS = CORS_RULE_MAX_BYTES - 1;
 const CORS_RULE_NAME_PATTERN = /^[A-Za-z0-9-]+$/;
 const CORS_RULE_NAME_DESCRIPTION =
   "Unique CORS rule name, 6-63 characters. Use only letters, digits, and hyphens; " +
   "names starting with 'b2-' are reserved for Backblaze.";
 const CORS_RULES_DESCRIPTION =
-  "CORS rules for browser-based access. At most 100 rules; each rule's combined " +
-  "UTF-8 bytes across corsRuleName, allowedOrigins, allowedOperations, " +
-  "allowedHeaders, and exposeHeaders must be less than 1,000. Rule names must " +
-  "be unique within the bucket.";
+  "CORS rules for browser-based access. At most 100 rules. allowedOrigins and " +
+  "allowedOperations each require 1-100 non-empty entries; allowedHeaders and " +
+  "exposeHeaders may contain up to 100 non-empty entries. String entries must " +
+  "be at most 999 characters. Each rule's combined UTF-8 bytes across " +
+  "corsRuleName, allowedOrigins, allowedOperations, allowedHeaders, and " +
+  "exposeHeaders must be less than 1,000. Rule names must be unique within the bucket.";
 
 const bucketInfoKeySchema = z
   .string()
@@ -116,9 +120,10 @@ const bucketInfoKeySchema = z
   .refine((value) => !value.toLowerCase().startsWith("b2-"), {
     message: "bucketInfo keys starting with 'b2-' are reserved for Backblaze",
   });
+const bucketInfoValueSchema = z.string().max(BUCKET_INFO_VALUES_MAX_BYTES);
 
 const bucketInfoSchema = z
-  .record(bucketInfoKeySchema, z.string())
+  .record(bucketInfoKeySchema, bucketInfoValueSchema)
   .superRefine((value, ctx) => {
     const message = bucketInfoInputError(value);
     if (message) ctx.addIssue({ code: "custom", message });
@@ -135,12 +140,16 @@ const corsRuleNameSchema = z
   })
   .describe(CORS_RULE_NAME_DESCRIPTION);
 
+const corsStringSchema = z.string().min(1).max(CORS_STRING_MAX_CHARS);
+const requiredCorsStringArraySchema = z.array(corsStringSchema).min(1).max(CORS_FIELD_MAX_ITEMS);
+const optionalCorsStringArraySchema = z.array(corsStringSchema).max(CORS_FIELD_MAX_ITEMS);
+
 const corsRuleSchema = z.object({
   corsRuleName: corsRuleNameSchema,
-  allowedOrigins: z.array(z.string()),
-  allowedHeaders: z.array(z.string()),
-  allowedOperations: z.array(z.string()),
-  exposeHeaders: z.array(z.string()).optional(),
+  allowedOrigins: requiredCorsStringArraySchema,
+  allowedHeaders: optionalCorsStringArraySchema,
+  allowedOperations: requiredCorsStringArraySchema,
+  exposeHeaders: optionalCorsStringArraySchema.optional(),
   maxAgeSeconds: z.number(),
 });
 
@@ -258,8 +267,11 @@ function bucketInfoInputError(bucketInfo: Record<string, string> | undefined): s
 
   let valuesBytes = 0;
   for (const [key, value] of entries) {
+    if (key.length < 1 || key.length > BUCKET_INFO_KEY_MAX_BYTES) {
+      return `bucketInfo key ${quotedName(key)} must be 1-${BUCKET_INFO_KEY_MAX_BYTES} UTF-8 bytes.`;
+    }
     const keyBytes = utf8Bytes(key);
-    if (keyBytes < 1 || keyBytes > BUCKET_INFO_KEY_MAX_BYTES) {
+    if (keyBytes > BUCKET_INFO_KEY_MAX_BYTES) {
       return `bucketInfo key ${quotedName(key)} must be 1-${BUCKET_INFO_KEY_MAX_BYTES} UTF-8 bytes.`;
     }
     if (!BUCKET_INFO_KEY_PATTERN.test(key)) {
@@ -268,12 +280,15 @@ function bucketInfoInputError(bucketInfo: Record<string, string> | undefined): s
     if (key.toLowerCase().startsWith("b2-")) {
       return `bucketInfo key ${quotedName(key)} must not start with 'b2-'; that prefix is reserved for Backblaze.`;
     }
+    if (value.length > BUCKET_INFO_VALUES_MAX_BYTES) {
+      return `bucketInfo value for ${quotedName(key)} must be at most ${BUCKET_INFO_VALUES_MAX_BYTES} characters.`;
+    }
     valuesBytes += utf8Bytes(value);
+    if (valuesBytes > BUCKET_INFO_VALUES_MAX_BYTES) {
+      return `bucketInfo values must total at most ${BUCKET_INFO_VALUES_MAX_BYTES} UTF-8 bytes.`;
+    }
   }
 
-  if (valuesBytes > BUCKET_INFO_VALUES_MAX_BYTES) {
-    return `bucketInfo values must total at most ${BUCKET_INFO_VALUES_MAX_BYTES} UTF-8 bytes.`;
-  }
   return null;
 }
 
@@ -290,14 +305,46 @@ function corsRuleNameError(name: string, path: string): string | null {
   return null;
 }
 
-function corsRuleStrings(rule: NonNullable<CreateBucketOptions["corsRules"]>[number]): string[] {
-  return [
-    rule.corsRuleName,
-    ...rule.allowedOrigins,
-    ...rule.allowedOperations,
-    ...(rule.allowedHeaders ?? []),
-    ...(rule.exposeHeaders ?? []),
-  ];
+function addCorsStringArrayBytes(
+  ruleBytes: number,
+  values: readonly string[] | null | undefined,
+  path: string,
+  minItems: number,
+  rulePath: string,
+): { ok: true; ruleBytes: number } | { ok: false; message: string } {
+  const items = values ?? [];
+  if (items.length < minItems) {
+    return { ok: false, message: `${path} must contain at least ${minItems} item.` };
+  }
+  if (items.length > CORS_FIELD_MAX_ITEMS) {
+    return {
+      ok: false,
+      message: `${path} must contain at most ${CORS_FIELD_MAX_ITEMS} items.`,
+    };
+  }
+
+  let total = ruleBytes;
+  for (const [index, value] of items.entries()) {
+    const itemPath = `${path}[${index}]`;
+    if (value.length < 1) {
+      return { ok: false, message: `${itemPath} must not be empty.` };
+    }
+    if (value.length > CORS_STRING_MAX_CHARS) {
+      return {
+        ok: false,
+        message: `${itemPath} must be at most ${CORS_STRING_MAX_CHARS} characters.`,
+      };
+    }
+    total += utf8Bytes(value);
+    if (total >= CORS_RULE_MAX_BYTES) {
+      return {
+        ok: false,
+        message: `${rulePath} must be less than ${CORS_RULE_MAX_BYTES} UTF-8 bytes across corsRuleName, allowedOrigins, allowedOperations, allowedHeaders, and exposeHeaders.`,
+      };
+    }
+  }
+
+  return { ok: true, ruleBytes: total };
 }
 
 function corsRulesInputError(
@@ -313,14 +360,30 @@ function corsRulesInputError(
     const path = `corsRules[${index}].corsRuleName`;
     const nameError = corsRuleNameError(rule.corsRuleName, path);
     if (nameError) return nameError;
+    let ruleBytes = rule.corsRuleName.length;
+    if (ruleBytes >= CORS_RULE_MAX_BYTES) {
+      return `corsRules[${index}] must be less than ${CORS_RULE_MAX_BYTES} UTF-8 bytes across corsRuleName, allowedOrigins, allowedOperations, allowedHeaders, and exposeHeaders.`;
+    }
     if (names.has(rule.corsRuleName)) {
       return `${path} ${quotedName(rule.corsRuleName)} must be unique within the bucket.`;
     }
     names.add(rule.corsRuleName);
 
-    const ruleBytes = corsRuleStrings(rule).reduce((sum, value) => sum + utf8Bytes(value), 0);
-    if (ruleBytes >= CORS_RULE_MAX_BYTES) {
-      return `corsRules[${index}] must be less than ${CORS_RULE_MAX_BYTES} UTF-8 bytes across corsRuleName, allowedOrigins, allowedOperations, allowedHeaders, and exposeHeaders.`;
+    for (const [field, minItems] of [
+      ["allowedOrigins", 1],
+      ["allowedOperations", 1],
+      ["allowedHeaders", 0],
+      ["exposeHeaders", 0],
+    ] as const) {
+      const result = addCorsStringArrayBytes(
+        ruleBytes,
+        rule[field],
+        `corsRules[${index}].${field}`,
+        minItems,
+        `corsRules[${index}]`,
+      );
+      if (!result.ok) return result.message;
+      ruleBytes = result.ruleBytes;
     }
   }
   return null;
@@ -540,10 +603,7 @@ export function registerBucketTools(
           .describe(
             "allPublic allows unauthenticated downloads; allPrivate requires authorization.",
           ),
-        bucketInfo: z
-          .record(bucketInfoKeySchema, z.string())
-          .optional()
-          .describe(BUCKET_INFO_DESCRIPTION),
+        bucketInfo: bucketInfoSchema.optional(),
         corsRules: corsRulesSchema.optional().describe(CORS_RULES_DESCRIPTION),
         lifecycleRules: z
           .array(

--- a/src/b2/buckets.ts
+++ b/src/b2/buckets.ts
@@ -91,26 +91,16 @@ const BUCKET_INFO_KEY_MAX_BYTES = 50;
 const BUCKET_INFO_VALUES_MAX_BYTES = 10_000;
 const BUCKET_INFO_KEY_PATTERN = /^[A-Za-z0-9._`~!#$%^&*'|+-]+$/;
 const BUCKET_INFO_DESCRIPTION =
-  "Custom bucket metadata. Up to 10 key-value pairs. Keys are 1-50 UTF-8 bytes, " +
-  "letters/digits plus - _ . ` ~ ! # $ % ^ & * ' | +, and must not start with " +
-  "'b2-' (case-insensitive; B2 lowercases keys). Values may contain any text, " +
-  "but all values together must be <= 10,000 UTF-8 bytes.";
+  "Custom metadata: <=10 pairs. Keys: 1-50 UTF-8 bytes, chars A-Z a-z 0-9 . _ ` ~ ! # $ % ^ & * ' | + -, no b2- prefix. Values total <=10,000 UTF-8 bytes.";
 
 const CORS_RULES_MAX_COUNT = 100;
 const CORS_RULE_MAX_BYTES = 1_000;
 const CORS_FIELD_MAX_ITEMS = 100;
 const CORS_STRING_MAX_CHARS = CORS_RULE_MAX_BYTES - 1;
 const CORS_RULE_NAME_PATTERN = /^[A-Za-z0-9-]+$/;
-const CORS_RULE_NAME_DESCRIPTION =
-  "Unique CORS rule name, 6-63 characters. Use only letters, digits, and hyphens; " +
-  "names starting with 'b2-' are reserved for Backblaze.";
+const CORS_RULE_NAME_DESCRIPTION = "Unique name: 6-63 letters, digits, hyphens; no b2- prefix.";
 const CORS_RULES_DESCRIPTION =
-  "CORS rules for browser-based access. At most 100 rules. allowedOrigins and " +
-  "allowedOperations each require 1-100 non-empty entries; allowedHeaders and " +
-  "exposeHeaders may contain up to 100 non-empty entries. String entries must " +
-  "be at most 999 characters. Each rule's combined UTF-8 bytes across " +
-  "corsRuleName, allowedOrigins, allowedOperations, allowedHeaders, and " +
-  "exposeHeaders must be less than 1,000. Rule names must be unique within the bucket.";
+  "CORS rules: <=100. allowedOrigins/allowedOperations require 1-100 non-empty strings; allowedHeaders/exposeHeaders allow <=100. Strings <=999 chars. Per-rule UTF-8 total <1,000. Names unique.";
 
 const bucketInfoKeySchema = z
   .string()
@@ -159,7 +149,8 @@ const corsRulesSchema = z
   .superRefine((value, ctx) => {
     const message = corsRulesInputError(value);
     if (message) ctx.addIssue({ code: "custom", message });
-  });
+  })
+  .describe(CORS_RULES_DESCRIPTION);
 
 type WebhookDnsLookup = (host: string) => Promise<Array<{ address: string }>>;
 let webhookDnsLookupForTests: WebhookDnsLookup | null = null;
@@ -258,6 +249,10 @@ function quotedName(value: string): string {
   return JSON.stringify(value.length > 80 ? `${value.slice(0, 77)}...` : value);
 }
 
+function bucketInfoKeySizeError(key: string): string {
+  return `bucketInfo key ${quotedName(key)} must be 1-${BUCKET_INFO_KEY_MAX_BYTES} UTF-8 bytes.`;
+}
+
 function bucketInfoInputError(bucketInfo: Record<string, string> | undefined): string | null {
   if (bucketInfo === undefined) return null;
   const entries = Object.entries(bucketInfo);
@@ -268,11 +263,10 @@ function bucketInfoInputError(bucketInfo: Record<string, string> | undefined): s
   let valuesBytes = 0;
   for (const [key, value] of entries) {
     if (key.length < 1 || key.length > BUCKET_INFO_KEY_MAX_BYTES) {
-      return `bucketInfo key ${quotedName(key)} must be 1-${BUCKET_INFO_KEY_MAX_BYTES} UTF-8 bytes.`;
+      return bucketInfoKeySizeError(key);
     }
-    const keyBytes = utf8Bytes(key);
-    if (keyBytes > BUCKET_INFO_KEY_MAX_BYTES) {
-      return `bucketInfo key ${quotedName(key)} must be 1-${BUCKET_INFO_KEY_MAX_BYTES} UTF-8 bytes.`;
+    if (utf8Bytes(key) > BUCKET_INFO_KEY_MAX_BYTES) {
+      return bucketInfoKeySizeError(key);
     }
     if (!BUCKET_INFO_KEY_PATTERN.test(key)) {
       return `bucketInfo key ${quotedName(key)} may contain only letters, digits, and these characters: - _ . \` ~ ! # $ % ^ & * ' | +.`;
@@ -290,6 +284,10 @@ function bucketInfoInputError(bucketInfo: Record<string, string> | undefined): s
   }
 
   return null;
+}
+
+function corsRuleSizeError(rulePath: string): string {
+  return `${rulePath} must be less than ${CORS_RULE_MAX_BYTES} UTF-8 bytes.`;
 }
 
 function corsRuleNameError(name: string, path: string): string | null {
@@ -339,7 +337,7 @@ function addCorsStringArrayBytes(
     if (total >= CORS_RULE_MAX_BYTES) {
       return {
         ok: false,
-        message: `${rulePath} must be less than ${CORS_RULE_MAX_BYTES} UTF-8 bytes across corsRuleName, allowedOrigins, allowedOperations, allowedHeaders, and exposeHeaders.`,
+        message: corsRuleSizeError(rulePath),
       };
     }
   }
@@ -361,9 +359,6 @@ function corsRulesInputError(
     const nameError = corsRuleNameError(rule.corsRuleName, path);
     if (nameError) return nameError;
     let ruleBytes = rule.corsRuleName.length;
-    if (ruleBytes >= CORS_RULE_MAX_BYTES) {
-      return `corsRules[${index}] must be less than ${CORS_RULE_MAX_BYTES} UTF-8 bytes across corsRuleName, allowedOrigins, allowedOperations, allowedHeaders, and exposeHeaders.`;
-    }
     if (names.has(rule.corsRuleName)) {
       return `${path} ${quotedName(rule.corsRuleName)} must be unique within the bucket.`;
     }
@@ -604,7 +599,7 @@ export function registerBucketTools(
             "allPublic allows unauthenticated downloads; allPrivate requires authorization.",
           ),
         bucketInfo: bucketInfoSchema.optional(),
-        corsRules: corsRulesSchema.optional().describe(CORS_RULES_DESCRIPTION),
+        corsRules: corsRulesSchema.optional(),
         lifecycleRules: z
           .array(
             z.object({
@@ -694,12 +689,8 @@ export function registerBucketTools(
       inputSchema: {
         bucketId: z.string().describe("The ID of the bucket to update."),
         bucketType: z.enum(["allPublic", "allPrivate"]).optional(),
-        bucketInfo: bucketInfoSchema
-          .optional()
-          .describe(`${BUCKET_INFO_DESCRIPTION} Replaces all existing bucketInfo when supplied.`),
-        corsRules: corsRulesSchema
-          .optional()
-          .describe(`${CORS_RULES_DESCRIPTION} Replaces all existing CORS rules when supplied.`),
+        bucketInfo: bucketInfoSchema.optional(),
+        corsRules: corsRulesSchema.optional(),
         lifecycleRules: z
           .array(
             z.object({

--- a/src/b2/buckets.ts
+++ b/src/b2/buckets.ts
@@ -86,6 +86,71 @@ const NON_GLOBAL_IPV6_CIDRS: Array<[string, number]> = [
 ];
 
 const WEBHOOK_DNS_LOOKUP_TIMEOUT_MS = 2_000;
+const BUCKET_INFO_MAX_PAIRS = 10;
+const BUCKET_INFO_KEY_MAX_BYTES = 50;
+const BUCKET_INFO_VALUES_MAX_BYTES = 10_000;
+const BUCKET_INFO_KEY_PATTERN = /^[A-Za-z0-9._`~!#$%^&*'|+-]+$/;
+const BUCKET_INFO_DESCRIPTION =
+  "Custom bucket metadata. Up to 10 key-value pairs. Keys are 1-50 UTF-8 bytes, " +
+  "letters/digits plus - _ . ` ~ ! # $ % ^ & * ' | +, and must not start with " +
+  "'b2-' (case-insensitive; B2 lowercases keys). Values may contain any text, " +
+  "but all values together must be <= 10,000 UTF-8 bytes.";
+
+const CORS_RULES_MAX_COUNT = 100;
+const CORS_RULE_MAX_BYTES = 1_000;
+const CORS_RULE_NAME_PATTERN = /^[A-Za-z0-9-]+$/;
+const CORS_RULE_NAME_DESCRIPTION =
+  "Unique CORS rule name, 6-63 characters. Use only letters, digits, and hyphens; " +
+  "names starting with 'b2-' are reserved for Backblaze.";
+const CORS_RULES_DESCRIPTION =
+  "CORS rules for browser-based access. At most 100 rules; each rule's combined " +
+  "UTF-8 bytes across corsRuleName, allowedOrigins, allowedOperations, " +
+  "allowedHeaders, and exposeHeaders must be less than 1,000. Rule names must " +
+  "be unique within the bucket.";
+
+const bucketInfoKeySchema = z
+  .string()
+  .min(1)
+  .max(BUCKET_INFO_KEY_MAX_BYTES)
+  .regex(BUCKET_INFO_KEY_PATTERN)
+  .refine((value) => !value.toLowerCase().startsWith("b2-"), {
+    message: "bucketInfo keys starting with 'b2-' are reserved for Backblaze",
+  });
+
+const bucketInfoSchema = z
+  .record(bucketInfoKeySchema, z.string())
+  .superRefine((value, ctx) => {
+    const message = bucketInfoInputError(value);
+    if (message) ctx.addIssue({ code: "custom", message });
+  })
+  .describe(BUCKET_INFO_DESCRIPTION);
+
+const corsRuleNameSchema = z
+  .string()
+  .min(6)
+  .max(63)
+  .regex(CORS_RULE_NAME_PATTERN)
+  .refine((value) => !value.toLowerCase().startsWith("b2-"), {
+    message: "corsRuleName values starting with 'b2-' are reserved for Backblaze",
+  })
+  .describe(CORS_RULE_NAME_DESCRIPTION);
+
+const corsRuleSchema = z.object({
+  corsRuleName: corsRuleNameSchema,
+  allowedOrigins: z.array(z.string()),
+  allowedHeaders: z.array(z.string()),
+  allowedOperations: z.array(z.string()),
+  exposeHeaders: z.array(z.string()).optional(),
+  maxAgeSeconds: z.number(),
+});
+
+const corsRulesSchema = z
+  .array(corsRuleSchema)
+  .max(CORS_RULES_MAX_COUNT)
+  .superRefine((value, ctx) => {
+    const message = corsRulesInputError(value);
+    if (message) ctx.addIssue({ code: "custom", message });
+  });
 
 type WebhookDnsLookup = (host: string) => Promise<Array<{ address: string }>>;
 let webhookDnsLookupForTests: WebhookDnsLookup | null = null;
@@ -174,6 +239,105 @@ function isNonGlobalIpLiteral(host: string): boolean {
 function unrefTimer(timer: ReturnType<typeof setTimeout>): void {
   const maybeUnref = (timer as { unref?: unknown }).unref;
   if (typeof maybeUnref === "function") maybeUnref.call(timer);
+}
+
+function utf8Bytes(value: string): number {
+  return new TextEncoder().encode(value).byteLength;
+}
+
+function quotedName(value: string): string {
+  return JSON.stringify(value.length > 80 ? `${value.slice(0, 77)}...` : value);
+}
+
+function bucketInfoInputError(bucketInfo: Record<string, string> | undefined): string | null {
+  if (bucketInfo === undefined) return null;
+  const entries = Object.entries(bucketInfo);
+  if (entries.length > BUCKET_INFO_MAX_PAIRS) {
+    return `bucketInfo must contain at most ${BUCKET_INFO_MAX_PAIRS} key-value pairs.`;
+  }
+
+  let valuesBytes = 0;
+  for (const [key, value] of entries) {
+    const keyBytes = utf8Bytes(key);
+    if (keyBytes < 1 || keyBytes > BUCKET_INFO_KEY_MAX_BYTES) {
+      return `bucketInfo key ${quotedName(key)} must be 1-${BUCKET_INFO_KEY_MAX_BYTES} UTF-8 bytes.`;
+    }
+    if (!BUCKET_INFO_KEY_PATTERN.test(key)) {
+      return `bucketInfo key ${quotedName(key)} may contain only letters, digits, and these characters: - _ . \` ~ ! # $ % ^ & * ' | +.`;
+    }
+    if (key.toLowerCase().startsWith("b2-")) {
+      return `bucketInfo key ${quotedName(key)} must not start with 'b2-'; that prefix is reserved for Backblaze.`;
+    }
+    valuesBytes += utf8Bytes(value);
+  }
+
+  if (valuesBytes > BUCKET_INFO_VALUES_MAX_BYTES) {
+    return `bucketInfo values must total at most ${BUCKET_INFO_VALUES_MAX_BYTES} UTF-8 bytes.`;
+  }
+  return null;
+}
+
+function corsRuleNameError(name: string, path: string): string | null {
+  if (name.length < 6 || name.length > 63) {
+    return `${path} must be 6-63 characters long.`;
+  }
+  if (!CORS_RULE_NAME_PATTERN.test(name)) {
+    return `${path} may contain only letters, digits, and hyphens.`;
+  }
+  if (name.toLowerCase().startsWith("b2-")) {
+    return `${path} must not start with 'b2-'; that prefix is reserved for Backblaze.`;
+  }
+  return null;
+}
+
+function corsRuleStrings(rule: NonNullable<CreateBucketOptions["corsRules"]>[number]): string[] {
+  return [
+    rule.corsRuleName,
+    ...rule.allowedOrigins,
+    ...rule.allowedOperations,
+    ...(rule.allowedHeaders ?? []),
+    ...(rule.exposeHeaders ?? []),
+  ];
+}
+
+function corsRulesInputError(
+  corsRules: CreateBucketOptions["corsRules"] | undefined,
+): string | null {
+  if (corsRules === undefined) return null;
+  if (corsRules.length > CORS_RULES_MAX_COUNT) {
+    return `corsRules must contain at most ${CORS_RULES_MAX_COUNT} rules.`;
+  }
+
+  const names = new Set<string>();
+  for (const [index, rule] of corsRules.entries()) {
+    const path = `corsRules[${index}].corsRuleName`;
+    const nameError = corsRuleNameError(rule.corsRuleName, path);
+    if (nameError) return nameError;
+    if (names.has(rule.corsRuleName)) {
+      return `${path} ${quotedName(rule.corsRuleName)} must be unique within the bucket.`;
+    }
+    names.add(rule.corsRuleName);
+
+    const ruleBytes = corsRuleStrings(rule).reduce((sum, value) => sum + utf8Bytes(value), 0);
+    if (ruleBytes >= CORS_RULE_MAX_BYTES) {
+      return `corsRules[${index}] must be less than ${CORS_RULE_MAX_BYTES} UTF-8 bytes across corsRuleName, allowedOrigins, allowedOperations, allowedHeaders, and exposeHeaders.`;
+    }
+  }
+  return null;
+}
+
+function failB2InputValidation(message: string): never {
+  throw { status: 400, code: "bad_request", message };
+}
+
+function validateBucketInfoInput(bucketInfo: Record<string, string> | undefined): void {
+  const message = bucketInfoInputError(bucketInfo);
+  if (message) failB2InputValidation(message);
+}
+
+function validateCorsRulesInput(corsRules: CreateBucketOptions["corsRules"] | undefined): void {
+  const message = corsRulesInputError(corsRules);
+  if (message) failB2InputValidation(message);
 }
 
 async function lookupWebhookHost(host: string): Promise<Array<{ address: string }>> {
@@ -377,22 +541,10 @@ export function registerBucketTools(
             "allPublic allows unauthenticated downloads; allPrivate requires authorization.",
           ),
         bucketInfo: z
-          .record(z.string(), z.string())
+          .record(bucketInfoKeySchema, z.string())
           .optional()
-          .describe("Up to 10 custom key-value pairs stored with the bucket."),
-        corsRules: z
-          .array(
-            z.object({
-              corsRuleName: z.string(),
-              allowedOrigins: z.array(z.string()),
-              allowedHeaders: z.array(z.string()),
-              allowedOperations: z.array(z.string()),
-              exposeHeaders: z.array(z.string()).optional(),
-              maxAgeSeconds: z.number(),
-            }),
-          )
-          .optional()
-          .describe("CORS rules for browser-based access."),
+          .describe(BUCKET_INFO_DESCRIPTION),
+        corsRules: corsRulesSchema.optional().describe(CORS_RULES_DESCRIPTION),
         lifecycleRules: z
           .array(
             z.object({
@@ -423,6 +575,8 @@ export function registerBucketTools(
     },
     async (args) => {
       try {
+        validateBucketInfoInput(args.bucketInfo);
+        validateCorsRulesInput(args.corsRules);
         const payload: CreateBucketOptions = {
           bucketName: args.bucketName,
           bucketType: args.bucketType,
@@ -480,19 +634,12 @@ export function registerBucketTools(
       inputSchema: {
         bucketId: z.string().describe("The ID of the bucket to update."),
         bucketType: z.enum(["allPublic", "allPrivate"]).optional(),
-        bucketInfo: z.record(z.string(), z.string()).optional(),
-        corsRules: z
-          .array(
-            z.object({
-              corsRuleName: z.string(),
-              allowedOrigins: z.array(z.string()),
-              allowedHeaders: z.array(z.string()),
-              allowedOperations: z.array(z.string()),
-              exposeHeaders: z.array(z.string()).optional(),
-              maxAgeSeconds: z.number(),
-            }),
-          )
-          .optional(),
+        bucketInfo: bucketInfoSchema
+          .optional()
+          .describe(`${BUCKET_INFO_DESCRIPTION} Replaces all existing bucketInfo when supplied.`),
+        corsRules: corsRulesSchema
+          .optional()
+          .describe(`${CORS_RULES_DESCRIPTION} Replaces all existing CORS rules when supplied.`),
         lifecycleRules: z
           .array(
             z.object({
@@ -578,6 +725,8 @@ export function registerBucketTools(
       try {
         const gate = checkDestructive("b2_update_bucket", args, config);
         if (!gate.ok) return toolError(new Error(gate.message));
+        validateBucketInfoInput(args.bucketInfo);
+        validateCorsRulesInput(args.corsRules);
         const payload: UpdateBucketOptions = {
           bucketId: args.bucketId,
           ...(args.bucketType !== undefined ? { bucketType: args.bucketType } : {}),

--- a/tests/fixtures/tool-contract/full.legacy.json
+++ b/tests/fixtures/tool-contract/full.legacy.json
@@ -146,7 +146,7 @@
               "maxLength": 10000,
               "type": "string"
             },
-            "description": "Custom bucket metadata. Up to 10 key-value pairs. Keys are 1-50 UTF-8 bytes, letters/digits plus - _ . ` ~ ! # $ % ^ & * ' | +, and must not start with 'b2-' (case-insensitive; B2 lowercases keys). Values may contain any text, but all values together must be <= 10,000 UTF-8 bytes.",
+            "description": "Custom metadata: <=10 pairs. Keys: 1-50 UTF-8 bytes, chars A-Z a-z 0-9 . _ ` ~ ! # $ % ^ & * ' | + -, no b2- prefix. Values total <=10,000 UTF-8 bytes.",
             "propertyNames": {
               "maxLength": 50,
               "minLength": 1,
@@ -165,7 +165,7 @@
             "type": "string"
           },
           "corsRules": {
-            "description": "CORS rules for browser-based access. At most 100 rules. allowedOrigins and allowedOperations each require 1-100 non-empty entries; allowedHeaders and exposeHeaders may contain up to 100 non-empty entries. String entries must be at most 999 characters. Each rule's combined UTF-8 bytes across corsRuleName, allowedOrigins, allowedOperations, allowedHeaders, and exposeHeaders must be less than 1,000. Rule names must be unique within the bucket.",
+            "description": "CORS rules: <=100. allowedOrigins/allowedOperations require 1-100 non-empty strings; allowedHeaders/exposeHeaders allow <=100. Strings <=999 chars. Per-rule UTF-8 total <1,000. Names unique.",
             "items": {
               "properties": {
                 "allowedHeaders": {
@@ -198,7 +198,7 @@
                   "type": "array"
                 },
                 "corsRuleName": {
-                  "description": "Unique CORS rule name, 6-63 characters. Use only letters, digits, and hyphens; names starting with 'b2-' are reserved for Backblaze.",
+                  "description": "Unique name: 6-63 letters, digits, hyphens; no b2- prefix.",
                   "maxLength": 63,
                   "minLength": 6,
                   "pattern": "^[A-Za-z0-9-]+$",
@@ -800,7 +800,7 @@
               "maxLength": 10000,
               "type": "string"
             },
-            "description": "Custom bucket metadata. Up to 10 key-value pairs. Keys are 1-50 UTF-8 bytes, letters/digits plus - _ . ` ~ ! # $ % ^ & * ' | +, and must not start with 'b2-' (case-insensitive; B2 lowercases keys). Values may contain any text, but all values together must be <= 10,000 UTF-8 bytes. Replaces all existing bucketInfo when supplied.",
+            "description": "Custom metadata: <=10 pairs. Keys: 1-50 UTF-8 bytes, chars A-Z a-z 0-9 . _ ` ~ ! # $ % ^ & * ' | + -, no b2- prefix. Values total <=10,000 UTF-8 bytes.",
             "propertyNames": {
               "maxLength": 50,
               "minLength": 1,
@@ -818,7 +818,7 @@
             "type": "boolean"
           },
           "corsRules": {
-            "description": "CORS rules for browser-based access. At most 100 rules. allowedOrigins and allowedOperations each require 1-100 non-empty entries; allowedHeaders and exposeHeaders may contain up to 100 non-empty entries. String entries must be at most 999 characters. Each rule's combined UTF-8 bytes across corsRuleName, allowedOrigins, allowedOperations, allowedHeaders, and exposeHeaders must be less than 1,000. Rule names must be unique within the bucket. Replaces all existing CORS rules when supplied.",
+            "description": "CORS rules: <=100. allowedOrigins/allowedOperations require 1-100 non-empty strings; allowedHeaders/exposeHeaders allow <=100. Strings <=999 chars. Per-rule UTF-8 total <1,000. Names unique.",
             "items": {
               "properties": {
                 "allowedHeaders": {
@@ -851,7 +851,7 @@
                   "type": "array"
                 },
                 "corsRuleName": {
-                  "description": "Unique CORS rule name, 6-63 characters. Use only letters, digits, and hyphens; names starting with 'b2-' are reserved for Backblaze.",
+                  "description": "Unique name: 6-63 letters, digits, hyphens; no b2- prefix.",
                   "maxLength": 63,
                   "minLength": 6,
                   "pattern": "^[A-Za-z0-9-]+$",
@@ -2028,5 +2028,5 @@
     "toolsListCacheHint": null,
     "discover": null
   },
-  "hash": "3c8c3a50d2fc751662cb6f41d894fae16871ac021da013381044aeac515e6a00"
+  "hash": "6cf6387cb398b095081f9379e3c8c9610ebc6ee8cdb103c9c5dff02f53733dd8"
 }

--- a/tests/fixtures/tool-contract/full.legacy.json
+++ b/tests/fixtures/tool-contract/full.legacy.json
@@ -143,6 +143,7 @@
         "properties": {
           "bucketInfo": {
             "additionalProperties": {
+              "maxLength": 10000,
               "type": "string"
             },
             "description": "Custom bucket metadata. Up to 10 key-value pairs. Keys are 1-50 UTF-8 bytes, letters/digits plus - _ . ` ~ ! # $ % ^ & * ' | +, and must not start with 'b2-' (case-insensitive; B2 lowercases keys). Values may contain any text, but all values together must be <= 10,000 UTF-8 bytes.",
@@ -164,25 +165,36 @@
             "type": "string"
           },
           "corsRules": {
-            "description": "CORS rules for browser-based access. At most 100 rules; each rule's combined UTF-8 bytes across corsRuleName, allowedOrigins, allowedOperations, allowedHeaders, and exposeHeaders must be less than 1,000. Rule names must be unique within the bucket.",
+            "description": "CORS rules for browser-based access. At most 100 rules. allowedOrigins and allowedOperations each require 1-100 non-empty entries; allowedHeaders and exposeHeaders may contain up to 100 non-empty entries. String entries must be at most 999 characters. Each rule's combined UTF-8 bytes across corsRuleName, allowedOrigins, allowedOperations, allowedHeaders, and exposeHeaders must be less than 1,000. Rule names must be unique within the bucket.",
             "items": {
               "properties": {
                 "allowedHeaders": {
                   "items": {
+                    "maxLength": 999,
+                    "minLength": 1,
                     "type": "string"
                   },
+                  "maxItems": 100,
                   "type": "array"
                 },
                 "allowedOperations": {
                   "items": {
+                    "maxLength": 999,
+                    "minLength": 1,
                     "type": "string"
                   },
+                  "maxItems": 100,
+                  "minItems": 1,
                   "type": "array"
                 },
                 "allowedOrigins": {
                   "items": {
+                    "maxLength": 999,
+                    "minLength": 1,
                     "type": "string"
                   },
+                  "maxItems": 100,
+                  "minItems": 1,
                   "type": "array"
                 },
                 "corsRuleName": {
@@ -194,8 +206,11 @@
                 },
                 "exposeHeaders": {
                   "items": {
+                    "maxLength": 999,
+                    "minLength": 1,
                     "type": "string"
                   },
+                  "maxItems": 100,
                   "type": "array"
                 },
                 "maxAgeSeconds": {
@@ -782,6 +797,7 @@
           },
           "bucketInfo": {
             "additionalProperties": {
+              "maxLength": 10000,
               "type": "string"
             },
             "description": "Custom bucket metadata. Up to 10 key-value pairs. Keys are 1-50 UTF-8 bytes, letters/digits plus - _ . ` ~ ! # $ % ^ & * ' | +, and must not start with 'b2-' (case-insensitive; B2 lowercases keys). Values may contain any text, but all values together must be <= 10,000 UTF-8 bytes. Replaces all existing bucketInfo when supplied.",
@@ -802,25 +818,36 @@
             "type": "boolean"
           },
           "corsRules": {
-            "description": "CORS rules for browser-based access. At most 100 rules; each rule's combined UTF-8 bytes across corsRuleName, allowedOrigins, allowedOperations, allowedHeaders, and exposeHeaders must be less than 1,000. Rule names must be unique within the bucket. Replaces all existing CORS rules when supplied.",
+            "description": "CORS rules for browser-based access. At most 100 rules. allowedOrigins and allowedOperations each require 1-100 non-empty entries; allowedHeaders and exposeHeaders may contain up to 100 non-empty entries. String entries must be at most 999 characters. Each rule's combined UTF-8 bytes across corsRuleName, allowedOrigins, allowedOperations, allowedHeaders, and exposeHeaders must be less than 1,000. Rule names must be unique within the bucket. Replaces all existing CORS rules when supplied.",
             "items": {
               "properties": {
                 "allowedHeaders": {
                   "items": {
+                    "maxLength": 999,
+                    "minLength": 1,
                     "type": "string"
                   },
+                  "maxItems": 100,
                   "type": "array"
                 },
                 "allowedOperations": {
                   "items": {
+                    "maxLength": 999,
+                    "minLength": 1,
                     "type": "string"
                   },
+                  "maxItems": 100,
+                  "minItems": 1,
                   "type": "array"
                 },
                 "allowedOrigins": {
                   "items": {
+                    "maxLength": 999,
+                    "minLength": 1,
                     "type": "string"
                   },
+                  "maxItems": 100,
+                  "minItems": 1,
                   "type": "array"
                 },
                 "corsRuleName": {
@@ -832,8 +859,11 @@
                 },
                 "exposeHeaders": {
                   "items": {
+                    "maxLength": 999,
+                    "minLength": 1,
                     "type": "string"
                   },
+                  "maxItems": 100,
                   "type": "array"
                 },
                 "maxAgeSeconds": {
@@ -1998,5 +2028,5 @@
     "toolsListCacheHint": null,
     "discover": null
   },
-  "hash": "bb370ed3c3de5796a66fcfe3fb7925234eda4c9f2b3374199a1a9eb6fbda0079"
+  "hash": "3c8c3a50d2fc751662cb6f41d894fae16871ac021da013381044aeac515e6a00"
 }

--- a/tests/fixtures/tool-contract/full.legacy.json
+++ b/tests/fixtures/tool-contract/full.legacy.json
@@ -145,8 +145,11 @@
             "additionalProperties": {
               "type": "string"
             },
-            "description": "Up to 10 custom key-value pairs stored with the bucket.",
+            "description": "Custom bucket metadata. Up to 10 key-value pairs. Keys are 1-50 UTF-8 bytes, letters/digits plus - _ . ` ~ ! # $ % ^ & * ' | +, and must not start with 'b2-' (case-insensitive; B2 lowercases keys). Values may contain any text, but all values together must be <= 10,000 UTF-8 bytes.",
             "propertyNames": {
+              "maxLength": 50,
+              "minLength": 1,
+              "pattern": "^[A-Za-z0-9._`~!#$%^&*'|+-]+$",
               "type": "string"
             },
             "type": "object"
@@ -161,7 +164,7 @@
             "type": "string"
           },
           "corsRules": {
-            "description": "CORS rules for browser-based access.",
+            "description": "CORS rules for browser-based access. At most 100 rules; each rule's combined UTF-8 bytes across corsRuleName, allowedOrigins, allowedOperations, allowedHeaders, and exposeHeaders must be less than 1,000. Rule names must be unique within the bucket.",
             "items": {
               "properties": {
                 "allowedHeaders": {
@@ -183,6 +186,10 @@
                   "type": "array"
                 },
                 "corsRuleName": {
+                  "description": "Unique CORS rule name, 6-63 characters. Use only letters, digits, and hyphens; names starting with 'b2-' are reserved for Backblaze.",
+                  "maxLength": 63,
+                  "minLength": 6,
+                  "pattern": "^[A-Za-z0-9-]+$",
                   "type": "string"
                 },
                 "exposeHeaders": {
@@ -204,6 +211,7 @@
               ],
               "type": "object"
             },
+            "maxItems": 100,
             "type": "array"
           },
           "defaultServerSideEncryption": {
@@ -776,7 +784,11 @@
             "additionalProperties": {
               "type": "string"
             },
+            "description": "Custom bucket metadata. Up to 10 key-value pairs. Keys are 1-50 UTF-8 bytes, letters/digits plus - _ . ` ~ ! # $ % ^ & * ' | +, and must not start with 'b2-' (case-insensitive; B2 lowercases keys). Values may contain any text, but all values together must be <= 10,000 UTF-8 bytes. Replaces all existing bucketInfo when supplied.",
             "propertyNames": {
+              "maxLength": 50,
+              "minLength": 1,
+              "pattern": "^[A-Za-z0-9._`~!#$%^&*'|+-]+$",
               "type": "string"
             },
             "type": "object"
@@ -790,6 +802,7 @@
             "type": "boolean"
           },
           "corsRules": {
+            "description": "CORS rules for browser-based access. At most 100 rules; each rule's combined UTF-8 bytes across corsRuleName, allowedOrigins, allowedOperations, allowedHeaders, and exposeHeaders must be less than 1,000. Rule names must be unique within the bucket. Replaces all existing CORS rules when supplied.",
             "items": {
               "properties": {
                 "allowedHeaders": {
@@ -811,6 +824,10 @@
                   "type": "array"
                 },
                 "corsRuleName": {
+                  "description": "Unique CORS rule name, 6-63 characters. Use only letters, digits, and hyphens; names starting with 'b2-' are reserved for Backblaze.",
+                  "maxLength": 63,
+                  "minLength": 6,
+                  "pattern": "^[A-Za-z0-9-]+$",
                   "type": "string"
                 },
                 "exposeHeaders": {
@@ -832,6 +849,7 @@
               ],
               "type": "object"
             },
+            "maxItems": 100,
             "type": "array"
           },
           "defaultRetention": {
@@ -1980,5 +1998,5 @@
     "toolsListCacheHint": null,
     "discover": null
   },
-  "hash": "0514a29fe155fd62b718351a65d7e41a079638cfbc7981241f89cfc6f93e8c94"
+  "hash": "bb370ed3c3de5796a66fcfe3fb7925234eda4c9f2b3374199a1a9eb6fbda0079"
 }

--- a/tests/fixtures/tool-contract/full.modern.json
+++ b/tests/fixtures/tool-contract/full.modern.json
@@ -143,6 +143,7 @@
         "properties": {
           "bucketInfo": {
             "additionalProperties": {
+              "maxLength": 10000,
               "type": "string"
             },
             "description": "Custom bucket metadata. Up to 10 key-value pairs. Keys are 1-50 UTF-8 bytes, letters/digits plus - _ . ` ~ ! # $ % ^ & * ' | +, and must not start with 'b2-' (case-insensitive; B2 lowercases keys). Values may contain any text, but all values together must be <= 10,000 UTF-8 bytes.",
@@ -164,25 +165,36 @@
             "type": "string"
           },
           "corsRules": {
-            "description": "CORS rules for browser-based access. At most 100 rules; each rule's combined UTF-8 bytes across corsRuleName, allowedOrigins, allowedOperations, allowedHeaders, and exposeHeaders must be less than 1,000. Rule names must be unique within the bucket.",
+            "description": "CORS rules for browser-based access. At most 100 rules. allowedOrigins and allowedOperations each require 1-100 non-empty entries; allowedHeaders and exposeHeaders may contain up to 100 non-empty entries. String entries must be at most 999 characters. Each rule's combined UTF-8 bytes across corsRuleName, allowedOrigins, allowedOperations, allowedHeaders, and exposeHeaders must be less than 1,000. Rule names must be unique within the bucket.",
             "items": {
               "properties": {
                 "allowedHeaders": {
                   "items": {
+                    "maxLength": 999,
+                    "minLength": 1,
                     "type": "string"
                   },
+                  "maxItems": 100,
                   "type": "array"
                 },
                 "allowedOperations": {
                   "items": {
+                    "maxLength": 999,
+                    "minLength": 1,
                     "type": "string"
                   },
+                  "maxItems": 100,
+                  "minItems": 1,
                   "type": "array"
                 },
                 "allowedOrigins": {
                   "items": {
+                    "maxLength": 999,
+                    "minLength": 1,
                     "type": "string"
                   },
+                  "maxItems": 100,
+                  "minItems": 1,
                   "type": "array"
                 },
                 "corsRuleName": {
@@ -194,8 +206,11 @@
                 },
                 "exposeHeaders": {
                   "items": {
+                    "maxLength": 999,
+                    "minLength": 1,
                     "type": "string"
                   },
+                  "maxItems": 100,
                   "type": "array"
                 },
                 "maxAgeSeconds": {
@@ -782,6 +797,7 @@
           },
           "bucketInfo": {
             "additionalProperties": {
+              "maxLength": 10000,
               "type": "string"
             },
             "description": "Custom bucket metadata. Up to 10 key-value pairs. Keys are 1-50 UTF-8 bytes, letters/digits plus - _ . ` ~ ! # $ % ^ & * ' | +, and must not start with 'b2-' (case-insensitive; B2 lowercases keys). Values may contain any text, but all values together must be <= 10,000 UTF-8 bytes. Replaces all existing bucketInfo when supplied.",
@@ -802,25 +818,36 @@
             "type": "boolean"
           },
           "corsRules": {
-            "description": "CORS rules for browser-based access. At most 100 rules; each rule's combined UTF-8 bytes across corsRuleName, allowedOrigins, allowedOperations, allowedHeaders, and exposeHeaders must be less than 1,000. Rule names must be unique within the bucket. Replaces all existing CORS rules when supplied.",
+            "description": "CORS rules for browser-based access. At most 100 rules. allowedOrigins and allowedOperations each require 1-100 non-empty entries; allowedHeaders and exposeHeaders may contain up to 100 non-empty entries. String entries must be at most 999 characters. Each rule's combined UTF-8 bytes across corsRuleName, allowedOrigins, allowedOperations, allowedHeaders, and exposeHeaders must be less than 1,000. Rule names must be unique within the bucket. Replaces all existing CORS rules when supplied.",
             "items": {
               "properties": {
                 "allowedHeaders": {
                   "items": {
+                    "maxLength": 999,
+                    "minLength": 1,
                     "type": "string"
                   },
+                  "maxItems": 100,
                   "type": "array"
                 },
                 "allowedOperations": {
                   "items": {
+                    "maxLength": 999,
+                    "minLength": 1,
                     "type": "string"
                   },
+                  "maxItems": 100,
+                  "minItems": 1,
                   "type": "array"
                 },
                 "allowedOrigins": {
                   "items": {
+                    "maxLength": 999,
+                    "minLength": 1,
                     "type": "string"
                   },
+                  "maxItems": 100,
+                  "minItems": 1,
                   "type": "array"
                 },
                 "corsRuleName": {
@@ -832,8 +859,11 @@
                 },
                 "exposeHeaders": {
                   "items": {
+                    "maxLength": 999,
+                    "minLength": 1,
                     "type": "string"
                   },
+                  "maxItems": 100,
                   "type": "array"
                 },
                 "maxAgeSeconds": {
@@ -2011,5 +2041,5 @@
       "resultType": "complete"
     }
   },
-  "hash": "bb370ed3c3de5796a66fcfe3fb7925234eda4c9f2b3374199a1a9eb6fbda0079"
+  "hash": "3c8c3a50d2fc751662cb6f41d894fae16871ac021da013381044aeac515e6a00"
 }

--- a/tests/fixtures/tool-contract/full.modern.json
+++ b/tests/fixtures/tool-contract/full.modern.json
@@ -146,7 +146,7 @@
               "maxLength": 10000,
               "type": "string"
             },
-            "description": "Custom bucket metadata. Up to 10 key-value pairs. Keys are 1-50 UTF-8 bytes, letters/digits plus - _ . ` ~ ! # $ % ^ & * ' | +, and must not start with 'b2-' (case-insensitive; B2 lowercases keys). Values may contain any text, but all values together must be <= 10,000 UTF-8 bytes.",
+            "description": "Custom metadata: <=10 pairs. Keys: 1-50 UTF-8 bytes, chars A-Z a-z 0-9 . _ ` ~ ! # $ % ^ & * ' | + -, no b2- prefix. Values total <=10,000 UTF-8 bytes.",
             "propertyNames": {
               "maxLength": 50,
               "minLength": 1,
@@ -165,7 +165,7 @@
             "type": "string"
           },
           "corsRules": {
-            "description": "CORS rules for browser-based access. At most 100 rules. allowedOrigins and allowedOperations each require 1-100 non-empty entries; allowedHeaders and exposeHeaders may contain up to 100 non-empty entries. String entries must be at most 999 characters. Each rule's combined UTF-8 bytes across corsRuleName, allowedOrigins, allowedOperations, allowedHeaders, and exposeHeaders must be less than 1,000. Rule names must be unique within the bucket.",
+            "description": "CORS rules: <=100. allowedOrigins/allowedOperations require 1-100 non-empty strings; allowedHeaders/exposeHeaders allow <=100. Strings <=999 chars. Per-rule UTF-8 total <1,000. Names unique.",
             "items": {
               "properties": {
                 "allowedHeaders": {
@@ -198,7 +198,7 @@
                   "type": "array"
                 },
                 "corsRuleName": {
-                  "description": "Unique CORS rule name, 6-63 characters. Use only letters, digits, and hyphens; names starting with 'b2-' are reserved for Backblaze.",
+                  "description": "Unique name: 6-63 letters, digits, hyphens; no b2- prefix.",
                   "maxLength": 63,
                   "minLength": 6,
                   "pattern": "^[A-Za-z0-9-]+$",
@@ -800,7 +800,7 @@
               "maxLength": 10000,
               "type": "string"
             },
-            "description": "Custom bucket metadata. Up to 10 key-value pairs. Keys are 1-50 UTF-8 bytes, letters/digits plus - _ . ` ~ ! # $ % ^ & * ' | +, and must not start with 'b2-' (case-insensitive; B2 lowercases keys). Values may contain any text, but all values together must be <= 10,000 UTF-8 bytes. Replaces all existing bucketInfo when supplied.",
+            "description": "Custom metadata: <=10 pairs. Keys: 1-50 UTF-8 bytes, chars A-Z a-z 0-9 . _ ` ~ ! # $ % ^ & * ' | + -, no b2- prefix. Values total <=10,000 UTF-8 bytes.",
             "propertyNames": {
               "maxLength": 50,
               "minLength": 1,
@@ -818,7 +818,7 @@
             "type": "boolean"
           },
           "corsRules": {
-            "description": "CORS rules for browser-based access. At most 100 rules. allowedOrigins and allowedOperations each require 1-100 non-empty entries; allowedHeaders and exposeHeaders may contain up to 100 non-empty entries. String entries must be at most 999 characters. Each rule's combined UTF-8 bytes across corsRuleName, allowedOrigins, allowedOperations, allowedHeaders, and exposeHeaders must be less than 1,000. Rule names must be unique within the bucket. Replaces all existing CORS rules when supplied.",
+            "description": "CORS rules: <=100. allowedOrigins/allowedOperations require 1-100 non-empty strings; allowedHeaders/exposeHeaders allow <=100. Strings <=999 chars. Per-rule UTF-8 total <1,000. Names unique.",
             "items": {
               "properties": {
                 "allowedHeaders": {
@@ -851,7 +851,7 @@
                   "type": "array"
                 },
                 "corsRuleName": {
-                  "description": "Unique CORS rule name, 6-63 characters. Use only letters, digits, and hyphens; names starting with 'b2-' are reserved for Backblaze.",
+                  "description": "Unique name: 6-63 letters, digits, hyphens; no b2- prefix.",
                   "maxLength": 63,
                   "minLength": 6,
                   "pattern": "^[A-Za-z0-9-]+$",
@@ -2041,5 +2041,5 @@
       "resultType": "complete"
     }
   },
-  "hash": "3c8c3a50d2fc751662cb6f41d894fae16871ac021da013381044aeac515e6a00"
+  "hash": "6cf6387cb398b095081f9379e3c8c9610ebc6ee8cdb103c9c5dff02f53733dd8"
 }

--- a/tests/fixtures/tool-contract/full.modern.json
+++ b/tests/fixtures/tool-contract/full.modern.json
@@ -145,8 +145,11 @@
             "additionalProperties": {
               "type": "string"
             },
-            "description": "Up to 10 custom key-value pairs stored with the bucket.",
+            "description": "Custom bucket metadata. Up to 10 key-value pairs. Keys are 1-50 UTF-8 bytes, letters/digits plus - _ . ` ~ ! # $ % ^ & * ' | +, and must not start with 'b2-' (case-insensitive; B2 lowercases keys). Values may contain any text, but all values together must be <= 10,000 UTF-8 bytes.",
             "propertyNames": {
+              "maxLength": 50,
+              "minLength": 1,
+              "pattern": "^[A-Za-z0-9._`~!#$%^&*'|+-]+$",
               "type": "string"
             },
             "type": "object"
@@ -161,7 +164,7 @@
             "type": "string"
           },
           "corsRules": {
-            "description": "CORS rules for browser-based access.",
+            "description": "CORS rules for browser-based access. At most 100 rules; each rule's combined UTF-8 bytes across corsRuleName, allowedOrigins, allowedOperations, allowedHeaders, and exposeHeaders must be less than 1,000. Rule names must be unique within the bucket.",
             "items": {
               "properties": {
                 "allowedHeaders": {
@@ -183,6 +186,10 @@
                   "type": "array"
                 },
                 "corsRuleName": {
+                  "description": "Unique CORS rule name, 6-63 characters. Use only letters, digits, and hyphens; names starting with 'b2-' are reserved for Backblaze.",
+                  "maxLength": 63,
+                  "minLength": 6,
+                  "pattern": "^[A-Za-z0-9-]+$",
                   "type": "string"
                 },
                 "exposeHeaders": {
@@ -204,6 +211,7 @@
               ],
               "type": "object"
             },
+            "maxItems": 100,
             "type": "array"
           },
           "defaultServerSideEncryption": {
@@ -776,7 +784,11 @@
             "additionalProperties": {
               "type": "string"
             },
+            "description": "Custom bucket metadata. Up to 10 key-value pairs. Keys are 1-50 UTF-8 bytes, letters/digits plus - _ . ` ~ ! # $ % ^ & * ' | +, and must not start with 'b2-' (case-insensitive; B2 lowercases keys). Values may contain any text, but all values together must be <= 10,000 UTF-8 bytes. Replaces all existing bucketInfo when supplied.",
             "propertyNames": {
+              "maxLength": 50,
+              "minLength": 1,
+              "pattern": "^[A-Za-z0-9._`~!#$%^&*'|+-]+$",
               "type": "string"
             },
             "type": "object"
@@ -790,6 +802,7 @@
             "type": "boolean"
           },
           "corsRules": {
+            "description": "CORS rules for browser-based access. At most 100 rules; each rule's combined UTF-8 bytes across corsRuleName, allowedOrigins, allowedOperations, allowedHeaders, and exposeHeaders must be less than 1,000. Rule names must be unique within the bucket. Replaces all existing CORS rules when supplied.",
             "items": {
               "properties": {
                 "allowedHeaders": {
@@ -811,6 +824,10 @@
                   "type": "array"
                 },
                 "corsRuleName": {
+                  "description": "Unique CORS rule name, 6-63 characters. Use only letters, digits, and hyphens; names starting with 'b2-' are reserved for Backblaze.",
+                  "maxLength": 63,
+                  "minLength": 6,
+                  "pattern": "^[A-Za-z0-9-]+$",
                   "type": "string"
                 },
                 "exposeHeaders": {
@@ -832,6 +849,7 @@
               ],
               "type": "object"
             },
+            "maxItems": 100,
             "type": "array"
           },
           "defaultRetention": {
@@ -1993,5 +2011,5 @@
       "resultType": "complete"
     }
   },
-  "hash": "0514a29fe155fd62b718351a65d7e41a079638cfbc7981241f89cfc6f93e8c94"
+  "hash": "bb370ed3c3de5796a66fcfe3fb7925234eda4c9f2b3374199a1a9eb6fbda0079"
 }

--- a/tests/fixtures/tool-contract/phase1-default.legacy.json
+++ b/tests/fixtures/tool-contract/phase1-default.legacy.json
@@ -153,7 +153,7 @@
               "maxLength": 10000,
               "type": "string"
             },
-            "description": "Custom bucket metadata. Up to 10 key-value pairs. Keys are 1-50 UTF-8 bytes, letters/digits plus - _ . ` ~ ! # $ % ^ & * ' | +, and must not start with 'b2-' (case-insensitive; B2 lowercases keys). Values may contain any text, but all values together must be <= 10,000 UTF-8 bytes.",
+            "description": "Custom metadata: <=10 pairs. Keys: 1-50 UTF-8 bytes, chars A-Z a-z 0-9 . _ ` ~ ! # $ % ^ & * ' | + -, no b2- prefix. Values total <=10,000 UTF-8 bytes.",
             "propertyNames": {
               "maxLength": 50,
               "minLength": 1,
@@ -172,7 +172,7 @@
             "type": "string"
           },
           "corsRules": {
-            "description": "CORS rules for browser-based access. At most 100 rules. allowedOrigins and allowedOperations each require 1-100 non-empty entries; allowedHeaders and exposeHeaders may contain up to 100 non-empty entries. String entries must be at most 999 characters. Each rule's combined UTF-8 bytes across corsRuleName, allowedOrigins, allowedOperations, allowedHeaders, and exposeHeaders must be less than 1,000. Rule names must be unique within the bucket.",
+            "description": "CORS rules: <=100. allowedOrigins/allowedOperations require 1-100 non-empty strings; allowedHeaders/exposeHeaders allow <=100. Strings <=999 chars. Per-rule UTF-8 total <1,000. Names unique.",
             "items": {
               "properties": {
                 "allowedHeaders": {
@@ -205,7 +205,7 @@
                   "type": "array"
                 },
                 "corsRuleName": {
-                  "description": "Unique CORS rule name, 6-63 characters. Use only letters, digits, and hyphens; names starting with 'b2-' are reserved for Backblaze.",
+                  "description": "Unique name: 6-63 letters, digits, hyphens; no b2- prefix.",
                   "maxLength": 63,
                   "minLength": 6,
                   "pattern": "^[A-Za-z0-9-]+$",
@@ -694,7 +694,7 @@
               "maxLength": 10000,
               "type": "string"
             },
-            "description": "Custom bucket metadata. Up to 10 key-value pairs. Keys are 1-50 UTF-8 bytes, letters/digits plus - _ . ` ~ ! # $ % ^ & * ' | +, and must not start with 'b2-' (case-insensitive; B2 lowercases keys). Values may contain any text, but all values together must be <= 10,000 UTF-8 bytes. Replaces all existing bucketInfo when supplied.",
+            "description": "Custom metadata: <=10 pairs. Keys: 1-50 UTF-8 bytes, chars A-Z a-z 0-9 . _ ` ~ ! # $ % ^ & * ' | + -, no b2- prefix. Values total <=10,000 UTF-8 bytes.",
             "propertyNames": {
               "maxLength": 50,
               "minLength": 1,
@@ -712,7 +712,7 @@
             "type": "boolean"
           },
           "corsRules": {
-            "description": "CORS rules for browser-based access. At most 100 rules. allowedOrigins and allowedOperations each require 1-100 non-empty entries; allowedHeaders and exposeHeaders may contain up to 100 non-empty entries. String entries must be at most 999 characters. Each rule's combined UTF-8 bytes across corsRuleName, allowedOrigins, allowedOperations, allowedHeaders, and exposeHeaders must be less than 1,000. Rule names must be unique within the bucket. Replaces all existing CORS rules when supplied.",
+            "description": "CORS rules: <=100. allowedOrigins/allowedOperations require 1-100 non-empty strings; allowedHeaders/exposeHeaders allow <=100. Strings <=999 chars. Per-rule UTF-8 total <1,000. Names unique.",
             "items": {
               "properties": {
                 "allowedHeaders": {
@@ -745,7 +745,7 @@
                   "type": "array"
                 },
                 "corsRuleName": {
-                  "description": "Unique CORS rule name, 6-63 characters. Use only letters, digits, and hyphens; names starting with 'b2-' are reserved for Backblaze.",
+                  "description": "Unique name: 6-63 letters, digits, hyphens; no b2- prefix.",
                   "maxLength": 63,
                   "minLength": 6,
                   "pattern": "^[A-Za-z0-9-]+$",
@@ -1922,5 +1922,5 @@
     "toolsListCacheHint": null,
     "discover": null
   },
-  "hash": "8668c4d39cf4d058fe39899979c91ee5b64bfa0001caf9ab2deedb62738ed935"
+  "hash": "d5bdcd66faa57a0aac0bb73599c0d16b72d5bee2e02de4cbeacbbba6af1da971"
 }

--- a/tests/fixtures/tool-contract/phase1-default.legacy.json
+++ b/tests/fixtures/tool-contract/phase1-default.legacy.json
@@ -150,6 +150,7 @@
         "properties": {
           "bucketInfo": {
             "additionalProperties": {
+              "maxLength": 10000,
               "type": "string"
             },
             "description": "Custom bucket metadata. Up to 10 key-value pairs. Keys are 1-50 UTF-8 bytes, letters/digits plus - _ . ` ~ ! # $ % ^ & * ' | +, and must not start with 'b2-' (case-insensitive; B2 lowercases keys). Values may contain any text, but all values together must be <= 10,000 UTF-8 bytes.",
@@ -171,25 +172,36 @@
             "type": "string"
           },
           "corsRules": {
-            "description": "CORS rules for browser-based access. At most 100 rules; each rule's combined UTF-8 bytes across corsRuleName, allowedOrigins, allowedOperations, allowedHeaders, and exposeHeaders must be less than 1,000. Rule names must be unique within the bucket.",
+            "description": "CORS rules for browser-based access. At most 100 rules. allowedOrigins and allowedOperations each require 1-100 non-empty entries; allowedHeaders and exposeHeaders may contain up to 100 non-empty entries. String entries must be at most 999 characters. Each rule's combined UTF-8 bytes across corsRuleName, allowedOrigins, allowedOperations, allowedHeaders, and exposeHeaders must be less than 1,000. Rule names must be unique within the bucket.",
             "items": {
               "properties": {
                 "allowedHeaders": {
                   "items": {
+                    "maxLength": 999,
+                    "minLength": 1,
                     "type": "string"
                   },
+                  "maxItems": 100,
                   "type": "array"
                 },
                 "allowedOperations": {
                   "items": {
+                    "maxLength": 999,
+                    "minLength": 1,
                     "type": "string"
                   },
+                  "maxItems": 100,
+                  "minItems": 1,
                   "type": "array"
                 },
                 "allowedOrigins": {
                   "items": {
+                    "maxLength": 999,
+                    "minLength": 1,
                     "type": "string"
                   },
+                  "maxItems": 100,
+                  "minItems": 1,
                   "type": "array"
                 },
                 "corsRuleName": {
@@ -201,8 +213,11 @@
                 },
                 "exposeHeaders": {
                   "items": {
+                    "maxLength": 999,
+                    "minLength": 1,
                     "type": "string"
                   },
+                  "maxItems": 100,
                   "type": "array"
                 },
                 "maxAgeSeconds": {
@@ -676,6 +691,7 @@
           },
           "bucketInfo": {
             "additionalProperties": {
+              "maxLength": 10000,
               "type": "string"
             },
             "description": "Custom bucket metadata. Up to 10 key-value pairs. Keys are 1-50 UTF-8 bytes, letters/digits plus - _ . ` ~ ! # $ % ^ & * ' | +, and must not start with 'b2-' (case-insensitive; B2 lowercases keys). Values may contain any text, but all values together must be <= 10,000 UTF-8 bytes. Replaces all existing bucketInfo when supplied.",
@@ -696,25 +712,36 @@
             "type": "boolean"
           },
           "corsRules": {
-            "description": "CORS rules for browser-based access. At most 100 rules; each rule's combined UTF-8 bytes across corsRuleName, allowedOrigins, allowedOperations, allowedHeaders, and exposeHeaders must be less than 1,000. Rule names must be unique within the bucket. Replaces all existing CORS rules when supplied.",
+            "description": "CORS rules for browser-based access. At most 100 rules. allowedOrigins and allowedOperations each require 1-100 non-empty entries; allowedHeaders and exposeHeaders may contain up to 100 non-empty entries. String entries must be at most 999 characters. Each rule's combined UTF-8 bytes across corsRuleName, allowedOrigins, allowedOperations, allowedHeaders, and exposeHeaders must be less than 1,000. Rule names must be unique within the bucket. Replaces all existing CORS rules when supplied.",
             "items": {
               "properties": {
                 "allowedHeaders": {
                   "items": {
+                    "maxLength": 999,
+                    "minLength": 1,
                     "type": "string"
                   },
+                  "maxItems": 100,
                   "type": "array"
                 },
                 "allowedOperations": {
                   "items": {
+                    "maxLength": 999,
+                    "minLength": 1,
                     "type": "string"
                   },
+                  "maxItems": 100,
+                  "minItems": 1,
                   "type": "array"
                 },
                 "allowedOrigins": {
                   "items": {
+                    "maxLength": 999,
+                    "minLength": 1,
                     "type": "string"
                   },
+                  "maxItems": 100,
+                  "minItems": 1,
                   "type": "array"
                 },
                 "corsRuleName": {
@@ -726,8 +753,11 @@
                 },
                 "exposeHeaders": {
                   "items": {
+                    "maxLength": 999,
+                    "minLength": 1,
                     "type": "string"
                   },
+                  "maxItems": 100,
                   "type": "array"
                 },
                 "maxAgeSeconds": {
@@ -1892,5 +1922,5 @@
     "toolsListCacheHint": null,
     "discover": null
   },
-  "hash": "f217d8a6a68f4a60ef506ab87604f260169987eb6d75357d061a8613c30fa1db"
+  "hash": "8668c4d39cf4d058fe39899979c91ee5b64bfa0001caf9ab2deedb62738ed935"
 }

--- a/tests/fixtures/tool-contract/phase1-default.legacy.json
+++ b/tests/fixtures/tool-contract/phase1-default.legacy.json
@@ -152,8 +152,11 @@
             "additionalProperties": {
               "type": "string"
             },
-            "description": "Up to 10 custom key-value pairs stored with the bucket.",
+            "description": "Custom bucket metadata. Up to 10 key-value pairs. Keys are 1-50 UTF-8 bytes, letters/digits plus - _ . ` ~ ! # $ % ^ & * ' | +, and must not start with 'b2-' (case-insensitive; B2 lowercases keys). Values may contain any text, but all values together must be <= 10,000 UTF-8 bytes.",
             "propertyNames": {
+              "maxLength": 50,
+              "minLength": 1,
+              "pattern": "^[A-Za-z0-9._`~!#$%^&*'|+-]+$",
               "type": "string"
             },
             "type": "object"
@@ -168,7 +171,7 @@
             "type": "string"
           },
           "corsRules": {
-            "description": "CORS rules for browser-based access.",
+            "description": "CORS rules for browser-based access. At most 100 rules; each rule's combined UTF-8 bytes across corsRuleName, allowedOrigins, allowedOperations, allowedHeaders, and exposeHeaders must be less than 1,000. Rule names must be unique within the bucket.",
             "items": {
               "properties": {
                 "allowedHeaders": {
@@ -190,6 +193,10 @@
                   "type": "array"
                 },
                 "corsRuleName": {
+                  "description": "Unique CORS rule name, 6-63 characters. Use only letters, digits, and hyphens; names starting with 'b2-' are reserved for Backblaze.",
+                  "maxLength": 63,
+                  "minLength": 6,
+                  "pattern": "^[A-Za-z0-9-]+$",
                   "type": "string"
                 },
                 "exposeHeaders": {
@@ -211,6 +218,7 @@
               ],
               "type": "object"
             },
+            "maxItems": 100,
             "type": "array"
           },
           "defaultServerSideEncryption": {
@@ -670,7 +678,11 @@
             "additionalProperties": {
               "type": "string"
             },
+            "description": "Custom bucket metadata. Up to 10 key-value pairs. Keys are 1-50 UTF-8 bytes, letters/digits plus - _ . ` ~ ! # $ % ^ & * ' | +, and must not start with 'b2-' (case-insensitive; B2 lowercases keys). Values may contain any text, but all values together must be <= 10,000 UTF-8 bytes. Replaces all existing bucketInfo when supplied.",
             "propertyNames": {
+              "maxLength": 50,
+              "minLength": 1,
+              "pattern": "^[A-Za-z0-9._`~!#$%^&*'|+-]+$",
               "type": "string"
             },
             "type": "object"
@@ -684,6 +696,7 @@
             "type": "boolean"
           },
           "corsRules": {
+            "description": "CORS rules for browser-based access. At most 100 rules; each rule's combined UTF-8 bytes across corsRuleName, allowedOrigins, allowedOperations, allowedHeaders, and exposeHeaders must be less than 1,000. Rule names must be unique within the bucket. Replaces all existing CORS rules when supplied.",
             "items": {
               "properties": {
                 "allowedHeaders": {
@@ -705,6 +718,10 @@
                   "type": "array"
                 },
                 "corsRuleName": {
+                  "description": "Unique CORS rule name, 6-63 characters. Use only letters, digits, and hyphens; names starting with 'b2-' are reserved for Backblaze.",
+                  "maxLength": 63,
+                  "minLength": 6,
+                  "pattern": "^[A-Za-z0-9-]+$",
                   "type": "string"
                 },
                 "exposeHeaders": {
@@ -726,6 +743,7 @@
               ],
               "type": "object"
             },
+            "maxItems": 100,
             "type": "array"
           },
           "defaultRetention": {
@@ -1874,5 +1892,5 @@
     "toolsListCacheHint": null,
     "discover": null
   },
-  "hash": "69e5ecbb1a8cadb95d5928d10813bfe7c869938b3821543cb85100064005c850"
+  "hash": "f217d8a6a68f4a60ef506ab87604f260169987eb6d75357d061a8613c30fa1db"
 }

--- a/tests/fixtures/tool-contract/phase1-default.modern.json
+++ b/tests/fixtures/tool-contract/phase1-default.modern.json
@@ -150,6 +150,7 @@
         "properties": {
           "bucketInfo": {
             "additionalProperties": {
+              "maxLength": 10000,
               "type": "string"
             },
             "description": "Custom bucket metadata. Up to 10 key-value pairs. Keys are 1-50 UTF-8 bytes, letters/digits plus - _ . ` ~ ! # $ % ^ & * ' | +, and must not start with 'b2-' (case-insensitive; B2 lowercases keys). Values may contain any text, but all values together must be <= 10,000 UTF-8 bytes.",
@@ -171,25 +172,36 @@
             "type": "string"
           },
           "corsRules": {
-            "description": "CORS rules for browser-based access. At most 100 rules; each rule's combined UTF-8 bytes across corsRuleName, allowedOrigins, allowedOperations, allowedHeaders, and exposeHeaders must be less than 1,000. Rule names must be unique within the bucket.",
+            "description": "CORS rules for browser-based access. At most 100 rules. allowedOrigins and allowedOperations each require 1-100 non-empty entries; allowedHeaders and exposeHeaders may contain up to 100 non-empty entries. String entries must be at most 999 characters. Each rule's combined UTF-8 bytes across corsRuleName, allowedOrigins, allowedOperations, allowedHeaders, and exposeHeaders must be less than 1,000. Rule names must be unique within the bucket.",
             "items": {
               "properties": {
                 "allowedHeaders": {
                   "items": {
+                    "maxLength": 999,
+                    "minLength": 1,
                     "type": "string"
                   },
+                  "maxItems": 100,
                   "type": "array"
                 },
                 "allowedOperations": {
                   "items": {
+                    "maxLength": 999,
+                    "minLength": 1,
                     "type": "string"
                   },
+                  "maxItems": 100,
+                  "minItems": 1,
                   "type": "array"
                 },
                 "allowedOrigins": {
                   "items": {
+                    "maxLength": 999,
+                    "minLength": 1,
                     "type": "string"
                   },
+                  "maxItems": 100,
+                  "minItems": 1,
                   "type": "array"
                 },
                 "corsRuleName": {
@@ -201,8 +213,11 @@
                 },
                 "exposeHeaders": {
                   "items": {
+                    "maxLength": 999,
+                    "minLength": 1,
                     "type": "string"
                   },
+                  "maxItems": 100,
                   "type": "array"
                 },
                 "maxAgeSeconds": {
@@ -676,6 +691,7 @@
           },
           "bucketInfo": {
             "additionalProperties": {
+              "maxLength": 10000,
               "type": "string"
             },
             "description": "Custom bucket metadata. Up to 10 key-value pairs. Keys are 1-50 UTF-8 bytes, letters/digits plus - _ . ` ~ ! # $ % ^ & * ' | +, and must not start with 'b2-' (case-insensitive; B2 lowercases keys). Values may contain any text, but all values together must be <= 10,000 UTF-8 bytes. Replaces all existing bucketInfo when supplied.",
@@ -696,25 +712,36 @@
             "type": "boolean"
           },
           "corsRules": {
-            "description": "CORS rules for browser-based access. At most 100 rules; each rule's combined UTF-8 bytes across corsRuleName, allowedOrigins, allowedOperations, allowedHeaders, and exposeHeaders must be less than 1,000. Rule names must be unique within the bucket. Replaces all existing CORS rules when supplied.",
+            "description": "CORS rules for browser-based access. At most 100 rules. allowedOrigins and allowedOperations each require 1-100 non-empty entries; allowedHeaders and exposeHeaders may contain up to 100 non-empty entries. String entries must be at most 999 characters. Each rule's combined UTF-8 bytes across corsRuleName, allowedOrigins, allowedOperations, allowedHeaders, and exposeHeaders must be less than 1,000. Rule names must be unique within the bucket. Replaces all existing CORS rules when supplied.",
             "items": {
               "properties": {
                 "allowedHeaders": {
                   "items": {
+                    "maxLength": 999,
+                    "minLength": 1,
                     "type": "string"
                   },
+                  "maxItems": 100,
                   "type": "array"
                 },
                 "allowedOperations": {
                   "items": {
+                    "maxLength": 999,
+                    "minLength": 1,
                     "type": "string"
                   },
+                  "maxItems": 100,
+                  "minItems": 1,
                   "type": "array"
                 },
                 "allowedOrigins": {
                   "items": {
+                    "maxLength": 999,
+                    "minLength": 1,
                     "type": "string"
                   },
+                  "maxItems": 100,
+                  "minItems": 1,
                   "type": "array"
                 },
                 "corsRuleName": {
@@ -726,8 +753,11 @@
                 },
                 "exposeHeaders": {
                   "items": {
+                    "maxLength": 999,
+                    "minLength": 1,
                     "type": "string"
                   },
+                  "maxItems": 100,
                   "type": "array"
                 },
                 "maxAgeSeconds": {
@@ -1905,5 +1935,5 @@
       "resultType": "complete"
     }
   },
-  "hash": "f217d8a6a68f4a60ef506ab87604f260169987eb6d75357d061a8613c30fa1db"
+  "hash": "8668c4d39cf4d058fe39899979c91ee5b64bfa0001caf9ab2deedb62738ed935"
 }

--- a/tests/fixtures/tool-contract/phase1-default.modern.json
+++ b/tests/fixtures/tool-contract/phase1-default.modern.json
@@ -153,7 +153,7 @@
               "maxLength": 10000,
               "type": "string"
             },
-            "description": "Custom bucket metadata. Up to 10 key-value pairs. Keys are 1-50 UTF-8 bytes, letters/digits plus - _ . ` ~ ! # $ % ^ & * ' | +, and must not start with 'b2-' (case-insensitive; B2 lowercases keys). Values may contain any text, but all values together must be <= 10,000 UTF-8 bytes.",
+            "description": "Custom metadata: <=10 pairs. Keys: 1-50 UTF-8 bytes, chars A-Z a-z 0-9 . _ ` ~ ! # $ % ^ & * ' | + -, no b2- prefix. Values total <=10,000 UTF-8 bytes.",
             "propertyNames": {
               "maxLength": 50,
               "minLength": 1,
@@ -172,7 +172,7 @@
             "type": "string"
           },
           "corsRules": {
-            "description": "CORS rules for browser-based access. At most 100 rules. allowedOrigins and allowedOperations each require 1-100 non-empty entries; allowedHeaders and exposeHeaders may contain up to 100 non-empty entries. String entries must be at most 999 characters. Each rule's combined UTF-8 bytes across corsRuleName, allowedOrigins, allowedOperations, allowedHeaders, and exposeHeaders must be less than 1,000. Rule names must be unique within the bucket.",
+            "description": "CORS rules: <=100. allowedOrigins/allowedOperations require 1-100 non-empty strings; allowedHeaders/exposeHeaders allow <=100. Strings <=999 chars. Per-rule UTF-8 total <1,000. Names unique.",
             "items": {
               "properties": {
                 "allowedHeaders": {
@@ -205,7 +205,7 @@
                   "type": "array"
                 },
                 "corsRuleName": {
-                  "description": "Unique CORS rule name, 6-63 characters. Use only letters, digits, and hyphens; names starting with 'b2-' are reserved for Backblaze.",
+                  "description": "Unique name: 6-63 letters, digits, hyphens; no b2- prefix.",
                   "maxLength": 63,
                   "minLength": 6,
                   "pattern": "^[A-Za-z0-9-]+$",
@@ -694,7 +694,7 @@
               "maxLength": 10000,
               "type": "string"
             },
-            "description": "Custom bucket metadata. Up to 10 key-value pairs. Keys are 1-50 UTF-8 bytes, letters/digits plus - _ . ` ~ ! # $ % ^ & * ' | +, and must not start with 'b2-' (case-insensitive; B2 lowercases keys). Values may contain any text, but all values together must be <= 10,000 UTF-8 bytes. Replaces all existing bucketInfo when supplied.",
+            "description": "Custom metadata: <=10 pairs. Keys: 1-50 UTF-8 bytes, chars A-Z a-z 0-9 . _ ` ~ ! # $ % ^ & * ' | + -, no b2- prefix. Values total <=10,000 UTF-8 bytes.",
             "propertyNames": {
               "maxLength": 50,
               "minLength": 1,
@@ -712,7 +712,7 @@
             "type": "boolean"
           },
           "corsRules": {
-            "description": "CORS rules for browser-based access. At most 100 rules. allowedOrigins and allowedOperations each require 1-100 non-empty entries; allowedHeaders and exposeHeaders may contain up to 100 non-empty entries. String entries must be at most 999 characters. Each rule's combined UTF-8 bytes across corsRuleName, allowedOrigins, allowedOperations, allowedHeaders, and exposeHeaders must be less than 1,000. Rule names must be unique within the bucket. Replaces all existing CORS rules when supplied.",
+            "description": "CORS rules: <=100. allowedOrigins/allowedOperations require 1-100 non-empty strings; allowedHeaders/exposeHeaders allow <=100. Strings <=999 chars. Per-rule UTF-8 total <1,000. Names unique.",
             "items": {
               "properties": {
                 "allowedHeaders": {
@@ -745,7 +745,7 @@
                   "type": "array"
                 },
                 "corsRuleName": {
-                  "description": "Unique CORS rule name, 6-63 characters. Use only letters, digits, and hyphens; names starting with 'b2-' are reserved for Backblaze.",
+                  "description": "Unique name: 6-63 letters, digits, hyphens; no b2- prefix.",
                   "maxLength": 63,
                   "minLength": 6,
                   "pattern": "^[A-Za-z0-9-]+$",
@@ -1935,5 +1935,5 @@
       "resultType": "complete"
     }
   },
-  "hash": "8668c4d39cf4d058fe39899979c91ee5b64bfa0001caf9ab2deedb62738ed935"
+  "hash": "d5bdcd66faa57a0aac0bb73599c0d16b72d5bee2e02de4cbeacbbba6af1da971"
 }

--- a/tests/fixtures/tool-contract/phase1-default.modern.json
+++ b/tests/fixtures/tool-contract/phase1-default.modern.json
@@ -152,8 +152,11 @@
             "additionalProperties": {
               "type": "string"
             },
-            "description": "Up to 10 custom key-value pairs stored with the bucket.",
+            "description": "Custom bucket metadata. Up to 10 key-value pairs. Keys are 1-50 UTF-8 bytes, letters/digits plus - _ . ` ~ ! # $ % ^ & * ' | +, and must not start with 'b2-' (case-insensitive; B2 lowercases keys). Values may contain any text, but all values together must be <= 10,000 UTF-8 bytes.",
             "propertyNames": {
+              "maxLength": 50,
+              "minLength": 1,
+              "pattern": "^[A-Za-z0-9._`~!#$%^&*'|+-]+$",
               "type": "string"
             },
             "type": "object"
@@ -168,7 +171,7 @@
             "type": "string"
           },
           "corsRules": {
-            "description": "CORS rules for browser-based access.",
+            "description": "CORS rules for browser-based access. At most 100 rules; each rule's combined UTF-8 bytes across corsRuleName, allowedOrigins, allowedOperations, allowedHeaders, and exposeHeaders must be less than 1,000. Rule names must be unique within the bucket.",
             "items": {
               "properties": {
                 "allowedHeaders": {
@@ -190,6 +193,10 @@
                   "type": "array"
                 },
                 "corsRuleName": {
+                  "description": "Unique CORS rule name, 6-63 characters. Use only letters, digits, and hyphens; names starting with 'b2-' are reserved for Backblaze.",
+                  "maxLength": 63,
+                  "minLength": 6,
+                  "pattern": "^[A-Za-z0-9-]+$",
                   "type": "string"
                 },
                 "exposeHeaders": {
@@ -211,6 +218,7 @@
               ],
               "type": "object"
             },
+            "maxItems": 100,
             "type": "array"
           },
           "defaultServerSideEncryption": {
@@ -670,7 +678,11 @@
             "additionalProperties": {
               "type": "string"
             },
+            "description": "Custom bucket metadata. Up to 10 key-value pairs. Keys are 1-50 UTF-8 bytes, letters/digits plus - _ . ` ~ ! # $ % ^ & * ' | +, and must not start with 'b2-' (case-insensitive; B2 lowercases keys). Values may contain any text, but all values together must be <= 10,000 UTF-8 bytes. Replaces all existing bucketInfo when supplied.",
             "propertyNames": {
+              "maxLength": 50,
+              "minLength": 1,
+              "pattern": "^[A-Za-z0-9._`~!#$%^&*'|+-]+$",
               "type": "string"
             },
             "type": "object"
@@ -684,6 +696,7 @@
             "type": "boolean"
           },
           "corsRules": {
+            "description": "CORS rules for browser-based access. At most 100 rules; each rule's combined UTF-8 bytes across corsRuleName, allowedOrigins, allowedOperations, allowedHeaders, and exposeHeaders must be less than 1,000. Rule names must be unique within the bucket. Replaces all existing CORS rules when supplied.",
             "items": {
               "properties": {
                 "allowedHeaders": {
@@ -705,6 +718,10 @@
                   "type": "array"
                 },
                 "corsRuleName": {
+                  "description": "Unique CORS rule name, 6-63 characters. Use only letters, digits, and hyphens; names starting with 'b2-' are reserved for Backblaze.",
+                  "maxLength": 63,
+                  "minLength": 6,
+                  "pattern": "^[A-Za-z0-9-]+$",
                   "type": "string"
                 },
                 "exposeHeaders": {
@@ -726,6 +743,7 @@
               ],
               "type": "object"
             },
+            "maxItems": 100,
             "type": "array"
           },
           "defaultRetention": {
@@ -1887,5 +1905,5 @@
       "resultType": "complete"
     }
   },
-  "hash": "69e5ecbb1a8cadb95d5928d10813bfe7c869938b3821543cb85100064005c850"
+  "hash": "f217d8a6a68f4a60ef506ab87604f260169987eb6d75357d061a8613c30fa1db"
 }

--- a/tests/unit/b2-tools.unit.test.ts
+++ b/tests/unit/b2-tools.unit.test.ts
@@ -1181,7 +1181,8 @@ describe("b2_update_bucket", () => {
     },
   };
 
-  async function expectUpdateBucketValidationError(
+  async function expectBucketValidationError(
+    toolName: "b2_create_bucket" | "b2_update_bucket",
     args: Record<string, unknown>,
     expectedMessage: RegExp,
   ) {
@@ -1192,14 +1193,25 @@ describe("b2_update_bucket", () => {
     installSdkTransport(transport);
     server = createServer(testConfig);
 
-    const result = await callTool(server, "b2_update_bucket", {
-      bucketId: "bucket-1",
-      ...args,
-    });
+    const baseArgs =
+      toolName === "b2_create_bucket"
+        ? { bucketName: "fixture-bucket", bucketType: "allPrivate" }
+        : { bucketId: "bucket-1" };
+    const result = await callTool(server, toolName, { ...baseArgs, ...args });
 
     expect(result.isError).toBe(true);
+    expect(result.content[0].text).toContain("B2 Error [bad_request] (HTTP 400)");
     expect(result.content[0].text).toMatch(expectedMessage);
     expect(transport.requests).toHaveLength(0);
+  }
+
+  async function expectCreateAndUpdateValidationError(
+    args: Record<string, unknown>,
+    expectedMessage: RegExp,
+  ) {
+    for (const toolName of ["b2_create_bucket", "b2_update_bucket"] as const) {
+      await expectBucketValidationError(toolName, args, expectedMessage);
+    }
   }
 
   it("updates bucket metadata and Object Lock settings", async () => {
@@ -1245,12 +1257,17 @@ describe("b2_update_bucket", () => {
       /bucketInfo must contain at most 10 key-value pairs/,
     ],
     [
-      "bucketInfo aggregate value size",
+      "bucketInfo individual value size",
       { bucketInfo: { safe: "x".repeat(10_001) } },
+      /bucketInfo value for "safe" must be at most 10000 characters/,
+    ],
+    [
+      "bucketInfo aggregate value size",
+      { bucketInfo: { safeA: "x".repeat(6000), safeB: "x".repeat(6000) } },
       /bucketInfo values must total at most 10000 UTF-8 bytes/,
     ],
-  ])("rejects invalid %s before SDK update", async (_label, args, expectedMessage) => {
-    await expectUpdateBucketValidationError(args, expectedMessage);
+  ])("rejects invalid %s before SDK call", async (_label, args, expectedMessage) => {
+    await expectCreateAndUpdateValidationError(args, expectedMessage);
   });
 
   const validCorsRule = {
@@ -1288,6 +1305,33 @@ describe("b2_update_bucket", () => {
       /corsRules must contain at most 100 rules/,
     ],
     [
+      "empty required CORS array",
+      { corsRules: [{ ...validCorsRule, allowedOrigins: [] }] },
+      /corsRules\[0\]\.allowedOrigins must contain at least 1 item/,
+    ],
+    [
+      "empty CORS string value",
+      { corsRules: [{ ...validCorsRule, allowedOperations: [""] }] },
+      /corsRules\[0\]\.allowedOperations\[0\] must not be empty/,
+    ],
+    [
+      "large CORS string value",
+      { corsRules: [{ ...validCorsRule, allowedOrigins: [`https://${"a".repeat(1000)}`] }] },
+      /corsRules\[0\]\.allowedOrigins\[0\] must be at most 999 characters/,
+    ],
+    [
+      "large CORS array",
+      {
+        corsRules: [
+          {
+            ...validCorsRule,
+            allowedOperations: Array.from({ length: 101 }, (_, index) => `op-${index}`),
+          },
+        ],
+      },
+      /corsRules\[0\]\.allowedOperations must contain at most 100 items/,
+    ],
+    [
       "duplicate CORS rule names",
       {
         corsRules: [
@@ -1303,14 +1347,17 @@ describe("b2_update_bucket", () => {
         corsRules: [
           {
             ...validCorsRule,
-            allowedOrigins: [`https://${"a".repeat(980)}.example.com`],
+            allowedOrigins: Array.from(
+              { length: 50 },
+              (_, index) => `https://origin-${index}.example.com`,
+            ),
           },
         ],
       },
       /corsRules\[0\] must be less than 1000 UTF-8 bytes/,
     ],
-  ])("rejects invalid %s before SDK update", async (_label, args, expectedMessage) => {
-    await expectUpdateBucketValidationError(args, expectedMessage);
+  ])("rejects invalid %s before SDK call", async (_label, args, expectedMessage) => {
+    await expectCreateAndUpdateValidationError(args, expectedMessage);
   });
 
   it("blocks replication updates without confirmation before SDK update", async () => {

--- a/tests/unit/b2-tools.unit.test.ts
+++ b/tests/unit/b2-tools.unit.test.ts
@@ -1181,6 +1181,27 @@ describe("b2_update_bucket", () => {
     },
   };
 
+  async function expectUpdateBucketValidationError(
+    args: Record<string, unknown>,
+    expectedMessage: RegExp,
+  ) {
+    invalidateAuthManagerCache();
+    const transport = new RecordingTransport((request) => {
+      throw new Error(`unexpected ${b2EndpointName(request)}`);
+    });
+    installSdkTransport(transport);
+    server = createServer(testConfig);
+
+    const result = await callTool(server, "b2_update_bucket", {
+      bucketId: "bucket-1",
+      ...args,
+    });
+
+    expect(result.isError).toBe(true);
+    expect(result.content[0].text).toMatch(expectedMessage);
+    expect(transport.requests).toHaveLength(0);
+  }
+
   it("updates bucket metadata and Object Lock settings", async () => {
     const bucket = await createBucket("update-bucket", BucketType.AllPrivate, {
       fileLockEnabled: true,
@@ -1201,6 +1222,95 @@ describe("b2_update_bucket", () => {
     expect(result.bucketType).toBe("allPublic");
     expect(result.defaultRetention).toEqual(defaultRetention);
     expect(result.fileLockConfiguration.value.isFileLockEnabled).toBe(true);
+  });
+
+  it.each([
+    [
+      "reserved bucketInfo prefix",
+      { bucketInfo: { "b2-mcp-qa": "x" } },
+      /bucketInfo key "b2-mcp-qa" must not start with 'b2-'/,
+    ],
+    [
+      "bucketInfo character set",
+      { bucketInfo: { "invalid/key": "x" } },
+      /bucketInfo key "invalid\/key" may contain only letters/,
+    ],
+    [
+      "bucketInfo pair count",
+      {
+        bucketInfo: Object.fromEntries(
+          Array.from({ length: 11 }, (_, index) => [`key${index}`, "x"]),
+        ),
+      },
+      /bucketInfo must contain at most 10 key-value pairs/,
+    ],
+    [
+      "bucketInfo aggregate value size",
+      { bucketInfo: { safe: "x".repeat(10_001) } },
+      /bucketInfo values must total at most 10000 UTF-8 bytes/,
+    ],
+  ])("rejects invalid %s before SDK update", async (_label, args, expectedMessage) => {
+    await expectUpdateBucketValidationError(args, expectedMessage);
+  });
+
+  const validCorsRule = {
+    corsRuleName: "valid-rule",
+    allowedOrigins: ["https://example.com"],
+    allowedHeaders: ["range"],
+    allowedOperations: ["b2_download_file_by_name"],
+    maxAgeSeconds: 3600,
+  };
+
+  it.each([
+    [
+      "reserved CORS rule prefix",
+      { corsRules: [{ ...validCorsRule, corsRuleName: "b2-mcp-qa-temporary" }] },
+      /corsRules\[0\]\.corsRuleName must not start with 'b2-'/,
+    ],
+    [
+      "CORS rule name length",
+      { corsRules: [{ ...validCorsRule, corsRuleName: "short" }] },
+      /corsRules\[0\]\.corsRuleName must be 6-63 characters long/,
+    ],
+    [
+      "CORS rule name character set",
+      { corsRules: [{ ...validCorsRule, corsRuleName: "invalid_rule" }] },
+      /corsRules\[0\]\.corsRuleName may contain only letters, digits, and hyphens/,
+    ],
+    [
+      "CORS rule count",
+      {
+        corsRules: Array.from({ length: 101 }, (_, index) => ({
+          ...validCorsRule,
+          corsRuleName: `rule-${index}`,
+        })),
+      },
+      /corsRules must contain at most 100 rules/,
+    ],
+    [
+      "duplicate CORS rule names",
+      {
+        corsRules: [
+          { ...validCorsRule, corsRuleName: "dup-rule" },
+          { ...validCorsRule, corsRuleName: "dup-rule" },
+        ],
+      },
+      /corsRules\[1\]\.corsRuleName "dup-rule" must be unique/,
+    ],
+    [
+      "CORS rule aggregate size",
+      {
+        corsRules: [
+          {
+            ...validCorsRule,
+            allowedOrigins: [`https://${"a".repeat(980)}.example.com`],
+          },
+        ],
+      },
+      /corsRules\[0\] must be less than 1000 UTF-8 bytes/,
+    ],
+  ])("rejects invalid %s before SDK update", async (_label, args, expectedMessage) => {
+    await expectUpdateBucketValidationError(args, expectedMessage);
   });
 
   it("blocks replication updates without confirmation before SDK update", async () => {

--- a/tests/unit/b2-tools.unit.test.ts
+++ b/tests/unit/b2-tools.unit.test.ts
@@ -1214,6 +1214,31 @@ describe("b2_update_bucket", () => {
     }
   }
 
+  function expectBucketSchemaValidation(
+    toolName: "b2_create_bucket" | "b2_update_bucket",
+    args: Record<string, unknown>,
+    expectedMessage?: RegExp,
+  ) {
+    server = createServer(testConfig);
+    const tool = getRegisteredTools(server)?.[toolName];
+    expect(tool).toBeDefined();
+    const baseArgs =
+      toolName === "b2_create_bucket"
+        ? { bucketName: "fixture-bucket", bucketType: "allPrivate" }
+        : { bucketId: "bucket-1" };
+    const parsed = tool?.inputSchema?.safeParse({ ...baseArgs, ...args });
+
+    if (!expectedMessage) {
+      expect(parsed?.success).toBe(true);
+      return;
+    }
+
+    expect(parsed?.success).toBe(false);
+    if (parsed?.success === false) {
+      expect(parsed.error.issues.map((issue) => issue.message).join("\n")).toMatch(expectedMessage);
+    }
+  }
+
   it("updates bucket metadata and Object Lock settings", async () => {
     const bucket = await createBucket("update-bucket", BucketType.AllPrivate, {
       fileLockEnabled: true,
@@ -1257,6 +1282,16 @@ describe("b2_update_bucket", () => {
       /bucketInfo must contain at most 10 key-value pairs/,
     ],
     [
+      "bucketInfo key character length",
+      { bucketInfo: { ["k".repeat(51)]: "x" } },
+      /bucketInfo key "kkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkk" must be 1-50 UTF-8 bytes/,
+    ],
+    [
+      "bucketInfo key UTF-8 byte length",
+      { bucketInfo: { ["\u00e9".repeat(26)]: "x" } },
+      /bucketInfo key .* must be 1-50 UTF-8 bytes/,
+    ],
+    [
       "bucketInfo individual value size",
       { bucketInfo: { safe: "x".repeat(10_001) } },
       /bucketInfo value for "safe" must be at most 10000 characters/,
@@ -1277,6 +1312,37 @@ describe("b2_update_bucket", () => {
     allowedOperations: ["b2_download_file_by_name"],
     maxAgeSeconds: 3600,
   };
+
+  it("applies bucketInfo and CORS rules through registered schemas", () => {
+    const validArgs = { bucketInfo: { qa: "ok" }, corsRules: [validCorsRule] };
+    const invalidSchemaCases: Array<[Record<string, unknown>, RegExp]> = [
+      [{ bucketInfo: { "b2-mcp-qa": "x" } }, /Invalid key in record/],
+      [
+        { bucketInfo: { safeA: "x".repeat(6000), safeB: "x".repeat(6000) } },
+        /bucketInfo values must total at most 10000 UTF-8 bytes/,
+      ],
+      [
+        { corsRules: [{ ...validCorsRule, corsRuleName: "b2-mcp-qa-temporary" }] },
+        /reserved for Backblaze/,
+      ],
+      [
+        {
+          corsRules: [
+            { ...validCorsRule, corsRuleName: "dup-rule" },
+            { ...validCorsRule, corsRuleName: "dup-rule" },
+          ],
+        },
+        /must be unique/,
+      ],
+    ];
+
+    for (const toolName of ["b2_create_bucket", "b2_update_bucket"] as const) {
+      expectBucketSchemaValidation(toolName, validArgs);
+      for (const [args, expectedMessage] of invalidSchemaCases) {
+        expectBucketSchemaValidation(toolName, args, expectedMessage);
+      }
+    }
+  });
 
   it.each([
     [


### PR DESCRIPTION
## Summary
- Adds shared schema and handler validation for bucketInfo and CORS rule constraints on bucket create/update payloads.
- Rejects reserved b2- prefixes, invalid names, over-limit bucket info, duplicate CORS rule names, too many CORS rules, and oversized CORS rules before the SDK/provider call.
- Keeps the documented schema constraints within package and Cloudflare source-size budgets, and adds schema-level coverage for the validation contract.
- Regenerates the tool profile contract fixtures for the updated tool schemas.

## Linked Issue
Closes #215

## Tests Run
- PATH=/Users/gpenacastellanos/miniforge3/envs/b2-mcp-issue-215/bin:$PATH pnpm run typecheck
- PATH=/Users/gpenacastellanos/miniforge3/envs/b2-mcp-issue-215/bin:$PATH pnpm run lint (passes with existing src/oauth-resource-server.ts warning)
- PATH=/Users/gpenacastellanos/miniforge3/envs/b2-mcp-issue-215/bin:$PATH pnpm run format:check
- PATH=/Users/gpenacastellanos/miniforge3/envs/b2-mcp-issue-215/bin:$PATH pnpm exec vitest run tests/unit/b2-tools.unit.test.ts --config vitest.config.mts
- PATH=/Users/gpenacastellanos/miniforge3/envs/b2-mcp-issue-215/bin:$PATH pnpm run test:coverage
- PATH=/Users/gpenacastellanos/miniforge3/envs/b2-mcp-issue-215/bin:$PATH pnpm run test:contract
- PATH=/Users/gpenacastellanos/miniforge3/envs/b2-mcp-issue-215/bin:$PATH pnpm run check:package-budget
- PATH=/Users/gpenacastellanos/miniforge3/envs/b2-mcp-issue-215/bin:$PATH pnpm run generate:tool-contract
- GitHub CI run 32429210336 succeeded for commit 575b52aa00e156682323ab019734b25ac065f776.

## Follow-up Notes
- No follow-up required.