### PR TITLE
fix: classify destructive refusals

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Scope `b2_list_buckets` to authorized bucket IDs for bucket-scoped keys when
   no bucketId/bucketName filter is supplied, and reject out-of-scope explicit
   bucket filters before calling B2 (fixes #211).
+- Classify destructive confirmation/policy refusals as stable non-500 tool
+  outcomes: `destructive_confirmation_required` and
+  `destructive_confirmation_refused` as HTTP 409, and
+  `destructive_policy_blocked` as HTTP 403, with `tool.call` audit logs
+  recording those codes/statuses instead of `internal_error`/500.
 - Aligned the package `engines.node` range with the supported Node.js 22.3+,
   24, and 26 lines so it matches the runtime policy and opossum 10 support,
   with drift guards for workflow and deployment documentation claims.

--- a/src/b2/buckets.ts
+++ b/src/b2/buckets.ts
@@ -13,7 +13,7 @@ import {
 } from "./client.js";
 import { B2Config } from "../utils/types.js";
 import { badRequest, toolJson, toolError } from "../utils/errors.js";
-import { checkDestructive } from "../utils/destructive-gate.js";
+import { checkDestructive, destructiveGateError } from "../utils/destructive-gate.js";
 import { isTestRuntime } from "../utils/runtime.js";
 
 /**
@@ -671,7 +671,7 @@ export function registerBucketTools(
     async (args) => {
       try {
         const gate = checkDestructive("b2_delete_bucket", args, config);
-        if (!gate.ok) return toolError(new Error(gate.message));
+        if (!gate.ok) return toolError(destructiveGateError(gate));
         const result = await client.deleteBucket(args.bucketId);
         return toolJson(result);
       } catch (err) {
@@ -775,7 +775,7 @@ export function registerBucketTools(
     async (args) => {
       try {
         const gate = checkDestructive("b2_update_bucket", args, config);
-        if (!gate.ok) return toolError(new Error(gate.message));
+        if (!gate.ok) return toolError(destructiveGateError(gate));
         validateBucketInfoInput(args.bucketInfo);
         validateCorsRulesInput(args.corsRules);
         const payload: UpdateBucketOptions = {
@@ -869,7 +869,7 @@ export function registerBucketTools(
     async (args) => {
       try {
         const gate = checkDestructive("b2_set_bucket_notification_rules", args, config);
-        if (!gate.ok) return toolError(new Error(gate.message));
+        if (!gate.ok) return toolError(destructiveGateError(gate));
         const eventNotificationRules: EventNotificationRuleInput[] =
           args.eventNotificationRules.map(normalizeNotificationRule);
         for (const rule of eventNotificationRules) {

--- a/src/b2/buckets.ts
+++ b/src/b2/buckets.ts
@@ -13,7 +13,7 @@ import {
 } from "./client.js";
 import { B2Config } from "../utils/types.js";
 import { badRequest, toolJson, toolError } from "../utils/errors.js";
-import { checkDestructive, destructiveGateError } from "../utils/destructive-gate.js";
+import { checkDestructive } from "../utils/destructive-gate.js";
 import { isTestRuntime } from "../utils/runtime.js";
 
 /**
@@ -671,7 +671,7 @@ export function registerBucketTools(
     async (args) => {
       try {
         const gate = checkDestructive("b2_delete_bucket", args, config);
-        if (!gate.ok) return toolError(destructiveGateError(gate));
+        if (!gate.ok) return toolError(gate.error);
         const result = await client.deleteBucket(args.bucketId);
         return toolJson(result);
       } catch (err) {
@@ -775,7 +775,7 @@ export function registerBucketTools(
     async (args) => {
       try {
         const gate = checkDestructive("b2_update_bucket", args, config);
-        if (!gate.ok) return toolError(destructiveGateError(gate));
+        if (!gate.ok) return toolError(gate.error);
         validateBucketInfoInput(args.bucketInfo);
         validateCorsRulesInput(args.corsRules);
         const payload: UpdateBucketOptions = {
@@ -869,7 +869,7 @@ export function registerBucketTools(
     async (args) => {
       try {
         const gate = checkDestructive("b2_set_bucket_notification_rules", args, config);
-        if (!gate.ok) return toolError(destructiveGateError(gate));
+        if (!gate.ok) return toolError(gate.error);
         const eventNotificationRules: EventNotificationRuleInput[] =
           args.eventNotificationRules.map(normalizeNotificationRule);
         for (const rule of eventNotificationRules) {

--- a/src/b2/keys.ts
+++ b/src/b2/keys.ts
@@ -4,7 +4,7 @@ import { B2Client, type FullApplicationKeyResult, type ListKeysOptions } from ".
 import { B2AuthManager } from "../auth.js";
 import { ALL_CAPABILITIES, B2Config } from "../utils/types.js";
 import { toolJson, toolError } from "../utils/errors.js";
-import { checkDestructive, destructiveGateError } from "../utils/destructive-gate.js";
+import { checkDestructive } from "../utils/destructive-gate.js";
 import {
   APPLICATION_KEY_REDACTED,
   durableSecretIdempotency,
@@ -170,7 +170,7 @@ export function registerKeyTools(
             { mode: "file" | "inline" }
           >;
           const gate = checkDestructive("b2_create_key", args, config);
-          if (!gate.ok) return toolError(destructiveGateError(gate));
+          if (!gate.ok) return toolError(gate.error);
           const bucketScope = normalizeCreateKeyBucketScope(args);
           validateCreateKeyPolicy(args);
           const createRequest = {
@@ -274,7 +274,7 @@ export function registerKeyTools(
     async (args) => {
       try {
         const gate = checkDestructive("b2_delete_key", args, config);
-        if (!gate.ok) return toolError(destructiveGateError(gate));
+        if (!gate.ok) return toolError(gate.error);
         const result = await client.deleteKey(args.applicationKeyId);
         return toolJson(result);
       } catch (err) {

--- a/src/b2/keys.ts
+++ b/src/b2/keys.ts
@@ -4,7 +4,7 @@ import { B2Client, type FullApplicationKeyResult, type ListKeysOptions } from ".
 import { B2AuthManager } from "../auth.js";
 import { ALL_CAPABILITIES, B2Config } from "../utils/types.js";
 import { toolJson, toolError } from "../utils/errors.js";
-import { checkDestructive } from "../utils/destructive-gate.js";
+import { checkDestructive, destructiveGateError } from "../utils/destructive-gate.js";
 import {
   APPLICATION_KEY_REDACTED,
   durableSecretIdempotency,
@@ -170,7 +170,7 @@ export function registerKeyTools(
             { mode: "file" | "inline" }
           >;
           const gate = checkDestructive("b2_create_key", args, config);
-          if (!gate.ok) return toolError(new Error(gate.message));
+          if (!gate.ok) return toolError(destructiveGateError(gate));
           const bucketScope = normalizeCreateKeyBucketScope(args);
           validateCreateKeyPolicy(args);
           const createRequest = {
@@ -274,7 +274,7 @@ export function registerKeyTools(
     async (args) => {
       try {
         const gate = checkDestructive("b2_delete_key", args, config);
-        if (!gate.ok) return toolError(new Error(gate.message));
+        if (!gate.ok) return toolError(destructiveGateError(gate));
         const result = await client.deleteKey(args.applicationKeyId);
         return toolJson(result);
       } catch (err) {

--- a/src/b2/object-lock.ts
+++ b/src/b2/object-lock.ts
@@ -3,7 +3,7 @@ import { z } from "zod";
 import { B2Client, type UpdateFileRetentionOptions } from "./client.js";
 import { toolJson, toolError } from "../utils/errors.js";
 import { B2Config } from "../utils/types.js";
-import { checkDestructive } from "../utils/destructive-gate.js";
+import { checkDestructive, destructiveGateError } from "../utils/destructive-gate.js";
 
 const CONFIRM_DESC =
   "Confirm this irreversible/protection-removing operation. Required when the server destructive policy is 'confirm' (the default).";
@@ -44,7 +44,7 @@ export function registerObjectLockTools(
     async (args) => {
       try {
         const gate = checkDestructive("b2_update_file_legal_hold", args, config);
-        if (!gate.ok) return toolError(new Error(gate.message));
+        if (!gate.ok) return toolError(destructiveGateError(gate));
         const result = await client.updateFileLegalHold({
           fileId: args.fileId,
           fileName: args.fileName,
@@ -100,7 +100,7 @@ export function registerObjectLockTools(
     async (args) => {
       try {
         const gate = checkDestructive("b2_update_file_retention", args, config);
-        if (!gate.ok) return toolError(new Error(gate.message));
+        if (!gate.ok) return toolError(destructiveGateError(gate));
         const payload: UpdateFileRetentionOptions = {
           fileId: args.fileId,
           fileName: args.fileName,

--- a/src/b2/object-lock.ts
+++ b/src/b2/object-lock.ts
@@ -3,7 +3,7 @@ import { z } from "zod";
 import { B2Client, type UpdateFileRetentionOptions } from "./client.js";
 import { toolJson, toolError } from "../utils/errors.js";
 import { B2Config } from "../utils/types.js";
-import { checkDestructive, destructiveGateError } from "../utils/destructive-gate.js";
+import { checkDestructive } from "../utils/destructive-gate.js";
 
 const CONFIRM_DESC =
   "Confirm this irreversible/protection-removing operation. Required when the server destructive policy is 'confirm' (the default).";
@@ -44,7 +44,7 @@ export function registerObjectLockTools(
     async (args) => {
       try {
         const gate = checkDestructive("b2_update_file_legal_hold", args, config);
-        if (!gate.ok) return toolError(destructiveGateError(gate));
+        if (!gate.ok) return toolError(gate.error);
         const result = await client.updateFileLegalHold({
           fileId: args.fileId,
           fileName: args.fileName,
@@ -100,7 +100,7 @@ export function registerObjectLockTools(
     async (args) => {
       try {
         const gate = checkDestructive("b2_update_file_retention", args, config);
-        if (!gate.ok) return toolError(destructiveGateError(gate));
+        if (!gate.ok) return toolError(gate.error);
         const payload: UpdateFileRetentionOptions = {
           fileId: args.fileId,
           fileName: args.fileName,

--- a/src/b2/partner.ts
+++ b/src/b2/partner.ts
@@ -4,7 +4,7 @@ import { toolJson, toolError } from "../utils/errors.js";
 import type { B2AuthManager } from "../auth.js";
 import type { B2Client } from "./client.js";
 import type { B2Config } from "../utils/types.js";
-import { checkDestructive, destructiveGateError } from "../utils/destructive-gate.js";
+import { checkDestructive } from "../utils/destructive-gate.js";
 import {
   APPLICATION_KEY_REDACTED,
   durableSecretIdempotency,
@@ -138,7 +138,7 @@ export function registerPartnerTools(
       async (args) => {
         try {
           const gate = checkDestructive("b2_create_group_member", args, config);
-          if (!gate.ok) return toolError(destructiveGateError(gate));
+          if (!gate.ok) return toolError(gate.error);
 
           const request = {
             adminAccountId: args.adminAccountId,
@@ -220,7 +220,7 @@ export function registerPartnerTools(
     async (args) => {
       try {
         const gate = checkDestructive("b2_eject_group_member", args, config);
-        if (!gate.ok) return toolError(destructiveGateError(gate));
+        if (!gate.ok) return toolError(gate.error);
 
         const result = await client.ejectGroupMember({
           adminAccountId: args.adminAccountId,
@@ -310,7 +310,7 @@ export function registerPartnerTools(
       async (args) => {
         try {
           const gate = checkDestructive("b2_reserve_trial_create_account", args, config);
-          if (!gate.ok) return toolError(destructiveGateError(gate));
+          if (!gate.ok) return toolError(gate.error);
 
           const request = {
             email: args.email,

--- a/src/b2/partner.ts
+++ b/src/b2/partner.ts
@@ -4,7 +4,7 @@ import { toolJson, toolError } from "../utils/errors.js";
 import type { B2AuthManager } from "../auth.js";
 import type { B2Client } from "./client.js";
 import type { B2Config } from "../utils/types.js";
-import { checkDestructive } from "../utils/destructive-gate.js";
+import { checkDestructive, destructiveGateError } from "../utils/destructive-gate.js";
 import {
   APPLICATION_KEY_REDACTED,
   durableSecretIdempotency,
@@ -138,7 +138,7 @@ export function registerPartnerTools(
       async (args) => {
         try {
           const gate = checkDestructive("b2_create_group_member", args, config);
-          if (!gate.ok) return toolError(new Error(gate.message));
+          if (!gate.ok) return toolError(destructiveGateError(gate));
 
           const request = {
             adminAccountId: args.adminAccountId,
@@ -220,7 +220,7 @@ export function registerPartnerTools(
     async (args) => {
       try {
         const gate = checkDestructive("b2_eject_group_member", args, config);
-        if (!gate.ok) return toolError(new Error(gate.message));
+        if (!gate.ok) return toolError(destructiveGateError(gate));
 
         const result = await client.ejectGroupMember({
           adminAccountId: args.adminAccountId,
@@ -310,7 +310,7 @@ export function registerPartnerTools(
       async (args) => {
         try {
           const gate = checkDestructive("b2_reserve_trial_create_account", args, config);
-          if (!gate.ok) return toolError(new Error(gate.message));
+          if (!gate.ok) return toolError(destructiveGateError(gate));
 
           const request = {
             email: args.email,

--- a/src/s3/buckets.ts
+++ b/src/s3/buckets.ts
@@ -3,7 +3,7 @@ import type { ToolRegistrar } from "../mcp.js";
 import { z } from "zod";
 import { toolError, toolSuccess } from "../utils/errors.js";
 import { B2Config } from "../utils/types.js";
-import { checkDestructive, destructiveGateError } from "../utils/destructive-gate.js";
+import { checkDestructive } from "../utils/destructive-gate.js";
 
 // Retained S3 bucket tools cover S3 reachability and lifecycle features that
 // lack native B2 equivalents. Expiration and empty-rules clearing are gated.
@@ -88,7 +88,7 @@ export function registerS3BucketTools(
     async (args) => {
       try {
         const gate = checkDestructive("s3_put_bucket_lifecycle", args, config);
-        if (!gate.ok) return toolError(destructiveGateError(gate));
+        if (!gate.ok) return toolError(gate.error);
         const rules = args.rules as B2S3LifecycleRule[];
         if (rules.length === 0) {
           await s3.deleteBucketLifecycle(args.bucket);

--- a/src/s3/buckets.ts
+++ b/src/s3/buckets.ts
@@ -3,7 +3,7 @@ import type { ToolRegistrar } from "../mcp.js";
 import { z } from "zod";
 import { toolError, toolSuccess } from "../utils/errors.js";
 import { B2Config } from "../utils/types.js";
-import { checkDestructive } from "../utils/destructive-gate.js";
+import { checkDestructive, destructiveGateError } from "../utils/destructive-gate.js";
 
 // Retained S3 bucket tools cover S3 reachability and lifecycle features that
 // lack native B2 equivalents. Expiration and empty-rules clearing are gated.
@@ -88,7 +88,7 @@ export function registerS3BucketTools(
     async (args) => {
       try {
         const gate = checkDestructive("s3_put_bucket_lifecycle", args, config);
-        if (!gate.ok) return toolError(new Error(gate.message));
+        if (!gate.ok) return toolError(destructiveGateError(gate));
         const rules = args.rules as B2S3LifecycleRule[];
         if (rules.length === 0) {
           await s3.deleteBucketLifecycle(args.bucket);

--- a/src/s3/multipart.ts
+++ b/src/s3/multipart.ts
@@ -3,7 +3,7 @@ import type { ToolRegistrar } from "../mcp.js";
 import { z } from "zod";
 import { toolJson, toolError, toolSuccess } from "../utils/errors.js";
 import { B2Config } from "../utils/types.js";
-import { checkDestructive, destructiveGateError } from "../utils/destructive-gate.js";
+import { checkDestructive } from "../utils/destructive-gate.js";
 
 type B2S3MultipartClient = Pick<
   B2S3PeerClient,
@@ -175,7 +175,7 @@ export function registerS3MultipartTools(
     async (args) => {
       try {
         const gate = checkDestructive("s3_abort_multipart_upload", args, config);
-        if (!gate.ok) return toolError(destructiveGateError(gate));
+        if (!gate.ok) return toolError(gate.error);
         await s3.abortMultipartUpload({
           bucket: args.bucket,
           key: args.key,

--- a/src/s3/multipart.ts
+++ b/src/s3/multipart.ts
@@ -3,7 +3,7 @@ import type { ToolRegistrar } from "../mcp.js";
 import { z } from "zod";
 import { toolJson, toolError, toolSuccess } from "../utils/errors.js";
 import { B2Config } from "../utils/types.js";
-import { checkDestructive } from "../utils/destructive-gate.js";
+import { checkDestructive, destructiveGateError } from "../utils/destructive-gate.js";
 
 type B2S3MultipartClient = Pick<
   B2S3PeerClient,
@@ -175,7 +175,7 @@ export function registerS3MultipartTools(
     async (args) => {
       try {
         const gate = checkDestructive("s3_abort_multipart_upload", args, config);
-        if (!gate.ok) return toolError(new Error(gate.message));
+        if (!gate.ok) return toolError(destructiveGateError(gate));
         await s3.abortMultipartUpload({
           bucket: args.bucket,
           key: args.key,

--- a/src/s3/objects.ts
+++ b/src/s3/objects.ts
@@ -8,7 +8,7 @@ import type { ReadableStream as WebReadableStream } from "node:stream/web";
 import { toolJson, toolError, toolSuccess } from "../utils/errors.js";
 import { resolveLocalPath } from "../utils/fs-guard.js";
 import type { B2Config } from "../utils/types.js";
-import { checkDestructive } from "../utils/destructive-gate.js";
+import { checkDestructive, destructiveGateError } from "../utils/destructive-gate.js";
 import { withS3Circuit, withS3LongCircuit } from "../utils/circuit-breaker.js";
 import { currentMcpRequestSignal } from "../request-context.js";
 import type { B2S3FileVersionBinding, B2S3VersionGuard } from "../utils/types.js";
@@ -649,7 +649,7 @@ export function registerS3ObjectTools(
     async (args) => {
       try {
         const gate = checkDestructive("s3_delete_object", args, config);
-        if (!gate.ok) return toolError(new Error(gate.message));
+        if (!gate.ok) return toolError(destructiveGateError(gate));
         await verifyVersionBinding(
           versions,
           {
@@ -696,7 +696,7 @@ export function registerS3ObjectTools(
     async (args) => {
       try {
         const gate = checkDestructive("s3_delete_objects", args, config);
-        if (!gate.ok) return toolError(new Error(gate.message));
+        if (!gate.ok) return toolError(destructiveGateError(gate));
         if (args.bypassGovernance === true && !allowBypassGovernance) {
           return toolError(
             Object.assign(

--- a/src/s3/objects.ts
+++ b/src/s3/objects.ts
@@ -8,7 +8,7 @@ import type { ReadableStream as WebReadableStream } from "node:stream/web";
 import { toolJson, toolError, toolSuccess } from "../utils/errors.js";
 import { resolveLocalPath } from "../utils/fs-guard.js";
 import type { B2Config } from "../utils/types.js";
-import { checkDestructive, destructiveGateError } from "../utils/destructive-gate.js";
+import { checkDestructive } from "../utils/destructive-gate.js";
 import { withS3Circuit, withS3LongCircuit } from "../utils/circuit-breaker.js";
 import { currentMcpRequestSignal } from "../request-context.js";
 import type { B2S3FileVersionBinding, B2S3VersionGuard } from "../utils/types.js";
@@ -649,7 +649,7 @@ export function registerS3ObjectTools(
     async (args) => {
       try {
         const gate = checkDestructive("s3_delete_object", args, config);
-        if (!gate.ok) return toolError(destructiveGateError(gate));
+        if (!gate.ok) return toolError(gate.error);
         await verifyVersionBinding(
           versions,
           {
@@ -696,7 +696,7 @@ export function registerS3ObjectTools(
     async (args) => {
       try {
         const gate = checkDestructive("s3_delete_objects", args, config);
-        if (!gate.ok) return toolError(destructiveGateError(gate));
+        if (!gate.ok) return toolError(gate.error);
         if (args.bypassGovernance === true && !allowBypassGovernance) {
           return toolError(
             Object.assign(

--- a/src/s3/presigned.ts
+++ b/src/s3/presigned.ts
@@ -1,7 +1,7 @@
 import type { ToolRegistrar } from "../mcp.js";
 import { z } from "zod";
 import { toolError, toolJson } from "../utils/errors.js";
-import { checkDestructive } from "../utils/destructive-gate.js";
+import { checkDestructive, destructiveGateError } from "../utils/destructive-gate.js";
 import type { B2Config, B2S3VersionGuard } from "../utils/types.js";
 import type { B2S3PeerClient } from "./aws-sdk-adapter.js";
 
@@ -110,7 +110,7 @@ export function registerS3PresignedTools(
           });
         }
         const gate = checkDestructive("s3_get_presigned_url", args, config);
-        if (!gate.ok) return toolError(new Error(gate.message));
+        if (!gate.ok) return toolError(destructiveGateError(gate));
         if (args.operation === "GetObject" && args.versionId) {
           if (!allowExplicitVersionInspection) {
             return toolError({

--- a/src/s3/presigned.ts
+++ b/src/s3/presigned.ts
@@ -1,7 +1,7 @@
 import type { ToolRegistrar } from "../mcp.js";
 import { z } from "zod";
 import { toolError, toolJson } from "../utils/errors.js";
-import { checkDestructive, destructiveGateError } from "../utils/destructive-gate.js";
+import { checkDestructive } from "../utils/destructive-gate.js";
 import type { B2Config, B2S3VersionGuard } from "../utils/types.js";
 import type { B2S3PeerClient } from "./aws-sdk-adapter.js";
 
@@ -110,7 +110,7 @@ export function registerS3PresignedTools(
           });
         }
         const gate = checkDestructive("s3_get_presigned_url", args, config);
-        if (!gate.ok) return toolError(destructiveGateError(gate));
+        if (!gate.ok) return toolError(gate.error);
         if (args.operation === "GetObject" && args.versionId) {
           if (!allowExplicitVersionInspection) {
             return toolError({

--- a/src/utils/destructive-elicitation.ts
+++ b/src/utils/destructive-elicitation.ts
@@ -12,6 +12,8 @@ import {
 import { createHash } from "crypto";
 import { toolError } from "./errors.js";
 import {
+  DESTRUCTIVE_CONFIRMATION_REFUSED_CODE,
+  DESTRUCTIVE_CONFIRMATION_STATUS,
   destructiveEffect,
   destructiveTargetDigest,
   getDestructivePolicy,
@@ -329,11 +331,11 @@ function destructiveElicitationRefused(
     onDecision,
     reason,
   );
-  return toolError(
-    new Error(
-      `Refused: ${toolName} requires explicit human approval by MCP elicitation; ${reason}.`,
-    ),
-  );
+  return toolError({
+    status: DESTRUCTIVE_CONFIRMATION_STATUS,
+    code: DESTRUCTIVE_CONFIRMATION_REFUSED_CODE,
+    message: `Refused: ${toolName} requires explicit human approval by MCP elicitation; ${reason}.`,
+  });
 }
 
 function safePromptValue(value: unknown, sanitizerOptions: SanitizerOptions): string | null {

--- a/src/utils/destructive-elicitation.ts
+++ b/src/utils/destructive-elicitation.ts
@@ -12,8 +12,6 @@ import {
 import { createHash } from "crypto";
 import { toolError } from "./errors.js";
 import {
-  DESTRUCTIVE_CONFIRMATION_REFUSED_CODE,
-  DESTRUCTIVE_CONFIRMATION_STATUS,
   destructiveEffect,
   destructiveTargetDigest,
   getDestructivePolicy,
@@ -332,8 +330,8 @@ function destructiveElicitationRefused(
     reason,
   );
   return toolError({
-    status: DESTRUCTIVE_CONFIRMATION_STATUS,
-    code: DESTRUCTIVE_CONFIRMATION_REFUSED_CODE,
+    status: 409,
+    code: "destructive_confirmation_refused",
     message: `Refused: ${toolName} requires explicit human approval by MCP elicitation; ${reason}.`,
   });
 }

--- a/src/utils/destructive-gate.ts
+++ b/src/utils/destructive-gate.ts
@@ -1,5 +1,6 @@
 import { AsyncLocalStorage } from "async_hooks";
 import { createHmac } from "crypto";
+import type { B2ApiError } from "./errors.js";
 import { B2Config, DestructivePolicy } from "./types.js";
 
 /**
@@ -174,11 +175,40 @@ export function getDestructivePolicy(config: B2Config): DestructivePolicy {
 export interface GateResult {
   ok: boolean;
   message?: string;
+  error?: B2ApiError;
+}
+
+export const DESTRUCTIVE_CONFIRMATION_REQUIRED_CODE = "destructive_confirmation_required";
+export const DESTRUCTIVE_CONFIRMATION_REFUSED_CODE = "destructive_confirmation_refused";
+export const DESTRUCTIVE_POLICY_BLOCKED_CODE = "destructive_policy_blocked";
+export const DESTRUCTIVE_CONFIRMATION_STATUS = 409;
+export const DESTRUCTIVE_POLICY_BLOCKED_STATUS = 403;
+
+function destructivePolicyError(status: number, code: string, message: string): B2ApiError {
+  return { status, code, message };
+}
+
+export function destructiveGateError(gate: GateResult): B2ApiError {
+  if (gate.ok) {
+    return destructivePolicyError(
+      DESTRUCTIVE_CONFIRMATION_STATUS,
+      DESTRUCTIVE_CONFIRMATION_REQUIRED_CODE,
+      "Destructive operation was not refused.",
+    );
+  }
+  return (
+    gate.error ??
+    destructivePolicyError(
+      DESTRUCTIVE_CONFIRMATION_STATUS,
+      DESTRUCTIVE_CONFIRMATION_REQUIRED_CODE,
+      gate.message ?? "Destructive operation requires confirmation.",
+    )
+  );
 }
 
 /**
  * Evaluate whether a tool call may proceed. Call at the top of a destructive
- * tool's handler; if `ok` is false, return `toolError(new Error(message))`.
+ * tool's handler; if `ok` is false, return `toolError(destructiveGateError(result))`.
  *
  * Under the `confirm` policy, approval can be supplied by the legacy
  * model-provided `confirm: true` fallback, or by the audited tool wrapper
@@ -199,11 +229,17 @@ export function checkDestructive(
   if (policy === "allow") return { ok: true };
 
   if (policy === "block") {
+    const message =
+      `Refused: this would ${effect}. Destructive operations are blocked on this ` +
+      `server (B2_DESTRUCTIVE_POLICY=block).`;
     return {
       ok: false,
-      message:
-        `Refused: this would ${effect}. Destructive operations are blocked on this ` +
-        `server (B2_DESTRUCTIVE_POLICY=block).`,
+      message,
+      error: destructivePolicyError(
+        DESTRUCTIVE_POLICY_BLOCKED_STATUS,
+        DESTRUCTIVE_POLICY_BLOCKED_CODE,
+        message,
+      ),
     };
   }
 
@@ -216,11 +252,17 @@ export function checkDestructive(
     return { ok: true };
   }
   if (args.confirm === true) return { ok: true };
+  const message =
+    `Confirmation required: this would ${effect} — a destructive/irreversible action. ` +
+    `Re-invoke the identical call with "confirm": true to proceed. ` +
+    `(Server policy B2_DESTRUCTIVE_POLICY=confirm; set it to "allow" to disable this gate.)`;
   return {
     ok: false,
-    message:
-      `Confirmation required: this would ${effect} — a destructive/irreversible action. ` +
-      `Re-invoke the identical call with "confirm": true to proceed. ` +
-      `(Server policy B2_DESTRUCTIVE_POLICY=confirm; set it to "allow" to disable this gate.)`,
+    message,
+    error: destructivePolicyError(
+      DESTRUCTIVE_CONFIRMATION_STATUS,
+      DESTRUCTIVE_CONFIRMATION_REQUIRED_CODE,
+      message,
+    ),
   };
 }

--- a/src/utils/destructive-gate.ts
+++ b/src/utils/destructive-gate.ts
@@ -172,37 +172,11 @@ export function getDestructivePolicy(config: B2Config): DestructivePolicy {
   return p === "allow" || p === "block" ? p : "confirm";
 }
 
-interface GateAllowed {
-  ok: true;
-  message?: undefined;
-  error?: undefined;
-}
-
-export interface GateRefused {
-  ok: false;
-  message: string;
-  error: B2ApiError;
-}
-
-export type GateResult = GateAllowed | GateRefused;
-
-export const DESTRUCTIVE_CONFIRMATION_REQUIRED_CODE = "destructive_confirmation_required";
-export const DESTRUCTIVE_CONFIRMATION_REFUSED_CODE = "destructive_confirmation_refused";
-export const DESTRUCTIVE_POLICY_BLOCKED_CODE = "destructive_policy_blocked";
-export const DESTRUCTIVE_CONFIRMATION_STATUS = 409;
-export const DESTRUCTIVE_POLICY_BLOCKED_STATUS = 403;
-
-function destructivePolicyError(status: number, code: string, message: string): B2ApiError {
-  return { status, code, message };
-}
-
-export function destructiveGateError(gate: GateRefused): B2ApiError {
-  return gate.error;
-}
+export type GateResult = { ok: true } | { ok: false; error: B2ApiError };
 
 /**
  * Evaluate whether a tool call may proceed. Call at the top of a destructive
- * tool's handler; if `ok` is false, return `toolError(destructiveGateError(result))`.
+ * tool's handler; if `ok` is false, return `toolError(result.error)`.
  *
  * Under the `confirm` policy, approval can be supplied by the legacy
  * model-provided `confirm: true` fallback, or by the audited tool wrapper
@@ -228,12 +202,11 @@ export function checkDestructive(
       `server (B2_DESTRUCTIVE_POLICY=block).`;
     return {
       ok: false,
-      message,
-      error: destructivePolicyError(
-        DESTRUCTIVE_POLICY_BLOCKED_STATUS,
-        DESTRUCTIVE_POLICY_BLOCKED_CODE,
+      error: {
+        status: 403,
+        code: "destructive_policy_blocked",
         message,
-      ),
+      },
     };
   }
 
@@ -252,11 +225,10 @@ export function checkDestructive(
     `(Server policy B2_DESTRUCTIVE_POLICY=confirm; set it to "allow" to disable this gate.)`;
   return {
     ok: false,
-    message,
-    error: destructivePolicyError(
-      DESTRUCTIVE_CONFIRMATION_STATUS,
-      DESTRUCTIVE_CONFIRMATION_REQUIRED_CODE,
+    error: {
+      status: 409,
+      code: "destructive_confirmation_required",
       message,
-    ),
+    },
   };
 }

--- a/src/utils/destructive-gate.ts
+++ b/src/utils/destructive-gate.ts
@@ -172,11 +172,19 @@ export function getDestructivePolicy(config: B2Config): DestructivePolicy {
   return p === "allow" || p === "block" ? p : "confirm";
 }
 
-export interface GateResult {
-  ok: boolean;
-  message?: string;
-  error?: B2ApiError;
+interface GateAllowed {
+  ok: true;
+  message?: undefined;
+  error?: undefined;
 }
+
+export interface GateRefused {
+  ok: false;
+  message: string;
+  error: B2ApiError;
+}
+
+export type GateResult = GateAllowed | GateRefused;
 
 export const DESTRUCTIVE_CONFIRMATION_REQUIRED_CODE = "destructive_confirmation_required";
 export const DESTRUCTIVE_CONFIRMATION_REFUSED_CODE = "destructive_confirmation_refused";
@@ -188,22 +196,8 @@ function destructivePolicyError(status: number, code: string, message: string): 
   return { status, code, message };
 }
 
-export function destructiveGateError(gate: GateResult): B2ApiError {
-  if (gate.ok) {
-    return destructivePolicyError(
-      DESTRUCTIVE_CONFIRMATION_STATUS,
-      DESTRUCTIVE_CONFIRMATION_REQUIRED_CODE,
-      "Destructive operation was not refused.",
-    );
-  }
-  return (
-    gate.error ??
-    destructivePolicyError(
-      DESTRUCTIVE_CONFIRMATION_STATUS,
-      DESTRUCTIVE_CONFIRMATION_REQUIRED_CODE,
-      gate.message ?? "Destructive operation requires confirmation.",
-    )
-  );
+export function destructiveGateError(gate: GateRefused): B2ApiError {
+  return gate.error;
 }
 
 /**

--- a/tests/protocol/http.modern-protocol.test.ts
+++ b/tests/protocol/http.modern-protocol.test.ts
@@ -14,10 +14,6 @@ import {
   type HttpServerHandle,
   type HttpServerOptions,
 } from "../../src/http-server";
-import {
-  DESTRUCTIVE_CONFIRMATION_REFUSED_CODE,
-  DESTRUCTIVE_CONFIRMATION_STATUS,
-} from "../../src/utils/destructive-gate";
 import { invalidateAuthManagerCache } from "../../src/server";
 import { B2Simulator } from "@backblaze-labs/b2-sdk/simulator";
 import { S3Client } from "@aws-sdk/client-s3";
@@ -332,7 +328,7 @@ describe("HTTP handler (MCP 2026-07-28)", () => {
       expect(swappedResult.isError).toBe(true);
       expect(swappedResult.content?.[0]?.text).toMatch(/target did not match/i);
       expect(swappedResult.content?.[0]?.text).toContain(
-        `B2 Error [${DESTRUCTIVE_CONFIRMATION_REFUSED_CODE}] (HTTP ${DESTRUCTIVE_CONFIRMATION_STATUS})`,
+        "B2 Error [destructive_confirmation_refused] (HTTP 409)",
       );
       expect(s3Send).toHaveBeenCalledTimes(1);
 
@@ -386,7 +382,7 @@ describe("HTTP handler (MCP 2026-07-28)", () => {
       expect(declinedResult.isError).toBe(true);
       expect(declinedResult.content?.[0]?.text).toMatch(/human confirmation was decline/i);
       expect(declinedResult.content?.[0]?.text).toContain(
-        `B2 Error [${DESTRUCTIVE_CONFIRMATION_REFUSED_CODE}] (HTTP ${DESTRUCTIVE_CONFIRMATION_STATUS})`,
+        "B2 Error [destructive_confirmation_refused] (HTTP 409)",
       );
       expect(s3Send).toHaveBeenCalledTimes(1);
     } finally {

--- a/tests/protocol/http.modern-protocol.test.ts
+++ b/tests/protocol/http.modern-protocol.test.ts
@@ -14,6 +14,10 @@ import {
   type HttpServerHandle,
   type HttpServerOptions,
 } from "../../src/http-server";
+import {
+  DESTRUCTIVE_CONFIRMATION_REFUSED_CODE,
+  DESTRUCTIVE_CONFIRMATION_STATUS,
+} from "../../src/utils/destructive-gate";
 import { invalidateAuthManagerCache } from "../../src/server";
 import { B2Simulator } from "@backblaze-labs/b2-sdk/simulator";
 import { S3Client } from "@aws-sdk/client-s3";
@@ -327,6 +331,9 @@ describe("HTTP handler (MCP 2026-07-28)", () => {
       expect(swapped.status).toBe(200);
       expect(swappedResult.isError).toBe(true);
       expect(swappedResult.content?.[0]?.text).toMatch(/target did not match/i);
+      expect(swappedResult.content?.[0]?.text).toContain(
+        `B2 Error [${DESTRUCTIVE_CONFIRMATION_REFUSED_CODE}] (HTTP ${DESTRUCTIVE_CONFIRMATION_STATUS})`,
+      );
       expect(s3Send).toHaveBeenCalledTimes(1);
 
       const tamperedState = await request(port, "POST", "/mcp", {
@@ -378,6 +385,9 @@ describe("HTTP handler (MCP 2026-07-28)", () => {
       expect(declined.status).toBe(200);
       expect(declinedResult.isError).toBe(true);
       expect(declinedResult.content?.[0]?.text).toMatch(/human confirmation was decline/i);
+      expect(declinedResult.content?.[0]?.text).toContain(
+        `B2 Error [${DESTRUCTIVE_CONFIRMATION_REFUSED_CODE}] (HTTP ${DESTRUCTIVE_CONFIRMATION_STATUS})`,
+      );
       expect(s3Send).toHaveBeenCalledTimes(1);
     } finally {
       if (savedPolicy === undefined) delete process.env.B2_DESTRUCTIVE_POLICY;

--- a/tests/unit/destructive-elicitation.unit.test.ts
+++ b/tests/unit/destructive-elicitation.unit.test.ts
@@ -14,6 +14,12 @@ import {
 } from "../../src/utils/destructive-elicitation";
 import {
   checkDestructive,
+  DESTRUCTIVE_CONFIRMATION_REFUSED_CODE,
+  DESTRUCTIVE_CONFIRMATION_REQUIRED_CODE,
+  DESTRUCTIVE_CONFIRMATION_STATUS,
+  DESTRUCTIVE_POLICY_BLOCKED_CODE,
+  DESTRUCTIVE_POLICY_BLOCKED_STATUS,
+  destructiveGateError,
   DESTRUCTIVE_TOOL_NAMES,
   destructiveEffect,
 } from "../../src/utils/destructive-gate";
@@ -175,7 +181,7 @@ function acceptedResponse() {
 function destructiveOriginal(config: B2Config, toolName = "s3_delete_object") {
   return vi.fn((args: Record<string, unknown>) => {
     const gate = checkDestructive(toolName, args, config);
-    if (!gate.ok) return toolError(new Error(gate.message));
+    if (!gate.ok) return toolError(destructiveGateError(gate));
     return { content: [{ type: "text" as const, text: "deleted" }] };
   });
 }
@@ -337,6 +343,9 @@ describe("destructive elicitation", () => {
 
       expect(result.isError).toBe(true);
       expect(result.content?.[0]?.text).toMatch(/requires explicit human approval/i);
+      expect(result.content?.[0]?.text).toContain(
+        `B2 Error [${DESTRUCTIVE_CONFIRMATION_REFUSED_CODE}] (HTTP ${DESTRUCTIVE_CONFIRMATION_STATUS})`,
+      );
       expect(original).not.toHaveBeenCalled();
     },
   );
@@ -352,6 +361,37 @@ describe("destructive elicitation", () => {
 
     expect(result.isError).toBe(true);
     expect(result.content?.[0]?.text).toMatch(/was not provided/i);
+    expect(result.content?.[0]?.text).toContain(
+      `B2 Error [${DESTRUCTIVE_CONFIRMATION_REFUSED_CODE}] (HTTP ${DESTRUCTIVE_CONFIRMATION_STATUS})`,
+    );
+    expect(original).not.toHaveBeenCalled();
+  });
+
+  it("treats accepted responses without positive confirmation as user refusal", async () => {
+    const config = cfg();
+    const original = destructiveOriginal(config);
+    const wrapped = createAuditedToolCallback("s3_delete_object", original, config, providers());
+    const args = { bucket: "photos", key: "old.jpg" };
+    const requestState = await requestStateFor(wrapped, args);
+
+    const result = await wrapped(
+      args,
+      extraWithElicitation(
+        {
+          [DESTRUCTIVE_ELICITATION_RESPONSE_KEY]: {
+            action: "accept",
+            content: { confirm: false },
+          },
+        },
+        requestState,
+      ),
+    );
+
+    expect(result.isError).toBe(true);
+    expect(result.content?.[0]?.text).toMatch(/did not approve/i);
+    expect(result.content?.[0]?.text).toContain(
+      `B2 Error [${DESTRUCTIVE_CONFIRMATION_REFUSED_CODE}] (HTTP ${DESTRUCTIVE_CONFIRMATION_STATUS})`,
+    );
     expect(original).not.toHaveBeenCalled();
   });
 
@@ -374,6 +414,11 @@ describe("destructive elicitation", () => {
       } else {
         expect(result.resultType).not.toBe("input_required");
         expect(result.content?.[0]?.text).toMatch(new RegExp(expectedText, "i"));
+        if (policy === "block") {
+          expect(result.content?.[0]?.text).toContain(
+            `B2 Error [${DESTRUCTIVE_POLICY_BLOCKED_CODE}] (HTTP ${DESTRUCTIVE_POLICY_BLOCKED_STATUS})`,
+          );
+        }
         expect(original).toHaveBeenCalledTimes(1);
       }
     },
@@ -401,12 +446,52 @@ describe("destructive elicitation", () => {
     expect(result.resultType).not.toBe("input_required");
     expect(result.isError).toBe(true);
     expect(result.content?.[0]?.text).toMatch(/Confirmation required/i);
+    expect(result.content?.[0]?.text).toContain(
+      `B2 Error [${DESTRUCTIVE_CONFIRMATION_REQUIRED_CODE}] (HTTP ${DESTRUCTIVE_CONFIRMATION_STATUS})`,
+    );
     expect(original).toHaveBeenCalledTimes(1);
 
     const confirmed = await wrapped({ bucket: "photos", key: "old.jpg", confirm: true }, {});
     expect(confirmed.content?.[0]?.text).toBe("deleted");
     expect(original).toHaveBeenCalledTimes(2);
   });
+
+  it.each([
+    [
+      "missing legacy confirmation",
+      cfg("confirm"),
+      providers(URL_ONLY_ELICITATION),
+      { bucket: "photos", key: "old.jpg" },
+      DESTRUCTIVE_CONFIRMATION_REQUIRED_CODE,
+      DESTRUCTIVE_CONFIRMATION_STATUS,
+    ],
+    [
+      "block policy",
+      cfg("block"),
+      providers(),
+      { bucket: "photos", key: "old.jpg", confirm: true },
+      DESTRUCTIVE_POLICY_BLOCKED_CODE,
+      DESTRUCTIVE_POLICY_BLOCKED_STATUS,
+    ],
+  ])(
+    "audits %s refusal as a non-500 policy outcome",
+    async (_case, config, context, args, expectedCode, expectedStatus) => {
+      const info = vi.spyOn(logger, "info").mockImplementation(() => undefined);
+      const original = destructiveOriginal(config);
+      const wrapped = createAuditedToolCallback("s3_delete_object", original, config, context);
+
+      const result = await wrapped(args, {});
+
+      expect(result.isError).toBe(true);
+      expect(result.content?.[0]?.text).toContain(
+        `B2 Error [${expectedCode}] (HTTP ${expectedStatus})`,
+      );
+      expect(info.mock.calls.find(([, message]) => message === "tool.call")?.[0]).toMatchObject({
+        code: expectedCode,
+        status: expectedStatus,
+      });
+    },
+  );
 
   it.each([
     ["missing form capability", { mcpReq: { envelope: envelope() } }],
@@ -466,6 +551,9 @@ describe("destructive elicitation", () => {
     const missingConfirm = await wrapped({ bucket: "photos", key: "old.jpg" }, extra);
     expect(missingConfirm.resultType).not.toBe("input_required");
     expect(missingConfirm.content?.[0]?.text).toMatch(/Confirmation required/i);
+    expect(missingConfirm.content?.[0]?.text).toContain(
+      `B2 Error [${DESTRUCTIVE_CONFIRMATION_REQUIRED_CODE}] (HTTP ${DESTRUCTIVE_CONFIRMATION_STATUS})`,
+    );
     expect(original).toHaveBeenCalledTimes(1);
 
     const confirmed = await wrapped({ bucket: "photos", key: "old.jpg", confirm: true }, extra);
@@ -642,6 +730,10 @@ describe("destructive elicitation", () => {
       { resultType: "input_required", outcome: "requested", handlerRan: false },
       { resultType: "complete", outcome: "declined", handlerRan: false },
     ]);
+    expect(toolCallLogs[toolCallLogs.length - 1]?.[0]).toMatchObject({
+      code: DESTRUCTIVE_CONFIRMATION_REFUSED_CODE,
+      status: DESTRUCTIVE_CONFIRMATION_STATUS,
+    });
     const serializedLogs = JSON.stringify(elicitationLogs);
     expect(serializedLogs).not.toContain("photos");
     expect(serializedLogs).not.toContain("old.jpg");

--- a/tests/unit/destructive-elicitation.unit.test.ts
+++ b/tests/unit/destructive-elicitation.unit.test.ts
@@ -14,12 +14,6 @@ import {
 } from "../../src/utils/destructive-elicitation";
 import {
   checkDestructive,
-  DESTRUCTIVE_CONFIRMATION_REFUSED_CODE,
-  DESTRUCTIVE_CONFIRMATION_REQUIRED_CODE,
-  DESTRUCTIVE_CONFIRMATION_STATUS,
-  DESTRUCTIVE_POLICY_BLOCKED_CODE,
-  DESTRUCTIVE_POLICY_BLOCKED_STATUS,
-  destructiveGateError,
   DESTRUCTIVE_TOOL_NAMES,
   destructiveEffect,
 } from "../../src/utils/destructive-gate";
@@ -181,7 +175,7 @@ function acceptedResponse() {
 function destructiveOriginal(config: B2Config, toolName = "s3_delete_object") {
   return vi.fn((args: Record<string, unknown>) => {
     const gate = checkDestructive(toolName, args, config);
-    if (!gate.ok) return toolError(destructiveGateError(gate));
+    if (!gate.ok) return toolError(gate.error);
     return { content: [{ type: "text" as const, text: "deleted" }] };
   });
 }
@@ -344,7 +338,7 @@ describe("destructive elicitation", () => {
       expect(result.isError).toBe(true);
       expect(result.content?.[0]?.text).toMatch(/requires explicit human approval/i);
       expect(result.content?.[0]?.text).toContain(
-        `B2 Error [${DESTRUCTIVE_CONFIRMATION_REFUSED_CODE}] (HTTP ${DESTRUCTIVE_CONFIRMATION_STATUS})`,
+        "B2 Error [destructive_confirmation_refused] (HTTP 409)",
       );
       expect(original).not.toHaveBeenCalled();
     },
@@ -362,7 +356,7 @@ describe("destructive elicitation", () => {
     expect(result.isError).toBe(true);
     expect(result.content?.[0]?.text).toMatch(/was not provided/i);
     expect(result.content?.[0]?.text).toContain(
-      `B2 Error [${DESTRUCTIVE_CONFIRMATION_REFUSED_CODE}] (HTTP ${DESTRUCTIVE_CONFIRMATION_STATUS})`,
+      "B2 Error [destructive_confirmation_refused] (HTTP 409)",
     );
     expect(original).not.toHaveBeenCalled();
   });
@@ -390,7 +384,7 @@ describe("destructive elicitation", () => {
     expect(result.isError).toBe(true);
     expect(result.content?.[0]?.text).toMatch(/did not approve/i);
     expect(result.content?.[0]?.text).toContain(
-      `B2 Error [${DESTRUCTIVE_CONFIRMATION_REFUSED_CODE}] (HTTP ${DESTRUCTIVE_CONFIRMATION_STATUS})`,
+      "B2 Error [destructive_confirmation_refused] (HTTP 409)",
     );
     expect(original).not.toHaveBeenCalled();
   });
@@ -416,7 +410,7 @@ describe("destructive elicitation", () => {
         expect(result.content?.[0]?.text).toMatch(new RegExp(expectedText, "i"));
         if (policy === "block") {
           expect(result.content?.[0]?.text).toContain(
-            `B2 Error [${DESTRUCTIVE_POLICY_BLOCKED_CODE}] (HTTP ${DESTRUCTIVE_POLICY_BLOCKED_STATUS})`,
+            "B2 Error [destructive_policy_blocked] (HTTP 403)",
           );
         }
         expect(original).toHaveBeenCalledTimes(1);
@@ -447,7 +441,7 @@ describe("destructive elicitation", () => {
     expect(result.isError).toBe(true);
     expect(result.content?.[0]?.text).toMatch(/Confirmation required/i);
     expect(result.content?.[0]?.text).toContain(
-      `B2 Error [${DESTRUCTIVE_CONFIRMATION_REQUIRED_CODE}] (HTTP ${DESTRUCTIVE_CONFIRMATION_STATUS})`,
+      "B2 Error [destructive_confirmation_required] (HTTP 409)",
     );
     expect(original).toHaveBeenCalledTimes(1);
 
@@ -462,16 +456,16 @@ describe("destructive elicitation", () => {
       cfg("confirm"),
       providers(URL_ONLY_ELICITATION),
       { bucket: "photos", key: "old.jpg" },
-      DESTRUCTIVE_CONFIRMATION_REQUIRED_CODE,
-      DESTRUCTIVE_CONFIRMATION_STATUS,
+      "destructive_confirmation_required",
+      409,
     ],
     [
       "block policy",
       cfg("block"),
       providers(),
       { bucket: "photos", key: "old.jpg", confirm: true },
-      DESTRUCTIVE_POLICY_BLOCKED_CODE,
-      DESTRUCTIVE_POLICY_BLOCKED_STATUS,
+      "destructive_policy_blocked",
+      403,
     ],
   ])(
     "audits %s refusal as a non-500 policy outcome",
@@ -552,7 +546,7 @@ describe("destructive elicitation", () => {
     expect(missingConfirm.resultType).not.toBe("input_required");
     expect(missingConfirm.content?.[0]?.text).toMatch(/Confirmation required/i);
     expect(missingConfirm.content?.[0]?.text).toContain(
-      `B2 Error [${DESTRUCTIVE_CONFIRMATION_REQUIRED_CODE}] (HTTP ${DESTRUCTIVE_CONFIRMATION_STATUS})`,
+      "B2 Error [destructive_confirmation_required] (HTTP 409)",
     );
     expect(original).toHaveBeenCalledTimes(1);
 
@@ -731,8 +725,8 @@ describe("destructive elicitation", () => {
       { resultType: "complete", outcome: "declined", handlerRan: false },
     ]);
     expect(toolCallLogs[toolCallLogs.length - 1]?.[0]).toMatchObject({
-      code: DESTRUCTIVE_CONFIRMATION_REFUSED_CODE,
-      status: DESTRUCTIVE_CONFIRMATION_STATUS,
+      code: "destructive_confirmation_refused",
+      status: 409,
     });
     const serializedLogs = JSON.stringify(elicitationLogs);
     expect(serializedLogs).not.toContain("photos");

--- a/tests/unit/destructive-gate.unit.test.ts
+++ b/tests/unit/destructive-gate.unit.test.ts
@@ -4,6 +4,10 @@
  */
 import {
   checkDestructive,
+  DESTRUCTIVE_CONFIRMATION_REQUIRED_CODE,
+  DESTRUCTIVE_CONFIRMATION_STATUS,
+  DESTRUCTIVE_POLICY_BLOCKED_CODE,
+  DESTRUCTIVE_POLICY_BLOCKED_STATUS,
   getDestructivePolicy,
   isDestructiveTool,
 } from "../../src/utils/destructive-gate";
@@ -62,6 +66,10 @@ describe("destructive-gate", () => {
       const r = checkDestructive("b2_delete_bucket", { bucketId: "b" }, cfg());
       expect(r.ok).toBe(false);
       expect(r.message).toMatch(/confirm/i);
+      expect(r.error).toMatchObject({
+        code: DESTRUCTIVE_CONFIRMATION_REQUIRED_CODE,
+        status: DESTRUCTIVE_CONFIRMATION_STATUS,
+      });
     });
 
     it("allows a destructive call with confirm:true", () => {
@@ -79,6 +87,10 @@ describe("destructive-gate", () => {
       );
       expect(r.ok).toBe(false);
       expect(r.message).toMatch(/blocked/i);
+      expect(r.error).toMatchObject({
+        code: DESTRUCTIVE_POLICY_BLOCKED_CODE,
+        status: DESTRUCTIVE_POLICY_BLOCKED_STATUS,
+      });
     });
   });
 

