### PR TITLE
docs: clarify B2_REGION quick start requirement

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -11,9 +11,9 @@ B2_APPLICATION_KEY=
 # Master key — used ONLY by the Partner API tools (falls back to the app key).
 # B2_MASTER_KEY_ID=
 # B2_MASTER_KEY=
-# Region for the S3-compatible endpoint. Required for accounts outside
-# us-west-004 until automatic region derivation is available, e.g. us-east-005.
-# B2_REGION=us-west-004
+# Default-region accounts can leave B2_REGION unset. Accounts outside
+# us-west-004 must set their S3-compatible endpoint region, e.g. us-east-005.
+# B2_REGION=us-east-005
 # Token appended to the outbound User-Agent (tag a deployment).
 # B2_MCP_UA_SUFFIX=
 # LLM-facing TextContent.text format for structured successes: json | toon.

--- a/.env.example
+++ b/.env.example
@@ -11,7 +11,8 @@ B2_APPLICATION_KEY=
 # Master key — used ONLY by the Partner API tools (falls back to the app key).
 # B2_MASTER_KEY_ID=
 # B2_MASTER_KEY=
-# Region for the S3-compatible endpoint.
+# Region for the S3-compatible endpoint. Required for accounts outside
+# us-west-004 until automatic region derivation is available, e.g. us-east-005.
 # B2_REGION=us-west-004
 # Token appended to the outbound User-Agent (tag a deployment).
 # B2_MCP_UA_SUFFIX=

--- a/README.md
+++ b/README.md
@@ -33,6 +33,13 @@ Destructive actions are gated, durable B2 secrets stay out of the model's contex
 
 The canonical package name is `@backblaze-labs/b2-mcp` and the canonical binary is `b2-mcp` (`b2-mcp-server` is a transition alias). The fastest setup runs it with `npx`, no clone or build.
 
