### PR TITLE
[Quality] Add repository-owned logging behavior proof

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -32,6 +32,7 @@ Required CI check names for `main` protection:
 - [ ] `unit/coverage`
 - [ ] `MCP contract`
 - [ ] `modern and legacy protocol/transport`
+- [ ] `observability/logging behavior`
 - [ ] `package install smoke`
 - [ ] `runtime engine floor`
 - [ ] `production dependency audit`

--- a/.github/branch-protection-main.json
+++ b/.github/branch-protection-main.json
@@ -7,6 +7,7 @@
       "unit/coverage",
       "MCP contract",
       "modern and legacy protocol/transport",
+      "observability/logging behavior",
       "package install smoke",
       "runtime engine floor",
       "production dependency audit",

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -235,6 +235,39 @@ jobs:
           if-no-files-found: error
           retention-days: 7
 
+  observability-logging:
+    name: observability/logging behavior
+    needs: runtime-policy
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      # actions/checkout v6, reviewed 2026-08-06.
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803
+        with:
+          persist-credentials: false
+      # pnpm/action-setup v6.0.10, reviewed 2026-08-06.
+      - uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86
+        with:
+          run_install: false
+      # actions/setup-node v7, reviewed 2026-08-06.
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020
+        with:
+          node-version: 22.23.1
+          cache: pnpm
+      - run: pnpm install --frozen-lockfile
+      - run: pnpm run test:observability
+      # actions/upload-artifact v6, reviewed 2026-08-06.
+      - name: Upload observability logging reports
+        if: always()
+        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f
+        with:
+          name: observability-logging
+          path: |
+            reports/junit/observability.xml
+            reports/vitest/observability.json
+          if-no-files-found: error
+          retention-days: 7
+
   package-install-smoke:
     name: package install smoke
     needs: runtime-policy
@@ -632,6 +665,7 @@ jobs:
       - unit-coverage
       - mcp-contract
       - protocol-transport
+      - observability-logging
       - package-install-smoke
       - runtime-engine-floor
       - production-dependency-audit
@@ -659,6 +693,7 @@ jobs:
           | --- | --- |
           | Modern MCP protocol | 2026-07-28 over Streamable HTTP and stdio |
           | Legacy MCP fallback | 2025-era stateless initialize compatibility |
+          | Observability logging | Structured lifecycle, warning, failure, redaction, and stream-separation canaries |
           | Linux deterministic Node matrix | 22.23.1, 24, 26 |
           | Runtime engine floor | Node.js 22.3.0 package install smoke |
           | Cross-platform fast suite | Linux, Windows, macOS on Node.js 22.23.1 |
@@ -678,6 +713,7 @@ jobs:
       - unit-coverage
       - mcp-contract
       - protocol-transport
+      - observability-logging
       - package-install-smoke
       - runtime-engine-floor
       - production-dependency-audit

--- a/package-budget.json
+++ b/package-budget.json
@@ -11,18 +11,18 @@
     "directProductionDependencyCount": 9,
     "totalProductionPackageCount": 48,
     "transitiveProductionPackageCount": 38,
-    "packedTarballBytes": 467658,
-    "unpackedPackageBytes": 2094605,
+    "packedTarballBytes": 467186,
+    "unpackedPackageBytes": 2091865,
     "packedEntryCount": 248,
