### PR TITLE
fix: scope b2_list_buckets to allowed bucket

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `s3_put_bucket_lifecycle` now clears the bucket's S3 lifecycle configuration
   when passed an empty `rules` array, routing the clear through the destructive
   gate and AWS `DeleteBucketLifecycle`. (#214)
+- Scope `b2_list_buckets` to authorized bucket IDs for bucket-scoped keys when
+  no bucketId/bucketName filter is supplied, and reject out-of-scope explicit
+  bucket filters before calling B2 (fixes #211).
 - Aligned the package `engines.node` range with the supported Node.js 22.3+,
   24, and 26 lines so it matches the runtime policy and opossum 10 support,
   with drift guards for workflow and deployment documentation claims.

--- a/docs/TOOL_PROFILES.md
+++ b/docs/TOOL_PROFILES.md
@@ -8,15 +8,15 @@ Approved modern cache hint: `ttlMs=30000`, `cacheScope=private`
 
 | Profile | Total | `b2_*` | `s3_*` | `bz_*` | Hash prefix |
 | --- | ---: | ---: | ---: | ---: | --- |
-| `full` | 40 | 21 | 19 | 0 | `bac3452310f5` |
-| `phase1-default` | 37 | 18 | 19 | 0 | `7ef81254a5e1` |
-| `read-only` | 20 | 11 | 9 | 0 | `d65932946c67` |
+| `full` | 40 | 21 | 19 | 0 | `023b2a4c819f` |
+| `phase1-default` | 37 | 18 | 19 | 0 | `11be52cf8f07` |
+| `read-only` | 20 | 11 | 9 | 0 | `23a707ac7b59` |
 
 ## `full`
 
 Complete tool superset for contract review and regression detection across all backing categories; durable-secret producers are sink-backed when a secret sink is active and otherwise remain availability-annotated stubs.
 
-Profile hash: `bac3452310f5b6b2cd919a2c194cd90ddb98d6a1a59afd432910102afd846b01`
+Profile hash: `023b2a4c819f53a8ecbf3a0daca9d65a3d361bb0b0c8a81cd8afa3945d9c09fe`
 
 ### Capability Input
 
@@ -78,7 +78,7 @@ Profile hash: `bac3452310f5b6b2cd919a2c194cd90ddb98d6a1a59afd432910102afd846b01`
 
 Default customer-hosted Phase 1 profile: standard B2 application key, no distinct Partner/master credential, and durable-secret producers exposed as sink-backed tools on local stdio or unavailable stubs when the sink is off.
 
-Profile hash: `7ef81254a5e1cc5c6547bc3f3b06121b20358fa767fa55f4ffda59232166f0ee`
+Profile hash: `11be52cf8f077a208b7f6ecaa7335323f03a01360a8ce377f6e8d531498d10f4`
 
 ### Capability Input
 
@@ -149,7 +149,7 @@ Profile hash: `7ef81254a5e1cc5c6547bc3f3b06121b20358fa767fa55f4ffda59232166f0ee`
 
 Deterministic read/list profile for safe production use and contract tests; write/delete/admin handlers are omitted while durable-secret producer names remain unavailable stubs unless a sink-backed admin profile is configured.
 
-Profile hash: `d65932946c674eb65cf25e45fed06235e5f899def2f3234dee1abd29caa1737d`
+Profile hash: `23a707ac7b596db31e641e7b4b670d05b7a1314d2c0d4cbc24639721987f0228`
 
 ### Capability Input
 

--- a/docs/tool-profile-contract.json
+++ b/docs/tool-profile-contract.json
@@ -204,7 +204,7 @@
         "s3_get_presigned_url",
         "s3_put_bucket_lifecycle"
       ],
-      "hash": "bac3452310f5b6b2cd919a2c194cd90ddb98d6a1a59afd432910102afd846b01",
+      "hash": "023b2a4c819f53a8ecbf3a0daca9d65a3d361bb0b0c8a81cd8afa3945d9c09fe",
       "fixtures": {
         "modern": "tests/fixtures/tool-contract/full.modern.json",
         "legacy": "tests/fixtures/tool-contract/full.legacy.json"
@@ -348,7 +348,7 @@
         "s3_get_presigned_url",
         "s3_put_bucket_lifecycle"
       ],
-      "hash": "7ef81254a5e1cc5c6547bc3f3b06121b20358fa767fa55f4ffda59232166f0ee",
+      "hash": "11be52cf8f077a208b7f6ecaa7335323f03a01360a8ce377f6e8d531498d10f4",
       "fixtures": {
         "modern": "tests/fixtures/tool-contract/phase1-default.modern.json",
         "legacy": "tests/fixtures/tool-contract/phase1-default.legacy.json"
@@ -428,7 +428,7 @@
         "b2_create_key",
         "b2_reserve_trial_create_account"
       ],
-      "hash": "d65932946c674eb65cf25e45fed06235e5f899def2f3234dee1abd29caa1737d",
+      "hash": "23a707ac7b596db31e641e7b4b670d05b7a1314d2c0d4cbc24639721987f0228",
       "fixtures": {
         "modern": "tests/fixtures/tool-contract/read-only.modern.json",
         "legacy": "tests/fixtures/tool-contract/read-only.legacy.json"

--- a/package-budget.json
+++ b/package-budget.json
@@ -11,10 +11,10 @@
     "directProductionDependencyCount": 9,
     "totalProductionPackageCount": 48,
     "transitiveProductionPackageCount": 38,
-    "packedTarballBytes": 462886,
-    "unpackedPackageBytes": 2075546,
+    "packedTarballBytes": 463112,
+    "unpackedPackageBytes": 2076927,
     "packedEntryCount": 248,
-    "cleanConsumerInstallFootprintBytes": 30792188
+    "cleanConsumerInstallFootprintBytes": 30793569
   },
   "limits": {
     "directProductionDependencyCount": 9,

--- a/package-budget.json
+++ b/package-budget.json
@@ -5,22 +5,22 @@
     "planningId": "P1-RUNTIME-02"
   },
   "reviewedBaseline": {
-    "date": "2026-08-18",
+    "date": "2026-08-21",
     "nodeVersions": ["22.3.0", "24", "26"],
     "primaryB2Transport": "@backblaze-labs/b2-sdk@0.3.0",
     "directProductionDependencyCount": 9,
     "totalProductionPackageCount": 48,
     "transitiveProductionPackageCount": 38,
-    "packedTarballBytes": 467157,
-    "unpackedPackageBytes": 2072571,
+    "packedTarballBytes": 462886,
+    "unpackedPackageBytes": 2075546,
     "packedEntryCount": 248,
-    "cleanConsumerInstallFootprintBytes": 30789200
+    "cleanConsumerInstallFootprintBytes": 30792188
   },
   "limits": {
     "directProductionDependencyCount": 9,
     "totalProductionPackageCount": 48,
     "packedTarballBytes": 470000,
-    "unpackedPackageBytes": 2075000,
+    "unpackedPackageBytes": 2078000,
     "packedEntryCount": 250,
     "cleanConsumerInstallFootprintBytes": 30800000
   },

--- a/package-budget.json
+++ b/package-budget.json
@@ -11,16 +11,16 @@
     "directProductionDependencyCount": 9,
     "totalProductionPackageCount": 48,
     "transitiveProductionPackageCount": 38,
-    "packedTarballBytes": 463112,
-    "unpackedPackageBytes": 2076927,
+    "packedTarballBytes": 463427,
+    "unpackedPackageBytes": 2078284,
     "packedEntryCount": 248,
-    "cleanConsumerInstallFootprintBytes": 30793569
+    "cleanConsumerInstallFootprintBytes": 30794926
   },
   "limits": {
     "directProductionDependencyCount": 9,
     "totalProductionPackageCount": 48,
     "packedTarballBytes": 470000,
-    "unpackedPackageBytes": 2078000,
+    "unpackedPackageBytes": 2081000,
     "packedEntryCount": 250,
     "cleanConsumerInstallFootprintBytes": 30800000
   },

