### PR TITLE
fix: classify PutObject contentType validation errors

### DIFF
--- a/src/b2/buckets.ts
+++ b/src/b2/buckets.ts
@@ -12,7 +12,7 @@ import {
   type UpdateBucketOptions,
 } from "./client.js";
 import { B2Config } from "../utils/types.js";
-import { toolJson, toolError } from "../utils/errors.js";
+import { badRequest, toolJson, toolError } from "../utils/errors.js";
 import { checkDestructive } from "../utils/destructive-gate.js";
 import { isTestRuntime } from "../utils/runtime.js";
 
@@ -385,7 +385,7 @@ function corsRulesInputError(
 }
 
 function failB2InputValidation(message: string): never {
-  throw { status: 400, code: "bad_request", message };
+  throw badRequest(message);
 }
 
 function validateBucketInfoInput(bucketInfo: Record<string, string> | undefined): void {

--- a/src/b2/buckets.ts
+++ b/src/b2/buckets.ts
@@ -385,7 +385,7 @@ function corsRulesInputError(
 }
 
 function failB2InputValidation(message: string): never {
-  throw badRequest(message);
+  badRequest(message);
 }
 
 function validateBucketInfoInput(bucketInfo: Record<string, string> | undefined): void {

--- a/src/b2/keys.ts
+++ b/src/b2/keys.ts
@@ -3,7 +3,7 @@ import { z } from "zod";
 import { B2Client, type FullApplicationKeyResult, type ListKeysOptions } from "./client.js";
 import { B2AuthManager } from "../auth.js";
 import { ALL_CAPABILITIES, B2Config } from "../utils/types.js";
-import { clientInputError, toolJson, toolError } from "../utils/errors.js";
+import { toolJson, toolError } from "../utils/errors.js";
 import { checkDestructive } from "../utils/destructive-gate.js";
 import {
   APPLICATION_KEY_REDACTED,
@@ -99,10 +99,11 @@ function normalizeCreateKeyBucketScope(args: { bucketId?: string; bucketIds?: st
   bucketIds?: string[];
 } {
   if (args.bucketId !== undefined && args.bucketIds !== undefined) {
-    clientInputError(
-      "invalid_bucket_scope",
-      "b2_create_key accepts either bucketId or bucketIds, not both.",
-    );
+    throw {
+      status: 400,
+      code: "invalid_bucket_scope",
+      message: "b2_create_key accepts either bucketId or bucketIds, not both.",
+    };
   }
   if (args.bucketId !== undefined) return { bucketId: args.bucketId };
   if (args.bucketIds !== undefined) return { bucketIds: args.bucketIds };

--- a/src/b2/keys.ts
+++ b/src/b2/keys.ts
@@ -99,7 +99,7 @@ function normalizeCreateKeyBucketScope(args: { bucketId?: string; bucketIds?: st
   bucketIds?: string[];
 } {
   if (args.bucketId !== undefined && args.bucketIds !== undefined) {
-    throw clientInputError(
+    clientInputError(
       "invalid_bucket_scope",
       "b2_create_key accepts either bucketId or bucketIds, not both.",
     );

--- a/src/b2/keys.ts
+++ b/src/b2/keys.ts
@@ -3,7 +3,7 @@ import { z } from "zod";
 import { B2Client, type FullApplicationKeyResult, type ListKeysOptions } from "./client.js";
 import { B2AuthManager } from "../auth.js";
 import { ALL_CAPABILITIES, B2Config } from "../utils/types.js";
-import { toolJson, toolError } from "../utils/errors.js";
+import { clientInputError, toolJson, toolError } from "../utils/errors.js";
 import { checkDestructive } from "../utils/destructive-gate.js";
 import {
   APPLICATION_KEY_REDACTED,
@@ -99,11 +99,10 @@ function normalizeCreateKeyBucketScope(args: { bucketId?: string; bucketIds?: st
   bucketIds?: string[];
 } {
   if (args.bucketId !== undefined && args.bucketIds !== undefined) {
-    throw {
-      status: 400,
-      code: "invalid_bucket_scope",
-      message: "b2_create_key accepts either bucketId or bucketIds, not both.",
-    };
+    throw clientInputError(
+      "invalid_bucket_scope",
+      "b2_create_key accepts either bucketId or bucketIds, not both.",
+    );
   }
   if (args.bucketId !== undefined) return { bucketId: args.bucketId };
   if (args.bucketIds !== undefined) return { bucketIds: args.bucketIds };

--- a/src/s3/aws-sdk-adapter.ts
+++ b/src/s3/aws-sdk-adapter.ts
@@ -35,6 +35,7 @@ import type {
 import { currentMcpRequestSignal } from "../request-context.js";
 import { withS3Circuit } from "../utils/circuit-breaker.js";
 import { forEachBounded } from "../utils/concurrency.js";
+import { badRequest } from "../utils/errors.js";
 
 type S3SendCommand<
   InputType extends ServiceInputTypes,
@@ -373,10 +374,6 @@ const BROWSER_EXECUTABLE_CONTENT_TYPE =
 function normalizedMediaType(contentType: string | undefined): string | null {
   const mediaType = contentType?.split(";")[0]?.trim().toLowerCase();
   return mediaType ? mediaType : null;
-}
-
-function badRequest(message: string): Error & { status: 400; code: "bad_request" } {
-  return Object.assign(new Error(message), { status: 400 as const, code: "bad_request" as const });
 }
 
 export function assertSafeObjectContentType(

--- a/src/s3/aws-sdk-adapter.ts
+++ b/src/s3/aws-sdk-adapter.ts
@@ -375,16 +375,20 @@ function normalizedMediaType(contentType: string | undefined): string | null {
   return mediaType ? mediaType : null;
 }
 
+function badRequest(message: string): Error & { status: 400; code: "bad_request" } {
+  return Object.assign(new Error(message), { status: 400 as const, code: "bad_request" as const });
+}
+
 export function assertSafeObjectContentType(
   contentType: string | undefined,
   context: string,
 ): void {
   const mediaType = normalizedMediaType(contentType);
   if (!mediaType) {
-    throw new Error(`${context} requires a signed contentType.`);
+    throw badRequest(`${context} requires a signed contentType.`);
   }
   if (BROWSER_EXECUTABLE_CONTENT_TYPE.test(mediaType)) {
-    throw new Error(`${context} rejects browser-executable content type '${contentType}'.`);
+    throw badRequest(`${context} rejects browser-executable content type '${contentType}'.`);
   }
 }
 

--- a/src/s3/aws-sdk-adapter.ts
+++ b/src/s3/aws-sdk-adapter.ts
@@ -35,7 +35,6 @@ import type {
 import { currentMcpRequestSignal } from "../request-context.js";
 import { withS3Circuit } from "../utils/circuit-breaker.js";
 import { forEachBounded } from "../utils/concurrency.js";
-import { badRequest } from "../utils/errors.js";
 
 type S3SendCommand<
   InputType extends ServiceInputTypes,
@@ -374,6 +373,11 @@ const BROWSER_EXECUTABLE_CONTENT_TYPE =
 function normalizedMediaType(contentType: string | undefined): string | null {
   const mediaType = contentType?.split(";")[0]?.trim().toLowerCase();
   return mediaType ? mediaType : null;
+}
+
+// Keep local to avoid adding a runtime errors.ts import to the Worker S3 adapter bundle.
+function badRequest(message: string): never {
+  throw { status: 400, code: "bad_request", message };
 }
 
 export function assertSafeObjectContentType(

--- a/src/s3/aws-sdk-adapter.ts
+++ b/src/s3/aws-sdk-adapter.ts
@@ -382,10 +382,10 @@ export function assertSafeObjectContentType(
 ): void {
   const mediaType = normalizedMediaType(contentType);
   if (!mediaType) {
-    throw badRequest(`${context} requires a signed contentType.`);
+    badRequest(`${context} requires a signed contentType.`);
   }
   if (BROWSER_EXECUTABLE_CONTENT_TYPE.test(mediaType)) {
-    throw badRequest(`${context} rejects browser-executable content type '${contentType}'.`);
+    badRequest(`${context} rejects browser-executable content type '${contentType}'.`);
   }
 }
 

--- a/src/s3/aws-sdk-adapter.ts
+++ b/src/s3/aws-sdk-adapter.ts
@@ -375,7 +375,7 @@ function normalizedMediaType(contentType: string | undefined): string | null {
   return mediaType ? mediaType : null;
 }
 
-// Keep local to avoid adding a runtime errors.ts import to the Worker S3 adapter bundle.
+// Local to keep the Worker S3 bundle under budget.
 function badRequest(message: string): never {
   throw { status: 400, code: "bad_request", message };
 }

--- a/src/utils/errors.ts
+++ b/src/utils/errors.ts
@@ -23,23 +23,9 @@ export interface B2ApiError {
   extendedRequestId?: string;
 }
 
-/**
- * Throw a normalized HTTP 400 client-input error with the given code.
- *
- * @throws A normalized B2 API error object.
- */
-export function clientInputError(code: string, message: string): never {
-  const error = { status: 400, code, message } satisfies B2ApiError;
-  throw error;
-}
-
-/**
- * Throw a normalized HTTP 400 bad_request client-input error.
- *
- * @throws A normalized B2 API error object.
- */
+/** Throw a normalized HTTP 400 bad_request client-input error. */
 export function badRequest(message: string): never {
-  clientInputError("bad_request", message);
+  throw { status: 400, code: "bad_request", message } satisfies B2ApiError;
 }
 
 /** Pull a request id out of HTTP response headers (B2 native / S3 proxy variants). */

--- a/src/utils/errors.ts
+++ b/src/utils/errors.ts
@@ -23,7 +23,11 @@ export interface B2ApiError {
   extendedRequestId?: string;
 }
 
-/** Throw a normalized HTTP 400 bad_request client-input error. */
+/**
+ * Throw HTTP 400 bad_request.
+ *
+ * @throws A normalized B2 API error object.
+ */
 export function badRequest(message: string): never {
   throw { status: 400, code: "bad_request", message } satisfies B2ApiError;
 }

--- a/src/utils/errors.ts
+++ b/src/utils/errors.ts
@@ -23,6 +23,14 @@ export interface B2ApiError {
   extendedRequestId?: string;
 }
 
+export function clientInputError(code: string, message: string): B2ApiError {
+  return { status: 400, code, message };
+}
+
+export function badRequest(message: string): B2ApiError {
+  return clientInputError("bad_request", message);
+}
+
 /** Pull a request id out of HTTP response headers (B2 native / S3 proxy variants). */
 function headerRequestId(headers: unknown): string | undefined {
   if (typeof headers !== "object" || headers === null) return undefined;

--- a/src/utils/errors.ts
+++ b/src/utils/errors.ts
@@ -23,12 +23,23 @@ export interface B2ApiError {
   extendedRequestId?: string;
 }
 
-export function clientInputError(code: string, message: string): B2ApiError {
-  return { status: 400, code, message };
+/**
+ * Throw a normalized HTTP 400 client-input error with the given code.
+ *
+ * @throws A normalized B2 API error object.
+ */
+export function clientInputError(code: string, message: string): never {
+  const error = { status: 400, code, message } satisfies B2ApiError;
+  throw error;
 }
 
-export function badRequest(message: string): B2ApiError {
-  return clientInputError("bad_request", message);
+/**
+ * Throw a normalized HTTP 400 bad_request client-input error.
+ *
+ * @throws A normalized B2 API error object.
+ */
+export function badRequest(message: string): never {
+  clientInputError("bad_request", message);
 }
 
 /** Pull a request id out of HTTP response headers (B2 native / S3 proxy variants). */

--- a/tests/unit/s3-tools.unit.test.ts
+++ b/tests/unit/s3-tools.unit.test.ts
@@ -1092,7 +1092,11 @@ describe("s3_get_presigned_url", () => {
       });
 
       expect(result.isError).toBe(true);
-      expect(parseResult(result)).toMatch(/browser-executable content type/i);
+      const errorText = parseResult(result);
+      expect(errorText).toMatch(/browser-executable content type/i);
+      expect(errorText).toContain("HTTP 400");
+      expect(errorText).not.toContain("internal_error");
+      expect(errorText).not.toContain("HTTP 500");
       expect(sendSpy).not.toHaveBeenCalled();
     },
   );

--- a/tests/unit/s3-tools.unit.test.ts
+++ b/tests/unit/s3-tools.unit.test.ts
@@ -8,6 +8,7 @@ import { B2Client } from "../../src/b2/client";
 import type { B2S3FileVersionBinding } from "../../src/utils/types";
 import type { McpServer } from "../../src/mcp";
 import { circuitBreaker, s3CircuitBreaker } from "../../src/utils/circuit-breaker";
+import { parseErrorText } from "../../src/utils/errors";
 import { callTool, parseResult, testConfig } from "../support/deterministic-fakes";
 import type { MockInstance } from "vitest";
 
@@ -35,6 +36,13 @@ function bodyFromText(value: string): ReadableStream<Uint8Array> {
       controller.close();
     },
   });
+}
+
+function expectBadRequestToolError(result: unknown, message: RegExp): void {
+  const errorText = parseResult(result);
+  expect(errorText).toEqual(expect.any(String));
+  expect(errorText).toMatch(message);
+  expect(parseErrorText(errorText)).toMatchObject({ code: "bad_request", status: 400 });
 }
 
 beforeEach(() => {
@@ -284,11 +292,7 @@ describe("s3_put_object and s3_get_object", () => {
     });
 
     expect(result.isError).toBe(true);
-    const errorText = parseResult(result);
-    expect(errorText).toMatch(/contentType/i);
-    expect(errorText).toContain("HTTP 400");
-    expect(errorText).not.toContain("internal_error");
-    expect(errorText).not.toContain("HTTP 500");
+    expectBadRequestToolError(result, /contentType/i);
     expect(sendSpy).not.toHaveBeenCalled();
   });
 
@@ -1045,11 +1049,7 @@ describe("s3_get_presigned_url", () => {
     });
 
     expect(result.isError).toBe(true);
-    const errorText = parseResult(result);
-    expect(errorText).toMatch(/contentType/i);
-    expect(errorText).toContain("HTTP 400");
-    expect(errorText).not.toContain("internal_error");
-    expect(errorText).not.toContain("HTTP 500");
+    expectBadRequestToolError(result, /contentType/i);
     expect(sendSpy).not.toHaveBeenCalled();
   });
 
@@ -1092,11 +1092,7 @@ describe("s3_get_presigned_url", () => {
       });
 
       expect(result.isError).toBe(true);
-      const errorText = parseResult(result);
-      expect(errorText).toMatch(/browser-executable content type/i);
-      expect(errorText).toContain("HTTP 400");
-      expect(errorText).not.toContain("internal_error");
-      expect(errorText).not.toContain("HTTP 500");
+      expectBadRequestToolError(result, /browser-executable content type/i);
       expect(sendSpy).not.toHaveBeenCalled();
     },
   );

--- a/tests/unit/s3-tools.unit.test.ts
+++ b/tests/unit/s3-tools.unit.test.ts
@@ -284,7 +284,11 @@ describe("s3_put_object and s3_get_object", () => {
     });
 
     expect(result.isError).toBe(true);
-    expect(parseResult(result)).toMatch(/contentType/i);
+    const errorText = parseResult(result);
+    expect(errorText).toMatch(/contentType/i);
+    expect(errorText).toContain("HTTP 400");
+    expect(errorText).not.toContain("internal_error");
+    expect(errorText).not.toContain("HTTP 500");
     expect(sendSpy).not.toHaveBeenCalled();
   });
 
@@ -1041,7 +1045,11 @@ describe("s3_get_presigned_url", () => {
     });
 
     expect(result.isError).toBe(true);
-    expect(parseResult(result)).toMatch(/contentType/i);
+    const errorText = parseResult(result);
+    expect(errorText).toMatch(/contentType/i);
+    expect(errorText).toContain("HTTP 400");
+    expect(errorText).not.toContain("internal_error");
+    expect(errorText).not.toContain("HTTP 500");
     expect(sendSpy).not.toHaveBeenCalled();
   });
 


### PR DESCRIPTION
## Summary
- Return PutObject `contentType` validation failures as HTTP 400 `bad_request` instead of `internal_error`/HTTP 500.
- Validate both missing signed `contentType` and browser-executable `contentType` values on the `s3_put_object` and presigned PutObject paths.
- Add parsed bad-request assertions so the validation contract is covered by status/code, not only formatted text.
- Keep B2 bucket validation on a shared `badRequest` helper while keeping the S3 adapter helper local to stay within the Cloudflare Worker bundle budget.

## Linked issue
Closes #213

## Tests run
- `pnpm run verify`
- `pnpm run test:contract -- tests/contract/deployment-docs-policy.contract.test.ts`
- `pnpm exec vitest run tests/unit/s3-tools.unit.test.ts`
- `pnpm run lint:docs`
- `pnpm run check:cloudflare-worker-bundle` from a short temp worktree

## Follow-up notes
- CI is passing for the PR head.
- `pnpm run lint` exits 0 with an existing warning in `src/oauth-resource-server.ts`.