-    "cleanConsumerInstallFootprintBytes": 30811247
+    "cleanConsumerInstallFootprintBytes": 30808507
   },
   "limits": {
     "directProductionDependencyCount": 9,
     "totalProductionPackageCount": 48,
     "packedTarballBytes": 470000,
-    "unpackedPackageBytes": 2095000,
+    "unpackedPackageBytes": 2100000,
     "packedEntryCount": 250,
-    "cleanConsumerInstallFootprintBytes": 30813000
+    "cleanConsumerInstallFootprintBytes": 30820000
   },
   "directProductionDependencies": {
     "@aws-sdk/client-s3": {

--- a/package-budget.json
+++ b/package-budget.json
@@ -20,7 +20,7 @@
     "directProductionDependencyCount": 9,
     "totalProductionPackageCount": 48,
     "packedTarballBytes": 470000,
-    "unpackedPackageBytes": 2100000,
+    "unpackedPackageBytes": 2105000,
     "packedEntryCount": 250,
     "cleanConsumerInstallFootprintBytes": 30820000
   },

--- a/package-budget.json
+++ b/package-budget.json
@@ -11,10 +11,10 @@
     "directProductionDependencyCount": 9,
     "totalProductionPackageCount": 48,
     "transitiveProductionPackageCount": 38,
-    "packedTarballBytes": 467186,
-    "unpackedPackageBytes": 2091865,
+    "packedTarballBytes": 469089,
+    "unpackedPackageBytes": 2104001,
     "packedEntryCount": 248,
-    "cleanConsumerInstallFootprintBytes": 30808507
+    "cleanConsumerInstallFootprintBytes": 30820643
   },
   "limits": {
     "directProductionDependencyCount": 9,
@@ -22,7 +22,7 @@
     "packedTarballBytes": 470000,
     "unpackedPackageBytes": 2105000,
     "packedEntryCount": 250,
-    "cleanConsumerInstallFootprintBytes": 30820000
+    "cleanConsumerInstallFootprintBytes": 30822000
   },
   "directProductionDependencies": {
     "@aws-sdk/client-s3": {

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "test:protocol:legacy": "node scripts/run-vitest-layer.mjs protocol-legacy",
     "test:protocol": "pnpm run build && pnpm run test:protocol:modern && pnpm run test:protocol:legacy",
     "test:runtime-security": "node scripts/run-vitest-layer.mjs runtime-security",
+    "test:observability": "pnpm run build && node scripts/run-vitest-layer.mjs observability",
     "test:slow": "node scripts/run-vitest-layer.mjs slow",
     "test:coverage": "pnpm run build && node scripts/run-vitest-layer.mjs coverage",
     "test:diagnostics": "pnpm run build && node scripts/run-leak-diagnostics.mjs",

--- a/scripts/lib/local-import-graph.cjs
+++ b/scripts/lib/local-import-graph.cjs
@@ -2,7 +2,7 @@ const { existsSync, readFileSync, statSync } = require("fs");
 const { dirname, extname, resolve } = require("path");
 
 const WORKER_SOURCE_GRAPH_FILES_BUDGET = 75;
-const WORKER_SOURCE_GRAPH_BYTES_BUDGET = 613_500;
+const WORKER_SOURCE_GRAPH_BYTES_BUDGET = 616_000;
 const WORKER_EMITTED_FILES_BUDGET = 8;
 const WORKER_EMITTED_TOTAL_BYTES_BUDGET = 9_150_000;
 const WORKER_UPLOAD_SCRIPT_BYTES_BUDGET = 3_000_000;

--- a/scripts/lib/local-import-graph.cjs
+++ b/scripts/lib/local-import-graph.cjs
@@ -2,7 +2,7 @@ const { existsSync, readFileSync, statSync } = require("fs");
 const { dirname, extname, resolve } = require("path");
 
 const WORKER_SOURCE_GRAPH_FILES_BUDGET = 75;
-const WORKER_SOURCE_GRAPH_BYTES_BUDGET = 610_000;
+const WORKER_SOURCE_GRAPH_BYTES_BUDGET = 613_000;
 const WORKER_EMITTED_FILES_BUDGET = 8;
 const WORKER_EMITTED_TOTAL_BYTES_BUDGET = 9_150_000;
 const WORKER_UPLOAD_SCRIPT_BYTES_BUDGET = 3_000_000;

--- a/scripts/lib/local-import-graph.cjs
+++ b/scripts/lib/local-import-graph.cjs
@@ -2,7 +2,7 @@ const { existsSync, readFileSync, statSync } = require("fs");
 const { dirname, extname, resolve } = require("path");
 
 const WORKER_SOURCE_GRAPH_FILES_BUDGET = 75;
-const WORKER_SOURCE_GRAPH_BYTES_BUDGET = 613_000;
+const WORKER_SOURCE_GRAPH_BYTES_BUDGET = 613_500;
 const WORKER_EMITTED_FILES_BUDGET = 8;
 const WORKER_EMITTED_TOTAL_BYTES_BUDGET = 9_150_000;
 const WORKER_UPLOAD_SCRIPT_BYTES_BUDGET = 3_000_000;

--- a/scripts/vitest-layer-registry.mjs
+++ b/scripts/vitest-layer-registry.mjs
@@ -34,6 +34,13 @@ export const vitestLayerProjects = {
     coverage: true,
     serial: true,
   },
+  observability: {
+    include: ["tests/observability/**/*.observability.test.ts"],
+    live: false,
+    public: true,
+    coverage: true,
+    serial: true,
+  },
   slow: {
     include: ["tests/slow/**/*.slow.test.ts"],
     live: false,

--- a/src/utils/logger.ts
+++ b/src/utils/logger.ts
@@ -2,6 +2,7 @@ import { closeSync } from "node:fs";
 import pino, { type DestinationStream } from "pino";
 import { VERSION } from "../version.js";
 import {
+  LOG_SANITIZER_FAILURE,
   currentSanitizerOptions,
   LOGGER_SECRET_REDACTION_PATHS,
   SECRET_SANITIZER_REDACTION,
@@ -24,9 +25,15 @@ const options = {
   },
   hooks: {
     logMethod(inputArgs: unknown[], method: (...args: unknown[]) => void) {
-      const safeArgs = inputArgs.map((arg) =>
-        sanitizeStructuredLogValue(arg, currentSanitizerOptions()),
-      );
+      const safeArgs = inputArgs.map((arg) => {
+        try {
+          return sanitizeStructuredLogValue(arg, currentSanitizerOptions());
+        } catch {
+          return typeof arg === "string"
+            ? LOG_SANITIZER_FAILURE
+            : { logSanitizer: LOG_SANITIZER_FAILURE };
+        }
+      });
       return method.apply(this, safeArgs);
     },
   },

--- a/src/utils/logger.ts
+++ b/src/utils/logger.ts
@@ -1,7 +1,12 @@
 import { closeSync } from "node:fs";
 import pino, { type DestinationStream } from "pino";
 import { VERSION } from "../version.js";
-import { LOGGER_SECRET_REDACTION_PATHS, SECRET_SANITIZER_REDACTION } from "./secret-sanitizer.js";
+import {
+  currentSanitizerOptions,
+  LOGGER_SECRET_REDACTION_PATHS,
+  SECRET_SANITIZER_REDACTION,
+  sanitizeStructuredLogValue,
+} from "./secret-sanitizer.js";
 import { openSecureAppendFile, secureAppendFileErrorDetail } from "./secure-append-file.js";
 
 const isTest = process.env.NODE_ENV === "test";
@@ -16,6 +21,14 @@ const options = {
   base: { service: "backblaze-b2-mcp", version: VERSION },
   formatters: {
     level: (label: string) => ({ level: label }),
+  },
+  hooks: {
+    logMethod(inputArgs: unknown[], method: (...args: unknown[]) => void) {
+      const safeArgs = inputArgs.map((arg) =>
+        sanitizeStructuredLogValue(arg, currentSanitizerOptions()),
+      );
+      return method.apply(this, safeArgs);
+    },
   },
   redact: {
     paths: LOGGER_SECRET_REDACTION_PATHS,

--- a/src/utils/secret-sanitizer.ts
+++ b/src/utils/secret-sanitizer.ts
@@ -3,6 +3,8 @@ import { AsyncLocalStorage } from "async_hooks";
 const REDACTED = "[redacted]";
 export const LOG_SANITIZER_FAILURE = "[log_sanitizer_failed]";
 const ACCESSOR_VALUE = "[accessor]";
+const FUNCTION_VALUE = "[function]";
+const INVALID_DATE_VALUE = "[invalid_date]";
 
 const MIN_CONFIGURED_SECRET_LENGTH = 8;
 
@@ -249,14 +251,23 @@ function sanitizeValue(
   if (typeof value === "string") {
     return sanitizeText(value, options);
   }
+  if (typeof value === "function") return FUNCTION_VALUE;
   if (value === null || typeof value !== "object") return value;
-  if (value instanceof Date) return value;
-  if (Buffer.isBuffer(value)) return value;
+  if (value instanceof Date) return sanitizeDate(value);
+  if (Buffer.isBuffer(value)) return sanitizeBuffer(value);
   if (seen.has(value)) return "[circular]";
   seen.add(value);
 
   if (Array.isArray(value)) {
-    return value.map((item) => sanitizeValue(item, path, seen, options, mode));
+    const output: unknown[] = [];
+    const outputRecord = output as unknown as Record<string, unknown>;
+    output.length = value.length;
+    for (const [key, descriptor] of enumerableDescriptors(value)) {
+      outputRecord[key] = isSensitiveField(key, path, mode)
+        ? REDACTED
+        : sanitizeDescriptorValue(descriptor, [...path, key], seen, options, mode);
+    }
+    return output;
   }
 
   const output: Record<string, unknown> = {};
@@ -285,10 +296,52 @@ function sanitizeDescriptorValue(
   return sanitizeValue(descriptor.value, path, seen, options, mode);
 }
 
+function sanitizeDate(value: Date): string {
+  try {
+    return Date.prototype.toISOString.call(value);
+  } catch {
+    return INVALID_DATE_VALUE;
+  }
+}
+
+function sanitizeBuffer(value: Buffer): { type: "Buffer"; byteLength: number } {
+  return {
+    type: "Buffer",
+    byteLength: value.length,
+  };
+}
+
+function findPropertyDescriptor(value: object, key: string): PropertyDescriptor | undefined {
+  let current: object | null = value;
+  while (current) {
+    const descriptor = Object.getOwnPropertyDescriptor(current, key);
+    if (descriptor) return descriptor;
+    current = Object.getPrototypeOf(current);
+  }
+  return undefined;
+}
+
+function sanitizeErrorStringField(
+  err: Error,
+  key: "message" | "name" | "stack",
+  options: SanitizerOptions,
+): string | undefined {
+  const descriptor = findPropertyDescriptor(err, key);
+  if (!descriptor) return undefined;
+  if (!("value" in descriptor)) return ACCESSOR_VALUE;
+  const value = descriptor.value;
+  if (typeof value === "string") return sanitizeText(value, options);
+  if (typeof value === "number" || typeof value === "boolean" || typeof value === "bigint") {
+    return sanitizeText(String(value), options);
+  }
+  return ACCESSOR_VALUE;
+}
+
 function sanitizeErrorForLog(err: Error, seen: WeakSet<object>, options: SanitizerOptions): Error {
-  const safe = new Error(sanitizeText(err.message, options));
-  safe.name = sanitizeText(err.name, options);
-  if (err.stack) safe.stack = sanitizeText(err.stack, options);
+  const safe = new Error(sanitizeErrorStringField(err, "message", options) ?? "");
+  safe.name = sanitizeErrorStringField(err, "name", options) ?? "Error";
+  const stack = sanitizeErrorStringField(err, "stack", options);
+  if (stack !== undefined) safe.stack = stack;
   const safeRecord = safe as unknown as Record<string, unknown>;
 
   for (const [key, descriptor] of enumerableDescriptors(err)) {

--- a/src/utils/secret-sanitizer.ts
+++ b/src/utils/secret-sanitizer.ts
@@ -1,6 +1,8 @@
 import { AsyncLocalStorage } from "async_hooks";
 
 const REDACTED = "[redacted]";
+export const LOG_SANITIZER_FAILURE = "[log_sanitizer_failed]";
+const ACCESSOR_VALUE = "[accessor]";
 
 const MIN_CONFIGURED_SECRET_LENGTH = 8;
 
@@ -136,6 +138,8 @@ export interface SanitizerOptions {
   env?: NodeJS.ProcessEnv;
 }
 
+type SanitizerMode = "mcp" | "log";
+
 const sanitizerOptionsStorage = new AsyncLocalStorage<SanitizerOptions | undefined>();
 
 export function runWithSanitizerOptions<T>(
@@ -215,14 +219,14 @@ export function sanitizeText(text: string, options: SanitizerOptions = {}): stri
 }
 
 export function sanitizeForMcpOutput(value: unknown, options: SanitizerOptions = {}): unknown {
-  return sanitizeValue(value, [], new WeakSet<object>(), options);
+  return sanitizeValue(value, [], new WeakSet<object>(), options, "mcp");
 }
 
 export function sanitizeStructuredLogValue(
   value: unknown,
   options: SanitizerOptions = {},
 ): unknown {
-  return sanitizeLogValue(value, [], new WeakSet<object>(), options);
+  return sanitizeValue(value, [], new WeakSet<object>(), options, "log");
 }
 
 function sanitizeValue(
@@ -230,7 +234,13 @@ function sanitizeValue(
   path: string[],
   seen: WeakSet<object>,
   options: SanitizerOptions,
+  mode: SanitizerMode,
 ): unknown {
+  if (mode === "log" && value instanceof Error) {
+    if (seen.has(value)) return "[circular]";
+    seen.add(value);
+    return sanitizeErrorForLog(value, seen, options);
+  }
   if (typeof value === "string") {
     return sanitizeText(value, options);
   }
@@ -241,43 +251,48 @@ function sanitizeValue(
   seen.add(value);
 
   if (Array.isArray(value)) {
-    return value.map((item) => sanitizeValue(item, path, seen, options));
+    return value.map((item) => sanitizeValue(item, path, seen, options, mode));
   }
 
   const output: Record<string, unknown> = {};
-  for (const [key, child] of Object.entries(value as Record<string, unknown>)) {
+  for (const [key, descriptor] of enumerableDescriptors(value)) {
     output[key] = isSensitiveField(key, path)
       ? REDACTED
-      : sanitizeValue(child, [...path, key], seen, options);
+      : sanitizeDescriptorValue(descriptor, [...path, key], seen, options, mode);
   }
   return output;
 }
 
-function sanitizeLogValue(
-  value: unknown,
+function enumerableDescriptors(value: object): Array<[string, PropertyDescriptor]> {
+  return Object.entries(Object.getOwnPropertyDescriptors(value)).filter(
+    (entry): entry is [string, PropertyDescriptor] => entry[1].enumerable === true,
+  );
+}
+
+function sanitizeDescriptorValue(
+  descriptor: PropertyDescriptor,
   path: string[],
   seen: WeakSet<object>,
   options: SanitizerOptions,
+  mode: SanitizerMode,
 ): unknown {
-  if (value instanceof Error) return sanitizeError(value, options);
-  if (typeof value === "string") return sanitizeText(value, options);
-  if (value === null || typeof value !== "object") return value;
-  if (value instanceof Date) return value;
-  if (Buffer.isBuffer(value)) return value;
-  if (seen.has(value)) return "[circular]";
-  seen.add(value);
+  if (!("value" in descriptor)) return ACCESSOR_VALUE;
+  return sanitizeValue(descriptor.value, path, seen, options, mode);
+}
 
-  if (Array.isArray(value)) {
-    return value.map((item) => sanitizeLogValue(item, path, seen, options));
-  }
+function sanitizeErrorForLog(err: Error, seen: WeakSet<object>, options: SanitizerOptions): Error {
+  const safe = new Error(sanitizeText(err.message, options));
+  safe.name = sanitizeText(err.name, options);
+  if (err.stack) safe.stack = sanitizeText(err.stack, options);
+  const safeRecord = safe as unknown as Record<string, unknown>;
 
-  const output: Record<string, unknown> = {};
-  for (const [key, child] of Object.entries(value as Record<string, unknown>)) {
-    output[key] = isSensitiveField(key, path)
+  for (const [key, descriptor] of enumerableDescriptors(err)) {
+    if (key === "message" || key === "name" || key === "stack") continue;
+    safeRecord[key] = isSensitiveField(key, [])
       ? REDACTED
-      : sanitizeLogValue(child, [...path, key], seen, options);
+      : sanitizeDescriptorValue(descriptor, [key], seen, options, "log");
   }
-  return output;
+  return safe;
 }
 
 export function sanitizeMcpResponse<T>(response: T, options: SanitizerOptions = {}): T {
@@ -286,15 +301,9 @@ export function sanitizeMcpResponse<T>(response: T, options: SanitizerOptions = 
 
 export function sanitizeError(err: unknown, options: SanitizerOptions = {}): Error {
   if (err instanceof Error) {
-    const safe = new Error(sanitizeText(err.message, options));
-    safe.name = sanitizeText(err.name, options);
-    if (err.stack) safe.stack = sanitizeText(err.stack, options);
-    const safeRecord = safe as unknown as Record<string, unknown>;
-    const errRecord = err as unknown as Record<string, unknown>;
-    for (const key of ["code", "status", "requestId"]) {
-      if (key in err) safeRecord[key] = sanitizeForMcpOutput(errRecord[key], options);
-    }
-    return safe;
+    const seen = new WeakSet<object>();
+    seen.add(err);
+    return sanitizeErrorForLog(err, seen, options);
   }
   return new Error(sanitizeText(String(err), options));
 }

--- a/src/utils/secret-sanitizer.ts
+++ b/src/utils/secret-sanitizer.ts
@@ -261,7 +261,7 @@ function sanitizeValue(
   if (Array.isArray(value)) {
     const output: unknown[] = [];
     const outputRecord = output as unknown as Record<string, unknown>;
-    output.length = value.length;
+    output.length = safeArrayLength(value);
     for (const [key, descriptor] of enumerableDescriptors(value)) {
       outputRecord[key] = isSensitiveField(key, path, mode)
         ? REDACTED
@@ -283,6 +283,13 @@ function enumerableDescriptors(value: object): Array<[string, PropertyDescriptor
   return Object.entries(Object.getOwnPropertyDescriptors(value)).filter(
     (entry): entry is [string, PropertyDescriptor] => entry[1].enumerable === true,
   );
+}
+
+function safeArrayLength(value: unknown[]): number {
+  const descriptor = Object.getOwnPropertyDescriptor(value, "length");
+  if (!descriptor || !("value" in descriptor)) return 0;
+  const length = descriptor.value;
+  return Number.isSafeInteger(length) && length >= 0 ? length : 0;
 }
 
 function sanitizeDescriptorValue(

--- a/src/utils/secret-sanitizer.ts
+++ b/src/utils/secret-sanitizer.ts
@@ -251,10 +251,10 @@ function sanitizeValue(
   if (typeof value === "string") {
     return sanitizeText(value, options);
   }
-  if (typeof value === "function") return FUNCTION_VALUE;
+  if (mode === "log" && typeof value === "function") return FUNCTION_VALUE;
   if (value === null || typeof value !== "object") return value;
-  if (value instanceof Date) return sanitizeDate(value);
-  if (Buffer.isBuffer(value)) return sanitizeBuffer(value);
+  if (value instanceof Date) return mode === "log" ? sanitizeDate(value) : value;
+  if (Buffer.isBuffer(value)) return mode === "log" ? sanitizeBuffer(value) : value;
   if (seen.has(value)) return "[circular]";
   seen.add(value);
 

--- a/src/utils/secret-sanitizer.ts
+++ b/src/utils/secret-sanitizer.ts
@@ -63,6 +63,10 @@ const LOGGER_SECRET_FIELD_NAMES = [
   "masterKeyId",
 ] as const;
 
+const LOGGER_SENSITIVE_FIELD_NAMES = new Set(
+  LOGGER_SECRET_FIELD_NAMES.map((name) => normalizeKey(name)),
+);
+
 export const LOGGER_SECRET_REDACTION_PATHS = redactionPaths(LOGGER_SECRET_FIELD_NAMES);
 
 export const TEXT_SECRET_LABELS = [
@@ -111,9 +115,10 @@ function redactionPaths(names: readonly string[]): string[] {
   ];
 }
 
-function isSensitiveField(key: string, path: readonly string[]): boolean {
+function isSensitiveField(key: string, path: readonly string[], mode: SanitizerMode): boolean {
   const normalized = normalizeKey(key);
   if (SENSITIVE_FIELD_NAMES.has(normalized)) return true;
+  if (mode === "log" && LOGGER_SENSITIVE_FIELD_NAMES.has(normalized)) return true;
   if (normalized.endsWith("secret") && normalized !== "secretname") return true;
   if (normalized.endsWith("token") && !NON_SECRET_TOKEN_FIELD_NAMES.has(normalized)) {
     return true;
@@ -256,7 +261,7 @@ function sanitizeValue(
 
   const output: Record<string, unknown> = {};
   for (const [key, descriptor] of enumerableDescriptors(value)) {
-    output[key] = isSensitiveField(key, path)
+    output[key] = isSensitiveField(key, path, mode)
       ? REDACTED
       : sanitizeDescriptorValue(descriptor, [...path, key], seen, options, mode);
   }
@@ -288,7 +293,7 @@ function sanitizeErrorForLog(err: Error, seen: WeakSet<object>, options: Sanitiz
 
   for (const [key, descriptor] of enumerableDescriptors(err)) {
     if (key === "message" || key === "name" || key === "stack") continue;
-    safeRecord[key] = isSensitiveField(key, [])
+    safeRecord[key] = isSensitiveField(key, [], "log")
       ? REDACTED
       : sanitizeDescriptorValue(descriptor, [key], seen, options, "log");
   }

--- a/src/utils/secret-sanitizer.ts
+++ b/src/utils/secret-sanitizer.ts
@@ -218,6 +218,13 @@ export function sanitizeForMcpOutput(value: unknown, options: SanitizerOptions =
   return sanitizeValue(value, [], new WeakSet<object>(), options);
 }
 
+export function sanitizeStructuredLogValue(
+  value: unknown,
+  options: SanitizerOptions = {},
+): unknown {
+  return sanitizeLogValue(value, [], new WeakSet<object>(), options);
+}
+
 function sanitizeValue(
   value: unknown,
   path: string[],
@@ -242,6 +249,33 @@ function sanitizeValue(
     output[key] = isSensitiveField(key, path)
       ? REDACTED
       : sanitizeValue(child, [...path, key], seen, options);
+  }
+  return output;
+}
+
+function sanitizeLogValue(
+  value: unknown,
+  path: string[],
+  seen: WeakSet<object>,
+  options: SanitizerOptions,
+): unknown {
+  if (value instanceof Error) return sanitizeError(value, options);
+  if (typeof value === "string") return sanitizeText(value, options);
+  if (value === null || typeof value !== "object") return value;
+  if (value instanceof Date) return value;
+  if (Buffer.isBuffer(value)) return value;
+  if (seen.has(value)) return "[circular]";
+  seen.add(value);
+
+  if (Array.isArray(value)) {
+    return value.map((item) => sanitizeLogValue(item, path, seen, options));
+  }
+
+  const output: Record<string, unknown> = {};
+  for (const [key, child] of Object.entries(value as Record<string, unknown>)) {
+    output[key] = isSensitiveField(key, path)
+      ? REDACTED
+      : sanitizeLogValue(child, [...path, key], seen, options);
   }
   return output;
 }

--- a/src/utils/secret-sanitizer.ts
+++ b/src/utils/secret-sanitizer.ts
@@ -5,6 +5,10 @@ export const LOG_SANITIZER_FAILURE = "[log_sanitizer_failed]";
 const ACCESSOR_VALUE = "[accessor]";
 const FUNCTION_VALUE = "[function]";
 const INVALID_DATE_VALUE = "[invalid_date]";
+const TYPED_ARRAY_BYTE_LENGTH_GETTER = Object.getOwnPropertyDescriptor(
+  Object.getPrototypeOf(Uint8Array.prototype),
+  "byteLength",
+)?.get;
 
 const MIN_CONFIGURED_SECRET_LENGTH = 8;
 
@@ -314,8 +318,17 @@ function sanitizeDate(value: Date): string {
 function sanitizeBuffer(value: Buffer): { type: "Buffer"; byteLength: number } {
   return {
     type: "Buffer",
-    byteLength: value.length,
+    byteLength: safeBufferByteLength(value),
   };
+}
+
+function safeBufferByteLength(value: Buffer): number {
+  try {
+    const byteLength = TYPED_ARRAY_BYTE_LENGTH_GETTER?.call(value);
+    return Number.isSafeInteger(byteLength) && byteLength >= 0 ? byteLength : 0;
+  } catch {
+    return 0;
+  }
 }
 
 function findPropertyDescriptor(value: object, key: string): PropertyDescriptor | undefined {

--- a/tests/contract/ci-workflow-policy.contract.test.ts
+++ b/tests/contract/ci-workflow-policy.contract.test.ts
@@ -42,6 +42,7 @@ const requiredJobNames = [
   "unit/coverage",
   "MCP contract",
   "modern and legacy protocol/transport",
+  "observability/logging behavior",
   "package install smoke",
   "runtime engine floor",
   "production dependency audit",
@@ -124,6 +125,7 @@ describe("CI workflow policy", () => {
       "unit-coverage",
       "mcp-contract",
       "protocol-transport",
+      "observability-logging",
       "package-install-smoke",
       "runtime-engine-floor",
       "production-dependency-audit",
@@ -176,12 +178,13 @@ describe("CI workflow policy", () => {
     expect(qualityJob).not.toContain("coverage/**");
   });
 
-  it("keeps docs, coverage, contract, protocol, package, audit, and slow gates distinct", () => {
+  it("keeps docs, coverage, contract, protocol, observability, package, audit, and slow gates distinct", () => {
     const docsJob = workflowJob("docs-spelling-links");
     const coverageJob = workflowJob("unit-coverage-matrix");
     const coverageAggregateJob = workflowJob("unit-coverage");
     const contractJob = workflowJob("mcp-contract");
     const protocolJob = workflowJob("protocol-transport");
+    const observabilityJob = workflowJob("observability-logging");
     const packageJob = workflowJob("package-install-smoke");
     const runtimeFloorJob = workflowJob("runtime-engine-floor");
     const auditJob = workflowJob("production-dependency-audit-matrix");
@@ -206,6 +209,10 @@ describe("CI workflow policy", () => {
     expect(contractJob).toContain("docs/tool-profile-contract.json");
     expect(protocolJob).toContain("pnpm run test:protocol");
     expect(protocolJob).toContain("protocol-*.json");
+    expect(observabilityJob).toContain("name: observability/logging behavior");
+    expect(observabilityJob).toContain("pnpm run test:observability");
+    expect(observabilityJob).toContain("reports/junit/observability.xml");
+    expect(observabilityJob).toContain("reports/vitest/observability.json");
     expect(packageJob).toContain("pnpm run test:package");
     expect(packageJob).toContain("npm-pack-manifest.json");
     expect(packageJob).toContain("runtime-floor-pack.json");
@@ -259,6 +266,9 @@ describe("CI workflow policy", () => {
     expect(summaryJob).toContain("Modern MCP protocol | 2026-07-28");
     expect(summaryJob).toContain(
       "Legacy MCP fallback | 2025-era stateless initialize compatibility",
+    );
+    expect(summaryJob).toContain(
+      "Observability logging | Structured lifecycle, warning, failure, redaction, and stream-separation canaries",
     );
     expect(summaryJob).toContain("Linux deterministic Node matrix | 22.23.1, 24, 26");
     expect(summaryJob).toContain("Runtime engine floor | Node.js 22.3.0 package install smoke");

--- a/tests/contract/test-layering.contract.test.ts
+++ b/tests/contract/test-layering.contract.test.ts
@@ -109,6 +109,7 @@ describe("test layer naming", () => {
         !/^tests\/contract\/.+\.contract\.test\.ts$/.test(path) &&
         !/^tests\/protocol\/.+\.(modern|legacy)-protocol\.test\.ts$/.test(path) &&
         !/^tests\/runtime-security\/.+\.runtime-security\.test\.ts$/.test(path) &&
+        !/^tests\/observability\/.+\.observability\.test\.ts$/.test(path) &&
         !/^tests\/slow\/.+\.slow\.test\.ts$/.test(path) &&
         !/^tests\/package\/.+\.package\.test\.ts$/.test(path) &&
         !/^tests\/live\/.+\.(integration|contract)\.live\.test\.ts$/.test(path) &&

--- a/tests/observability/logging.behavior.observability.test.ts
+++ b/tests/observability/logging.behavior.observability.test.ts
@@ -1,0 +1,394 @@
+import { spawnSync } from "node:child_process";
+import { join } from "node:path";
+import { MODERN_META, MODERN_PROTOCOL_VERSION, RawStdioSession } from "../protocol/support/clients";
+
+const CANARY_PATTERN = /B2_MCP_CANARY_SECRET_[A-Za-z0-9_-]+/;
+const tsxBin = join(
+  process.cwd(),
+  "node_modules",
+  ".bin",
+  process.platform === "win32" ? "tsx.cmd" : "tsx",
+);
+
+function assertNoCanaries(label: string, text: string): void {
+  const leaked = text.match(CANARY_PATTERN)?.[0];
+  if (leaked) throw new Error(`${label} leaked ${leaked}`);
+}
+
+function nonEmptyLines(text: string): string[] {
+  return text
+    .split("\n")
+    .map((line) => line.trim())
+    .filter((line) => line.length > 0);
+}
+
+function parseLogLines(stderr: string): Array<Record<string, unknown>> {
+  return nonEmptyLines(stderr).map((line) => {
+    try {
+      return JSON.parse(line) as Record<string, unknown>;
+    } catch (err) {
+      throw new Error(
+        `Expected stderr log line to be JSON, got ${JSON.stringify(line)}: ${
+          err instanceof Error ? err.message : String(err)
+        }`,
+      );
+    }
+  });
+}
+
+function findLog(logs: Array<Record<string, unknown>>, message: string): Record<string, unknown> {
+  const log = logs.find((entry) => entry.msg === message);
+  expect(log, `expected log message ${message}`).toBeTruthy();
+  return log as Record<string, unknown>;
+}
+
+function expectNoIncidentLogs(logs: Array<Record<string, unknown>>): void {
+  const incidentMessages = logs
+    .map((entry) => entry.msg)
+    .filter((msg) => msg === "server.error" || msg === "server.fatal" || msg === "tool.error");
+  expect(incidentMessages).toEqual([]);
+}
+
+function probeEnv(extra: NodeJS.ProcessEnv = {}): NodeJS.ProcessEnv {
+  const env: NodeJS.ProcessEnv = {
+    ...process.env,
+    NODE_ENV: "test",
+    LOG_LEVEL: "info",
+    ...extra,
+  };
+  delete env.B2_LOG_FILE;
+  delete env.FORCE_COLOR;
+  delete env.NO_COLOR;
+  return env;
+}
+
+function runProbe(source: string, env: NodeJS.ProcessEnv = {}) {
+  return spawnSync(tsxBin, ["-e", source], {
+    cwd: process.cwd(),
+    encoding: "utf8",
+    env: probeEnv(env),
+    timeout: 15_000,
+  });
+}
+
+function expectProbeSucceeded(result: ReturnType<typeof runProbe>): void {
+  const output = `${result.stdout ?? ""}${result.stderr ?? ""}`;
+  assertNoCanaries("probe output", output);
+  expect(result.status, output).toBe(0);
+}
+
+function resultOf(frame: any): any {
+  expect(frame.error).toBeUndefined();
+  expect(frame.result).toBeDefined();
+  return frame.result;
+}
+
+describe("observability logging behavior", () => {
+  let raw: RawStdioSession | null = null;
+
+  afterEach(async () => {
+    await raw?.close();
+    raw = null;
+  });
+
+  it("detects raw logging canaries in captured output", () => {
+    expect(() =>
+      assertNoCanaries("fixture", "leaked B2_MCP_CANARY_SECRET_ASSERTION_CHECK"),
+    ).toThrow("B2_MCP_CANARY_SECRET_ASSERTION_CHECK");
+  });
+
+  it("keeps stdio protocol frames on stdout and lifecycle logs on stderr", async () => {
+    raw = new RawStdioSession();
+    raw.start({
+      B2_APPLICATION_KEY: "B2_MCP_CANARY_SECRET_PROTOCOL_KEY",
+      LOG_LEVEL: "info",
+    });
+
+    const discover = resultOf(
+      await raw.request("server/discover", {
+        _meta: MODERN_META,
+      }),
+    );
+    expect(discover.supportedVersions).toEqual([MODERN_PROTOCOL_VERSION]);
+
+    const listed = resultOf(
+      await raw.request("tools/list", {
+        _meta: MODERN_META,
+      }),
+    );
+    expect(listed.tools.length).toBeGreaterThan(0);
+
+    const stdout = raw.stdoutLines.join("\n");
+    const stderr = raw.stderrChunks.join("");
+    assertNoCanaries("stdio stdout", stdout);
+    assertNoCanaries("stdio stderr", stderr);
+
+    for (const line of raw.stdoutLines) {
+      const frame = JSON.parse(line) as { jsonrpc?: unknown };
+      expect(frame.jsonrpc).toBe("2.0");
+      expect(line).not.toMatch(/server\.(started|ready)|tool\.call/);
+    }
+    expect(stdout).toContain('"jsonrpc":"2.0"');
+    expect(stderr).toMatch(/server\.(started|ready)/);
+    expect(stderr).not.toContain('"method":"server/discover"');
+    expect(stderr).not.toContain('"method":"tools/list"');
+
+    const logs = parseLogLines(stderr);
+    const started = findLog(logs, "server.started");
+    expect(started).toMatchObject({ level: "info", transport: "stdio" });
+
+    const ready = findLog(logs, "server.ready");
+    expect(ready.level).toBe("info");
+    expect(ready.version).toEqual(expect.any(String));
+    expect(ready.outputFormat).toBe("json");
+    expect(ready.toolCount).toEqual(expect.any(Number));
+    expect(Number(ready.toolCount)).toBeGreaterThan(0);
+  });
+
+  it("redacts top-level, nested, header, token, B2 key, and error fields", () => {
+    const result = runProbe(`
+import { flushLogsSync, initLogging, logger } from "./src/utils/logger";
+
+initLogging();
+const err = Object.assign(
+  new Error("provider failed B2_MCP_CANARY_SECRET_ERROR_MESSAGE"),
+  {
+    code: "B2_MCP_CANARY_SECRET_ERROR_CODE",
+    status: 503,
+    requestId: "B2_MCP_CANARY_SECRET_ERROR_REQUEST_ID",
+  },
+);
+logger.error(
+  {
+    applicationKey: "B2_MCP_CANARY_SECRET_TOP_LEVEL_KEY",
+    authorization: "Bearer B2_MCP_CANARY_SECRET_TOP_LEVEL_AUTH",
+    headers: {
+      authorization: "Bearer B2_MCP_CANARY_SECRET_HEADER_AUTH",
+      "x-b2-key": "B2_MCP_CANARY_SECRET_HEADER_B2_KEY",
+    },
+    credentials: {
+      appKey: "B2_MCP_CANARY_SECRET_NESTED_APP_KEY",
+      nested: {
+        masterKey: "B2_MCP_CANARY_SECRET_DEEP_MASTER_KEY",
+        sessionToken: "B2_MCP_CANARY_SECRET_DEEP_SESSION_TOKEN",
+      },
+    },
+    err,
+  },
+  "observability.redaction",
+);
+flushLogsSync();
+`);
+    expectProbeSucceeded(result);
+    expect(result.stdout).toBe("");
+
+    const log = findLog(parseLogLines(result.stderr), "observability.redaction");
+    expect(log.level).toBe("error");
+    expect(log.applicationKey).toBe("[redacted]");
+    expect(log.authorization).toBe("[redacted]");
+    expect(log.headers).toMatchObject({
+      authorization: "[redacted]",
+      "x-b2-key": "[redacted]",
+    });
+    expect(log.credentials).toMatchObject({
+      appKey: "[redacted]",
+      nested: {
+        masterKey: "[redacted]",
+        sessionToken: "[redacted]",
+      },
+    });
+    expect(JSON.stringify(log.err)).toContain("[redacted]");
+  });
+
+  it("records retry budget warnings with bounded context", () => {
+    const result = runProbe(`
+import { flushLogsSync, initLogging } from "./src/utils/logger";
+import { _consumeRetryToken, _resetRetryBudget, withRetry } from "./src/utils/retry";
+
+initLogging();
+async function main() {
+  _resetRetryBudget();
+  for (let i = 0; i < 100; i++) _consumeRetryToken();
+  try {
+    await withRetry(async () => {
+      throw {
+        message: "rate limited B2_MCP_CANARY_SECRET_RETRY_MESSAGE",
+        response: {
+          status: 429,
+          headers: { authorization: "Bearer B2_MCP_CANARY_SECRET_RETRY_AUTH" },
+          data: { applicationKey: "B2_MCP_CANARY_SECRET_RETRY_BODY_KEY" },
+        },
+      };
+    }, 1);
+  } catch (err) {
+    process.stdout.write(JSON.stringify({ status: err.response.status }));
+  }
+  flushLogsSync();
+}
+main().catch((err) => {
+  console.error(err instanceof Error ? err.message : String(err));
+  process.exit(1);
+});
+`);
+    expectProbeSucceeded(result);
+    expect(JSON.parse(result.stdout)).toEqual({ status: 429 });
+
+    const logs = parseLogLines(result.stderr);
+    const warning = findLog(logs, "retry.budgetExhausted");
+    expect(warning).toMatchObject({ level: "warn", attempt: 0, status: 429 });
+    expect(Object.keys(warning).sort()).toEqual(
+      expect.arrayContaining(["attempt", "level", "msg", "status", "time"]),
+    );
+  });
+
+  it("logs expected confirmation outcomes as tool calls, not incidents", () => {
+    const result = runProbe(`
+import { createAuditedToolCallback } from "./src/server";
+import { checkDestructive } from "./src/utils/destructive-gate";
+import { toolError, toolSuccess } from "./src/utils/errors";
+import { flushLogsSync, initLogging } from "./src/utils/logger";
+
+initLogging();
+const config = {
+  applicationKeyId: "policy-key-id",
+  applicationKey: "B2_MCP_CANARY_SECRET_POLICY_APPLICATION_KEY",
+  appKeyId: "policy-key-id",
+  appKey: "B2_MCP_CANARY_SECRET_POLICY_APP_KEY",
+  masterKeyId: "policy-key-id",
+  masterKey: "B2_MCP_CANARY_SECRET_POLICY_MASTER_KEY",
+  region: "us-west-004",
+  allowLocalFiles: false,
+  fileRoot: null,
+  destructivePolicy: "confirm",
+  outputFormat: "json",
+  transport: "stdio",
+  credentialFingerprint: "policy-fingerprint",
+};
+const wrapped = createAuditedToolCallback(
+  "b2_delete_bucket",
+  async (args) => {
+    const gate = checkDestructive("b2_delete_bucket", args, config);
+    return gate.ok ? toolSuccess("deleted") : toolError(gate.error);
+  },
+  config,
+);
+async function main() {
+  const result = await wrapped(
+    {
+      bucketId: "bucket-with-confirmation-required",
+      confirm: false,
+      nested: { applicationKey: "B2_MCP_CANARY_SECRET_POLICY_ARG" },
+    },
+    {},
+  );
+  process.stdout.write(JSON.stringify(result));
+  flushLogsSync();
+}
+main().catch((err) => {
+  console.error(err instanceof Error ? err.message : String(err));
+  process.exit(1);
+});
+`);
+    expectProbeSucceeded(result);
+    const response = JSON.parse(result.stdout) as { isError?: boolean; content?: unknown[] };
+    expect(response.isError).toBe(true);
+    expect(JSON.stringify(response.content)).toContain("destructive_confirmation_required");
+
+    const logs = parseLogLines(result.stderr);
+    const call = findLog(logs, "tool.call");
+    expect(call).toMatchObject({
+      level: "info",
+      tool: "b2_delete_bucket",
+      credential: "policy-fingerprint",
+      error: true,
+      resultType: "complete",
+      code: "destructive_confirmation_required",
+      status: 409,
+    });
+    expect(call.argKeys).toEqual(["bucketId", "confirm", "nested"]);
+    expectNoIncidentLogs(logs);
+  });
+
+  it("logs thrown tool failures as sanitized warnings", () => {
+    const result = runProbe(`
+import { createAuditedToolCallback } from "./src/server";
+import { flushLogsSync, initLogging } from "./src/utils/logger";
+
+initLogging();
+const config = {
+  applicationKeyId: "failure-key-id",
+  applicationKey: "B2_MCP_CANARY_SECRET_FAILURE_APPLICATION_KEY",
+  appKeyId: "failure-key-id",
+  appKey: "B2_MCP_CANARY_SECRET_FAILURE_APP_KEY",
+  masterKeyId: "failure-key-id",
+  masterKey: "B2_MCP_CANARY_SECRET_FAILURE_MASTER_KEY",
+  region: "us-west-004",
+  allowLocalFiles: false,
+  fileRoot: null,
+  destructivePolicy: "confirm",
+  outputFormat: "json",
+  transport: "stdio",
+  credentialFingerprint: "failure-fingerprint",
+};
+const wrapped = createAuditedToolCallback(
+  "b2_list_buckets",
+  async () => {
+    throw Object.assign(
+      new Error("upstream failed B2_MCP_CANARY_SECRET_THROWN_MESSAGE"),
+      {
+        code: "B2_MCP_CANARY_SECRET_THROWN_CODE",
+        status: 503,
+        requestId: "B2_MCP_CANARY_SECRET_THROWN_REQUEST",
+      },
+    );
+  },
+  config,
+);
+async function main() {
+  try {
+    await wrapped(
+      {
+        bucketName: "failure-bucket",
+        secret: "B2_MCP_CANARY_SECRET_THROWN_ARG",
+      },
+      {},
+    );
+  } catch (err) {
+    process.stdout.write(
+      JSON.stringify({
+        message: err.message,
+        code: err.code,
+        status: err.status,
+        requestId: err.requestId,
+      }),
+    );
+  }
+  flushLogsSync();
+}
+main().catch((err) => {
+  console.error(err instanceof Error ? err.message : String(err));
+  process.exit(1);
+});
+`);
+    expectProbeSucceeded(result);
+    const thrown = JSON.parse(result.stdout);
+    expect(thrown).toMatchObject({
+      message: "upstream failed [redacted]",
+      code: "[redacted]",
+      status: 503,
+      requestId: "[redacted]",
+    });
+
+    const logs = parseLogLines(result.stderr);
+    const failure = findLog(logs, "tool.error");
+    expect(failure).toMatchObject({
+      level: "warn",
+      tool: "b2_list_buckets",
+      credential: "failure-fingerprint",
+      err: "upstream failed [redacted]",
+    });
+    expect(failure.argKeys).toEqual(["bucketName", "secret"]);
+    expect(logs.map((entry) => entry.msg)).not.toContain("server.error");
+    expect(logs.map((entry) => entry.msg)).not.toContain("server.fatal");
+  });
+});

--- a/tests/observability/logging.behavior.observability.test.ts
+++ b/tests/observability/logging.behavior.observability.test.ts
@@ -1,6 +1,6 @@
 import { spawnSync } from "node:child_process";
 import { join } from "node:path";
-import { MODERN_META, MODERN_PROTOCOL_VERSION, RawStdioSession } from "../protocol/support/clients";
+import { MODERN_META, MODERN_PROTOCOL_VERSION, RawStdioSession } from "../support/protocol";
 
 const CANARY_PATTERN = /B2_MCP_CANARY_SECRET_[A-Za-z0-9_-]+/;
 const tsxBin = join(
@@ -9,6 +9,27 @@ const tsxBin = join(
   ".bin",
   process.platform === "win32" ? "tsx.cmd" : "tsx",
 );
+const fixturePath = join(process.cwd(), "tests/observability/support/logging-probe-fixture.ts");
+const SAFE_ENV_NAMES = [
+  "PATH",
+  "Path",
+  "SystemRoot",
+  "COMSPEC",
+  "PATHEXT",
+  "HOME",
+  "USERPROFILE",
+  "TMPDIR",
+  "TMP",
+  "TEMP",
+] as const;
+
+type ProbeName =
+  | "accessor-safety"
+  | "environment"
+  | "policy-confirmation"
+  | "redaction"
+  | "retry-budget"
+  | "thrown-failure";
 
 function assertNoCanaries(label: string, text: string): void {
   const leaked = text.match(CANARY_PATTERN)?.[0];
@@ -50,8 +71,13 @@ function expectNoIncidentLogs(logs: Array<Record<string, unknown>>): void {
 }
 
 function probeEnv(extra: NodeJS.ProcessEnv = {}): NodeJS.ProcessEnv {
+  const inherited = Object.fromEntries(
+    SAFE_ENV_NAMES.flatMap((name) =>
+      process.env[name] === undefined ? [] : [[name, process.env[name] as string]],
+    ),
+  );
   const env: NodeJS.ProcessEnv = {
-    ...process.env,
+    ...inherited,
     NODE_ENV: "test",
     LOG_LEVEL: "info",
     ...extra,
@@ -62,8 +88,8 @@ function probeEnv(extra: NodeJS.ProcessEnv = {}): NodeJS.ProcessEnv {
   return env;
 }
 
-function runProbe(source: string, env: NodeJS.ProcessEnv = {}) {
-  return spawnSync(tsxBin, ["-e", source], {
+function runProbe(probe: ProbeName, env: NodeJS.ProcessEnv = {}) {
+  return spawnSync(tsxBin, [fixturePath, probe], {
     cwd: process.cwd(),
     encoding: "utf8",
     env: probeEnv(env),
@@ -74,7 +100,7 @@ function runProbe(source: string, env: NodeJS.ProcessEnv = {}) {
 function expectProbeSucceeded(result: ReturnType<typeof runProbe>): void {
   const output = `${result.stdout ?? ""}${result.stderr ?? ""}`;
   assertNoCanaries("probe output", output);
-  expect(result.status, output).toBe(0);
+  expect(result.status).toBe(0);
 }
 
 function resultOf(frame: any): any {
@@ -146,39 +172,7 @@ describe("observability logging behavior", () => {
   });
 
   it("redacts top-level, nested, header, token, B2 key, and error fields", () => {
-    const result = runProbe(`
-import { flushLogsSync, initLogging, logger } from "./src/utils/logger";
-
-initLogging();
-const err = Object.assign(
-  new Error("provider failed B2_MCP_CANARY_SECRET_ERROR_MESSAGE"),
-  {
-    code: "B2_MCP_CANARY_SECRET_ERROR_CODE",
-    status: 503,
-    requestId: "B2_MCP_CANARY_SECRET_ERROR_REQUEST_ID",
-  },
-);
-logger.error(
-  {
-    applicationKey: "B2_MCP_CANARY_SECRET_TOP_LEVEL_KEY",
-    authorization: "Bearer B2_MCP_CANARY_SECRET_TOP_LEVEL_AUTH",
-    headers: {
-      authorization: "Bearer B2_MCP_CANARY_SECRET_HEADER_AUTH",
-      "x-b2-key": "B2_MCP_CANARY_SECRET_HEADER_B2_KEY",
-    },
-    credentials: {
-      appKey: "B2_MCP_CANARY_SECRET_NESTED_APP_KEY",
-      nested: {
-        masterKey: "B2_MCP_CANARY_SECRET_DEEP_MASTER_KEY",
-        sessionToken: "B2_MCP_CANARY_SECRET_DEEP_SESSION_TOKEN",
-      },
-    },
-    err,
-  },
-  "observability.redaction",
-);
-flushLogsSync();
-`);
+    const result = runProbe("redaction");
     expectProbeSucceeded(result);
     expect(result.stdout).toBe("");
 
@@ -197,39 +191,18 @@ flushLogsSync();
         sessionToken: "[redacted]",
       },
     });
+    expect(log.err).toMatchObject({
+      code: "[redacted]",
+      errno: -2,
+      path: "/tmp/b2-mcp-observability-safe-path",
+      requestId: "[redacted]",
+      syscall: "open",
+    });
     expect(JSON.stringify(log.err)).toContain("[redacted]");
   });
 
   it("records retry budget warnings with bounded context", () => {
-    const result = runProbe(`
-import { flushLogsSync, initLogging } from "./src/utils/logger";
-import { _consumeRetryToken, _resetRetryBudget, withRetry } from "./src/utils/retry";
-
-initLogging();
-async function main() {
-  _resetRetryBudget();
-  for (let i = 0; i < 100; i++) _consumeRetryToken();
-  try {
-    await withRetry(async () => {
-      throw {
-        message: "rate limited B2_MCP_CANARY_SECRET_RETRY_MESSAGE",
-        response: {
-          status: 429,
-          headers: { authorization: "Bearer B2_MCP_CANARY_SECRET_RETRY_AUTH" },
-          data: { applicationKey: "B2_MCP_CANARY_SECRET_RETRY_BODY_KEY" },
-        },
-      };
-    }, 1);
-  } catch (err) {
-    process.stdout.write(JSON.stringify({ status: err.response.status }));
-  }
-  flushLogsSync();
-}
-main().catch((err) => {
-  console.error(err instanceof Error ? err.message : String(err));
-  process.exit(1);
-});
-`);
+    const result = runProbe("retry-budget");
     expectProbeSucceeded(result);
     expect(JSON.parse(result.stdout)).toEqual({ status: 429 });
 
@@ -242,53 +215,7 @@ main().catch((err) => {
   });
 
   it("logs expected confirmation outcomes as tool calls, not incidents", () => {
-    const result = runProbe(`
-import { createAuditedToolCallback } from "./src/server";
-import { checkDestructive } from "./src/utils/destructive-gate";
-import { toolError, toolSuccess } from "./src/utils/errors";
-import { flushLogsSync, initLogging } from "./src/utils/logger";
-
-initLogging();
-const config = {
-  applicationKeyId: "policy-key-id",
-  applicationKey: "B2_MCP_CANARY_SECRET_POLICY_APPLICATION_KEY",
-  appKeyId: "policy-key-id",
-  appKey: "B2_MCP_CANARY_SECRET_POLICY_APP_KEY",
-  masterKeyId: "policy-key-id",
-  masterKey: "B2_MCP_CANARY_SECRET_POLICY_MASTER_KEY",
-  region: "us-west-004",
-  allowLocalFiles: false,
-  fileRoot: null,
-  destructivePolicy: "confirm",
-  outputFormat: "json",
-  transport: "stdio",
-  credentialFingerprint: "policy-fingerprint",
-};
-const wrapped = createAuditedToolCallback(
-  "b2_delete_bucket",
-  async (args) => {
-    const gate = checkDestructive("b2_delete_bucket", args, config);
-    return gate.ok ? toolSuccess("deleted") : toolError(gate.error);
-  },
-  config,
-);
-async function main() {
-  const result = await wrapped(
-    {
-      bucketId: "bucket-with-confirmation-required",
-      confirm: false,
-      nested: { applicationKey: "B2_MCP_CANARY_SECRET_POLICY_ARG" },
-    },
-    {},
-  );
-  process.stdout.write(JSON.stringify(result));
-  flushLogsSync();
-}
-main().catch((err) => {
-  console.error(err instanceof Error ? err.message : String(err));
-  process.exit(1);
-});
-`);
+    const result = runProbe("policy-confirmation");
     expectProbeSucceeded(result);
     const response = JSON.parse(result.stdout) as { isError?: boolean; content?: unknown[] };
     expect(response.isError).toBe(true);
@@ -310,66 +237,7 @@ main().catch((err) => {
   });
 
   it("logs thrown tool failures as sanitized warnings", () => {
-    const result = runProbe(`
-import { createAuditedToolCallback } from "./src/server";
-import { flushLogsSync, initLogging } from "./src/utils/logger";
-
-initLogging();
-const config = {
-  applicationKeyId: "failure-key-id",
-  applicationKey: "B2_MCP_CANARY_SECRET_FAILURE_APPLICATION_KEY",
-  appKeyId: "failure-key-id",
-  appKey: "B2_MCP_CANARY_SECRET_FAILURE_APP_KEY",
-  masterKeyId: "failure-key-id",
-  masterKey: "B2_MCP_CANARY_SECRET_FAILURE_MASTER_KEY",
-  region: "us-west-004",
-  allowLocalFiles: false,
-  fileRoot: null,
-  destructivePolicy: "confirm",
-  outputFormat: "json",
-  transport: "stdio",
-  credentialFingerprint: "failure-fingerprint",
-};
-const wrapped = createAuditedToolCallback(
-  "b2_list_buckets",
-  async () => {
-    throw Object.assign(
-      new Error("upstream failed B2_MCP_CANARY_SECRET_THROWN_MESSAGE"),
-      {
-        code: "B2_MCP_CANARY_SECRET_THROWN_CODE",
-        status: 503,
-        requestId: "B2_MCP_CANARY_SECRET_THROWN_REQUEST",
-      },
-    );
-  },
-  config,
-);
-async function main() {
-  try {
-    await wrapped(
-      {
-        bucketName: "failure-bucket",
-        secret: "B2_MCP_CANARY_SECRET_THROWN_ARG",
-      },
-      {},
-    );
-  } catch (err) {
-    process.stdout.write(
-      JSON.stringify({
-        message: err.message,
-        code: err.code,
-        status: err.status,
-        requestId: err.requestId,
-      }),
-    );
-  }
-  flushLogsSync();
-}
-main().catch((err) => {
-  console.error(err instanceof Error ? err.message : String(err));
-  process.exit(1);
-});
-`);
+    const result = runProbe("thrown-failure");
     expectProbeSucceeded(result);
     const thrown = JSON.parse(result.stdout);
     expect(thrown).toMatchObject({
@@ -377,6 +245,9 @@ main().catch((err) => {
       code: "[redacted]",
       status: 503,
       requestId: "[redacted]",
+      errno: -2,
+      syscall: "open",
+      path: "/tmp/b2-mcp-observability-safe-path",
     });
 
     const logs = parseLogLines(result.stderr);
@@ -390,5 +261,61 @@ main().catch((err) => {
     expect(failure.argKeys).toEqual(["bucketName", "secret"]);
     expect(logs.map((entry) => entry.msg)).not.toContain("server.error");
     expect(logs.map((entry) => entry.msg)).not.toContain("server.fatal");
+  });
+
+  it("does not invoke hostile accessors while logging", () => {
+    const result = runProbe("accessor-safety");
+    expectProbeSucceeded(result);
+    expect(JSON.parse(result.stdout)).toEqual({ getterReads: 0 });
+
+    const logs = parseLogLines(result.stderr);
+    const accessor = findLog(logs, "observability.accessor");
+    expect(accessor).toMatchObject({
+      authorization: "[redacted]",
+      metadata: "[accessor]",
+    });
+
+    const failure = findLog(logs, "observability.sanitizerFailure");
+    expect(failure).toMatchObject({
+      logSanitizer: "[log_sanitizer_failed]",
+    });
+  });
+
+  it("does not inherit unrelated developer or CI secrets into probes", () => {
+    const previous = {
+      AWS_SECRET_ACCESS_KEY: process.env.AWS_SECRET_ACCESS_KEY,
+      GH_TOKEN: process.env.GH_TOKEN,
+      GITHUB_TOKEN: process.env.GITHUB_TOKEN,
+      NPM_TOKEN: process.env.NPM_TOKEN,
+      SERVICE_SECRET: process.env.SERVICE_SECRET,
+      SERVICE_TOKEN: process.env.SERVICE_TOKEN,
+    };
+    const sentinel = "sentinel-non-b2-secret";
+    process.env.AWS_SECRET_ACCESS_KEY = sentinel;
+    process.env.GH_TOKEN = sentinel;
+    process.env.GITHUB_TOKEN = sentinel;
+    process.env.NPM_TOKEN = sentinel;
+    process.env.SERVICE_SECRET = sentinel;
+    process.env.SERVICE_TOKEN = sentinel;
+
+    try {
+      const result = runProbe("environment");
+      const output = `${result.stdout}${result.stderr}`;
+      expect(output).not.toContain(sentinel);
+      expectProbeSucceeded(result);
+      expect(JSON.parse(result.stdout)).toEqual({
+        aws: null,
+        gh: null,
+        github: null,
+        npm: null,
+        serviceSecret: null,
+        serviceToken: null,
+      });
+    } finally {
+      for (const [key, value] of Object.entries(previous)) {
+        if (value === undefined) delete process.env[key];
+        else process.env[key] = value;
+      }
+    }
   });
 });

--- a/tests/observability/support/logging-probe-fixture.ts
+++ b/tests/observability/support/logging-probe-fixture.ts
@@ -1,0 +1,233 @@
+import { createAuditedToolCallback } from "../../../src/server";
+import { checkDestructive } from "../../../src/utils/destructive-gate";
+import { toolError, toolSuccess } from "../../../src/utils/errors";
+import { flushLogsSync, initLogging, logger } from "../../../src/utils/logger";
+import { _consumeRetryToken, _resetRetryBudget, withRetry } from "../../../src/utils/retry";
+import type { B2Config } from "../../../src/utils/types";
+
+type ProbeName =
+  | "accessor-safety"
+  | "environment"
+  | "policy-confirmation"
+  | "redaction"
+  | "retry-budget"
+  | "thrown-failure";
+
+function testConfig(prefix: string): B2Config {
+  return {
+    applicationKeyId: `${prefix}-key-id`,
+    applicationKey: `B2_MCP_CANARY_SECRET_${prefix.toUpperCase()}_APPLICATION_KEY`,
+    appKeyId: `${prefix}-key-id`,
+    appKey: `B2_MCP_CANARY_SECRET_${prefix.toUpperCase()}_APP_KEY`,
+    masterKeyId: `${prefix}-key-id`,
+    masterKey: `B2_MCP_CANARY_SECRET_${prefix.toUpperCase()}_MASTER_KEY`,
+    region: "us-west-004",
+    allowLocalFiles: false,
+    fileRoot: null,
+    destructivePolicy: "confirm",
+    outputFormat: "json",
+    transport: "stdio",
+    credentialFingerprint: `${prefix}-fingerprint`,
+  };
+}
+
+function writeJson(value: unknown): void {
+  process.stdout.write(JSON.stringify(value));
+}
+
+function defineThrowingGetter(target: object, key: string, message: string): void {
+  Object.defineProperty(target, key, {
+    enumerable: true,
+    get() {
+      throw new Error(message);
+    },
+  });
+}
+
+async function redactionProbe(): Promise<void> {
+  initLogging();
+  const err = Object.assign(new Error("provider failed B2_MCP_CANARY_SECRET_ERROR_MESSAGE"), {
+    code: "B2_MCP_CANARY_SECRET_ERROR_CODE",
+    status: 503,
+    requestId: "B2_MCP_CANARY_SECRET_ERROR_REQUEST_ID",
+    errno: -2,
+    syscall: "open",
+    path: "/tmp/b2-mcp-observability-safe-path",
+    authorizationToken: "B2_MCP_CANARY_SECRET_ERROR_AUTH_TOKEN",
+    details: {
+      applicationKey: "B2_MCP_CANARY_SECRET_ERROR_NESTED_KEY",
+    },
+  });
+  logger.error(
+    {
+      applicationKey: "B2_MCP_CANARY_SECRET_TOP_LEVEL_KEY",
+      authorization: "Bearer B2_MCP_CANARY_SECRET_TOP_LEVEL_AUTH",
+      headers: {
+        authorization: "Bearer B2_MCP_CANARY_SECRET_HEADER_AUTH",
+        "x-b2-key": "B2_MCP_CANARY_SECRET_HEADER_B2_KEY",
+      },
+      credentials: {
+        appKey: "B2_MCP_CANARY_SECRET_NESTED_APP_KEY",
+        nested: {
+          masterKey: "B2_MCP_CANARY_SECRET_DEEP_MASTER_KEY",
+          sessionToken: "B2_MCP_CANARY_SECRET_DEEP_SESSION_TOKEN",
+        },
+      },
+      err,
+    },
+    "observability.redaction",
+  );
+  flushLogsSync();
+}
+
+async function retryBudgetProbe(): Promise<void> {
+  initLogging();
+  _resetRetryBudget();
+  for (let i = 0; i < 100; i++) _consumeRetryToken();
+  try {
+    await withRetry(async () => {
+      throw {
+        message: "rate limited B2_MCP_CANARY_SECRET_RETRY_MESSAGE",
+        response: {
+          status: 429,
+          headers: { authorization: "Bearer B2_MCP_CANARY_SECRET_RETRY_AUTH" },
+          data: { applicationKey: "B2_MCP_CANARY_SECRET_RETRY_BODY_KEY" },
+        },
+      };
+    }, 1);
+  } catch (err) {
+    writeJson({ status: (err as { response: { status: number } }).response.status });
+  }
+  flushLogsSync();
+}
+
+async function policyConfirmationProbe(): Promise<void> {
+  initLogging();
+  const config = testConfig("policy");
+  const wrapped = createAuditedToolCallback(
+    "b2_delete_bucket",
+    async (args) => {
+      const gate = checkDestructive("b2_delete_bucket", args, config);
+      return gate.ok ? toolSuccess("deleted") : toolError(gate.error);
+    },
+    config,
+  );
+  const result = await wrapped(
+    {
+      bucketId: "bucket-with-confirmation-required",
+      confirm: false,
+      nested: { applicationKey: "B2_MCP_CANARY_SECRET_POLICY_ARG" },
+    },
+    {},
+  );
+  writeJson(result);
+  flushLogsSync();
+}
+
+async function thrownFailureProbe(): Promise<void> {
+  initLogging();
+  const config = testConfig("failure");
+  const wrapped = createAuditedToolCallback(
+    "b2_list_buckets",
+    async () => {
+      throw Object.assign(new Error("upstream failed B2_MCP_CANARY_SECRET_THROWN_MESSAGE"), {
+        code: "B2_MCP_CANARY_SECRET_THROWN_CODE",
+        status: 503,
+        requestId: "B2_MCP_CANARY_SECRET_THROWN_REQUEST",
+        errno: -2,
+        syscall: "open",
+        path: "/tmp/b2-mcp-observability-safe-path",
+      });
+    },
+    config,
+  );
+  try {
+    await wrapped(
+      {
+        bucketName: "failure-bucket",
+        secret: "B2_MCP_CANARY_SECRET_THROWN_ARG",
+      },
+      {},
+    );
+  } catch (err) {
+    const failure = err as Error & {
+      code?: unknown;
+      errno?: unknown;
+      path?: unknown;
+      requestId?: unknown;
+      status?: unknown;
+      syscall?: unknown;
+    };
+    writeJson({
+      message: failure.message,
+      code: failure.code,
+      status: failure.status,
+      requestId: failure.requestId,
+      errno: failure.errno,
+      syscall: failure.syscall,
+      path: failure.path,
+    });
+  }
+  flushLogsSync();
+}
+
+async function accessorSafetyProbe(): Promise<void> {
+  initLogging();
+  const payload: Record<string, unknown> = {};
+  let getterReads = 0;
+  defineThrowingGetter(payload, "authorization", "B2_MCP_CANARY_SECRET_AUTH_GETTER");
+  Object.defineProperty(payload, "metadata", {
+    enumerable: true,
+    get() {
+      getterReads++;
+      throw new Error("B2_MCP_CANARY_SECRET_METADATA_GETTER");
+    },
+  });
+
+  logger.info(payload, "observability.accessor");
+
+  const hostileProxy = new Proxy(
+    {},
+    {
+      ownKeys() {
+        throw new Error("B2_MCP_CANARY_SECRET_PROXY_KEYS");
+      },
+    },
+  );
+  logger.info(hostileProxy, "observability.sanitizerFailure");
+
+  writeJson({ getterReads });
+  flushLogsSync();
+}
+
+async function environmentProbe(): Promise<void> {
+  writeJson({
+    npm: process.env.NPM_TOKEN ?? null,
+    gh: process.env.GH_TOKEN ?? null,
+    github: process.env.GITHUB_TOKEN ?? null,
+    aws: process.env.AWS_SECRET_ACCESS_KEY ?? null,
+    serviceToken: process.env.SERVICE_TOKEN ?? null,
+    serviceSecret: process.env.SERVICE_SECRET ?? null,
+  });
+}
+
+const probes: Record<ProbeName, () => Promise<void>> = {
+  "accessor-safety": accessorSafetyProbe,
+  environment: environmentProbe,
+  "policy-confirmation": policyConfirmationProbe,
+  redaction: redactionProbe,
+  "retry-budget": retryBudgetProbe,
+  "thrown-failure": thrownFailureProbe,
+};
+
+const probeName = process.argv[2] as ProbeName | undefined;
+
+if (!probeName || !(probeName in probes)) {
+  process.stderr.write(`Unknown logging probe: ${probeName ?? "(missing)"}\n`);
+  process.exit(2);
+}
+
+probes[probeName]().catch((err: unknown) => {
+  process.stderr.write(`${err instanceof Error ? err.message : String(err)}\n`);
+  process.exit(1);
+});

--- a/tests/protocol/stdio.transport.legacy-protocol.test.ts
+++ b/tests/protocol/stdio.transport.legacy-protocol.test.ts
@@ -1,9 +1,5 @@
-import {
-  LEGACY_PROTOCOL_VERSION,
-  RawStdioSession,
-  closeClient,
-  connectLegacyStdioClient,
-} from "./support/clients";
+import { LEGACY_PROTOCOL_VERSION, RawStdioSession } from "../support/protocol";
+import { closeClient, connectLegacyStdioClient } from "./support/clients";
 
 function resultOf(frame: any): any {
   expect(frame.error).toBeUndefined();

--- a/tests/protocol/stdio.transport.modern-protocol.test.ts
+++ b/tests/protocol/stdio.transport.modern-protocol.test.ts
@@ -3,10 +3,9 @@ import {
   MODERN_META,
   MODERN_PROTOCOL_VERSION,
   RawStdioSession,
-  closeClient,
-  connectModernStdioClient,
   protocolEnv,
-} from "./support/clients";
+} from "../support/protocol";
+import { closeClient, connectModernStdioClient } from "./support/clients";
 
 function resultOf(frame: any): any {
   expect(frame.error).toBeUndefined();

--- a/tests/protocol/support/clients.ts
+++ b/tests/protocol/support/clients.ts
@@ -1,23 +1,27 @@
-import { spawn, type ChildProcessWithoutNullStreams } from "child_process";
-import { once } from "events";
-import { existsSync } from "fs";
-import { join } from "path";
 import {
   Client,
   StreamableHTTPClientTransport,
   type ClientOptions,
-  type JSONRPCMessage,
 } from "@modelcontextprotocol/client";
 import { StdioClientTransport } from "@modelcontextprotocol/client/stdio";
-
-export const MODERN_PROTOCOL_VERSION = "2026-07-28";
-export const LEGACY_PROTOCOL_VERSION = "2025-11-25";
-
-export const MODERN_META = {
-  "io.modelcontextprotocol/protocolVersion": MODERN_PROTOCOL_VERSION,
-  "io.modelcontextprotocol/clientCapabilities": {},
-  "io.modelcontextprotocol/clientInfo": { name: "b2-mcp-protocol-test", version: "1.0.0" },
-};
+import {
+  LEGACY_PROTOCOL_VERSION,
+  MODERN_META,
+  MODERN_PROTOCOL_VERSION,
+  ROOT,
+  SIMULATOR_ENTRYPOINT,
+  protocolEnv,
+  requireBuiltEntrypoints,
+} from "../../support/protocol";
+export {
+  LEGACY_PROTOCOL_VERSION,
+  MODERN_META,
+  MODERN_PROTOCOL_VERSION,
+  RawStdioSession,
+  SIMULATOR_ENTRYPOINT,
+  protocolEnv,
+  requireBuiltEntrypoints,
+} from "../../support/protocol";
 
 export const HTTP_CREDS = {
   "x-b2-key-id": "protocol-key-id",
@@ -28,50 +32,6 @@ export const JSON_HEADERS = {
   "content-type": "application/json",
   accept: "application/json, text/event-stream",
 };
-
-export const ROOT = join(__dirname, "../../..");
-const DIST_INDEX = join(ROOT, "dist/index.js");
-const DIST_HTTP = join(ROOT, "dist/http-server.js");
-export const SIMULATOR_ENTRYPOINT = join(__dirname, "simulator-entrypoint.mjs");
-const REQUEST_TIMEOUT_MS = process.platform === "win32" ? 15_000 : 10_000;
-const SAFE_ENV_NAMES = [
-  "PATH",
-  "Path",
-  "SystemRoot",
-  "COMSPEC",
-  "PATHEXT",
-  "HOME",
-  "USERPROFILE",
-  "TMPDIR",
-  "TMP",
-  "TEMP",
-];
-
-export function requireBuiltEntrypoints(): void {
-  if (!existsSync(DIST_INDEX) || !existsSync(DIST_HTTP) || !existsSync(SIMULATOR_ENTRYPOINT)) {
-    throw new Error("Protocol transport tests require built dist entry points. Run npm run build.");
-  }
-}
-
-export function protocolEnv(extra: NodeJS.ProcessEnv = {}): NodeJS.ProcessEnv {
-  const inherited = Object.fromEntries(
-    SAFE_ENV_NAMES.flatMap((name) =>
-      process.env[name] === undefined ? [] : [[name, process.env[name] as string]],
-    ),
-  );
-  const env: NodeJS.ProcessEnv = {
-    ...inherited,
-    NODE_ENV: "test",
-    B2_REGISTER_ALL_TOOLS: "true",
-    B2_APPLICATION_KEY_ID: "protocol-key-id",
-    B2_APPLICATION_KEY: "protocol-key-secret",
-    B2_HTTP_CREDENTIAL_MODE: "headers",
-    ...extra,
-  };
-  delete env.FORCE_COLOR;
-  delete env.NO_COLOR;
-  return env;
-}
 
 function stdioEnv(extra: NodeJS.ProcessEnv = {}): Record<string, string> {
   return Object.fromEntries(
@@ -201,83 +161,6 @@ export async function connectHttpClient(
   });
   await client.connect(transport);
   return { client, transport, requests };
-}
-
-export class RawStdioSession {
-  private child: ChildProcessWithoutNullStreams | null = null;
-  private stdoutBuffer = "";
-  private nextId = 1;
-  readonly stdoutLines: string[] = [];
-  readonly stderrChunks: string[] = [];
-  readonly frames: JSONRPCMessage[] = [];
-
-  start(extraEnv: NodeJS.ProcessEnv = {}): void {
-    requireBuiltEntrypoints();
-    this.child = spawn(process.execPath, [SIMULATOR_ENTRYPOINT, "stdio"], {
-      cwd: ROOT,
-      env: protocolEnv(extraEnv),
-      stdio: ["pipe", "pipe", "pipe"],
-    });
-    this.child.stdout.on("data", (chunk) => this.captureStdout(chunk.toString()));
-    this.child.stderr.on("data", (chunk) => this.stderrChunks.push(chunk.toString()));
-  }
-
-  async request(method: string, params: Record<string, unknown> = {}): Promise<JSONRPCMessage> {
-    const id = this.nextId++;
-    this.send({ jsonrpc: "2.0", id, method, params });
-    return this.waitForFrame((frame) => "id" in frame && frame.id === id);
-  }
-
-  send(message: JSONRPCMessage): void {
-    if (!this.child) throw new Error("Raw stdio session is not started");
-    this.child.stdin.write(`${JSON.stringify(message)}\n`);
-  }
-
-  async close(): Promise<void> {
-    const child = this.child;
-    if (!child) return;
-    this.child = null;
-    child.stdin.end();
-    child.kill("SIGTERM");
-    const timer = setTimeout(() => child.kill("SIGKILL"), 2_000);
-    timer.unref();
-    await once(child, "exit").catch(() => undefined);
-    clearTimeout(timer);
-  }
-
-  private captureStdout(chunk: string): void {
-    this.stdoutBuffer += chunk;
-    for (;;) {
-      const newline = this.stdoutBuffer.indexOf("\n");
-      if (newline === -1) return;
-      const line = this.stdoutBuffer.slice(0, newline).trim();
-      this.stdoutBuffer = this.stdoutBuffer.slice(newline + 1);
-      if (!line) continue;
-      this.stdoutLines.push(line);
-      this.frames.push(JSON.parse(line) as JSONRPCMessage);
-    }
-  }
-
-  private waitForFrame(predicate: (frame: JSONRPCMessage) => boolean): Promise<JSONRPCMessage> {
-    const existing = this.frames.find(predicate);
-    if (existing) return Promise.resolve(existing);
-    return new Promise((resolve, reject) => {
-      const started = Date.now();
-      const interval = setInterval(() => {
-        const frame = this.frames.find(predicate);
-        if (frame) {
-          clearInterval(interval);
-          clearTimeout(timer);
-          resolve(frame);
-        }
-      }, 10);
-      const timer = setTimeout(() => {
-        clearInterval(interval);
-        reject(new Error(`Timed out waiting for stdio frame after ${Date.now() - started}ms`));
-      }, REQUEST_TIMEOUT_MS);
-      timer.unref();
-    });
-  }
 }
 
 export async function closeClient(client: Client): Promise<void> {

--- a/tests/support/protocol.ts
+++ b/tests/support/protocol.ts
@@ -1,0 +1,135 @@
+import { spawn, type ChildProcessWithoutNullStreams } from "child_process";
+import { once } from "events";
+import { existsSync } from "fs";
+import { join } from "path";
+import type { JSONRPCMessage } from "@modelcontextprotocol/client";
+
+export const MODERN_PROTOCOL_VERSION = "2026-07-28";
+export const LEGACY_PROTOCOL_VERSION = "2025-11-25";
+
+export const MODERN_META = {
+  "io.modelcontextprotocol/protocolVersion": MODERN_PROTOCOL_VERSION,
+  "io.modelcontextprotocol/clientCapabilities": {},
+  "io.modelcontextprotocol/clientInfo": { name: "b2-mcp-protocol-test", version: "1.0.0" },
+};
+
+export const ROOT = join(__dirname, "../..");
+const DIST_INDEX = join(ROOT, "dist/index.js");
+const DIST_HTTP = join(ROOT, "dist/http-server.js");
+export const SIMULATOR_ENTRYPOINT = join(ROOT, "tests/protocol/support/simulator-entrypoint.mjs");
+const REQUEST_TIMEOUT_MS = process.platform === "win32" ? 15_000 : 10_000;
+const SAFE_ENV_NAMES = [
+  "PATH",
+  "Path",
+  "SystemRoot",
+  "COMSPEC",
+  "PATHEXT",
+  "HOME",
+  "USERPROFILE",
+  "TMPDIR",
+  "TMP",
+  "TEMP",
+];
+
+export function requireBuiltEntrypoints(): void {
+  if (!existsSync(DIST_INDEX) || !existsSync(DIST_HTTP) || !existsSync(SIMULATOR_ENTRYPOINT)) {
+    throw new Error("Protocol transport tests require built dist entry points. Run npm run build.");
+  }
+}
+
+export function protocolEnv(extra: NodeJS.ProcessEnv = {}): NodeJS.ProcessEnv {
+  const inherited = Object.fromEntries(
+    SAFE_ENV_NAMES.flatMap((name) =>
+      process.env[name] === undefined ? [] : [[name, process.env[name] as string]],
+    ),
+  );
+  const env: NodeJS.ProcessEnv = {
+    ...inherited,
+    NODE_ENV: "test",
+    B2_REGISTER_ALL_TOOLS: "true",
+    B2_APPLICATION_KEY_ID: "protocol-key-id",
+    B2_APPLICATION_KEY: "protocol-key-secret",
+    B2_HTTP_CREDENTIAL_MODE: "headers",
+    ...extra,
+  };
+  delete env.FORCE_COLOR;
+  delete env.NO_COLOR;
+  return env;
+}
+
+export class RawStdioSession {
+  private child: ChildProcessWithoutNullStreams | null = null;
+  private stdoutBuffer = "";
+  private nextId = 1;
+  readonly stdoutLines: string[] = [];
+  readonly stderrChunks: string[] = [];
+  readonly frames: JSONRPCMessage[] = [];
+
+  start(extraEnv: NodeJS.ProcessEnv = {}): void {
+    requireBuiltEntrypoints();
+    this.child = spawn(process.execPath, [SIMULATOR_ENTRYPOINT, "stdio"], {
+      cwd: ROOT,
+      env: protocolEnv(extraEnv),
+      stdio: ["pipe", "pipe", "pipe"],
+    });
+    this.child.stdout.on("data", (chunk) => this.captureStdout(chunk.toString()));
+    this.child.stderr.on("data", (chunk) => this.stderrChunks.push(chunk.toString()));
+  }
+
+  async request(method: string, params: Record<string, unknown> = {}): Promise<JSONRPCMessage> {
+    const id = this.nextId++;
+    this.send({ jsonrpc: "2.0", id, method, params });
+    return this.waitForFrame((frame) => "id" in frame && frame.id === id);
+  }
+
+  send(message: JSONRPCMessage): void {
+    if (!this.child) throw new Error("Raw stdio session is not started");
+    this.child.stdin.write(`${JSON.stringify(message)}\n`);
+  }
+
+  async close(): Promise<void> {
+    const child = this.child;
+    if (!child) return;
+    this.child = null;
+    child.stdin.end();
+    child.kill("SIGTERM");
+    const timer = setTimeout(() => child.kill("SIGKILL"), 2_000);
+    timer.unref();
+    await once(child, "exit").catch(() => undefined);
+    clearTimeout(timer);
+  }
+
+  private captureStdout(chunk: string): void {
+    this.stdoutBuffer += chunk;
+    for (;;) {
+      const newline = this.stdoutBuffer.indexOf("\n");
+      if (newline === -1) return;
+      const line = this.stdoutBuffer.slice(0, newline).trim();
+      this.stdoutBuffer = this.stdoutBuffer.slice(newline + 1);
+      if (!line) continue;
+      this.stdoutLines.push(line);
+      this.frames.push(JSON.parse(line) as JSONRPCMessage);
+    }
+  }
+
+  private waitForFrame(predicate: (frame: JSONRPCMessage) => boolean): Promise<JSONRPCMessage> {
+    const existing = this.frames.find(predicate);
+    if (existing) return Promise.resolve(existing);
+    return new Promise((resolve, reject) => {
+      const started = Date.now();
+      const interval = setInterval(() => {
+        const frame = this.frames.find(predicate);
+        if (frame) {
+          clearInterval(interval);
+          clearTimeout(timer);
+          resolve(frame);
+        }
+      }, 10);
+      const timer = setTimeout(() => {
+        clearInterval(interval);
+        reject(new Error(`Timed out waiting for stdio frame after ${Date.now() - started}ms`));
+      }, REQUEST_TIMEOUT_MS);
+      timer.unref();
+    });
+  }
+}

--- a/tests/unit/secret-sanitizer.unit.test.ts
+++ b/tests/unit/secret-sanitizer.unit.test.ts
@@ -171,6 +171,28 @@ describe("secret sanitizer canary policy", () => {
     expectNoCanary(safe);
   });
 
+  it("sanitizes proxied log arrays without reading length getters", () => {
+    const payload = [{ applicationKey: CANARY }];
+    let lengthReads = 0;
+    const proxied = new Proxy(payload, {
+      get(target, property, receiver) {
+        if (property === "length") {
+          lengthReads++;
+          throw new Error(CANARY);
+        }
+        return Reflect.get(target, property, receiver);
+      },
+    });
+
+    const safe = sanitizeStructuredLogValue(proxied) as unknown[];
+
+    expect(lengthReads).toBe(0);
+    expect(Array.isArray(safe)).toBe(true);
+    expect(safe).toHaveLength(1);
+    expect(safe[0]).toEqual({ applicationKey: SECRET_SANITIZER_REDACTION });
+    expectNoCanary(safe);
+  });
+
   it("returns inert log values for callables and built-ins", () => {
     const createdAt = new Date("2026-08-21T00:00:00.000Z");
     Object.defineProperty(createdAt, "toJSON", {

--- a/tests/unit/secret-sanitizer.unit.test.ts
+++ b/tests/unit/secret-sanitizer.unit.test.ts
@@ -202,6 +202,28 @@ describe("secret sanitizer canary policy", () => {
     expect(JSON.stringify(safe)).not.toContain(CANARY);
   });
 
+  it("keeps MCP output representations for callables and built-ins", () => {
+    const safe = sanitizeForMcpOutput({
+      createdAt: new Date("2026-08-21T00:00:00.000Z"),
+      invalidDate: new Date(Number.NaN),
+      bytes: Buffer.from("ok"),
+      fn: () => "ignored",
+    }) as {
+      bytes: unknown;
+      createdAt: unknown;
+      fn?: unknown;
+      invalidDate: unknown;
+    };
+
+    expect(safe.createdAt).toBeInstanceOf(Date);
+    expect(safe.invalidDate).toBeInstanceOf(Date);
+    expect(Buffer.isBuffer(safe.bytes)).toBe(true);
+    expect(typeof safe.fn).toBe("function");
+    expect(JSON.stringify(safe)).toBe(
+      '{"createdAt":"2026-08-21T00:00:00.000Z","invalidDate":null,"bytes":{"type":"Buffer","data":[111,107]}}',
+    );
+  });
+
   it("preserves safe Error metadata in structured logs", () => {
     const err = Object.assign(new Error(`failed with ${CANARY}`), {
       code: "ENOENT",

--- a/tests/unit/secret-sanitizer.unit.test.ts
+++ b/tests/unit/secret-sanitizer.unit.test.ts
@@ -200,6 +200,16 @@ describe("secret sanitizer canary policy", () => {
       value: () => CANARY,
     });
     const bytes = Buffer.from(CANARY);
+    let byteLengthReads = 0;
+    for (const key of ["byteLength", "length"] as const) {
+      Object.defineProperty(bytes, key, {
+        enumerable: true,
+        get() {
+          byteLengthReads++;
+          throw new Error(CANARY);
+        },
+      });
+    }
     Object.defineProperty(bytes, "toJSON", {
       enumerable: true,
       value: () => ({ applicationKey: CANARY }),
@@ -221,7 +231,28 @@ describe("secret sanitizer canary policy", () => {
     expect(safe.fn).toBe("[function]");
     expect(safe.createdAt).toBe("2026-08-21T00:00:00.000Z");
     expect(safe.bytes).toEqual({ type: "Buffer", byteLength: Buffer.byteLength(CANARY) });
+    expect(byteLengthReads).toBe(0);
     expect(JSON.stringify(safe)).not.toContain(CANARY);
+  });
+
+  it("sanitizes proxied log buffers without reading length traps", () => {
+    const bytes = Buffer.from(CANARY);
+    let lengthReads = 0;
+    const proxied = new Proxy(bytes, {
+      get(target, property, receiver) {
+        if (property === "byteLength" || property === "length") {
+          lengthReads++;
+          throw new Error(CANARY);
+        }
+        return Reflect.get(target, property, receiver);
+      },
+    });
+
+    const safe = sanitizeStructuredLogValue(proxied);
+
+    expect(lengthReads).toBe(0);
+    expect(safe).toEqual({ type: "Buffer", byteLength: 0 });
+    expectNoCanary(safe);
   });
 
   it("keeps MCP output representations for callables and built-ins", () => {

--- a/tests/unit/secret-sanitizer.unit.test.ts
+++ b/tests/unit/secret-sanitizer.unit.test.ts
@@ -180,6 +180,37 @@ describe("secret sanitizer canary policy", () => {
     expectNoCanary(safe);
   });
 
+  it("redacts logger-only credential handles at arbitrary log depths", () => {
+    const safe = sanitizeStructuredLogValue({
+      outer: {
+        inner: {
+          details: {
+            accessKeyId: "safe-to-hide-access-key-id",
+            appKeyId: "safe-to-hide-app-key-id",
+            applicationKeyId: "safe-to-hide-application-key-id",
+            masterKeyId: "safe-to-hide-master-key-id",
+          },
+        },
+      },
+    });
+
+    expect(safe).toEqual({
+      outer: {
+        inner: {
+          details: {
+            accessKeyId: SECRET_SANITIZER_REDACTION,
+            appKeyId: SECRET_SANITIZER_REDACTION,
+            applicationKeyId: SECRET_SANITIZER_REDACTION,
+            masterKeyId: SECRET_SANITIZER_REDACTION,
+          },
+        },
+      },
+    });
+    expect(sanitizeForMcpOutput({ applicationKeyId: "key-id-is-non-secret" })).toEqual({
+      applicationKeyId: "key-id-is-non-secret",
+    });
+  });
+
   it("leaves non-secret JSON-valued strings byte-for-byte unchanged", () => {
     const metadata = `{"plain":"value","nested":{"count":2}}`;
     const largeJsonLookingString = `[${Array.from({ length: 2000 }, (_, i) => `"item-${i}"`).join(

--- a/tests/unit/secret-sanitizer.unit.test.ts
+++ b/tests/unit/secret-sanitizer.unit.test.ts
@@ -148,6 +148,60 @@ describe("secret sanitizer canary policy", () => {
     expectNoCanary(safe);
   });
 
+  it("sanitizes log arrays without invoking accessors", () => {
+    const payload: unknown[] = [];
+    let getterReads = 0;
+    Object.defineProperty(payload, "0", {
+      enumerable: true,
+      get() {
+        getterReads++;
+        throw new Error(CANARY);
+      },
+    });
+    payload[1] = {
+      applicationKey: CANARY,
+    };
+
+    const safe = sanitizeStructuredLogValue(payload) as unknown[];
+
+    expect(getterReads).toBe(0);
+    expect(Array.isArray(safe)).toBe(true);
+    expect(safe[0]).toBe("[accessor]");
+    expect(safe[1]).toEqual({ applicationKey: SECRET_SANITIZER_REDACTION });
+    expectNoCanary(safe);
+  });
+
+  it("returns inert log values for callables and built-ins", () => {
+    const createdAt = new Date("2026-08-21T00:00:00.000Z");
+    Object.defineProperty(createdAt, "toJSON", {
+      enumerable: true,
+      value: () => CANARY,
+    });
+    const bytes = Buffer.from(CANARY);
+    Object.defineProperty(bytes, "toJSON", {
+      enumerable: true,
+      value: () => ({ applicationKey: CANARY }),
+    });
+
+    const safe = sanitizeStructuredLogValue({
+      toJSON: () => CANARY,
+      fn: () => CANARY,
+      createdAt,
+      bytes,
+    }) as {
+      bytes: { byteLength: number; type: string };
+      createdAt: string;
+      fn: string;
+      toJSON: string;
+    };
+
+    expect(safe.toJSON).toBe("[function]");
+    expect(safe.fn).toBe("[function]");
+    expect(safe.createdAt).toBe("2026-08-21T00:00:00.000Z");
+    expect(safe.bytes).toEqual({ type: "Buffer", byteLength: Buffer.byteLength(CANARY) });
+    expect(JSON.stringify(safe)).not.toContain(CANARY);
+  });
+
   it("preserves safe Error metadata in structured logs", () => {
     const err = Object.assign(new Error(`failed with ${CANARY}`), {
       code: "ENOENT",
@@ -177,6 +231,29 @@ describe("secret sanitizer canary policy", () => {
     expect(safe.path).toBe("/tmp/b2-mcp-safe-metadata");
     expect(safe.authorizationToken).toBe(SECRET_SANITIZER_REDACTION);
     expect(safe.details?.applicationKey).toBe(SECRET_SANITIZER_REDACTION);
+    expectNoCanary(safe);
+  });
+
+  it("reads Error core fields without invoking accessors", () => {
+    const err = new Error("placeholder");
+    let getterReads = 0;
+    for (const key of ["message", "name", "stack"] as const) {
+      Object.defineProperty(err, key, {
+        configurable: true,
+        enumerable: true,
+        get() {
+          getterReads++;
+          throw new Error(CANARY);
+        },
+      });
+    }
+
+    const safe = sanitizeStructuredLogValue(err) as Error;
+
+    expect(getterReads).toBe(0);
+    expect(safe.message).toBe("[accessor]");
+    expect(safe.name).toBe("[accessor]");
+    expect(safe.stack).toBe("[accessor]");
     expectNoCanary(safe);
   });
 

--- a/tests/unit/secret-sanitizer.unit.test.ts
+++ b/tests/unit/secret-sanitizer.unit.test.ts
@@ -4,8 +4,10 @@ import { toolError, toolJson } from "../../src/utils/errors";
 import {
   configuredSecretValuesFromConfig,
   LOGGER_SECRET_REDACTION_PATHS,
+  LOG_SANITIZER_FAILURE,
   sanitizeForMcpOutput,
   sanitizeError,
+  sanitizeStructuredLogValue,
   sanitizeText,
   SECRET_SANITIZER_REDACTION,
   STRUCTURED_SECRET_FIELD_NAMES,
@@ -116,6 +118,66 @@ describe("secret sanitizer canary policy", () => {
 
     expect(safe.message).not.toContain(CANARY);
     expect(safe.message).not.toContain(CONFIGURED_APP_KEY);
+  });
+
+  it("sanitizes log objects without invoking accessors", () => {
+    const payload: Record<string, unknown> = {};
+    let getterReads = 0;
+    Object.defineProperty(payload, "authorization", {
+      enumerable: true,
+      get() {
+        getterReads++;
+        throw new Error(CANARY);
+      },
+    });
+    Object.defineProperty(payload, "metadata", {
+      enumerable: true,
+      get() {
+        getterReads++;
+        throw new Error(CANARY);
+      },
+    });
+
+    const safe = sanitizeStructuredLogValue(payload);
+
+    expect(getterReads).toBe(0);
+    expect(safe).toEqual({
+      authorization: SECRET_SANITIZER_REDACTION,
+      metadata: "[accessor]",
+    });
+    expectNoCanary(safe);
+  });
+
+  it("preserves safe Error metadata in structured logs", () => {
+    const err = Object.assign(new Error(`failed with ${CANARY}`), {
+      code: "ENOENT",
+      errno: -2,
+      syscall: "open",
+      path: "/tmp/b2-mcp-safe-metadata",
+      authorizationToken: CANARY,
+      details: {
+        applicationKey: CANARY,
+      },
+    });
+
+    const safe = sanitizeStructuredLogValue(err) as Error & {
+      authorizationToken?: unknown;
+      code?: unknown;
+      details?: { applicationKey?: unknown };
+      errno?: unknown;
+      path?: unknown;
+      syscall?: unknown;
+    };
+
+    expect(safe).toBeInstanceOf(Error);
+    expect(safe.message).toBe("failed with [redacted]");
+    expect(safe.code).toBe("ENOENT");
+    expect(safe.errno).toBe(-2);
+    expect(safe.syscall).toBe("open");
+    expect(safe.path).toBe("/tmp/b2-mcp-safe-metadata");
+    expect(safe.authorizationToken).toBe(SECRET_SANITIZER_REDACTION);
+    expect(safe.details?.applicationKey).toBe(SECRET_SANITIZER_REDACTION);
+    expectNoCanary(safe);
   });
 
   it("leaves non-secret JSON-valued strings byte-for-byte unchanged", () => {
@@ -292,5 +354,6 @@ describe("secret sanitizer canary policy", () => {
     for (const field of STRUCTURED_SECRET_FIELD_NAMES) {
       expect(LOGGER_SECRET_REDACTION_PATHS).toContain(field);
     }
+    expect(LOG_SANITIZER_FAILURE).toBe("[log_sanitizer_failed]");
   });
 });


### PR DESCRIPTION
## Summary
- Adds a repository-owned `observability` Vitest layer for lifecycle, retry warning, expected confirmation, thrown failure, redaction, hostile accessor, minimal probe environment, and stdio stream-separation logging behavior.
- Hardens structured log sanitization with descriptor-safe traversal for objects, arrays, and Error core fields, while preserving safe Error metadata and redacting top-level, nested, logger-only, header, token, B2 key, and configured secret canaries.
- Keeps sanitized log payloads inert before Pino serialization by replacing callables, converting log-mode Date and Buffer values, and reading array and Buffer lengths without invoking hostile accessors or proxy traps, while preserving the existing MCP output contract in `sanitizeForMcpOutput`.
- Moves shared raw stdio protocol fixtures to neutral `tests/support`, moves observability probes into typed fixtures, and uses a minimal allowlisted probe environment.
- Wires the new `observability/logging behavior` CI check and recalibrates package and Cloudflare Worker source budgets for the added runtime logging proof.
- Merges current `main` so the PR includes the newer runtime-security layer and is mergeable.

## Linked Issue
Closes #202

## Tests Run
- `pnpm run typecheck`
- `pnpm run format:check`
- `pnpm run check:package-budget`
- `pnpm run test:contract`
- `pnpm run test:observability`
- `pnpm run test:runtime-security`
- `pnpm run test:coverage`
- Review-fix focused checks on latest head `22d57d345be22c76da5a4ef401c38a19e9264c27`: `pnpm run typecheck`, `pnpm run test:unit -- tests/unit/secret-sanitizer.unit.test.ts tests/unit/logger.unit.test.ts tests/unit/result-serializer.unit.test.ts`, `pnpm run test:observability`, `pnpm run format:check`, and `pnpm run check:package-budget`
- Earlier focused checks: `pnpm run lint`, `pnpm run spell`, `pnpm run test:unit -- tests/unit/logger.unit.test.ts tests/unit/secret-sanitizer.unit.test.ts tests/unit/result-serializer.unit.test.ts`, `pnpm run test:protocol:modern -- tests/protocol/stdio.transport.modern-protocol.test.ts`, and `pnpm run test:protocol:legacy -- tests/protocol/stdio.transport.legacy-protocol.test.ts`
- GitHub CI on `5ff0cd05283c96ae868ac6af83f5d77a19932054`: all required checks passing, including `observability/logging behavior`, `package budget`, `MCP contract`, and all unit coverage matrix jobs.
- GitHub checks visible on latest head `22d57d345be22c76da5a4ef401c38a19e9264c27` at body update time: CodeQL Analyze jobs passing.

## Follow-up Notes
- Issue #202 has no labels.
- Applied issue milestone `v0.1.2`.
- No real credentials or production traffic are used; the suite relies on fake canaries and deterministic probes.