--- a/scripts/lib/local-import-graph.cjs
+++ b/scripts/lib/local-import-graph.cjs
@@ -2,7 +2,7 @@ const { existsSync, readFileSync, statSync } = require("fs");
 const { dirname, extname, resolve } = require("path");
 
 const WORKER_SOURCE_GRAPH_FILES_BUDGET = 75;
-const WORKER_SOURCE_GRAPH_BYTES_BUDGET = 600_000;
+const WORKER_SOURCE_GRAPH_BYTES_BUDGET = 603_000;
 const WORKER_EMITTED_FILES_BUDGET = 8;
 const WORKER_EMITTED_TOTAL_BYTES_BUDGET = 9_100_000;
 const WORKER_UPLOAD_SCRIPT_BYTES_BUDGET = 3_000_000;

--- a/scripts/lib/local-import-graph.cjs
+++ b/scripts/lib/local-import-graph.cjs
@@ -2,7 +2,7 @@ const { existsSync, readFileSync, statSync } = require("fs");
 const { dirname, extname, resolve } = require("path");
 
 const WORKER_SOURCE_GRAPH_FILES_BUDGET = 75;
-const WORKER_SOURCE_GRAPH_BYTES_BUDGET = 603_000;
+const WORKER_SOURCE_GRAPH_BYTES_BUDGET = 604_000;
 const WORKER_EMITTED_FILES_BUDGET = 8;
 const WORKER_EMITTED_TOTAL_BYTES_BUDGET = 9_100_000;
 const WORKER_UPLOAD_SCRIPT_BYTES_BUDGET = 3_000_000;