--- a/tests/unit/destructive-gate.unit.test.ts
+++ b/tests/unit/destructive-gate.unit.test.ts
@@ -4,10 +4,6 @@
  */
 import {
   checkDestructive,
-  DESTRUCTIVE_CONFIRMATION_REQUIRED_CODE,
-  DESTRUCTIVE_CONFIRMATION_STATUS,
-  DESTRUCTIVE_POLICY_BLOCKED_CODE,
-  DESTRUCTIVE_POLICY_BLOCKED_STATUS,
   getDestructivePolicy,
   isDestructiveTool,
 } from "../../src/utils/destructive-gate";
@@ -64,11 +60,13 @@ describe("destructive-gate", () => {
   describe("confirm policy (default)", () => {
     it("blocks a destructive call without confirm", () => {
       const r = checkDestructive("b2_delete_bucket", { bucketId: "b" }, cfg());
-      expect(r.ok).toBe(false);
-      expect(r.message).toMatch(/confirm/i);
-      expect(r.error).toMatchObject({
-        code: DESTRUCTIVE_CONFIRMATION_REQUIRED_CODE,
-        status: DESTRUCTIVE_CONFIRMATION_STATUS,
+      expect(r).toMatchObject({
+        ok: false,
+        error: {
+          code: "destructive_confirmation_required",
+          status: 409,
+          message: expect.stringMatching(/confirm/i),
+        },
       });
     });
 
@@ -85,11 +83,13 @@ describe("destructive-gate", () => {
         { applicationKeyId: "k", confirm: true },
         cfg("block"),
       );
-      expect(r.ok).toBe(false);
-      expect(r.message).toMatch(/blocked/i);
-      expect(r.error).toMatchObject({
-        code: DESTRUCTIVE_POLICY_BLOCKED_CODE,
-        status: DESTRUCTIVE_POLICY_BLOCKED_STATUS,
+      expect(r).toMatchObject({
+        ok: false,
+        error: {
+          code: "destructive_policy_blocked",
+          status: 403,
+          message: expect.stringMatching(/blocked/i),
+        },
       });
     });
   });
@@ -104,9 +104,13 @@ describe("destructive-gate", () => {
   describe("s3_delete_objects Object Lock bypass text", () => {
     it("keeps the plain delete effect unchanged", () => {
       const r = checkDestructive("s3_delete_objects", { bucket: "b", objects: [] }, cfg());
-      expect(r.ok).toBe(false);
-      expect(r.message).toContain("permanently delete multiple objects (irreversible)");
-      expect(r.message).not.toMatch(/Object Lock|retention/i);
+      expect(r).toMatchObject({
+        ok: false,
+        error: {
+          message: expect.stringContaining("permanently delete multiple objects (irreversible)"),
+        },
+      });
+      if (!r.ok) expect(r.error.message).not.toMatch(/Object Lock|retention/i);
     });
 
     it("states when governance-mode Object Lock retention is bypassed", () => {
@@ -115,8 +119,12 @@ describe("destructive-gate", () => {
         { bucket: "b", objects: [], bypassGovernance: true },
         cfg(),
       );
-      expect(r.ok).toBe(false);
-      expect(r.message).toContain("bypass governance-mode Object Lock retention");
+      expect(r).toMatchObject({
+        ok: false,
+        error: {
+          message: expect.stringContaining("bypass governance-mode Object Lock retention"),
+        },
+      });
     });
   });
 
@@ -127,8 +135,10 @@ describe("destructive-gate", () => {
         { bucket: "b", key: "k", operation: "PutObject" },
         cfg(),
       );
-      expect(r.ok).toBe(false);
-      expect(r.message).toMatch(/PutObject presigned URL/i);
+      expect(r).toMatchObject({
+        ok: false,
+        error: { message: expect.stringMatching(/PutObject presigned URL/i) },
+      });
     });
 
     it("allows confirmed PutObject presigning", () => {


### PR DESCRIPTION
## Summary
- Classify destructive confirmation, elicitation, and policy refusals as stable non-500 tool errors.
- Return `destructive_confirmation_required` / `destructive_confirmation_refused` as HTTP 409 tool outcomes, and `destructive_policy_blocked` as HTTP 403.
- Preserve audit parsing so `tool.call` logs record the policy/confirmation code and status instead of `internal_error` / 500.
- Tighten `GateResult` into a discriminated union so refusal paths must carry the classified `B2ApiError`, and update handlers to forward that error directly.
- Keep protocol/audit-facing tests pinned to literal public error codes/statuses and keep the Worker/package byte budgets under their CI limits.

## Linked Issue
Fixes #203

## Tests
- `pnpm run typecheck`
- `pnpm exec vitest run tests/unit/destructive-gate.unit.test.ts tests/unit/destructive-elicitation.unit.test.ts tests/protocol/http.modern-protocol.test.ts`
- `pnpm run test:unit`
- `pnpm run test:protocol:modern`
- `pnpm run build`
- `pnpm run test:contract`
- `pnpm run check:package-budget`
- `pnpm run test:coverage`
- `pnpm run lint` (passes with existing warning in `src/oauth-resource-server.ts`)
- `pnpm run format:check`
- GitHub CI on `790d2e6`

## Follow-up Notes
- No follow-up required.
