### PR TITLE
Add credential-free local MCP runtime smoke

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -289,6 +289,10 @@ jobs:
       - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803
         with:
           persist-credentials: false
+      # pnpm/action-setup v6.0.10, reviewed 2026-08-06.
+      - uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86
+        with:
+          run_install: false
       # actions/setup-node v7, reviewed 2026-08-06.
       - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020
         with:
@@ -307,6 +311,24 @@ jobs:
             exit 1
           fi
           node scripts/packed-consumer-smoke.mjs --tarball "$tarball"
+      - name: Run local runtime smoke on Node.js 22.3.0
+        run: |
+          set -euo pipefail
+          tarball="$(find reports/package-install-smoke -name '*.tgz' -type f -print -quit)"
+          if [[ -z "$tarball" ]]; then
+            echo "::error::package-install-smoke artifact did not contain a packed tarball"
+            exit 1
+          fi
+          tarball_path="$(realpath "$tarball")"
+          smoke_root="$(mktemp -d)"
+          (
+            cd "$smoke_root"
+            npm init -y >/dev/null
+            npm install --ignore-scripts --omit=dev --no-audit --no-fund "$tarball_path"
+          )
+          B2_MCP_LOCAL_SMOKE_ROOT="$smoke_root/node_modules/@backblaze-labs/b2-mcp" \
+            B2_MCP_LOCAL_SMOKE_SKIP_BUILD=true \
+            pnpm run smoke:local
 
   production-dependency-audit-matrix:
     name: production dependency audit / Node ${{ matrix.node-version }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -55,6 +55,8 @@ jobs:
       - run: pnpm install --frozen-lockfile
       - name: Run local verification entry point
         run: pnpm run verify
+      - name: Run local runtime smoke
+        run: pnpm run smoke:local
       # actions/upload-artifact v6, reviewed 2026-08-06.
       - name: Upload primary verification reports
         if: always()

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -289,10 +289,6 @@ jobs:
       - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803
         with:
           persist-credentials: false
-      # pnpm/action-setup v6.0.10, reviewed 2026-08-06.
-      - uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86
-        with:
-          run_install: false
       # actions/setup-node v7, reviewed 2026-08-06.
       - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020
         with:
@@ -328,7 +324,7 @@ jobs:
           )
           B2_MCP_LOCAL_SMOKE_ROOT="$smoke_root/node_modules/@backblaze-labs/b2-mcp" \
             B2_MCP_LOCAL_SMOKE_SKIP_BUILD=true \
-            pnpm run smoke:local
+            node scripts/local-mcp-smoke.mjs
 
   production-dependency-audit-matrix:
     name: production dependency audit / Node ${{ matrix.node-version }}

--- a/README.md
+++ b/README.md
@@ -504,6 +504,7 @@ pnpm start                        # stdio transport
 pnpm run start:http --port 3000   # MCP 2026-07-28 HTTP transport
 b2-mcp --help                     # installed package CLI help after publish/install
 b2-mcp --transport http --port 3000 # installed package HTTP command after publish/install
+pnpm run smoke:local        # deterministic local MCP smoke; no endpoint or B2 credentials
 pnpm run smoke:client       # advisory SDK client smoke; requires existing dist/, no B2 calls
 pnpm run smoke:inspector    # advisory locked Inspector CLI smoke; requires existing dist/
 ```

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -21,6 +21,9 @@ Markdown link validation, Node-based bundled skills-pack validation, the Biome-s
 format check, spelling, and listener diagnostics across the fast non-live
 layers. Coverage, slow lifecycle, and packed-package installation evidence stay
 in distinct scripts and CI jobs so their failures do not mask each other.
+Use `pnpm run smoke:local` for deterministic runtime-startup evidence without a
+deployed endpoint or real B2 credentials; CI runs it on Node.js 22.23.1 after
+the primary verification gate.
 The individual deterministic layers are:
 
 | Command                 | Layer                                                                                |
@@ -36,6 +39,7 @@ The individual deterministic layers are:
 | `pnpm run test:package`  | Builds, packs, installs through an npm consumer, and verifies installed entry points. |
 | `pnpm run test:coverage` | Coverage for all deterministic non-live layers.                                      |
 | `pnpm run test:diagnostics` | Builds first, then checks unit/protocol layers for MaxListeners and open-handle warnings. |
+| `pnpm run smoke:local`  | Builds, starts local HTTP MCP on 127.0.0.1:0, validates discovery/tools, and stops.   |
 
 Local scripts can call each deterministic layer independently. Required PR jobs
 keep the major evidence classes distinct so coverage regression, contract drift,
@@ -200,11 +204,30 @@ Tool-surface tests inspect the repository-owned registration registry, not SDK
 private fields. The registry is sorted by tool name and mirrors the public
 `registerTool()` calls made at server construction.
 
+## Deterministic Local Runtime Smoke
+
+The local runtime smoke is the credential-free startup check for clean
+checkouts and QK runtime evidence:
+
+```bash
+pnpm install --frozen-lockfile
+pnpm run smoke:local
+```
+
+`smoke:local` builds `dist/`, starts the built HTTP MCP server in a sanitized
+child process bound to `127.0.0.1` on an ephemeral port, connects with the
+official MCP client SDK, validates `server/discover` and `tools/list` against
+the frozen full profile, sends a missing-credential request and expects a
+JSON-RPC error, blocks outbound B2 network access in the server worker, and
+shuts the child process down with a bounded timeout. It does not read `MCP_URL`
+and does not require real Backblaze B2 credentials.
+
 ## Supplemental External Client Smoke
 
-The required PR gate remains repo-native: `pnpm run verify` and the protocol
-layers above are the correctness oracle. External clients are advisory evidence
-until they prove deterministic enough for CI.
+The external-client checks below remain supplemental: `pnpm run verify`, the
+protocol layers above, and `pnpm run smoke:local` are the repo-native
+credential-free evidence. External clients are advisory evidence until they
+prove deterministic enough for CI.
 
 Manual Inspector compatibility is pinned by the repository wrapper to
 `@modelcontextprotocol/inspector@2.1.0`. That Inspector release requires

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -22,8 +22,8 @@ format check, spelling, and listener diagnostics across the fast non-live
 layers. Coverage, slow lifecycle, and packed-package installation evidence stay
 in distinct scripts and CI jobs so their failures do not mask each other.
 Use `pnpm run smoke:local` for deterministic runtime-startup evidence without a
-deployed endpoint or real B2 credentials; CI runs it on Node.js 22.23.1 after
-the primary verification gate.
+deployed endpoint or real B2 credentials; CI runs it after the primary
+verification gate and again on the Node.js 22.3.0 runtime floor.
 The individual deterministic layers are:
 
 | Command                 | Layer                                                                                |
@@ -215,12 +215,12 @@ pnpm run smoke:local
 ```
 
 `smoke:local` builds `dist/`, starts the built HTTP MCP server in a sanitized
-child process bound to `127.0.0.1` on an ephemeral port, connects with the
-official MCP client SDK, validates `server/discover` and `tools/list` against
+child process bound to `127.0.0.1` on an ephemeral port, connects with a minimal
+modern HTTP MCP client, validates `server/discover` and `tools/list` against
 the frozen full profile, sends a missing-credential request and expects a
-JSON-RPC error, blocks outbound B2 network access in the server worker, and
-shuts the child process down with a bounded timeout. It does not read `MCP_URL`
-and does not require real Backblaze B2 credentials.
+JSON-RPC error, blocks non-loopback runner egress and outbound B2 network access
+in the server worker, and shuts the child process down with a bounded timeout.
+It does not read `MCP_URL` and does not require real Backblaze B2 credentials.
 
 ## Supplemental External Client Smoke
 

--- a/package-budget.json
+++ b/package-budget.json
@@ -11,10 +11,10 @@
     "directProductionDependencyCount": 9,
     "totalProductionPackageCount": 48,
     "transitiveProductionPackageCount": 38,
-    "packedTarballBytes": 467186,
-    "unpackedPackageBytes": 2091865,
+    "packedTarballBytes": 467658,
+    "unpackedPackageBytes": 2094605,
     "packedEntryCount": 248,