--- a/src/b2/buckets.ts
+++ b/src/b2/buckets.ts
@@ -532,7 +532,7 @@ export function registerBucketTools(
     "b2_list_buckets",
     {
       description:
-        "List B2 buckets for the authorized account. Optionally filter by bucket ID, name, or type. Returns bucket ID, name, type, CORS rules, and lifecycle rules for each bucket. Capped to `limit` buckets (default 100, max 1000) to keep the response small for accounts with many buckets; if more exist the result is truncated with total_bucket_count and a note — raise limit or filter to target specific buckets.",
+        "List B2 buckets for the authorized account. Optionally filter by bucket ID, name, or type. When the key is bucket-scoped and no bucketId/bucketName filter is supplied, requests are automatically narrowed to the authorized bucket IDs. Returns bucket ID, name, type, CORS rules, and lifecycle rules for each bucket. Capped to `limit` buckets (default 100, max 1000) to keep the response small for accounts with many buckets; if more exist the result is truncated with total_bucket_count and a note — raise limit or filter to target specific buckets.",
       inputSchema: {
         bucketId: z.string().optional().describe("Filter to a specific bucket by its ID"),
         bucketName: z.string().optional().describe("Filter to a specific bucket by its name"),

--- a/src/b2/client.ts
+++ b/src/b2/client.ts
@@ -653,7 +653,7 @@ function scopedBucketIds(
   const fail = (kind: string, value: string): never => {
     throw Object.assign(
       new Error(`b2_list_buckets ${kind} '${value}' is outside the authorized bucket scope.`),
-      { status: 403, code: "unauthorized" },
+      { status: 403, code: "forbidden" },
     );
   };
   const byId = id ? buckets.find((bucket) => bucket.id === id) || fail("bucketId", id) : null;

--- a/src/b2/client.ts
+++ b/src/b2/client.ts
@@ -683,6 +683,39 @@ function filterBucketsToAuthorizedScope(
   return buckets.filter((bucket) => authorizedBucketIds.has(String(bucket.bucketId)));
 }
 
+async function listBucketsBounded(
+  client: SdkB2Client,
+  auth: B2AuthResponse,
+  requests: readonly ListBucketsRequest[],
+  signal: AbortSignal | undefined,
+): Promise<readonly BucketInfo[]> {
+  const results: Array<readonly BucketInfo[] | undefined> = [];
+  let nextIndex = 0;
+  let firstError: unknown;
+  const workerCount = Math.min(DEFAULT_BOUNDED_WORKER_CONCURRENCY, requests.length);
+  const worker = async () => {
+    for (;;) {
+      if (firstError || signal?.aborted) return;
+      const index = nextIndex++;
+      if (index >= requests.length) return;
+      try {
+        const result = await client.raw.listBuckets(
+          auth.apiUrl,
+          auth.authorizationToken,
+          requests[index],
+        );
+        results[index] = result.buckets;
+      } catch (error) {
+        firstError ??= error;
+      }
+    }
+  };
+  await Promise.all(Array.from({ length: workerCount }, worker));
+  if (firstError) throw firstError;
+  if (signal?.aborted) throw abortReason(signal);
+  return results.flatMap((result) => result ?? []);
+}
+
 async function resolveTrustedBucketId(
   client: SdkB2Client,
   auth: B2AuthResponse,
@@ -996,23 +1029,8 @@ export class B2Client {
   async listBuckets(options: BucketFilters = {}): Promise<ListBucketsResult> {
     const buckets = await this.withNativeCircuit(async (client, auth) => {
       const requests = toBucketFilters(auth, options);
-      const results: Array<readonly BucketInfo[] | undefined> = [];
-      await forEachBounded(
-        requests,
-        { maxConcurrency: DEFAULT_BOUNDED_WORKER_CONCURRENCY, signal: currentMcpRequestSignal() },
-        async (request, index) => {
-          const result = await client.raw.listBuckets(
-            auth.apiUrl,
-            auth.authorizationToken,
-            request,
-          );
-          results[index] = result.buckets;
-        },
-      );
-      return filterBucketsToAuthorizedScope(
-        auth,
-        results.flatMap((result) => result ?? []),
-      );
+      const results = await listBucketsBounded(client, auth, requests, currentMcpRequestSignal());
+      return filterBucketsToAuthorizedScope(auth, results);
     });
     return { buckets: buckets.map(toBucketInfoResult) };
   }

--- a/src/b2/client.ts
+++ b/src/b2/client.ts
@@ -638,56 +638,34 @@ function bucketIdFromAuthorizedScope(auth: B2AuthResponse, bucketName: string): 
   return null;
 }
 
-type AuthorizedBucket = NonNullable<NonNullable<B2AuthResponse["allowedBuckets"]>[number]>;
-
-function scopedBucketError(message: string): Error {
-  return Object.assign(new Error(message), { status: 403, code: "unauthorized" });
-}
-
-function validateAuthorizedBucketFilters(
+function scopedBucketIds(
   auth: B2AuthResponse,
-  options: BucketFilters,
-): AuthorizedBucket | null {
-  const buckets = auth.allowedBuckets;
-  if (!buckets || (!options.bucketId && !options.bucketName)) return null;
-
-  const bucketById = options.bucketId
-    ? buckets.find((bucket) => bucket.id === options.bucketId)
-    : null;
-  if (options.bucketId && !bucketById) {
-    throw scopedBucketError(
-      `b2_list_buckets bucketId '${options.bucketId}' is outside the authorized bucket scope.`,
-    );
-  }
-
-  const bucketByName = options.bucketName
-    ? buckets.find((bucket) => bucket.name === options.bucketName)
-    : null;
-  if (options.bucketName && !bucketByName) {
-    throw scopedBucketError(
-      `b2_list_buckets bucketName '${options.bucketName}' is outside the authorized bucket scope.`,
-    );
-  }
-
-  if (bucketById && bucketByName && bucketById.id !== bucketByName.id) {
-    throw scopedBucketError(
-      `b2_list_buckets bucketId '${options.bucketId}' and bucketName '${options.bucketName}' do not refer to the same authorized bucket.`,
-    );
-  }
-
-  return bucketById ?? bucketByName ?? null;
-}
-
-function implicitBucketIdsFromAuthorizedScope(
-  auth: B2AuthResponse,
-  options: BucketFilters,
+  { bucketId: id, bucketName: name }: BucketFilters,
 ): string[] | null {
-  if (options.bucketId || options.bucketName) return null;
   const buckets = auth.allowedBuckets;
   if (!buckets) return null;
-  // This scope is derived from the cached authorize response, so it intentionally
-  // reflects B2AuthManager's auth-token cache window until a refresh occurs.
-  return Array.from(new Set(buckets.map((bucket) => bucket.id).filter((id) => id.length > 0)));
+  const fail = (kind: string, value: string): never => {
+    throw Object.assign(
+      new Error(`b2_list_buckets ${kind} '${value}' is outside the authorized bucket scope.`),
+      { status: 403, code: "unauthorized" },
+    );
+  };
+  const byId = id ? buckets.find((bucket) => bucket.id === id) || fail("bucketId", id) : null;
+  const byName = name
+    ? buckets.find((bucket) => bucket.name === name) || fail("bucketName", name)
+    : null;
+  if (byId && byName && byId.id !== byName.id) fail("bucketName", name!);
+  if (byId || byName) return [(byId ?? byName)!.id];
+
+  // Uses B2AuthManager's cached authorize scope until auth refresh.
+  const ids = Array.from(new Set(buckets.map(({ id }) => id).filter(Boolean)));
+  if (ids.length) {
+    logger.debug(
+      { bucketCount: ids.length, bucketIds: ids, tool: "b2_list_buckets" },
+      "b2.list_buckets.auto_scoped",
+    );
+  }
+  return ids;
 }
 
 async function resolveTrustedBucketId(
@@ -710,13 +688,10 @@ function maybeApplicationKeyId(value: string | undefined): ApplicationKeyId | un
   return value ? applicationKeyId(value) : undefined;
 }
 
-function toBucketFilter(
-  auth: B2AuthResponse,
-  options: BucketFilters,
-  bucketIdValue: string | null,
-): ListBucketsRequest {
+function toBucketFilters(auth: B2AuthResponse, options: BucketFilters): ListBucketsRequest[] {
   const requestedTypes = options.bucketTypes?.includes("all") ? ["all"] : options.bucketTypes;
-  return {
+  const bucketIds = scopedBucketIds(auth, options) ?? [options.bucketId ?? null];
+  return bucketIds.map((bucketIdValue) => ({
     accountId: accountId(auth.accountId),
     bucketId: maybeBucketId(bucketIdValue ?? undefined),
     bucketName: options.bucketName,
@@ -725,26 +700,7 @@ function toBucketFilter(
     bucketTypes: requestedTypes?.length
       ? (requestedTypes as unknown as ListBucketsRequest["bucketTypes"])
       : undefined,
-  };
-}
-
-function toBucketFilters(auth: B2AuthResponse, options: BucketFilters): ListBucketsRequest[] {
-  const explicitBucket = validateAuthorizedBucketFilters(auth, options);
-  const implicitBucketIds = implicitBucketIdsFromAuthorizedScope(auth, options);
-  if (implicitBucketIds !== null) {
-    if (implicitBucketIds.length > 0) {
-      logger.debug(
-        {
-          bucketCount: implicitBucketIds.length,
-          bucketIds: implicitBucketIds,
-          tool: "b2_list_buckets",
-        },
-        "b2.list_buckets.auto_scoped",
-      );
-    }
-    return implicitBucketIds.map((bucketIdValue) => toBucketFilter(auth, options, bucketIdValue));
-  }
-  return [toBucketFilter(auth, options, options.bucketId ?? explicitBucket?.id ?? null)];
+  }));
 }
 
 function normalizeCorsRule(rule: CorsRuleInput): SdkCorsRule {

--- a/src/b2/client.ts
+++ b/src/b2/client.ts
@@ -637,6 +637,16 @@ function bucketIdFromAuthorizedScope(auth: B2AuthResponse, bucketName: string): 
   return null;
 }
 
+function implicitBucketIdFromAuthorizedScope(
+  auth: B2AuthResponse,
+  options: BucketFilters,
+): string | undefined {
+  if (options.bucketId || options.bucketName) return undefined;
+  const buckets = auth.allowedBuckets;
+  if (!buckets || buckets.length !== 1) return undefined;
+  return buckets[0]?.id || undefined;
+}
+
 async function resolveTrustedBucketId(
   client: SdkB2Client,
   auth: B2AuthResponse,
@@ -659,9 +669,10 @@ function maybeApplicationKeyId(value: string | undefined): ApplicationKeyId | un
 
 function toBucketFilters(auth: B2AuthResponse, options: BucketFilters): ListBucketsRequest {
   const requestedTypes = options.bucketTypes?.includes("all") ? ["all"] : options.bucketTypes;
+  const bucketIdValue = options.bucketId ?? implicitBucketIdFromAuthorizedScope(auth, options);
   return {
     accountId: accountId(auth.accountId),
-    bucketId: maybeBucketId(options.bucketId),
+    bucketId: maybeBucketId(bucketIdValue),
     bucketName: options.bucketName,
     // The native B2 API accepts the "all" wildcard, but the SDK type only
     // models concrete bucket types. Keep the compatibility cast isolated here.

--- a/src/b2/client.ts
+++ b/src/b2/client.ts
@@ -48,6 +48,7 @@ import {
   withCircuit,
   withPartnerCircuit as withPartnerApiCircuit,
 } from "../utils/circuit-breaker.js";
+import { logger } from "../utils/logger.js";
 import { currentMcpRequestSignal, runWithMcpRequestSignal } from "../request-context.js";
 import type {
   B2Config,
@@ -637,14 +638,56 @@ function bucketIdFromAuthorizedScope(auth: B2AuthResponse, bucketName: string): 
   return null;
 }
 
-function implicitBucketIdFromAuthorizedScope(
+type AuthorizedBucket = NonNullable<NonNullable<B2AuthResponse["allowedBuckets"]>[number]>;
+
+function scopedBucketError(message: string): Error {
+  return Object.assign(new Error(message), { status: 403, code: "unauthorized" });
+}
+
+function validateAuthorizedBucketFilters(
   auth: B2AuthResponse,
   options: BucketFilters,
-): string | undefined {
-  if (options.bucketId || options.bucketName) return undefined;
+): AuthorizedBucket | null {
   const buckets = auth.allowedBuckets;
-  if (!buckets || buckets.length !== 1) return undefined;
-  return buckets[0]?.id || undefined;
+  if (!buckets || (!options.bucketId && !options.bucketName)) return null;
+
+  const bucketById = options.bucketId
+    ? buckets.find((bucket) => bucket.id === options.bucketId)
+    : null;
+  if (options.bucketId && !bucketById) {
+    throw scopedBucketError(
+      `b2_list_buckets bucketId '${options.bucketId}' is outside the authorized bucket scope.`,
+    );
+  }
+
+  const bucketByName = options.bucketName
+    ? buckets.find((bucket) => bucket.name === options.bucketName)
+    : null;
+  if (options.bucketName && !bucketByName) {
+    throw scopedBucketError(
+      `b2_list_buckets bucketName '${options.bucketName}' is outside the authorized bucket scope.`,
+    );
+  }
+
+  if (bucketById && bucketByName && bucketById.id !== bucketByName.id) {
+    throw scopedBucketError(
+      `b2_list_buckets bucketId '${options.bucketId}' and bucketName '${options.bucketName}' do not refer to the same authorized bucket.`,
+    );
+  }
+
+  return bucketById ?? bucketByName ?? null;
+}
+
+function implicitBucketIdsFromAuthorizedScope(
+  auth: B2AuthResponse,
+  options: BucketFilters,
+): string[] | null {
+  if (options.bucketId || options.bucketName) return null;
+  const buckets = auth.allowedBuckets;
+  if (!buckets) return null;
+  // This scope is derived from the cached authorize response, so it intentionally
+  // reflects B2AuthManager's auth-token cache window until a refresh occurs.
+  return Array.from(new Set(buckets.map((bucket) => bucket.id).filter((id) => id.length > 0)));
 }
 
 async function resolveTrustedBucketId(
@@ -667,12 +710,15 @@ function maybeApplicationKeyId(value: string | undefined): ApplicationKeyId | un
   return value ? applicationKeyId(value) : undefined;
 }
 
-function toBucketFilters(auth: B2AuthResponse, options: BucketFilters): ListBucketsRequest {
+function toBucketFilter(
+  auth: B2AuthResponse,
+  options: BucketFilters,
+  bucketIdValue: string | null,
+): ListBucketsRequest {
   const requestedTypes = options.bucketTypes?.includes("all") ? ["all"] : options.bucketTypes;
-  const bucketIdValue = options.bucketId ?? implicitBucketIdFromAuthorizedScope(auth, options);
   return {
     accountId: accountId(auth.accountId),
-    bucketId: maybeBucketId(bucketIdValue),
+    bucketId: maybeBucketId(bucketIdValue ?? undefined),
     bucketName: options.bucketName,
     // The native B2 API accepts the "all" wildcard, but the SDK type only
     // models concrete bucket types. Keep the compatibility cast isolated here.
@@ -680,6 +726,25 @@ function toBucketFilters(auth: B2AuthResponse, options: BucketFilters): ListBuck
       ? (requestedTypes as unknown as ListBucketsRequest["bucketTypes"])
       : undefined,
   };
+}
+
+function toBucketFilters(auth: B2AuthResponse, options: BucketFilters): ListBucketsRequest[] {
+  const explicitBucket = validateAuthorizedBucketFilters(auth, options);
+  const implicitBucketIds = implicitBucketIdsFromAuthorizedScope(auth, options);
+  if (implicitBucketIds !== null) {
+    if (implicitBucketIds.length > 0) {
+      logger.debug(
+        {
+          bucketCount: implicitBucketIds.length,
+          bucketIds: implicitBucketIds,
+          tool: "b2_list_buckets",
+        },
+        "b2.list_buckets.auto_scoped",
+      );
+    }
+    return implicitBucketIds.map((bucketIdValue) => toBucketFilter(auth, options, bucketIdValue));
+  }
+  return [toBucketFilter(auth, options, options.bucketId ?? explicitBucket?.id ?? null)];
 }
 
 function normalizeCorsRule(rule: CorsRuleInput): SdkCorsRule {
@@ -958,10 +1023,16 @@ export class B2Client {
   constructor(private readonly auth: B2AuthManager) {}
 
   async listBuckets(options: BucketFilters = {}): Promise<ListBucketsResult> {
-    const result = await this.withNativeCircuit((client, auth) =>
-      client.raw.listBuckets(auth.apiUrl, auth.authorizationToken, toBucketFilters(auth, options)),
-    );
-    return { buckets: result.buckets.map(toBucketInfoResult) };
+    const buckets = await this.withNativeCircuit(async (client, auth) => {
+      const requests = toBucketFilters(auth, options);
+      const results = await Promise.all(
+        requests.map((request) =>
+          client.raw.listBuckets(auth.apiUrl, auth.authorizationToken, request),
+        ),
+      );
+      return results.flatMap((result) => result.buckets);
+    });
+    return { buckets: buckets.map(toBucketInfoResult) };
   }
 
   async createBucket(options: CreateBucketOptions): Promise<BucketInfoResult> {

--- a/src/b2/client.ts
+++ b/src/b2/client.ts
@@ -57,7 +57,7 @@ import type {
   B2S3FileVersionResolution,
   B2S3VersionTarget,
 } from "../utils/types.js";
-import { forEachBounded } from "../utils/concurrency.js";
+import { DEFAULT_BOUNDED_WORKER_CONCURRENCY, forEachBounded } from "../utils/concurrency.js";
 import { isTestRuntime } from "../utils/runtime.js";
 import { abortError } from "../utils/named-error.js";
 
@@ -638,6 +638,12 @@ function bucketIdFromAuthorizedScope(auth: B2AuthResponse, bucketName: string): 
   return null;
 }
 
+function authorizedBucketIdSet(auth: B2AuthResponse): Set<string> | null {
+  const buckets = auth.allowedBuckets;
+  if (!buckets) return null;
+  return new Set(buckets.map(({ id }) => id).filter(Boolean));
+}
+
 function scopedBucketIds(
   auth: B2AuthResponse,
   { bucketId: id, bucketName: name }: BucketFilters,
@@ -658,7 +664,7 @@ function scopedBucketIds(
   if (byId || byName) return [(byId ?? byName)!.id];
 
   // Uses B2AuthManager's cached authorize scope until auth refresh.
-  const ids = Array.from(new Set(buckets.map(({ id }) => id).filter(Boolean)));
+  const ids = [...(authorizedBucketIdSet(auth) ?? [])];
   if (ids.length) {
     logger.debug(
       { bucketCount: ids.length, bucketIds: ids, tool: "b2_list_buckets" },
@@ -666,6 +672,15 @@ function scopedBucketIds(
     );
   }
   return ids;
+}
+
+function filterBucketsToAuthorizedScope(
+  auth: B2AuthResponse,
+  buckets: readonly BucketInfo[],
+): readonly BucketInfo[] {
+  const authorizedBucketIds = authorizedBucketIdSet(auth);
+  if (!authorizedBucketIds) return buckets;
+  return buckets.filter((bucket) => authorizedBucketIds.has(String(bucket.bucketId)));
 }
 
 async function resolveTrustedBucketId(
@@ -981,12 +996,23 @@ export class B2Client {
   async listBuckets(options: BucketFilters = {}): Promise<ListBucketsResult> {
     const buckets = await this.withNativeCircuit(async (client, auth) => {
       const requests = toBucketFilters(auth, options);
-      const results = await Promise.all(
-        requests.map((request) =>
-          client.raw.listBuckets(auth.apiUrl, auth.authorizationToken, request),
-        ),
+      const results: Array<readonly BucketInfo[] | undefined> = [];
+      await forEachBounded(
+        requests,
+        { maxConcurrency: DEFAULT_BOUNDED_WORKER_CONCURRENCY, signal: currentMcpRequestSignal() },
+        async (request, index) => {
+          const result = await client.raw.listBuckets(
+            auth.apiUrl,
+            auth.authorizationToken,
+            request,
+          );
+          results[index] = result.buckets;
+        },
       );
-      return results.flatMap((result) => result.buckets);
+      return filterBucketsToAuthorizedScope(
+        auth,
+        results.flatMap((result) => result ?? []),
+      );
     });
     return { buckets: buckets.map(toBucketInfoResult) };
   }

--- a/tests/fixtures/tool-contract/full.legacy.json
+++ b/tests/fixtures/tool-contract/full.legacy.json
@@ -506,7 +506,7 @@
     },
     {
       "name": "b2_list_buckets",
-      "descriptionSha256": "d23dc0ed897958bc0b6649b672e8e1b76e0fe8401db912446d4047d08e4d7499",
+      "descriptionSha256": "07b4f2dc6621c8309ca3574b90a0c96afe8ef7df9a9b67023a3bbc2b8a73c23c",
       "inputSchema": {
         "$schema": "https://json-schema.org/draft/2020-12/schema",
         "properties": {
@@ -2029,5 +2029,5 @@
     "toolsListCacheHint": null,
     "discover": null
   },
-  "hash": "bac3452310f5b6b2cd919a2c194cd90ddb98d6a1a59afd432910102afd846b01"
+  "hash": "023b2a4c819f53a8ecbf3a0daca9d65a3d361bb0b0c8a81cd8afa3945d9c09fe"
 }

--- a/tests/fixtures/tool-contract/full.modern.json
+++ b/tests/fixtures/tool-contract/full.modern.json
@@ -506,7 +506,7 @@
     },
     {
       "name": "b2_list_buckets",
-      "descriptionSha256": "d23dc0ed897958bc0b6649b672e8e1b76e0fe8401db912446d4047d08e4d7499",
+      "descriptionSha256": "07b4f2dc6621c8309ca3574b90a0c96afe8ef7df9a9b67023a3bbc2b8a73c23c",
       "inputSchema": {
         "$schema": "https://json-schema.org/draft/2020-12/schema",
         "properties": {
@@ -2042,5 +2042,5 @@
       "resultType": "complete"
     }
   },
-  "hash": "bac3452310f5b6b2cd919a2c194cd90ddb98d6a1a59afd432910102afd846b01"
+  "hash": "023b2a4c819f53a8ecbf3a0daca9d65a3d361bb0b0c8a81cd8afa3945d9c09fe"
 }

--- a/tests/fixtures/tool-contract/phase1-default.legacy.json
+++ b/tests/fixtures/tool-contract/phase1-default.legacy.json
@@ -474,7 +474,7 @@
     },
     {
       "name": "b2_list_buckets",
-      "descriptionSha256": "d23dc0ed897958bc0b6649b672e8e1b76e0fe8401db912446d4047d08e4d7499",
+      "descriptionSha256": "07b4f2dc6621c8309ca3574b90a0c96afe8ef7df9a9b67023a3bbc2b8a73c23c",
       "inputSchema": {
         "$schema": "https://json-schema.org/draft/2020-12/schema",
         "properties": {
@@ -1923,5 +1923,5 @@
     "toolsListCacheHint": null,
     "discover": null
   },
-  "hash": "7ef81254a5e1cc5c6547bc3f3b06121b20358fa767fa55f4ffda59232166f0ee"
+  "hash": "11be52cf8f077a208b7f6ecaa7335323f03a01360a8ce377f6e8d531498d10f4"
 }

--- a/tests/fixtures/tool-contract/phase1-default.modern.json
+++ b/tests/fixtures/tool-contract/phase1-default.modern.json
@@ -474,7 +474,7 @@
     },
     {
       "name": "b2_list_buckets",
-      "descriptionSha256": "d23dc0ed897958bc0b6649b672e8e1b76e0fe8401db912446d4047d08e4d7499",
+      "descriptionSha256": "07b4f2dc6621c8309ca3574b90a0c96afe8ef7df9a9b67023a3bbc2b8a73c23c",
       "inputSchema": {
         "$schema": "https://json-schema.org/draft/2020-12/schema",
         "properties": {
@@ -1936,5 +1936,5 @@
       "resultType": "complete"
     }
   },
-  "hash": "7ef81254a5e1cc5c6547bc3f3b06121b20358fa767fa55f4ffda59232166f0ee"
+  "hash": "11be52cf8f077a208b7f6ecaa7335323f03a01360a8ce377f6e8d531498d10f4"
 }

--- a/tests/fixtures/tool-contract/read-only.legacy.json
+++ b/tests/fixtures/tool-contract/read-only.legacy.json
@@ -216,7 +216,7 @@
     },
     {
       "name": "b2_list_buckets",
-      "descriptionSha256": "d23dc0ed897958bc0b6649b672e8e1b76e0fe8401db912446d4047d08e4d7499",
+      "descriptionSha256": "07b4f2dc6621c8309ca3574b90a0c96afe8ef7df9a9b67023a3bbc2b8a73c23c",
       "inputSchema": {
         "$schema": "https://json-schema.org/draft/2020-12/schema",
         "properties": {
@@ -697,5 +697,5 @@
     "toolsListCacheHint": null,
     "discover": null
   },
-  "hash": "d65932946c674eb65cf25e45fed06235e5f899def2f3234dee1abd29caa1737d"
+  "hash": "23a707ac7b596db31e641e7b4b670d05b7a1314d2c0d4cbc24639721987f0228"
 }

--- a/tests/fixtures/tool-contract/read-only.modern.json
+++ b/tests/fixtures/tool-contract/read-only.modern.json
@@ -216,7 +216,7 @@
     },
     {
       "name": "b2_list_buckets",
-      "descriptionSha256": "d23dc0ed897958bc0b6649b672e8e1b76e0fe8401db912446d4047d08e4d7499",
+      "descriptionSha256": "07b4f2dc6621c8309ca3574b90a0c96afe8ef7df9a9b67023a3bbc2b8a73c23c",
       "inputSchema": {
         "$schema": "https://json-schema.org/draft/2020-12/schema",
         "properties": {
@@ -710,5 +710,5 @@
       "resultType": "complete"
     }
   },
-  "hash": "d65932946c674eb65cf25e45fed06235e5f899def2f3234dee1abd29caa1737d"
+  "hash": "23a707ac7b596db31e641e7b4b670d05b7a1314d2c0d4cbc24639721987f0228"
 }

--- a/tests/support/sdk-test-helpers.ts
+++ b/tests/support/sdk-test-helpers.ts
@@ -89,6 +89,36 @@ export function authorizeResponse(capabilities: string[] = []) {
   };
 }
 
+export interface AuthorizedBucketFixture {
+  id: string;
+  name: string | null;
+}
+
+export function scopedAuthorizeResponse(
+  capabilities: string[] = [],
+  buckets: AuthorizedBucketFixture[] = [{ id: "bucket-1", name: "scoped-bucket" }],
+) {
+  const base = authorizeResponse(capabilities);
+  const singleBucket = buckets.length === 1 ? (buckets[0] ?? null) : null;
+  return {
+    ...base,
+    apiInfo: {
+      ...base.apiInfo,
+      storageApi: {
+        ...base.apiInfo.storageApi,
+        bucketId: singleBucket?.id ?? null,
+        bucketName: singleBucket?.name ?? null,
+        allowed: {
+          ...base.apiInfo.storageApi.allowed,
+          buckets,
+          bucketId: singleBucket?.id ?? null,
+          bucketName: singleBucket?.name ?? null,
+        },
+      },
+    },
+  };
+}
+
 export function installSdkTransport(
   transport: HttpTransport,
   retry: Partial<RetryOptions> = {

--- a/tests/unit/b2-tools.unit.test.ts
+++ b/tests/unit/b2-tools.unit.test.ts
@@ -786,6 +786,56 @@ describe("b2_list_buckets", () => {
     expect(maxInFlight).toBeLessThanOrEqual(DEFAULT_BOUNDED_WORKER_CONCURRENCY);
   });
 
+  it("drains failed listBuckets fan-out before unauthorized retry", async () => {
+    invalidateAuthManagerCache();
+    const buckets = Array.from({ length: DEFAULT_BOUNDED_WORKER_CONCURRENCY + 4 }, (_, index) => ({
+      id: `bucket-${index + 1}`,
+      name: `scoped-${index + 1}`,
+    }));
+    const auth = scopedAuthorizeResponse(["listBuckets"], buckets);
+    let authorizeCalls = 0;
+    let inFlight = 0;
+    let maxInFlight = 0;
+    let listCalls = 0;
+    const transport = new RecordingTransport(async (request) => {
+      const endpoint = b2EndpointName(request);
+      if (endpoint === "b2_authorize_account") {
+        authorizeCalls++;
+        return new StaticHttpResponse(200, auth);
+      }
+      if (endpoint === "b2_list_buckets") {
+        const body = requestJson(request);
+        inFlight++;
+        listCalls++;
+        maxInFlight = Math.max(maxInFlight, inFlight);
+        try {
+          if (body.bucketId === "bucket-1") {
+            return new StaticHttpResponse(401, {
+              status: 401,
+              code: "expired_auth_token",
+              message: "expired",
+            });
+          }
+          await new Promise((resolve) => setTimeout(resolve, 10));
+          return new StaticHttpResponse(200, { buckets: [] });
+        } finally {
+          inFlight--;
+        }
+      }
+      return new StaticHttpResponse(500, { status: 500, code: "unexpected", message: endpoint });
+    });
+    installSdkTransport(transport);
+    server = createServer(testConfig);
+
+    const result = await callTool(server, "b2_list_buckets", {});
+    await new Promise((resolve) => setTimeout(resolve, 30));
+
+    expect(result.isError).toBe(true);
+    expect(authorizeCalls).toBe(2);
+    expect(listCalls).toBe(DEFAULT_BOUNDED_WORKER_CONCURRENCY * 2);
+    expect(maxInFlight).toBeLessThanOrEqual(DEFAULT_BOUNDED_WORKER_CONCURRENCY);
+  });
+
   it("returns buckets and supports bucketTypes filtering", async () => {
     await createBucket("private-bucket", BucketType.AllPrivate);
     await createBucket("public-bucket", BucketType.AllPublic);

--- a/tests/unit/b2-tools.unit.test.ts
+++ b/tests/unit/b2-tools.unit.test.ts
@@ -16,6 +16,7 @@ import { B2AuthManager } from "../../src/auth";
 import { B2Client } from "../../src/b2/client";
 import { setB2SdkClientFactoryForTests } from "../support/sdk-factory-hook";
 import { logger } from "../../src/utils/logger";
+import { DEFAULT_BOUNDED_WORKER_CONCURRENCY } from "../../src/utils/concurrency";
 import { secretSinkFileOpsForTests } from "../../src/utils/secret-sink";
 import { LOGGER_SECRET_REDACTION_PATHS } from "../../src/utils/secret-sanitizer";
 import type { McpServer } from "../../src/mcp";
@@ -665,6 +666,34 @@ describe("b2_list_buckets", () => {
     ]);
   });
 
+  it("filters returned buckets to the authorized scope before serialization", async () => {
+    invalidateAuthManagerCache();
+    const auth = scopedAuthorizeResponse(["listBuckets"]);
+    const transport = new RecordingTransport((request) => {
+      const endpoint = b2EndpointName(request);
+      if (endpoint === "b2_authorize_account") return new StaticHttpResponse(200, auth);
+      if (endpoint === "b2_list_buckets") {
+        return new StaticHttpResponse(200, {
+          buckets: [
+            bucketInfoFixture("bucket-1", "scoped-bucket"),
+            bucketInfoFixture("victim-bucket-id", "prod-secrets"),
+          ],
+        });
+      }
+      return new StaticHttpResponse(500, { status: 500, code: "unexpected", message: endpoint });
+    });
+    installSdkTransport(transport);
+    server = createServer(testConfig);
+
+    const result = parseResult(
+      await callTool(server, "b2_list_buckets", { bucketName: "scoped-bucket" }),
+    );
+
+    expect(result.buckets.map((bucket: { bucketName: string }) => bucket.bucketName)).toEqual([
+      "scoped-bucket",
+    ]);
+  });
+
   it("rejects out-of-scope bucketId before listing buckets", async () => {
     invalidateAuthManagerCache();
     const auth = scopedAuthorizeResponse(["listBuckets"]);
@@ -717,6 +746,44 @@ describe("b2_list_buckets", () => {
     expect(
       transport.requests.filter((request) => b2EndpointName(request) === "b2_list_buckets"),
     ).toHaveLength(0);
+  });
+
+  it("caps native listBuckets concurrency for large bucket-scoped keys", async () => {
+    invalidateAuthManagerCache();
+    const buckets = Array.from({ length: DEFAULT_BOUNDED_WORKER_CONCURRENCY + 4 }, (_, index) => ({
+      id: `bucket-${index + 1}`,
+      name: `scoped-${index + 1}`,
+    }));
+    const auth = scopedAuthorizeResponse(["listBuckets"], buckets);
+    let inFlight = 0;
+    let maxInFlight = 0;
+    const transport = new RecordingTransport(async (request) => {
+      const endpoint = b2EndpointName(request);
+      if (endpoint === "b2_authorize_account") return new StaticHttpResponse(200, auth);
+      if (endpoint === "b2_list_buckets") {
+        const body = requestJson(request);
+        const requestedBucketId = typeof body.bucketId === "string" ? body.bucketId : "";
+        const bucket = buckets.find(({ id }) => id === requestedBucketId);
+        inFlight++;
+        maxInFlight = Math.max(maxInFlight, inFlight);
+        await new Promise((resolve) => setTimeout(resolve, 10));
+        inFlight--;
+        return new StaticHttpResponse(200, {
+          buckets: bucket ? [bucketInfoFixture(bucket.id, bucket.name)] : [],
+        });
+      }
+      return new StaticHttpResponse(500, { status: 500, code: "unexpected", message: endpoint });
+    });
+    installSdkTransport(transport);
+    server = createServer(testConfig);
+
+    const result = parseResult(await callTool(server, "b2_list_buckets", {}));
+
+    expect(result.buckets).toHaveLength(buckets.length);
+    expect(
+      transport.requests.filter((request) => b2EndpointName(request) === "b2_list_buckets"),
+    ).toHaveLength(buckets.length);
+    expect(maxInFlight).toBeLessThanOrEqual(DEFAULT_BOUNDED_WORKER_CONCURRENCY);
   });
 
   it("returns buckets and supports bucketTypes filtering", async () => {

--- a/tests/unit/b2-tools.unit.test.ts
+++ b/tests/unit/b2-tools.unit.test.ts
@@ -507,6 +507,56 @@ describe("SDK 401 re-auth-and-retry", () => {
 });
 
 describe("b2_list_buckets", () => {
+  it("uses the authorized bucket scope when no bucket filter is supplied", async () => {
+    invalidateAuthManagerCache();
+    const auth = authorizeResponse(["listBuckets"]) as any;
+    auth.apiInfo.storageApi.allowed.buckets = [{ id: "bucket-1", name: "scoped-bucket" }];
+    auth.apiInfo.storageApi.allowed.bucketId = "bucket-1";
+    auth.apiInfo.storageApi.allowed.bucketName = "scoped-bucket";
+    const listBucketBodies: Record<string, unknown>[] = [];
+    const transport = new RecordingTransport((request) => {
+      const endpoint = b2EndpointName(request);
+      if (endpoint === "b2_authorize_account") return new StaticHttpResponse(200, auth);
+      if (endpoint === "b2_list_buckets") {
+        const body = requestJson(request);
+        listBucketBodies.push(body);
+        if (body.bucketId !== "bucket-1") {
+          return new StaticHttpResponse(401, {
+            status: 401,
+            code: "unauthorized",
+            message: "",
+          });
+        }
+        return new StaticHttpResponse(200, {
+          buckets: [
+            {
+              accountId: "test-account-123",
+              bucketId: "bucket-1",
+              bucketName: "scoped-bucket",
+              bucketType: "allPrivate",
+              bucketInfo: {},
+              corsRules: [],
+              lifecycleRules: [],
+              revision: 1,
+              options: [],
+            },
+          ],
+        });
+      }
+      return new StaticHttpResponse(500, { status: 500, code: "unexpected", message: endpoint });
+    });
+    installSdkTransport(transport);
+    server = createServer(testConfig);
+
+    const result = parseResult(await callTool(server, "b2_list_buckets", {}));
+
+    expect(result.buckets).toHaveLength(1);
+    expect(result.buckets[0].bucketName).toBe("scoped-bucket");
+    expect(listBucketBodies).toEqual([
+      expect.objectContaining({ accountId: "test-account-123", bucketId: "bucket-1" }),
+    ]);
+  });
+
   it("returns buckets and supports bucketTypes filtering", async () => {
     await createBucket("private-bucket", BucketType.AllPrivate);
     await createBucket("public-bucket", BucketType.AllPublic);

--- a/tests/unit/b2-tools.unit.test.ts
+++ b/tests/unit/b2-tools.unit.test.ts
@@ -26,6 +26,7 @@ import {
   installSdkTransport,
   RecordingTransport,
   requestJson,
+  scopedAuthorizeResponse,
   StaticHttpResponse,
 } from "../support/sdk-test-helpers";
 
@@ -82,6 +83,20 @@ async function createBucket(
   options: Record<string, unknown> = {},
 ) {
   return seed.createBucket({ bucketName: name, bucketType, ...options } as never);
+}
+
+function bucketInfoFixture(bucketId: string, bucketName: string, bucketType = "allPrivate") {
+  return {
+    accountId: "test-account-123",
+    bucketId,
+    bucketName,
+    bucketType,
+    bucketInfo: {},
+    corsRules: [],
+    lifecycleRules: [],
+    revision: 1,
+    options: [],
+  };
 }
 
 async function usePartnerSimulator() {
@@ -195,10 +210,7 @@ describe("B2Client S3 version guard", () => {
 
   it("uses authorize bucket scope for version binding without listBuckets", async () => {
     invalidateAuthManagerCache();
-    const auth = authorizeResponse(["readFiles"]) as any;
-    auth.apiInfo.storageApi.allowed.buckets = [{ id: "bucket-1", name: "scoped-bucket" }];
-    auth.apiInfo.storageApi.allowed.bucketId = "bucket-1";
-    auth.apiInfo.storageApi.allowed.bucketName = "scoped-bucket";
+    const auth = scopedAuthorizeResponse(["readFiles"]);
     const transport = new RecordingTransport((request) => {
       const endpoint = b2EndpointName(request);
       if (endpoint === "b2_authorize_account") return new StaticHttpResponse(200, auth);
@@ -242,10 +254,7 @@ describe("B2Client S3 version guard", () => {
 
   it("does not trust unnamed authorize bucket scope for version binding", async () => {
     invalidateAuthManagerCache();
-    const auth = authorizeResponse(["readFiles"]) as any;
-    auth.apiInfo.storageApi.allowed.buckets = [{ id: "bucket-1", name: null }];
-    auth.apiInfo.storageApi.allowed.bucketId = "bucket-1";
-    auth.apiInfo.storageApi.allowed.bucketName = null;
+    const auth = scopedAuthorizeResponse(["readFiles"], [{ id: "bucket-1", name: null }]);
     const transport = new RecordingTransport((request) => {
       const endpoint = b2EndpointName(request);
       if (endpoint === "b2_authorize_account") return new StaticHttpResponse(200, auth);
@@ -507,12 +516,10 @@ describe("SDK 401 re-auth-and-retry", () => {
 });
 
 describe("b2_list_buckets", () => {
-  it("uses the authorized bucket scope when no bucket filter is supplied", async () => {
+  it("uses the single authorized bucket scope when no bucket filter is supplied", async () => {
     invalidateAuthManagerCache();
-    const auth = authorizeResponse(["listBuckets"]) as any;
-    auth.apiInfo.storageApi.allowed.buckets = [{ id: "bucket-1", name: "scoped-bucket" }];
-    auth.apiInfo.storageApi.allowed.bucketId = "bucket-1";
-    auth.apiInfo.storageApi.allowed.bucketName = "scoped-bucket";
+    const auth = scopedAuthorizeResponse(["listBuckets"]);
+    const logSpy = vi.spyOn(logger, "debug").mockImplementation(() => undefined as never);
     const listBucketBodies: Record<string, unknown>[] = [];
     const transport = new RecordingTransport((request) => {
       const endpoint = b2EndpointName(request);
@@ -528,19 +535,7 @@ describe("b2_list_buckets", () => {
           });
         }
         return new StaticHttpResponse(200, {
-          buckets: [
-            {
-              accountId: "test-account-123",
-              bucketId: "bucket-1",
-              bucketName: "scoped-bucket",
-              bucketType: "allPrivate",
-              bucketInfo: {},
-              corsRules: [],
-              lifecycleRules: [],
-              revision: 1,
-              options: [],
-            },
-          ],
+          buckets: [bucketInfoFixture("bucket-1", "scoped-bucket")],
         });
       }
       return new StaticHttpResponse(500, { status: 500, code: "unexpected", message: endpoint });
@@ -555,6 +550,173 @@ describe("b2_list_buckets", () => {
     expect(listBucketBodies).toEqual([
       expect.objectContaining({ accountId: "test-account-123", bucketId: "bucket-1" }),
     ]);
+    expect(logSpy).toHaveBeenCalledWith(
+      expect.objectContaining({
+        bucketCount: 1,
+        bucketIds: ["bucket-1"],
+        tool: "b2_list_buckets",
+      }),
+      "b2.list_buckets.auto_scoped",
+    );
+  });
+
+  it("fans out multi-bucket authorized scope when no bucket filter is supplied", async () => {
+    invalidateAuthManagerCache();
+    const auth = scopedAuthorizeResponse(
+      ["listBuckets"],
+      [
+        { id: "bucket-1", name: "scoped-one" },
+        { id: "bucket-2", name: "scoped-two" },
+      ],
+    );
+    const bucketNames = new Map([
+      ["bucket-1", "scoped-one"],
+      ["bucket-2", "scoped-two"],
+    ]);
+    const listBucketBodies: Record<string, unknown>[] = [];
+    const transport = new RecordingTransport((request) => {
+      const endpoint = b2EndpointName(request);
+      if (endpoint === "b2_authorize_account") return new StaticHttpResponse(200, auth);
+      if (endpoint === "b2_list_buckets") {
+        const body = requestJson(request);
+        listBucketBodies.push(body);
+        const requestedBucketId = typeof body.bucketId === "string" ? body.bucketId : "";
+        const bucketName = bucketNames.get(requestedBucketId);
+        if (!bucketName) {
+          return new StaticHttpResponse(401, {
+            status: 401,
+            code: "unauthorized",
+            message: "",
+          });
+        }
+        return new StaticHttpResponse(200, {
+          buckets: [bucketInfoFixture(requestedBucketId, bucketName)],
+        });
+      }
+      return new StaticHttpResponse(500, { status: 500, code: "unexpected", message: endpoint });
+    });
+    installSdkTransport(transport);
+    server = createServer(testConfig);
+
+    const result = parseResult(await callTool(server, "b2_list_buckets", {}));
+
+    expect(result.buckets.map((bucket: { bucketName: string }) => bucket.bucketName)).toEqual([
+      "scoped-one",
+      "scoped-two",
+    ]);
+    expect(listBucketBodies).toEqual([
+      expect.objectContaining({ accountId: "test-account-123", bucketId: "bucket-1" }),
+      expect.objectContaining({ accountId: "test-account-123", bucketId: "bucket-2" }),
+    ]);
+  });
+
+  it("allows explicit filters that match the authorized bucket scope", async () => {
+    invalidateAuthManagerCache();
+    const auth = scopedAuthorizeResponse(
+      ["listBuckets"],
+      [
+        { id: "bucket-1", name: "scoped-one" },
+        { id: "bucket-2", name: "scoped-two" },
+      ],
+    );
+    const bucketNames = new Map([
+      ["bucket-1", "scoped-one"],
+      ["bucket-2", "scoped-two"],
+    ]);
+    const listBucketBodies: Record<string, unknown>[] = [];
+    const transport = new RecordingTransport((request) => {
+      const endpoint = b2EndpointName(request);
+      if (endpoint === "b2_authorize_account") return new StaticHttpResponse(200, auth);
+      if (endpoint === "b2_list_buckets") {
+        const body = requestJson(request);
+        listBucketBodies.push(body);
+        const requestedBucketId = typeof body.bucketId === "string" ? body.bucketId : "";
+        const bucketName = bucketNames.get(requestedBucketId);
+        if (!bucketName) {
+          return new StaticHttpResponse(401, {
+            status: 401,
+            code: "unauthorized",
+            message: "",
+          });
+        }
+        return new StaticHttpResponse(200, {
+          buckets: [bucketInfoFixture(requestedBucketId, bucketName)],
+        });
+      }
+      return new StaticHttpResponse(500, { status: 500, code: "unexpected", message: endpoint });
+    });
+    installSdkTransport(transport);
+    server = createServer(testConfig);
+
+    const byId = parseResult(await callTool(server, "b2_list_buckets", { bucketId: "bucket-2" }));
+    const byName = parseResult(
+      await callTool(server, "b2_list_buckets", { bucketName: "scoped-one" }),
+    );
+
+    expect(byId.buckets[0].bucketName).toBe("scoped-two");
+    expect(byName.buckets[0].bucketName).toBe("scoped-one");
+    expect(listBucketBodies).toEqual([
+      expect.objectContaining({ accountId: "test-account-123", bucketId: "bucket-2" }),
+      expect.objectContaining({
+        accountId: "test-account-123",
+        bucketId: "bucket-1",
+        bucketName: "scoped-one",
+      }),
+    ]);
+  });
+
+  it("rejects out-of-scope bucketId before listing buckets", async () => {
+    invalidateAuthManagerCache();
+    const auth = scopedAuthorizeResponse(["listBuckets"]);
+    const transport = new RecordingTransport((request) => {
+      const endpoint = b2EndpointName(request);
+      if (endpoint === "b2_authorize_account") return new StaticHttpResponse(200, auth);
+      if (endpoint === "b2_list_buckets") {
+        return new StaticHttpResponse(500, {
+          status: 500,
+          code: "unexpected",
+          message: "listBuckets should not be called",
+        });
+      }
+      return new StaticHttpResponse(500, { status: 500, code: "unexpected", message: endpoint });
+    });
+    installSdkTransport(transport);
+    server = createServer(testConfig);
+
+    const result = await callTool(server, "b2_list_buckets", { bucketId: "victim-bucket-id" });
+
+    expect(result.isError).toBe(true);
+    expect(result.content[0].text).toContain("outside the authorized bucket scope");
+    expect(
+      transport.requests.filter((request) => b2EndpointName(request) === "b2_list_buckets"),
+    ).toHaveLength(0);
+  });
+
+  it("rejects out-of-scope bucketName before listing buckets", async () => {
+    invalidateAuthManagerCache();
+    const auth = scopedAuthorizeResponse(["listBuckets"]);
+    const transport = new RecordingTransport((request) => {
+      const endpoint = b2EndpointName(request);
+      if (endpoint === "b2_authorize_account") return new StaticHttpResponse(200, auth);
+      if (endpoint === "b2_list_buckets") {
+        return new StaticHttpResponse(500, {
+          status: 500,
+          code: "unexpected",
+          message: "listBuckets should not be called",
+        });
+      }
+      return new StaticHttpResponse(500, { status: 500, code: "unexpected", message: endpoint });
+    });
+    installSdkTransport(transport);
+    server = createServer(testConfig);
+
+    const result = await callTool(server, "b2_list_buckets", { bucketName: "victim-bucket" });
+
+    expect(result.isError).toBe(true);
+    expect(result.content[0].text).toContain("outside the authorized bucket scope");
+    expect(
+      transport.requests.filter((request) => b2EndpointName(request) === "b2_list_buckets"),
+    ).toHaveLength(0);
   });
 
   it("returns buckets and supports bucketTypes filtering", async () => {


### PR DESCRIPTION
## Summary
- Auto-scope `b2_list_buckets` to `authorize.allowedBuckets` when bucket-scoped callers omit `bucketId` and `bucketName`, including multi-bucket keys by issuing one native `listBuckets` request per authorized bucket ID.
- Reject explicit `bucketId` or `bucketName` filters outside the authorized bucket scope before calling the native API, and post-filter returned bucket metadata to authorized bucket IDs before serialization.
- Cap native multi-bucket `listBuckets` fan-out concurrency, drain failed fan-out workers before retrying or returning, add structured debug logging for auto-scoped calls, document the scoped behavior in the tool description and changelog, refresh generated tool contracts, and refresh package budget metadata.

## Linked issue
Fixes #211

## Tests run
- `pnpm exec vitest run tests/unit/b2-tools.unit.test.ts`
- `pnpm run test:unit`
- `pnpm run test:contract`
- `pnpm run typecheck`
- `pnpm run build`
- `pnpm run lint`
- `pnpm run format:check`
- `pnpm run check:package-budget`

## Follow-up notes
- `pnpm run lint` exits successfully with the existing warning in `src/oauth-resource-server.ts`.