+Before copying the config, check the account's B2 S3-compatible endpoint
+region. Accounts in the default `us-west-004` region can omit `B2_REGION` or
+set it to `us-west-004`. For any non-default account, add `B2_REGION` to the
+`env` block and replace the example below with the account's region, such as
+`us-east-005`; otherwise S3-compatible tools target `us-west-004`. See
+[Configuration](#configuration) for the full requirement.
+
 **Connect Claude Desktop** by editing `~/Library/Application Support/Claude/claude_desktop_config.json`:
 
 ```json
@@ -43,7 +50,8 @@ The canonical package name is `@backblaze-labs/b2-mcp` and the canonical binary 
       "args": ["-y", "@backblaze-labs/b2-mcp"],
       "env": {
         "B2_APPLICATION_KEY_ID": "your-application-key-id",
-        "B2_APPLICATION_KEY": "your-application-key-secret"
+        "B2_APPLICATION_KEY": "your-application-key-secret",
+        "B2_REGION": "us-east-005"
       }
     }
   }
@@ -185,7 +193,7 @@ the healthcheck probes the same port the server binds.
 | `B2_APPLICATION_KEY_ID`                                       | stdio / HTTP `server` | —                     | Application key ID (non-master) — the workhorse for native B2 and S3-compatible tools                                      |
 | `B2_APPLICATION_KEY`                                          | stdio / HTTP `server` | —                     | Application key secret                                                                                                     |
 | `B2_MASTER_KEY_ID` / `B2_MASTER_KEY`                          | —                     | falls back to app key | Master credential for SDK-backed Partner/Groups tools; required with Partner API entitlement for those operations          |
-| `B2_REGION`                                                   | —                     | `us-west-004`         | Region for the S3-compatible endpoint                                                                                      |
+| `B2_REGION`                                                   | non-default B2 regions | `us-west-004`         | Region for the S3-compatible endpoint                                                                                      |
 | `B2_MCP_UA_SUFFIX`                                            | —                     | —                     | Token appended to the outbound User-Agent (tag a deployment)                                                               |
 | `B2_MCP_OUTPUT_FORMAT`                                        | —                     | `json`                | LLM-facing `TextContent.text` format for structured successes: compact `json` or opt-in `toon`                             |
 | `B2_MCP_TRANSPORT`                                            | —                     | `stdio`               | CLI default transport when no `stdio` / `http` argument or `--transport` flag is passed; Docker images set this to `http`  |
@@ -197,6 +205,11 @@ the healthcheck probes the same port the server binds.
 | `B2_HTTP_CREDENTIAL_MODE`                                     | HTTP only             | `headers`             | `headers`, `server`, or `principal`; unset preserves existing header-based clients. Set explicitly for hosted deployments  |
 | `B2_PRINCIPAL_CREDENTIAL_MAP`                                 | HTTP `principal`      | —                     | JSON map from verified MCP principal to a customer-managed credential reference                                            |
 | `B2_CREDENTIAL_<REF>_APPLICATION_KEY_ID` / `_APPLICATION_KEY` | HTTP `principal`      | —                     | Env-backed secret-broker material for the mapped reference                                                                 |
+
+`B2_REGION` is required for accounts outside the default `us-west-004` region
+until automatic region derivation is available. Use the region in your B2
+S3-compatible endpoint, such as `us-east-005`; the [Quick start](#quick-start)
+sample shows where to add it.
 
 **Security / policy (safe defaults; override as needed):**
 

--- a/README.md
+++ b/README.md
@@ -36,9 +36,9 @@ The canonical package name is `@backblaze-labs/b2-mcp` and the canonical binary 
 Before copying the config, check the account's B2 S3-compatible endpoint
 region. Accounts in the default `us-west-004` region can omit `B2_REGION` or
 set it to `us-west-004`. For any non-default account, add `B2_REGION` to the
-`env` block and replace the example below with the account's region, such as
-`us-east-005`; otherwise S3-compatible tools target `us-west-004`. See
-[Configuration](#configuration) for the full requirement.
+`env` block with the account's region, such as `us-east-005`; otherwise
+S3-compatible tools target `us-west-004`. See [Configuration](#configuration)
+for the full requirement.
 
 **Connect Claude Desktop** by editing `~/Library/Application Support/Claude/claude_desktop_config.json`:
 
@@ -50,11 +50,21 @@ set it to `us-west-004`. For any non-default account, add `B2_REGION` to the
       "args": ["-y", "@backblaze-labs/b2-mcp"],
       "env": {
         "B2_APPLICATION_KEY_ID": "your-application-key-id",
-        "B2_APPLICATION_KEY": "your-application-key-secret",
-        "B2_REGION": "us-east-005"
+        "B2_APPLICATION_KEY": "your-application-key-secret"
       }
     }
   }
+}
+```
+
+For a non-default-region account, include `B2_REGION` in the same `env` block
+before restarting Claude Desktop:
+
+```json
+{
+  "B2_APPLICATION_KEY_ID": "your-application-key-id",
+  "B2_APPLICATION_KEY": "your-application-key-secret",
+  "B2_REGION": "us-east-005"
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -33,12 +33,7 @@ Destructive actions are gated, durable B2 secrets stay out of the model's contex
 
 The canonical package name is `@backblaze-labs/b2-mcp` and the canonical binary is `b2-mcp` (`b2-mcp-server` is a transition alias). The fastest setup runs it with `npx`, no clone or build.
 
-Before copying the config, check the account's B2 S3-compatible endpoint
-region. Accounts in the default `us-west-004` region can omit `B2_REGION` or
-set it to `us-west-004`. For any non-default account, add `B2_REGION` to the
-`env` block with the account's region, such as `us-east-005`; otherwise
-S3-compatible tools target `us-west-004`. See [Configuration](#configuration)
-for the full requirement.
+Before copying the config, check the account's B2 S3-compatible endpoint region. Accounts in the default `us-west-004` region can omit `B2_REGION` or set it to `us-west-004`. For any non-default account, add `B2_REGION` to the `env` block with the account's region, such as `us-east-005`; otherwise S3-compatible tools target `us-west-004`. See [Configuration](#configuration) for the full requirement.
 
 **Connect Claude Desktop** by editing `~/Library/Application Support/Claude/claude_desktop_config.json`:
 
@@ -57,8 +52,7 @@ for the full requirement.
 }
 ```
 
-For a non-default-region account, include `B2_REGION` in the same `env` block
-before restarting Claude Desktop:
+For a non-default-region account, include `B2_REGION` in the same `env` block before restarting Claude Desktop:
 
 ```json
 {
@@ -216,10 +210,7 @@ the healthcheck probes the same port the server binds.
 | `B2_PRINCIPAL_CREDENTIAL_MAP`                                 | HTTP `principal`      | —                     | JSON map from verified MCP principal to a customer-managed credential reference                                            |
 | `B2_CREDENTIAL_<REF>_APPLICATION_KEY_ID` / `_APPLICATION_KEY` | HTTP `principal`      | —                     | Env-backed secret-broker material for the mapped reference                                                                 |
 
-`B2_REGION` is required for accounts outside the default `us-west-004` region
-until automatic region derivation is available. Use the region in your B2
-S3-compatible endpoint, such as `us-east-005`; the [Quick start](#quick-start)
-sample shows where to add it.
+`B2_REGION` is required for accounts outside the default `us-west-004` region until automatic region derivation is available. Use the region in your B2 S3-compatible endpoint, such as `us-east-005`; the [Quick start](#quick-start) sample shows where to add it.
 
 **Security / policy (safe defaults; override as needed):**
 


### PR DESCRIPTION
## Summary
- Clarifies the quick-start region contract: default-region accounts can omit `B2_REGION` or use `us-west-004`, while non-default-region accounts must set their B2 S3-compatible endpoint region.
- Keeps the primary Claude Desktop copy-paste config safe for default-region accounts and adds a conditional `B2_REGION` example using `us-east-005`.
- Cross-links the requirement from Configuration and updates `.env.example` with the same default/non-default guidance.

## Linked issue
Closes #210

## Tests run
- `pnpm run lint:docs`
- `pnpm run lint:links`
- `pnpm run spell`
- `pnpm run format:check`

## Follow-up notes
- None.