-    "cleanConsumerInstallFootprintBytes": 30808507
+    "cleanConsumerInstallFootprintBytes": 30811247
   },
   "limits": {
     "directProductionDependencyCount": 9,
@@ -22,7 +22,7 @@
     "packedTarballBytes": 470000,
     "unpackedPackageBytes": 2095000,
     "packedEntryCount": 250,
-    "cleanConsumerInstallFootprintBytes": 30810000
+    "cleanConsumerInstallFootprintBytes": 30813000
   },
   "directProductionDependencies": {
     "@aws-sdk/client-s3": {

--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "verify": "pnpm run typecheck && pnpm run build && pnpm run check:doc-examples && pnpm run check:deployment-contracts && pnpm run lint && pnpm run lint:docs && pnpm run lint:links && pnpm run validate:skills && pnpm run format:check && pnpm run spell && pnpm run test:runtime-security && pnpm run test:diagnostics",
     "test:cross-platform": "node scripts/run-cross-platform-tests.mjs",
     "smoke": "node scripts/smoke-test.mjs",
-    "smoke:local": "pnpm run build && node scripts/local-mcp-smoke.mjs",
+    "smoke:local": "node scripts/local-mcp-smoke.mjs",
     "smoke:client": "node scripts/mcp-client-smoke.mjs",
     "smoke:inspector": "node scripts/mcp-inspector-smoke.mjs",
     "generate:tool-contract": "pnpm run build && node scripts/generate-tool-contract.mjs",

--- a/package.json
+++ b/package.json
@@ -52,6 +52,7 @@
     "verify": "pnpm run typecheck && pnpm run build && pnpm run check:doc-examples && pnpm run check:deployment-contracts && pnpm run lint && pnpm run lint:docs && pnpm run lint:links && pnpm run validate:skills && pnpm run format:check && pnpm run spell && pnpm run test:runtime-security && pnpm run test:diagnostics",
     "test:cross-platform": "node scripts/run-cross-platform-tests.mjs",
     "smoke": "node scripts/smoke-test.mjs",
+    "smoke:local": "pnpm run build && node scripts/local-mcp-smoke.mjs",
     "smoke:client": "node scripts/mcp-client-smoke.mjs",
     "smoke:inspector": "node scripts/mcp-inspector-smoke.mjs",
     "generate:tool-contract": "pnpm run build && node scripts/generate-tool-contract.mjs",

--- a/scripts/lib/smoke-contract.cjs
+++ b/scripts/lib/smoke-contract.cjs
@@ -15,6 +15,17 @@ function candidateProfiles(toolContract, expectedProfile, allowAnyProfile) {
   return allowAnyProfile ? Object.entries(toolContract.profiles) : [];
 }
 
+function toolContractSnapshot(tools, helpers) {
+  const sortedTools = [...(tools ?? [])]
+    .filter((tool) => tool?.name)
+    .sort((a, b) => a.name.localeCompare(b.name));
+  const names = sortedTools.map((tool) => tool.name);
+  return {
+    names,
+    hash: helpers.fixtureHash({ names, tools: sortedTools.map(helpers.normalizeTool) }),
+  };
+}
+
 function profileMatchDetail(snapshot, nameMatchedProfile, matchedProfile) {
   const actualHash = snapshot.hash.slice(0, 12);
   if (matchedProfile) {
@@ -73,4 +84,5 @@ function evaluateProfileContract({
 module.exports = {
   arraysEqual,
   evaluateProfileContract,
+  toolContractSnapshot,
 };

--- a/scripts/local-mcp-smoke.mjs
+++ b/scripts/local-mcp-smoke.mjs
@@ -1,0 +1,559 @@
+#!/usr/bin/env node
+/**
+ * Deterministic local MCP runtime smoke.
+ *
+ * Bootstrap mode strips sensitive parent environment variables before importing
+ * the MCP client SDK. Runner mode starts a local HTTP server worker from the
+ * built dist/ artifacts, connects over 127.0.0.1, validates discovery and
+ * tools/list, then verifies a missing-credential request returns a JSON-RPC
+ * error instead of crashing.
+ */
+
+import { spawn } from "node:child_process";
+import { once } from "node:events";
+import { existsSync, readFileSync } from "node:fs";
+import { createRequire } from "node:module";
+import { dirname, join } from "node:path";
+import { fileURLToPath, pathToFileURL } from "node:url";
+
+const require = createRequire(import.meta.url);
+const { sanitizedEnv, secretNamePattern } = require("./lib/sanitized-env.cjs");
+const { arraysEqual, evaluateProfileContract } = require("./lib/smoke-contract.cjs");
+
+const root = dirname(dirname(fileURLToPath(import.meta.url)));
+const scriptPath = fileURLToPath(import.meta.url);
+const TARGET_PROTOCOL_VERSION = "2026-07-28";
+const EXPECTED_PROFILE = "full";
+const EXPECTED_FIXTURE = "tests/fixtures/tool-contract/full.modern.json";
+const MODE_ENV_NAME = "B2_MCP_LOCAL_SMOKE_MODE";
+const RUNNER_MODE = "runner";
+const SERVER_MODE = "server";
+const NETWORK_GUARD_SCRIPT = "scripts/no-network-guard.mjs";
+const NETWORK_GUARD_SIGNAL = "MCP_CLIENT_SMOKE_NETWORK_BLOCKED";
+const READY_TIMEOUT_MS = 10_000;
+const REQUEST_TIMEOUT_MS = 10_000;
+const SHUTDOWN_TIMEOUT_MS = 5_000;
+const STDERR_TAIL_BYTES = 8192;
+const MISSING_CREDENTIAL_REQUEST_ID = 7001;
+
+const allowedSensitiveEnvNames = new Set([
+  MODE_ENV_NAME,
+  "B2_ALLOWED_HOSTS",
+  "B2_HTTP_CREDENTIAL_MODE",
+  "B2_REGISTER_ALL_TOOLS",
+]);
+
+const fakeCredentialHeaders = {
+  "x-b2-key-id": "local-smoke-key-id",
+  "x-b2-key": "local-smoke-key-secret",
+};
+
+function readJson(relativePath) {
+  return JSON.parse(readFileSync(join(root, relativePath), "utf8"));
+}
+
+function assertBuiltArtifacts() {
+  const missing = ["dist/http-server.js", "dist/tool-contract.js"].filter(
+    (relativePath) => !existsSync(join(root, relativePath)),
+  );
+  if (missing.length > 0) {
+    throw new Error(
+      `Missing built artifact(s): ${missing.join(
+        ", ",
+      )}. Run pnpm run build before node scripts/local-mcp-smoke.mjs.`,
+    );
+  }
+}
+
+function createModeEnv(mode, extra = {}, sourceEnv = process.env) {
+  return sanitizedEnv(
+    {
+      [MODE_ENV_NAME]: mode,
+      ...extra,
+    },
+    {
+      sourceEnv,
+      nonSecretEnvNames: allowedSensitiveEnvNames,
+    },
+  );
+}
+
+function createServerEnv(sourceEnv = process.env) {
+  return createModeEnv(
+    SERVER_MODE,
+    {
+      B2_ALLOWED_HOSTS: "127.0.0.1",
+      B2_HTTP_CREDENTIAL_MODE: "headers",
+      B2_REGISTER_ALL_TOOLS: "true",
+      LOG_LEVEL: "silent",
+      NO_COLOR: "1",
+      NODE_OPTIONS: `--import ${pathToFileURL(join(root, NETWORK_GUARD_SCRIPT)).href}`,
+    },
+    sourceEnv,
+  );
+}
+
+function sensitiveEnvNames(env) {
+  return Object.keys(env)
+    .filter((name) => secretNamePattern.test(name) && !allowedSensitiveEnvNames.has(name))
+    .sort();
+}
+
+function assertEnvIsSanitized(env = process.env) {
+  const leaked = sensitiveEnvNames(env);
+  if (leaked.length > 0) {
+    throw new Error(
+      `Refusing to run local smoke with sensitive environment variables present: ${leaked.join(
+        ", ",
+      )}`,
+    );
+  }
+}
+
+function createBoundedTextMonitor(maxTailBytes = STDERR_TAIL_BYTES) {
+  let tail = "";
+  let networkBlocked = false;
+  return {
+    observe(chunk) {
+      const text = chunk.toString();
+      if (text.includes(NETWORK_GUARD_SIGNAL)) networkBlocked = true;
+      tail = `${tail}${text}`.slice(-maxTailBytes);
+    },
+    get networkBlocked() {
+      return networkBlocked;
+    },
+    get tail() {
+      return tail;
+    },
+  };
+}
+
+function recordCheck(checks, name, ok, detail = "") {
+  checks.push({ name, ok, detail });
+  const mark = ok ? "PASS" : "FAIL";
+  console.log(`  [${mark}] ${name}${detail ? " - " + detail : ""}`);
+}
+
+function loadContractHelpers() {
+  const helpers = require(join(root, "dist/tool-contract.js"));
+  if (typeof helpers.normalizeTool !== "function" || typeof helpers.fixtureHash !== "function") {
+    throw new Error("dist/tool-contract.js does not export contract helpers");
+  }
+  return helpers;
+}
+
+function toolContractSnapshot(tools, helpers) {
+  const sortedTools = [...(tools ?? [])]
+    .filter((tool) => tool?.name)
+    .sort((a, b) => a.name.localeCompare(b.name));
+  const names = sortedTools.map((tool) => tool.name);
+  return {
+    names,
+    hash: helpers.fixtureHash({ names, tools: sortedTools.map(helpers.normalizeTool) }),
+  };
+}
+
+function modernBody(method, params = {}, id = 1) {
+  return JSON.stringify({
+    jsonrpc: "2.0",
+    id,
+    method,
+    params: {
+      ...params,
+      _meta: {
+        "io.modelcontextprotocol/clientCapabilities": {},
+        "io.modelcontextprotocol/clientInfo": {
+          name: "b2-mcp-local-smoke",
+          version: "1.0.0",
+        },
+        "io.modelcontextprotocol/protocolVersion": TARGET_PROTOCOL_VERSION,
+      },
+    },
+  });
+}
+
+function modernHeaders(method, name) {
+  return {
+    accept: "application/json, text/event-stream",
+    "content-type": "application/json",
+    "mcp-method": method,
+    "mcp-protocol-version": TARGET_PROTOCOL_VERSION,
+    ...(name ? { "mcp-name": name } : {}),
+  };
+}
+
+function assertLocalFetchTarget(input) {
+  const rawUrl =
+    input instanceof Request ? input.url : input instanceof URL ? input.href : String(input);
+  const url = new URL(rawUrl);
+  if (url.protocol !== "http:" || url.hostname !== "127.0.0.1") {
+    throw new Error(`local smoke refused non-local fetch target: ${url.origin}`);
+  }
+}
+
+function localFetch(input, init) {
+  assertLocalFetchTarget(input);
+  return fetch(input, init);
+}
+
+function withTimeout(promise, label, timeoutMs) {
+  let timer;
+  const timeout = new Promise((_, reject) => {
+    timer = setTimeout(
+      () => reject(new Error(`${label} timed out after ${timeoutMs}ms`)),
+      timeoutMs,
+    );
+    timer.unref?.();
+  });
+  return Promise.race([promise, timeout]).finally(() => clearTimeout(timer));
+}
+
+function waitForReady(child) {
+  let buffer = "";
+  return new Promise((resolve, reject) => {
+    const onData = (chunk) => {
+      buffer += chunk.toString();
+      for (;;) {
+        const newline = buffer.indexOf("\n");
+        if (newline === -1) return;
+        const line = buffer.slice(0, newline).trim();
+        buffer = buffer.slice(newline + 1);
+        if (!line) continue;
+        try {
+          const event = JSON.parse(line);
+          if (event.event === "ready" && Number.isInteger(event.port)) {
+            cleanup();
+            resolve({ port: event.port });
+            return;
+          }
+        } catch {
+          cleanup();
+          reject(new Error(`local smoke server wrote non-JSON stdout: ${line}`));
+          return;
+        }
+      }
+    };
+    const onExit = (code, signal) => {
+      cleanup();
+      reject(
+        new Error(
+          `local smoke server exited before readiness (code=${code ?? "null"} signal=${
+            signal ?? "null"
+          })`,
+        ),
+      );
+    };
+    const onError = (error) => {
+      cleanup();
+      reject(error);
+    };
+    const cleanup = () => {
+      child.stdout.off("data", onData);
+      child.off("exit", onExit);
+      child.off("error", onError);
+    };
+    child.stdout.on("data", onData);
+    child.once("exit", onExit);
+    child.once("error", onError);
+  });
+}
+
+async function stopChild(child) {
+  if (child.exitCode !== null || child.signalCode !== null) {
+    return { code: child.exitCode, signal: child.signalCode };
+  }
+  child.kill("SIGTERM");
+  const killTimer = setTimeout(() => child.kill("SIGKILL"), SHUTDOWN_TIMEOUT_MS);
+  killTimer.unref?.();
+  try {
+    const [code, signal] = await withTimeout(
+      once(child, "exit"),
+      "local smoke server shutdown",
+      SHUTDOWN_TIMEOUT_MS + 1_000,
+    );
+    return { code, signal };
+  } finally {
+    clearTimeout(killTimer);
+  }
+}
+
+async function requestWithoutCredentials(endpoint) {
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), REQUEST_TIMEOUT_MS);
+  timeout.unref?.();
+  try {
+    const response = await localFetch(endpoint, {
+      method: "POST",
+      headers: modernHeaders("tools/list"),
+      body: modernBody("tools/list", {}, MISSING_CREDENTIAL_REQUEST_ID),
+      signal: controller.signal,
+    });
+    const body = await response.json();
+    return { status: response.status, body };
+  } finally {
+    clearTimeout(timeout);
+  }
+}
+
+async function listenOnLocalhost(handle) {
+  return new Promise((resolve, reject) => {
+    const onError = (error) => {
+      handle.server.off("error", onError);
+      reject(error);
+    };
+    handle.server.once("error", onError);
+    handle.server.listen(0, "127.0.0.1", () => {
+      handle.server.off("error", onError);
+      const address = handle.server.address();
+      if (!address || typeof address === "string") {
+        reject(new Error("local smoke server did not expose a TCP port"));
+        return;
+      }
+      resolve(address.port);
+    });
+  });
+}
+
+async function closeServerHandle(handle, exitCode = 0) {
+  handle.drain();
+  const closeTimer = setTimeout(() => process.exit(1), SHUTDOWN_TIMEOUT_MS);
+  closeTimer.unref?.();
+  await new Promise((resolve) => handle.server.close(() => resolve()));
+  clearTimeout(closeTimer);
+  process.exit(exitCode);
+}
+
+async function runServerWorker() {
+  assertBuiltArtifacts();
+  assertEnvIsSanitized();
+  const [{ buildHttpServer }, { validateHttpStartupConfiguration }] = await Promise.all([
+    import(pathToFileURL(join(root, "dist/http-server.js")).href),
+    import(pathToFileURL(join(root, "dist/credentials.js")).href),
+  ]);
+
+  validateHttpStartupConfiguration();
+  const handle = buildHttpServer();
+  let shuttingDown = false;
+  const shutdown = (exitCode = 0) => {
+    if (shuttingDown) return;
+    shuttingDown = true;
+    void closeServerHandle(handle, exitCode);
+  };
+
+  process.once("SIGTERM", () => shutdown(0));
+  process.once("SIGINT", () => shutdown(0));
+  handle.server.once("error", (error) => {
+    process.stderr.write(`local smoke server error: ${error.message}\n`);
+    shutdown(1);
+  });
+
+  const port = await listenOnLocalhost(handle);
+  process.stdout.write(`${JSON.stringify({ event: "ready", port })}\n`);
+}
+
+async function runRunner() {
+  assertBuiltArtifacts();
+  assertEnvIsSanitized();
+  const helpers = loadContractHelpers();
+  const expectedFixture = readJson(EXPECTED_FIXTURE);
+  const toolContract = readJson("docs/tool-profile-contract.json");
+  const [{ Client, StreamableHTTPClientTransport }] = await Promise.all([
+    import("@modelcontextprotocol/client"),
+  ]);
+  const checks = [];
+  let client;
+  let primaryError = null;
+  const server = spawn(process.execPath, [scriptPath], {
+    cwd: root,
+    env: createServerEnv(),
+    stdio: ["ignore", "pipe", "pipe"],
+  });
+  const stderrMonitor = createBoundedTextMonitor();
+  server.stderr.on("data", (chunk) => stderrMonitor.observe(chunk));
+
+  console.log("Local MCP runtime smoke");
+  console.log(`  transport=http host=127.0.0.1 targetProtocol=${TARGET_PROTOCOL_VERSION}`);
+
+  try {
+    const { port } = await withTimeout(
+      waitForReady(server),
+      "local HTTP server readiness",
+      READY_TIMEOUT_MS,
+    );
+    const endpoint = new URL(`http://127.0.0.1:${port}/mcp`);
+    const transport = new StreamableHTTPClientTransport(endpoint, {
+      requestInit: { headers: fakeCredentialHeaders },
+      fetch: localFetch,
+    });
+    client = new Client(
+      { name: "b2-mcp-local-smoke", version: "1.0.0" },
+      {
+        versionNegotiation: { mode: { pin: TARGET_PROTOCOL_VERSION } },
+        defaultCacheTtlMs: 0,
+      },
+    );
+
+    await client.connect(transport, { timeoutMs: REQUEST_TIMEOUT_MS });
+    const era = client.getProtocolEra();
+    const protocolVersion = client.getNegotiatedProtocolVersion();
+    const serverVersion = client.getServerVersion();
+    const discover =
+      client.getDiscoverResult() ?? (await client.discover({ timeoutMs: REQUEST_TIMEOUT_MS }));
+
+    console.log(
+      `  negotiatedEra=${era ?? "unknown"} negotiatedProtocol=${protocolVersion ?? "unknown"}`,
+    );
+    console.log(
+      `  server=${serverVersion?.name ?? "unknown"}@${
+        serverVersion?.version ?? "unknown"
+      } port=${port}`,
+    );
+
+    recordCheck(checks, "server process reported local readiness", port > 0, `port=${port}`);
+    recordCheck(checks, "client negotiated modern protocol era", era === "modern", `era=${era}`);
+    recordCheck(
+      checks,
+      "client negotiated target protocol revision",
+      protocolVersion === TARGET_PROTOCOL_VERSION,
+      `protocol=${protocolVersion ?? "unknown"}`,
+    );
+    recordCheck(
+      checks,
+      "server/discover advertises target protocol",
+      discover.supportedVersions?.includes(TARGET_PROTOCOL_VERSION) === true,
+      `supported=${(discover.supportedVersions ?? []).join(",")}`,
+    );
+    recordCheck(
+      checks,
+      "server/discover exposes tool capability",
+      typeof discover.capabilities?.tools === "object" && discover.capabilities.tools !== null,
+    );
+    recordCheck(
+      checks,
+      "server name/version is reported",
+      serverVersion?.name === "backblaze-b2" && typeof serverVersion.version === "string",
+      `server=${serverVersion?.name ?? "unknown"}@${serverVersion?.version ?? "unknown"}`,
+    );
+
+    const listed = await client.listTools(undefined, {
+      cacheMode: "refresh",
+      timeoutMs: REQUEST_TIMEOUT_MS,
+    });
+    const snapshot = toolContractSnapshot(listed.tools, helpers);
+    const profileResult = evaluateProfileContract({
+      snapshot,
+      toolContract,
+      expectedProfile: EXPECTED_PROFILE,
+    });
+    recordCheck(
+      checks,
+      "tools/list returns registered tools",
+      Array.isArray(listed.tools) && listed.tools.length > 0,
+      `${listed.tools?.length ?? 0} tools`,
+    );
+    for (const result of profileResult.checks) {
+      recordCheck(checks, result.name, result.ok, result.detail);
+    }
+    recordCheck(
+      checks,
+      `tools/list names match ${EXPECTED_FIXTURE}`,
+      arraysEqual(snapshot.names, expectedFixture.names),
+      `${snapshot.names.length} tools`,
+    );
+    recordCheck(
+      checks,
+      `tools/list hash matches ${EXPECTED_FIXTURE}`,
+      snapshot.hash === expectedFixture.hash,
+      `hash=${snapshot.hash.slice(0, 12)}`,
+    );
+    recordCheck(
+      checks,
+      "tools/list includes representative B2 and S3 tools",
+      snapshot.names.includes("b2_list_buckets") && snapshot.names.includes("s3_list_objects_v2"),
+    );
+
+    const missingCredentials = await requestWithoutCredentials(endpoint);
+    const missingBody = missingCredentials.body;
+    const missingText = JSON.stringify(missingBody);
+    recordCheck(
+      checks,
+      "no-credential request returns HTTP 401",
+      missingCredentials.status === 401,
+      `status=${missingCredentials.status}`,
+    );
+    recordCheck(
+      checks,
+      "no-credential request returns JSON-RPC error",
+      missingBody?.jsonrpc === "2.0" &&
+        missingBody?.id === MISSING_CREDENTIAL_REQUEST_ID &&
+        missingBody?.error?.code === -32001 &&
+        missingBody?.error?.data?.code === "missing_credentials",
+      `code=${missingBody?.error?.code ?? "missing"}`,
+    );
+    recordCheck(
+      checks,
+      "no-credential error is sanitized",
+      !missingText.includes("B2_APPLICATION_KEY") &&
+        !missingText.includes("local-smoke-key") &&
+        !missingText.includes("process.env"),
+    );
+    await new Promise((resolve) => setImmediate(resolve));
+    recordCheck(checks, "startup avoided B2 network access", !stderrMonitor.networkBlocked);
+  } catch (error) {
+    primaryError = error;
+  } finally {
+    await client?.close().catch(() => undefined);
+    const stopped = await stopChild(server).catch((error) => {
+      primaryError ??= error;
+      return { code: null, signal: "cleanup-error" };
+    });
+    recordCheck(
+      checks,
+      "server process stopped cleanly",
+      stopped.code === 0 && !stopped.signal,
+      `code=${stopped.code ?? "null"} signal=${stopped.signal ?? "null"}`,
+    );
+  }
+
+  if (primaryError) {
+    if (stderrMonitor.tail) process.stderr.write(stderrMonitor.tail);
+    throw primaryError;
+  }
+
+  const failed = checks.filter((result) => !result.ok);
+  if (failed.length > 0) {
+    if (stderrMonitor.tail) process.stderr.write(stderrMonitor.tail);
+    throw new Error(`FAILED (${failed.length}): ${failed.map((result) => result.name).join(", ")}`);
+  }
+
+  console.log("All checks passed.");
+}
+
+async function runBootstrap() {
+  assertBuiltArtifacts();
+  const child = spawn(process.execPath, [scriptPath], {
+    cwd: root,
+    env: createModeEnv(RUNNER_MODE),
+    stdio: "inherit",
+  });
+  const [code, signal] = await once(child, "exit");
+  if (signal) {
+    console.error(`local smoke runner terminated by ${signal}`);
+    process.exitCode = 1;
+    return;
+  }
+  process.exitCode = typeof code === "number" ? code : 1;
+}
+
+async function main() {
+  if (process.env[MODE_ENV_NAME] === SERVER_MODE) await runServerWorker();
+  else if (process.env[MODE_ENV_NAME] === RUNNER_MODE) await runRunner();
+  else await runBootstrap();
+}
+
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+  main().catch((err) => {
+    console.error("Fatal:", err.message ?? err);
+    process.exit(1);
+  });
+}

--- a/scripts/local-mcp-smoke.mjs
+++ b/scripts/local-mcp-smoke.mjs
@@ -77,12 +77,21 @@ function assertBuiltArtifacts() {
 
 function buildIfNeeded() {
   if (process.env.B2_MCP_LOCAL_SMOKE_SKIP_BUILD === "true") return;
-  const command =
-    typeof process.env.npm_execpath === "string" && process.env.npm_execpath.includes("pnpm")
-      ? process.execPath
-      : "pnpm";
-  const args =
-    command === process.execPath ? [process.env.npm_execpath, "run", "build"] : ["run", "build"];
+  const execpath = process.env.npm_execpath;
+  let command;
+  let args;
+  if (typeof execpath === "string" && /\.[cm]?js$/.test(execpath)) {
+    // JS package-manager entry (e.g. the corepack pnpm shim): run it with Node.
+    command = process.execPath;
+    args = [execpath, "run", "build"];
+  } else if (typeof execpath === "string" && execpath.toLowerCase().includes("pnpm")) {
+    // Native pnpm executable (@pnpm/exe): invoke it directly, not via Node.
+    command = execpath;
+    args = ["run", "build"];
+  } else {
+    command = "pnpm";
+    args = ["run", "build"];
+  }
   const result = spawnSync(command, args, { cwd: root, stdio: "inherit" });
   if (result.error) throw result.error;
   if (result.status !== 0) {

--- a/scripts/local-mcp-smoke.mjs
+++ b/scripts/local-mcp-smoke.mjs
@@ -2,25 +2,34 @@
 /**
  * Deterministic local MCP runtime smoke.
  *
- * Bootstrap mode strips sensitive parent environment variables before importing
- * the MCP client SDK. Runner mode starts a local HTTP server worker from the
- * built dist/ artifacts, connects over 127.0.0.1, validates discovery and
- * tools/list, then verifies a missing-credential request returns a JSON-RPC
- * error instead of crashing.
+ * Bootstrap mode builds by default, then strips sensitive parent environment
+ * variables before starting the runner. Runner mode starts a local HTTP server
+ * worker from the built dist/ artifacts, connects over 127.0.0.1 with a minimal
+ * modern MCP HTTP client, validates discovery and tools/list, then verifies a
+ * missing-credential request returns a JSON-RPC error instead of crashing.
  */
 
-import { spawn } from "node:child_process";
+import { spawn, spawnSync } from "node:child_process";
 import { once } from "node:events";
 import { existsSync, readFileSync } from "node:fs";
 import { createRequire } from "node:module";
-import { dirname, join } from "node:path";
+import { dirname, join, resolve } from "node:path";
 import { fileURLToPath, pathToFileURL } from "node:url";
 
 const require = createRequire(import.meta.url);
+const http = require("node:http");
+const https = require("node:https");
+const net = require("node:net");
+const tls = require("node:tls");
 const { sanitizedEnv, secretNamePattern } = require("./lib/sanitized-env.cjs");
-const { arraysEqual, evaluateProfileContract } = require("./lib/smoke-contract.cjs");
+const {
+  arraysEqual,
+  evaluateProfileContract,
+  toolContractSnapshot,
+} = require("./lib/smoke-contract.cjs");
 
-const root = dirname(dirname(fileURLToPath(import.meta.url)));
+const scriptRoot = dirname(dirname(fileURLToPath(import.meta.url)));
+const root = resolve(process.env.B2_MCP_LOCAL_SMOKE_ROOT ?? scriptRoot);
 const scriptPath = fileURLToPath(import.meta.url);
 const TARGET_PROTOCOL_VERSION = "2026-07-28";
 const EXPECTED_PROFILE = "full";
@@ -29,7 +38,7 @@ const MODE_ENV_NAME = "B2_MCP_LOCAL_SMOKE_MODE";
 const RUNNER_MODE = "runner";
 const SERVER_MODE = "server";
 const NETWORK_GUARD_SCRIPT = "scripts/no-network-guard.mjs";
-const NETWORK_GUARD_SIGNAL = "MCP_CLIENT_SMOKE_NETWORK_BLOCKED";
+export const NETWORK_GUARD_SIGNAL = "MCP_CLIENT_SMOKE_NETWORK_BLOCKED";
 const READY_TIMEOUT_MS = 10_000;
 const REQUEST_TIMEOUT_MS = 10_000;
 const SHUTDOWN_TIMEOUT_MS = 5_000;
@@ -40,6 +49,7 @@ const allowedSensitiveEnvNames = new Set([
   MODE_ENV_NAME,
   "B2_ALLOWED_HOSTS",
   "B2_HTTP_CREDENTIAL_MODE",
+  "B2_MCP_LOCAL_SMOKE_ROOT",
   "B2_REGISTER_ALL_TOOLS",
 ]);
 
@@ -60,8 +70,23 @@ function assertBuiltArtifacts() {
     throw new Error(
       `Missing built artifact(s): ${missing.join(
         ", ",
-      )}. Run pnpm run build before node scripts/local-mcp-smoke.mjs.`,
+      )}. Run pnpm run build before node scripts/local-mcp-smoke.mjs, or set B2_MCP_LOCAL_SMOKE_ROOT to a built package root.`,
     );
+  }
+}
+
+function buildIfNeeded() {
+  if (process.env.B2_MCP_LOCAL_SMOKE_SKIP_BUILD === "true") return;
+  const command =
+    typeof process.env.npm_execpath === "string" && process.env.npm_execpath.includes("pnpm")
+      ? process.execPath
+      : "pnpm";
+  const args =
+    command === process.execPath ? [process.env.npm_execpath, "run", "build"] : ["run", "build"];
+  const result = spawnSync(command, args, { cwd: root, stdio: "inherit" });
+  if (result.error) throw result.error;
+  if (result.status !== 0) {
+    throw new Error(`pnpm run build failed with exit code ${result.status ?? "unknown"}`);
   }
 }
 
@@ -69,6 +94,7 @@ function createModeEnv(mode, extra = {}, sourceEnv = process.env) {
   return sanitizedEnv(
     {
       [MODE_ENV_NAME]: mode,
+      B2_MCP_LOCAL_SMOKE_ROOT: root,
       ...extra,
     },
     {
@@ -87,7 +113,7 @@ function createServerEnv(sourceEnv = process.env) {
       B2_REGISTER_ALL_TOOLS: "true",
       LOG_LEVEL: "silent",
       NO_COLOR: "1",
-      NODE_OPTIONS: `--import ${pathToFileURL(join(root, NETWORK_GUARD_SCRIPT)).href}`,
+      NODE_OPTIONS: `--import ${pathToFileURL(join(scriptRoot, NETWORK_GUARD_SCRIPT)).href}`,
     },
     sourceEnv,
   );
@@ -110,7 +136,7 @@ function assertEnvIsSanitized(env = process.env) {
   }
 }
 
-function createBoundedTextMonitor(maxTailBytes = STDERR_TAIL_BYTES) {
+export function createBoundedTextMonitor(maxTailBytes = STDERR_TAIL_BYTES) {
   let tail = "";
   let networkBlocked = false;
   return {
@@ -140,17 +166,6 @@ function loadContractHelpers() {
     throw new Error("dist/tool-contract.js does not export contract helpers");
   }
   return helpers;
-}
-
-function toolContractSnapshot(tools, helpers) {
-  const sortedTools = [...(tools ?? [])]
-    .filter((tool) => tool?.name)
-    .sort((a, b) => a.name.localeCompare(b.name));
-  const names = sortedTools.map((tool) => tool.name);
-  return {
-    names,
-    hash: helpers.fixtureHash({ names, tools: sortedTools.map(helpers.normalizeTool) }),
-  };
 }
 
 function modernBody(method, params = {}, id = 1) {
@@ -194,6 +209,114 @@ function assertLocalFetchTarget(input) {
 function localFetch(input, init) {
   assertLocalFetchTarget(input);
   return fetch(input, init);
+}
+
+function isLoopbackHostname(hostname) {
+  let normalized = String(hostname ?? "")
+    .trim()
+    .toLowerCase();
+  if (normalized.startsWith("[")) {
+    normalized = normalized.slice(1).replace(/\].*$/, "");
+  } else if ((normalized.match(/:/g) ?? []).length === 1) {
+    normalized = normalized.replace(/:\d+$/, "");
+  }
+  return (
+    normalized === "localhost" ||
+    normalized === "::1" ||
+    /^(?:::ffff:)?127(?:\.\d{1,3}){3}$/.test(normalized)
+  );
+}
+
+function hostFromHttpOptions(options) {
+  if (!options || typeof options !== "object") return "";
+  return options.hostname ?? options.host ?? "";
+}
+
+function hostFromHttpArgs(args) {
+  const [input, options] = args;
+  if (input instanceof URL) return input.hostname;
+  if (typeof input === "string") {
+    try {
+      return new URL(input).hostname;
+    } catch {
+      return hostFromHttpOptions(options);
+    }
+  }
+  return hostFromHttpOptions({ ...input, ...options });
+}
+
+function hostFromNetArgs(args) {
+  const [input, host] = args;
+  if (typeof input === "object" && input !== null) return input.host ?? input.hostname ?? "";
+  if (typeof input === "number") return typeof host === "string" ? host : "localhost";
+  return "";
+}
+
+function assertLoopbackOutbound(kind, host) {
+  if (isLoopbackHostname(host)) return;
+  throw new Error(`local smoke runner blocked outbound network: ${kind} ${host || "unknown"}`);
+}
+
+export function installRunnerOutboundGuard() {
+  const originalFetch = globalThis.fetch?.bind(globalThis);
+  const originals = {
+    fetch: globalThis.fetch,
+    httpGet: http.get,
+    httpRequest: http.request,
+    httpsGet: https.get,
+    httpsRequest: https.request,
+    netConnect: net.connect,
+    netCreateConnection: net.createConnection,
+    tlsConnect: tls.connect,
+  };
+
+  if (originalFetch) {
+    globalThis.fetch = (input, init) => {
+      const rawUrl =
+        input instanceof Request ? input.url : input instanceof URL ? input.href : String(input);
+      assertLoopbackOutbound("fetch", new URL(rawUrl).hostname);
+      return originalFetch(input, init);
+    };
+  }
+  http.request = function guardedHttpRequest(...args) {
+    assertLoopbackOutbound("http.request", hostFromHttpArgs(args));
+    return originals.httpRequest.apply(this, args);
+  };
+  http.get = function guardedHttpGet(...args) {
+    assertLoopbackOutbound("http.get", hostFromHttpArgs(args));
+    return originals.httpGet.apply(this, args);
+  };
+  https.request = function guardedHttpsRequest(...args) {
+    assertLoopbackOutbound("https.request", hostFromHttpArgs(args));
+    return originals.httpsRequest.apply(this, args);
+  };
+  https.get = function guardedHttpsGet(...args) {
+    assertLoopbackOutbound("https.get", hostFromHttpArgs(args));
+    return originals.httpsGet.apply(this, args);
+  };
+  net.connect = function guardedNetConnect(...args) {
+    assertLoopbackOutbound("net.connect", hostFromNetArgs(args));
+    return originals.netConnect.apply(this, args);
+  };
+  net.createConnection = function guardedNetCreateConnection(...args) {
+    assertLoopbackOutbound("net.createConnection", hostFromNetArgs(args));
+    return originals.netCreateConnection.apply(this, args);
+  };
+  tls.connect = function guardedTlsConnect(...args) {
+    assertLoopbackOutbound("tls.connect", hostFromNetArgs(args));
+    return originals.tlsConnect.apply(this, args);
+  };
+
+  return () => {
+    globalThis.fetch = originals.fetch;
+    http.get = originals.httpGet;
+    http.request = originals.httpRequest;
+    https.get = originals.httpsGet;
+    https.request = originals.httpsRequest;
+    net.connect = originals.netConnect;
+    net.createConnection = originals.netCreateConnection;
+    tls.connect = originals.tlsConnect;
+  };
 }
 
 function withTimeout(promise, label, timeoutMs) {
@@ -267,7 +390,7 @@ async function stopChild(child) {
   killTimer.unref?.();
   try {
     const [code, signal] = await withTimeout(
-      once(child, "exit"),
+      once(child, "close"),
       "local smoke server shutdown",
       SHUTDOWN_TIMEOUT_MS + 1_000,
     );
@@ -290,6 +413,31 @@ async function requestWithoutCredentials(endpoint) {
     });
     const body = await response.json();
     return { status: response.status, body };
+  } finally {
+    clearTimeout(timeout);
+  }
+}
+
+let nextMcpRequestId = 1;
+
+async function mcpRequest(endpoint, method, params = {}) {
+  const id = nextMcpRequestId++;
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), REQUEST_TIMEOUT_MS);
+  timeout.unref?.();
+  try {
+    const response = await localFetch(endpoint, {
+      method: "POST",
+      headers: { ...fakeCredentialHeaders, ...modernHeaders(method, params.name) },
+      body: modernBody(method, params, id),
+      signal: controller.signal,
+    });
+    const body = await response.json();
+    if (!response.ok || body.error) {
+      const message = body?.error?.message ?? `HTTP ${response.status}`;
+      throw new Error(`${method} failed: ${message}`);
+    }
+    return body.result;
   } finally {
     clearTimeout(timeout);
   }
@@ -354,14 +502,11 @@ async function runServerWorker() {
 async function runRunner() {
   assertBuiltArtifacts();
   assertEnvIsSanitized();
+  installRunnerOutboundGuard();
   const helpers = loadContractHelpers();
   const expectedFixture = readJson(EXPECTED_FIXTURE);
   const toolContract = readJson("docs/tool-profile-contract.json");
-  const [{ Client, StreamableHTTPClientTransport }] = await Promise.all([
-    import("@modelcontextprotocol/client"),
-  ]);
   const checks = [];
-  let client;
   let primaryError = null;
   const server = spawn(process.execPath, [scriptPath], {
     cwd: root,
@@ -381,41 +526,22 @@ async function runRunner() {
       READY_TIMEOUT_MS,
     );
     const endpoint = new URL(`http://127.0.0.1:${port}/mcp`);
-    const transport = new StreamableHTTPClientTransport(endpoint, {
-      requestInit: { headers: fakeCredentialHeaders },
-      fetch: localFetch,
-    });
-    client = new Client(
-      { name: "b2-mcp-local-smoke", version: "1.0.0" },
-      {
-        versionNegotiation: { mode: { pin: TARGET_PROTOCOL_VERSION } },
-        defaultCacheTtlMs: 0,
-      },
-    );
+    const discover = await mcpRequest(endpoint, "server/discover");
+    const listed = await mcpRequest(endpoint, "tools/list");
+    const serverInfo =
+      discover?._meta?.["io.modelcontextprotocol/serverInfo"] ??
+      listed?._meta?.["io.modelcontextprotocol/serverInfo"];
 
-    await client.connect(transport, { timeoutMs: REQUEST_TIMEOUT_MS });
-    const era = client.getProtocolEra();
-    const protocolVersion = client.getNegotiatedProtocolVersion();
-    const serverVersion = client.getServerVersion();
-    const discover =
-      client.getDiscoverResult() ?? (await client.discover({ timeoutMs: REQUEST_TIMEOUT_MS }));
-
+    console.log(`  protocol=${TARGET_PROTOCOL_VERSION}`);
     console.log(
-      `  negotiatedEra=${era ?? "unknown"} negotiatedProtocol=${protocolVersion ?? "unknown"}`,
+      `  server=${serverInfo?.name ?? "unknown"}@${serverInfo?.version ?? "unknown"} port=${port}`,
     );
-    console.log(
-      `  server=${serverVersion?.name ?? "unknown"}@${
-        serverVersion?.version ?? "unknown"
-      } port=${port}`,
-    );
-
     recordCheck(checks, "server process reported local readiness", port > 0, `port=${port}`);
-    recordCheck(checks, "client negotiated modern protocol era", era === "modern", `era=${era}`);
     recordCheck(
       checks,
-      "client negotiated target protocol revision",
-      protocolVersion === TARGET_PROTOCOL_VERSION,
-      `protocol=${protocolVersion ?? "unknown"}`,
+      "local client connected over modern HTTP",
+      discover?.resultType === "complete" && Array.isArray(listed?.tools),
+      `protocol=${TARGET_PROTOCOL_VERSION}`,
     );
     recordCheck(
       checks,
@@ -431,14 +557,10 @@ async function runRunner() {
     recordCheck(
       checks,
       "server name/version is reported",
-      serverVersion?.name === "backblaze-b2" && typeof serverVersion.version === "string",
-      `server=${serverVersion?.name ?? "unknown"}@${serverVersion?.version ?? "unknown"}`,
+      serverInfo?.name === "backblaze-b2" && typeof serverInfo.version === "string",
+      `server=${serverInfo?.name ?? "unknown"}@${serverInfo?.version ?? "unknown"}`,
     );
 
-    const listed = await client.listTools(undefined, {
-      cacheMode: "refresh",
-      timeoutMs: REQUEST_TIMEOUT_MS,
-    });
     const snapshot = toolContractSnapshot(listed.tools, helpers);
     const profileResult = evaluateProfileContract({
       snapshot,
@@ -497,12 +619,9 @@ async function runRunner() {
         !missingText.includes("local-smoke-key") &&
         !missingText.includes("process.env"),
     );
-    await new Promise((resolve) => setImmediate(resolve));
-    recordCheck(checks, "startup avoided B2 network access", !stderrMonitor.networkBlocked);
   } catch (error) {
     primaryError = error;
   } finally {
-    await client?.close().catch(() => undefined);
     const stopped = await stopChild(server).catch((error) => {
       primaryError ??= error;
       return { code: null, signal: "cleanup-error" };
@@ -513,6 +632,8 @@ async function runRunner() {
       stopped.code === 0 && !stopped.signal,
       `code=${stopped.code ?? "null"} signal=${stopped.signal ?? "null"}`,
     );
+    await new Promise((resolve) => setImmediate(resolve));
+    recordCheck(checks, "server avoided B2 network access", !stderrMonitor.networkBlocked);
   }
 
   if (primaryError) {
@@ -530,6 +651,7 @@ async function runRunner() {
 }
 
 async function runBootstrap() {
+  buildIfNeeded();
   assertBuiltArtifacts();
   const child = spawn(process.execPath, [scriptPath], {
     cwd: root,

--- a/scripts/smoke-test.mjs
+++ b/scripts/smoke-test.mjs
@@ -36,7 +36,7 @@ import { fileURLToPath, pathToFileURL } from "node:url";
 import { redactB2CredentialValues } from "./b2-credential-env.mjs";
 import smokeContract from "./lib/smoke-contract.cjs";
 
-const { evaluateProfileContract } = smokeContract;
+const { evaluateProfileContract, toolContractSnapshot } = smokeContract;
 
 const root = dirname(dirname(fileURLToPath(import.meta.url)));
 const toolContract = JSON.parse(
@@ -184,14 +184,7 @@ export function sortedToolNames(tools) {
 }
 
 export function liveToolContractSnapshot(tools, helpers) {
-  const sortedTools = [...(tools ?? [])]
-    .filter((tool) => tool?.name)
-    .sort((a, b) => a.name.localeCompare(b.name));
-  const names = sortedTools.map((tool) => tool.name);
-  return {
-    names,
-    hash: helpers.fixtureHash({ names, tools: sortedTools.map(helpers.normalizeTool) }),
-  };
+  return toolContractSnapshot(tools, helpers);
 }
 
 function configureRequestContext() {

--- a/src/http-fetch-handler.ts
+++ b/src/http-fetch-handler.ts
@@ -324,36 +324,26 @@ function runIdleSweep(): void {
   sweepAuthManagerCache(now);
 }
 
-type CredentialErrorResponseShape =
-  | { kind: "plain" }
-  | { kind: "json-rpc"; requestId: string | number | null };
+type CredentialErrorShape = { kind: "plain" } | { kind: "json-rpc"; id: string | number | null };
 
-const PLAIN_CREDENTIAL_ERROR_RESPONSE: CredentialErrorResponseShape = { kind: "plain" };
+const PLAIN_CREDENTIAL_ERROR: CredentialErrorShape = { kind: "plain" };
 
-function credentialErrorResponse(err: unknown, shape: CredentialErrorResponseShape): Response {
-  if (err instanceof CredentialResolutionError) {
-    if (shape.kind === "json-rpc") {
-      return jsonResponse(
-        err.status,
-        jsonRpcErrorBody(JSON_RPC_CREDENTIAL_RESOLUTION_FAILED, err.message, shape.requestId, {
-          code: err.code,
-          status: err.status,
-        }),
-      );
-    }
-    return jsonResponse(err.status, { error: err.message });
-  }
+function credentialErrorResponse(err: unknown, shape: CredentialErrorShape): Response {
+  const isCredentialError = err instanceof CredentialResolutionError;
+  const status = isCredentialError ? err.status : 500;
+  const message = isCredentialError ? err.message : "Credential resolution failed";
   if (shape.kind === "json-rpc") {
     return jsonResponse(
-      500,
+      status,
       jsonRpcErrorBody(
         JSON_RPC_CREDENTIAL_RESOLUTION_FAILED,
-        "Credential resolution failed",
-        shape.requestId,
+        message,
+        shape.id,
+        isCredentialError ? { code: err.code, status } : undefined,
       ),
     );
   }
-  return jsonResponse(500, { error: "Credential resolution failed" });
+  return jsonResponse(status, { error: message });
 }
 
 function internalMcpErrorResponse(): Response {
@@ -463,9 +453,13 @@ interface ProtocolRejection {
 
 interface ProtocolPreflight {
   protocolOnly: boolean;
-  credentialErrorResponse: CredentialErrorResponseShape;
+  credError: CredentialErrorShape;
   rejection?: ProtocolRejection;
   sdkHeaders?: Record<string, string | string[] | undefined>;
+}
+
+function plainPreflight(protocolOnly: boolean): ProtocolPreflight {
+  return { protocolOnly, credError: PLAIN_CREDENTIAL_ERROR };
 }
 
 function inferredModernHeaders(
@@ -488,19 +482,13 @@ function classifyProtocolPreflight(
   parsed: ParsedJsonBody,
 ): ProtocolPreflight {
   const httpMethod = request.method.toUpperCase();
-  if (httpMethod === "GET" || httpMethod === "DELETE") {
-    return { protocolOnly: true, credentialErrorResponse: PLAIN_CREDENTIAL_ERROR_RESPONSE };
-  }
-  if (httpMethod !== "POST") {
-    return { protocolOnly: false, credentialErrorResponse: PLAIN_CREDENTIAL_ERROR_RESPONSE };
-  }
+  if (httpMethod === "GET" || httpMethod === "DELETE") return plainPreflight(true);
+  if (httpMethod !== "POST") return plainPreflight(false);
   if (!isJsonContentType(headerValue(sanitizedHeaders, "content-type") ?? null)) {
-    return { protocolOnly: true, credentialErrorResponse: PLAIN_CREDENTIAL_ERROR_RESPONSE };
+    return plainPreflight(true);
   }
 
-  if (!parsed.ok) {
-    return { protocolOnly: false, credentialErrorResponse: PLAIN_CREDENTIAL_ERROR_RESPONSE };
-  }
+  if (!parsed.ok) return plainPreflight(false);
   const outcome = classifyInboundRequest({
     httpMethod,
     protocolVersionHeader: headerValue(sanitizedHeaders, "mcp-protocol-version"),
@@ -509,19 +497,15 @@ function classifyProtocolPreflight(
     body: parsed.body,
   });
 
-  if (outcome.kind === "reject") {
-    return { protocolOnly: true, credentialErrorResponse: PLAIN_CREDENTIAL_ERROR_RESPONSE };
-  }
-  if (outcome.kind !== "modern") {
-    return { protocolOnly: false, credentialErrorResponse: PLAIN_CREDENTIAL_ERROR_RESPONSE };
-  }
+  if (outcome.kind === "reject") return plainPreflight(true);
+  if (outcome.kind !== "modern") return plainPreflight(false);
   if (outcome.classification.revision !== MODERN_MCP_PROTOCOL_VERSION) {
-    return { protocolOnly: true, credentialErrorResponse: PLAIN_CREDENTIAL_ERROR_RESPONSE };
+    return plainPreflight(true);
   }
 
-  const credentialErrorResponseShape: CredentialErrorResponseShape = {
+  const credError: CredentialErrorShape = {
     kind: "json-rpc",
-    requestId: requestIdFromParsedBody(parsed.body),
+    id: requestIdFromParsedBody(parsed.body),
   };
   const sdkHeaders = inferredModernHeaders(
     sanitizedHeaders,
@@ -530,36 +514,23 @@ function classifyProtocolPreflight(
   );
   const headerName = headerValue(sanitizedHeaders, "mcp-name");
   const bodyMethod = requestMethodFromParsedBody(parsed.body);
-  if (bodyMethod !== "tools/call" || !headerName) {
-    return {
-      protocolOnly: false,
-      credentialErrorResponse: credentialErrorResponseShape,
-      sdkHeaders,
-    };
-  }
-
   const bodyName = toolNameFromParsedBody(parsed.body);
-  if (headerName === bodyName) {
-    return {
-      protocolOnly: false,
-      credentialErrorResponse: credentialErrorResponseShape,
-      sdkHeaders,
-    };
+  if (bodyMethod !== "tools/call" || !headerName || headerName === bodyName) {
+    return { protocolOnly: false, credError, sdkHeaders };
   }
 
-  const requestId = requestIdFromParsedBody(parsed.body);
   return {
     protocolOnly: false,
-    credentialErrorResponse: credentialErrorResponseShape,
+    credError,
     rejection: {
       status: 400,
       code: JSON_RPC_HEADER_BODY_MISMATCH,
       reason: "mcp-name-mismatch",
-      requestId,
+      requestId: credError.id,
       body: jsonRpcErrorBody(
         JSON_RPC_HEADER_BODY_MISMATCH,
         "Bad Request: Mcp-Name header does not match tool name",
-        requestId,
+        credError.id,
         { mismatch: { header: headerName, body: bodyName ?? null } },
       ),
     },
@@ -693,7 +664,7 @@ function publicCredentialHeaderRejection(
   provider: CredentialProvider,
   request: Request,
   authInfo: AuthInfo | null | undefined,
-  responseShape: CredentialErrorResponseShape,
+  responseShape: CredentialErrorShape,
 ): Response | null {
   if (!shouldRejectPublicCredentialHeaders(provider)) return null;
   if (!hasCredentialHeaders(headersToIncoming(request.headers))) return null;
@@ -902,7 +873,7 @@ export function createB2McpFetchHandler(options: HttpPipelineOptions = {}): B2Mc
         credentialProvider,
         request,
         authInfo,
-        protocolPreflight.credentialErrorResponse,
+        protocolPreflight.credError,
       );
       if (credentialHeaderRejection) {
         return responseWithCleanup(credentialHeaderRejection, () => finalize(limitKey, prepared));
@@ -923,9 +894,8 @@ export function createB2McpFetchHandler(options: HttpPipelineOptions = {}): B2Mc
         resolved = credentialProvider.resolve({ req: credentialRequest });
       } catch (err) {
         logCredentialResolutionFailure(credentialProvider, request, authInfo, err);
-        return responseWithCleanup(
-          credentialErrorResponse(err, protocolPreflight.credentialErrorResponse),
-          () => finalize(limitKey, prepared),
+        return responseWithCleanup(credentialErrorResponse(err, protocolPreflight.credError), () =>
+          finalize(limitKey, prepared),
         );
       }
 
@@ -958,9 +928,8 @@ export function createB2McpFetchHandler(options: HttpPipelineOptions = {}): B2Mc
           resolved.cacheKey,
         );
       } catch (err) {
-        return responseWithCleanup(
-          credentialErrorResponse(err, protocolPreflight.credentialErrorResponse),
-          () => finalize(limitKey, prepared),
+        return responseWithCleanup(credentialErrorResponse(err, protocolPreflight.credError), () =>
+          finalize(limitKey, prepared),
         );
       }
 

--- a/src/http-fetch-handler.ts
+++ b/src/http-fetch-handler.ts
@@ -324,12 +324,18 @@ function runIdleSweep(): void {
   sweepAuthManagerCache(now);
 }
 
-function credentialErrorResponse(err: unknown, mcpRequestId?: string | number | null): Response {
+type CredentialErrorResponseShape =
+  | { kind: "plain" }
+  | { kind: "json-rpc"; requestId: string | number | null };
+
+const PLAIN_CREDENTIAL_ERROR_RESPONSE: CredentialErrorResponseShape = { kind: "plain" };
+
+function credentialErrorResponse(err: unknown, shape: CredentialErrorResponseShape): Response {
   if (err instanceof CredentialResolutionError) {
-    if (mcpRequestId !== undefined) {
+    if (shape.kind === "json-rpc") {
       return jsonResponse(
         err.status,
-        jsonRpcErrorBody(JSON_RPC_CREDENTIAL_RESOLUTION_FAILED, err.message, mcpRequestId, {
+        jsonRpcErrorBody(JSON_RPC_CREDENTIAL_RESOLUTION_FAILED, err.message, shape.requestId, {
           code: err.code,
           status: err.status,
         }),
@@ -337,13 +343,13 @@ function credentialErrorResponse(err: unknown, mcpRequestId?: string | number | 
     }
     return jsonResponse(err.status, { error: err.message });
   }
-  if (mcpRequestId !== undefined) {
+  if (shape.kind === "json-rpc") {
     return jsonResponse(
       500,
       jsonRpcErrorBody(
         JSON_RPC_CREDENTIAL_RESOLUTION_FAILED,
         "Credential resolution failed",
-        mcpRequestId,
+        shape.requestId,
       ),
     );
   }
@@ -457,6 +463,7 @@ interface ProtocolRejection {
 
 interface ProtocolPreflight {
   protocolOnly: boolean;
+  credentialErrorResponse: CredentialErrorResponseShape;
   rejection?: ProtocolRejection;
   sdkHeaders?: Record<string, string | string[] | undefined>;
 }
@@ -481,13 +488,19 @@ function classifyProtocolPreflight(
   parsed: ParsedJsonBody,
 ): ProtocolPreflight {
   const httpMethod = request.method.toUpperCase();
-  if (httpMethod === "GET" || httpMethod === "DELETE") return { protocolOnly: true };
-  if (httpMethod !== "POST") return { protocolOnly: false };
+  if (httpMethod === "GET" || httpMethod === "DELETE") {
+    return { protocolOnly: true, credentialErrorResponse: PLAIN_CREDENTIAL_ERROR_RESPONSE };
+  }
+  if (httpMethod !== "POST") {
+    return { protocolOnly: false, credentialErrorResponse: PLAIN_CREDENTIAL_ERROR_RESPONSE };
+  }
   if (!isJsonContentType(headerValue(sanitizedHeaders, "content-type") ?? null)) {
-    return { protocolOnly: true };
+    return { protocolOnly: true, credentialErrorResponse: PLAIN_CREDENTIAL_ERROR_RESPONSE };
   }
 
-  if (!parsed.ok) return { protocolOnly: false };
+  if (!parsed.ok) {
+    return { protocolOnly: false, credentialErrorResponse: PLAIN_CREDENTIAL_ERROR_RESPONSE };
+  }
   const outcome = classifyInboundRequest({
     httpMethod,
     protocolVersionHeader: headerValue(sanitizedHeaders, "mcp-protocol-version"),
@@ -496,12 +509,20 @@ function classifyProtocolPreflight(
     body: parsed.body,
   });
 
-  if (outcome.kind === "reject") return { protocolOnly: true };
-  if (outcome.kind !== "modern") return { protocolOnly: false };
+  if (outcome.kind === "reject") {
+    return { protocolOnly: true, credentialErrorResponse: PLAIN_CREDENTIAL_ERROR_RESPONSE };
+  }
+  if (outcome.kind !== "modern") {
+    return { protocolOnly: false, credentialErrorResponse: PLAIN_CREDENTIAL_ERROR_RESPONSE };
+  }
   if (outcome.classification.revision !== MODERN_MCP_PROTOCOL_VERSION) {
-    return { protocolOnly: true };
+    return { protocolOnly: true, credentialErrorResponse: PLAIN_CREDENTIAL_ERROR_RESPONSE };
   }
 
+  const credentialErrorResponseShape: CredentialErrorResponseShape = {
+    kind: "json-rpc",
+    requestId: requestIdFromParsedBody(parsed.body),
+  };
   const sdkHeaders = inferredModernHeaders(
     sanitizedHeaders,
     outcome.classification.revision,
@@ -509,14 +530,27 @@ function classifyProtocolPreflight(
   );
   const headerName = headerValue(sanitizedHeaders, "mcp-name");
   const bodyMethod = requestMethodFromParsedBody(parsed.body);
-  if (bodyMethod !== "tools/call" || !headerName) return { protocolOnly: false, sdkHeaders };
+  if (bodyMethod !== "tools/call" || !headerName) {
+    return {
+      protocolOnly: false,
+      credentialErrorResponse: credentialErrorResponseShape,
+      sdkHeaders,
+    };
+  }
 
   const bodyName = toolNameFromParsedBody(parsed.body);
-  if (headerName === bodyName) return { protocolOnly: false, sdkHeaders };
+  if (headerName === bodyName) {
+    return {
+      protocolOnly: false,
+      credentialErrorResponse: credentialErrorResponseShape,
+      sdkHeaders,
+    };
+  }
 
   const requestId = requestIdFromParsedBody(parsed.body);
   return {
     protocolOnly: false,
+    credentialErrorResponse: credentialErrorResponseShape,
     rejection: {
       status: 400,
       code: JSON_RPC_HEADER_BODY_MISMATCH,
@@ -659,6 +693,7 @@ function publicCredentialHeaderRejection(
   provider: CredentialProvider,
   request: Request,
   authInfo: AuthInfo | null | undefined,
+  responseShape: CredentialErrorResponseShape,
 ): Response | null {
   if (!shouldRejectPublicCredentialHeaders(provider)) return null;
   if (!hasCredentialHeaders(headersToIncoming(request.headers))) return null;
@@ -667,7 +702,7 @@ function publicCredentialHeaderRejection(
     return null;
   } catch (err) {
     logCredentialResolutionFailure(provider, request, authInfo, err);
-    return credentialErrorResponse(err);
+    return credentialErrorResponse(err, responseShape);
   }
 }
 
@@ -852,15 +887,6 @@ export function createB2McpFetchHandler(options: HttpPipelineOptions = {}): B2Mc
         );
       }
 
-      const credentialHeaderRejection = publicCredentialHeaderRejection(
-        credentialProvider,
-        request,
-        authInfo,
-      );
-      if (credentialHeaderRejection) {
-        return responseWithCleanup(credentialHeaderRejection, () => finalize(limitKey, prepared));
-      }
-
       const sanitizedHeaders = sanitizedHeadersFromRequest(request);
       const parsedBody =
         method === "POST" ? parsedJsonBody(rawBody) : ({ ok: true, body: undefined } as const);
@@ -871,6 +897,15 @@ export function createB2McpFetchHandler(options: HttpPipelineOptions = {}): B2Mc
           jsonResponse(protocolPreflight.rejection.status, protocolPreflight.rejection.body),
           () => finalize(limitKey, prepared),
         );
+      }
+      const credentialHeaderRejection = publicCredentialHeaderRejection(
+        credentialProvider,
+        request,
+        authInfo,
+        protocolPreflight.credentialErrorResponse,
+      );
+      if (credentialHeaderRejection) {
+        return responseWithCleanup(credentialHeaderRejection, () => finalize(limitKey, prepared));
       }
       if (protocolPreflight.protocolOnly) {
         const response = await dispatchToMcp(
@@ -884,13 +919,13 @@ export function createB2McpFetchHandler(options: HttpPipelineOptions = {}): B2Mc
 
       let resolved: CredentialResolution;
       const credentialRequest = makeCredentialRequest(request, authInfo);
-      const mcpRequestId = parsedBody.ok ? requestIdFromParsedBody(parsedBody.body) : null;
       try {
         resolved = credentialProvider.resolve({ req: credentialRequest });
       } catch (err) {
         logCredentialResolutionFailure(credentialProvider, request, authInfo, err);
-        return responseWithCleanup(credentialErrorResponse(err, mcpRequestId), () =>
-          finalize(limitKey, prepared),
+        return responseWithCleanup(
+          credentialErrorResponse(err, protocolPreflight.credentialErrorResponse),
+          () => finalize(limitKey, prepared),
         );
       }
 
@@ -923,8 +958,9 @@ export function createB2McpFetchHandler(options: HttpPipelineOptions = {}): B2Mc
           resolved.cacheKey,
         );
       } catch (err) {
-        return responseWithCleanup(credentialErrorResponse(err, mcpRequestId), () =>
-          finalize(limitKey, prepared),
+        return responseWithCleanup(
+          credentialErrorResponse(err, protocolPreflight.credentialErrorResponse),
+          () => finalize(limitKey, prepared),
         );
       }
 

--- a/src/http-fetch-handler.ts
+++ b/src/http-fetch-handler.ts
@@ -47,6 +47,7 @@ const DEFAULT_MAX_IN_FLIGHT_PER_KEY = 20;
 const STATELESS_ACTIVE_SESSIONS = 0;
 const STATELESS_OPEN_SUBSCRIPTIONS = 0;
 const MODERN_MCP_PROTOCOL_VERSION = "2026-07-28";
+const JSON_RPC_CREDENTIAL_RESOLUTION_FAILED = -32001;
 const JSON_RPC_HEADER_BODY_MISMATCH = -32020;
 const LOCALHOST_NAMES = new Set(["localhost", "127.0.0.1", "::1", "[::1]"]);
 
@@ -323,9 +324,28 @@ function runIdleSweep(): void {
   sweepAuthManagerCache(now);
 }
 
-function credentialErrorResponse(err: unknown): Response {
+function credentialErrorResponse(err: unknown, mcpRequestId?: string | number | null): Response {
   if (err instanceof CredentialResolutionError) {
+    if (mcpRequestId !== undefined) {
+      return jsonResponse(
+        err.status,
+        jsonRpcErrorBody(JSON_RPC_CREDENTIAL_RESOLUTION_FAILED, err.message, mcpRequestId, {
+          code: err.code,
+          status: err.status,
+        }),
+      );
+    }
     return jsonResponse(err.status, { error: err.message });
+  }
+  if (mcpRequestId !== undefined) {
+    return jsonResponse(
+      500,
+      jsonRpcErrorBody(
+        JSON_RPC_CREDENTIAL_RESOLUTION_FAILED,
+        "Credential resolution failed",
+        mcpRequestId,
+      ),
+    );
   }
   return jsonResponse(500, { error: "Credential resolution failed" });
 }
@@ -842,7 +862,8 @@ export function createB2McpFetchHandler(options: HttpPipelineOptions = {}): B2Mc
       }
 
       const sanitizedHeaders = sanitizedHeadersFromRequest(request);
-      const parsedBody = method === "POST" ? parsedJsonBody(rawBody) : ({ ok: true } as const);
+      const parsedBody =
+        method === "POST" ? parsedJsonBody(rawBody) : ({ ok: true, body: undefined } as const);
       const protocolPreflight = classifyProtocolPreflight(request, sanitizedHeaders, parsedBody);
       if (protocolPreflight.rejection) {
         logProtocolRejection(request, protocolPreflight.rejection);
@@ -863,11 +884,12 @@ export function createB2McpFetchHandler(options: HttpPipelineOptions = {}): B2Mc
 
       let resolved: CredentialResolution;
       const credentialRequest = makeCredentialRequest(request, authInfo);
+      const mcpRequestId = parsedBody.ok ? requestIdFromParsedBody(parsedBody.body) : null;
       try {
         resolved = credentialProvider.resolve({ req: credentialRequest });
       } catch (err) {
         logCredentialResolutionFailure(credentialProvider, request, authInfo, err);
-        return responseWithCleanup(credentialErrorResponse(err), () =>
+        return responseWithCleanup(credentialErrorResponse(err, mcpRequestId), () =>
           finalize(limitKey, prepared),
         );
       }
@@ -901,7 +923,7 @@ export function createB2McpFetchHandler(options: HttpPipelineOptions = {}): B2Mc
           resolved.cacheKey,
         );
       } catch (err) {
-        return responseWithCleanup(credentialErrorResponse(err), () =>
+        return responseWithCleanup(credentialErrorResponse(err, mcpRequestId), () =>
           finalize(limitKey, prepared),
         );
       }

--- a/tests/contract/smoke-script-policy.contract.test.ts
+++ b/tests/contract/smoke-script-policy.contract.test.ts
@@ -105,7 +105,7 @@ describe("smoke script release contract", () => {
     expect(smokeScript).toContain("B2_MCP_EXPECTED_TOOL_PROFILE");
     expect(smokeScript).toContain("B2_MCP_ALLOW_ANY_TOOL_PROFILE");
     expect(smokeScript).toContain("liveToolContractSnapshot");
-    expect(smokeScript).toContain("fixtureHash");
+    expect(`${smokeScript}\n${smokeContractScript}`).toContain("fixtureHash");
     expect(`${smokeScript}\n${smokeContractScript}`).toContain(
       "tools/list matches expected frozen profile contract",
     );

--- a/tests/protocol/http.modern-protocol.test.ts
+++ b/tests/protocol/http.modern-protocol.test.ts
@@ -446,6 +446,28 @@ describe("HTTP handler (MCP 2026-07-28)", () => {
     });
   });
 
+  it("returns MCP-shaped errors for server-mode credential-header rejections", async () => {
+    process.env.B2_HTTP_CREDENTIAL_MODE = "server";
+    await replaceHandle();
+
+    const res = await request(port, "POST", "/mcp", {
+      headers: { ...creds, ...modernHeaders("tools/list") },
+      body: LIST_TOOLS,
+    });
+    const body = parsedJson(res.body);
+
+    expect(res.status).toBe(400);
+    expect(body).toMatchObject({
+      jsonrpc: "2.0",
+      id: 1,
+      error: {
+        code: -32001,
+        message: "B2 credential headers are not accepted in this mode",
+        data: { code: "credential_headers_rejected", status: 400 },
+      },
+    });
+  });
+
   it("ignores Last-Event-ID on stateless POST requests and does not replay", async () => {
     const res = await request(port, "POST", "/mcp", {
       headers: { ...creds, ...modernHeaders("tools/list"), "last-event-id": "stale-event" },

--- a/tests/protocol/http.modern-protocol.test.ts
+++ b/tests/protocol/http.modern-protocol.test.ts
@@ -427,6 +427,25 @@ describe("HTTP handler (MCP 2026-07-28)", () => {
     expect(JSON.parse(res.body).result.tools.length).toBeGreaterThan(0);
   });
 
+  it("returns MCP-shaped errors when modern requests omit credentials", async () => {
+    const res = await request(port, "POST", "/mcp", {
+      headers: modernHeaders("tools/list"),
+      body: LIST_TOOLS,
+    });
+    const body = parsedJson(res.body);
+
+    expect(res.status).toBe(401);
+    expect(body).toMatchObject({
+      jsonrpc: "2.0",
+      id: 1,
+      error: {
+        code: -32001,
+        message: "B2 application credentials are required",
+        data: { code: "missing_credentials", status: 401 },
+      },
+    });
+  });
+
   it("ignores Last-Event-ID on stateless POST requests and does not replay", async () => {
     const res = await request(port, "POST", "/mcp", {
       headers: { ...creds, ...modernHeaders("tools/list"), "last-event-id": "stale-event" },

--- a/tests/unit/cloudflare-worker-adapter.unit.test.ts
+++ b/tests/unit/cloudflare-worker-adapter.unit.test.ts
@@ -395,10 +395,21 @@ describe("Cloudflare Worker adapter", () => {
       }),
       validAuthInfo,
     );
-    const body = (await response.json()) as { error: string };
+    const body = (await response.json()) as {
+      error: { message: string; data: { code: string; status: number } };
+      id: number;
+      jsonrpc: string;
+    };
 
     expect(response.status).toBe(400);
-    expect(body.error).toMatch(/not accepted/i);
+    expect(body).toMatchObject({
+      jsonrpc: "2.0",
+      id: 1,
+      error: {
+        message: expect.stringMatching(/not accepted/i),
+        data: { code: "credential_headers_rejected", status: 400 },
+      },
+    });
   });
 
   it("fails closed when Worker header credential mode is not explicitly enabled", async () => {

--- a/tests/unit/local-mcp-smoke.unit.test.ts
+++ b/tests/unit/local-mcp-smoke.unit.test.ts
@@ -1,0 +1,50 @@
+import * as http from "http";
+import { join } from "path";
+import { pathToFileURL } from "url";
+
+interface LocalSmokeModule {
+  NETWORK_GUARD_SIGNAL: string;
+  createBoundedTextMonitor(): {
+    observe(chunk: Buffer | string): void;
+    readonly networkBlocked: boolean;
+  };
+  installRunnerOutboundGuard(): () => void;
+}
+
+async function loadLocalSmoke(): Promise<LocalSmokeModule> {
+  return import(
+    pathToFileURL(join(__dirname, "../../scripts/local-mcp-smoke.mjs")).href
+  ) as Promise<LocalSmokeModule>;
+}
+
+describe("local MCP smoke helpers", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("blocks non-loopback runner egress before network calls", async () => {
+    const smoke = await loadLocalSmoke();
+    const restore = smoke.installRunnerOutboundGuard();
+    try {
+      expect(() => globalThis.fetch("https://example.com/mcp")).toThrow(/blocked outbound network/);
+      expect(() => http.get("http://example.com/mcp")).toThrow(/blocked outbound network/);
+    } finally {
+      restore();
+    }
+  });
+
+  it("keeps delayed server egress guard signals sticky", async () => {
+    const smoke = await loadLocalSmoke();
+    const monitor = smoke.createBoundedTextMonitor();
+
+    expect(monitor.networkBlocked).toBe(false);
+    await new Promise<void>((resolve) =>
+      setImmediate(() => {
+        monitor.observe(`late ${smoke.NETWORK_GUARD_SIGNAL}`);
+        resolve();
+      }),
+    );
+
+    expect(monitor.networkBlocked).toBe(true);
+  });
+});

--- a/tests/unit/vercel-adapter.unit.test.ts
+++ b/tests/unit/vercel-adapter.unit.test.ts
@@ -527,10 +527,21 @@ describe("Vercel adapter", () => {
       }),
       validAuthInfo,
     );
-    const body = (await response.json()) as { error: string };
+    const body = (await response.json()) as {
+      error: { message: string; data: { code: string; status: number } };
+      id: number;
+      jsonrpc: string;
+    };
 
     expect(response.status).toBe(400);
-    expect(body.error).toMatch(/not accepted/i);
+    expect(body).toMatchObject({
+      jsonrpc: "2.0",
+      id: 1,
+      error: {
+        message: expect.stringMatching(/not accepted/i),
+        data: { code: "credential_headers_rejected", status: 400 },
+      },
+    });
   });
 
   it.each(["GET", "DELETE"])(


### PR DESCRIPTION
## Summary
- add `pnpm run smoke:local` to build and smoke the local HTTP MCP runtime on `127.0.0.1:0` without `MCP_URL` or real B2 credentials
- use a minimal local HTTP MCP client and shared tool-contract snapshot helper while blocking runner non-loopback egress and server B2 egress through shutdown
- shape credential errors from explicit MCP protocol preflight so modern missing-credential and rejected-header responses preserve JSON-RPC request IDs
- exercise the local smoke in CI, including the Node.js 22.3.0 runtime-engine-floor job without invoking pnpm on that engine floor
- build package-root local smoke fixtures through the native pnpm executable so CI and packed-consumer smoke paths do not depend on shell shims
- refresh reviewed package-budget metadata for the shipped local smoke package footprint
- document local runtime smoke separately from deployed/live `pnpm run smoke`

## Linked issue
Closes #193

## Tests run
- `pnpm run verify`
- `pnpm run test:coverage`
- `pnpm run test:contract`
- `pnpm run smoke:local`
- package-root smoke simulation with `npm pack`, `npm install --omit=dev`, `B2_MCP_LOCAL_SMOKE_ROOT`, and `B2_MCP_LOCAL_SMOKE_SKIP_BUILD=true`
- `pnpm run check:package-budget`
- `pnpm run check:runtime-policy`
- `pnpm run test:protocol:modern`
- `node scripts/run-vitest-layer.mjs unit -- tests/unit/package-budget-policy.unit.test.ts`
- `node scripts/run-vitest-layer.mjs unit -- tests/unit/local-mcp-smoke.unit.test.ts tests/unit/smoke-test.unit.test.ts`
- `node scripts/run-vitest-layer.mjs unit -- tests/unit/vercel-adapter.unit.test.ts tests/unit/cloudflare-worker-adapter.unit.test.ts tests/unit/local-mcp-smoke.unit.test.ts`
- `node scripts/run-vitest-layer.mjs contract -- tests/contract/ci-workflow-policy.contract.test.ts tests/contract/deployment-docs-policy.contract.test.ts`
- `node scripts/run-vitest-layer.mjs contract -- tests/contract/smoke-script-policy.contract.test.ts`

## CI
- Latest PR checks pass on commit `ceb57d795c3bf98f6af232420392ddec5f6feb37`.

## Follow-up notes
- No follow-up required for the addressed review comments or CI failures.