### PR TITLE
Establish advisory local performance baseline

### DIFF
--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -67,6 +67,8 @@ The baseline measures local protocol overhead only: stdio startup-to-ready,
 `server/discover`, heap growth across repeated local `tools/list` requests, and
 fake OAuth/JWKS cold-cache and warm-cache verification. It does not use real B2
 credentials and does not claim to measure end-to-end Backblaze B2 latency.
+The stdio startup measurement explicitly sets `B2_SECRET_SINK=off`; file secret
+sink startup and writes are outside this protocol-overhead baseline.
 Measurement failures still write the JSON and Markdown reports with the failed
 phase, error message, runtime metadata, and any partial metrics collected before
 the failure.

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -41,6 +41,39 @@ The individual deterministic layers are:
 | `pnpm run test:diagnostics` | Builds first, then checks unit/protocol layers for MaxListeners and open-handle warnings. |
 | `pnpm run smoke:local`  | Builds, starts local HTTP MCP on 127.0.0.1:0, validates discovery/tools, and stops.   |
 
+## Advisory Local Performance Baseline
+
+Issue
+[#199](https://github.com/backblaze-labs/b2-mcp/issues/199) tracks the local
+performance regression baseline. It is advisory first and is not part of
+`pnpm run verify` until repeated main-branch runs prove the budgets stable.
+
+Run it with:
+
+```bash
+pnpm run perf:baseline
+```
+
+The script builds the package, uses fake deterministic credentials, and writes:
+
+- Machine-readable artifact: `reports/performance/local-baseline.json`
+- Human-readable summary: `reports/performance/local-baseline-summary.md`
+
+The baseline measures local protocol overhead only: stdio startup-to-ready,
+`tools/list` latency and serialized response size for the `full`,
+`phase1-default`, and `read-only` profiles, modest concurrent
+`server/discover`, heap growth across repeated local `tools/list` requests, and
+fake OAuth/JWKS cold-cache and warm-cache verification. It does not use real B2
+credentials and does not claim to measure end-to-end Backblaze B2 latency.
+
+Budgets and runtime applicability decisions live in
+[`../performance-baseline.json`](../performance-baseline.json). Node stdio and
+Node HTTP are locally timed. Vercel and Cloudflare Worker adapters are covered
+by the shared OAuth/JWKS fake-path budget here; platform cold starts and edge
+placement latency stay outside this deterministic local baseline. Once the
+reviewed baseline is stable, `pnpm run perf:baseline:enforce` is the blocking
+form to promote into CI.
+
 Local scripts can call each deterministic layer independently. Required PR jobs
 keep the major evidence classes distinct so coverage regression, contract drift,
 protocol failure, production-audit findings, package-budget drift, and broken

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -54,7 +54,9 @@ Run it with:
 pnpm run perf:baseline
 ```
 
-The script builds the package, uses fake deterministic credentials, and writes:
+The script builds the package, runs measurements in a sanitized worker process
+with fake deterministic credentials, blocks non-local network egress, and
+writes:
 
 - Machine-readable artifact: `reports/performance/local-baseline.json`
 - Human-readable summary: `reports/performance/local-baseline-summary.md`
@@ -65,6 +67,9 @@ The baseline measures local protocol overhead only: stdio startup-to-ready,
 `server/discover`, heap growth across repeated local `tools/list` requests, and
 fake OAuth/JWKS cold-cache and warm-cache verification. It does not use real B2
 credentials and does not claim to measure end-to-end Backblaze B2 latency.
+Measurement failures still write the JSON and Markdown reports with the failed
+phase, error message, runtime metadata, and any partial metrics collected before
+the failure.
 
 Budgets and runtime applicability decisions live in
 [`../performance-baseline.json`](../performance-baseline.json). Node stdio and

--- a/package.json
+++ b/package.json
@@ -42,6 +42,8 @@
     "test:slow": "node scripts/run-vitest-layer.mjs slow",
     "test:coverage": "pnpm run build && node scripts/run-vitest-layer.mjs coverage",
     "test:diagnostics": "pnpm run build && node scripts/run-leak-diagnostics.mjs",
+    "perf:baseline": "pnpm run build && node --expose-gc scripts/performance-baseline.mjs",
+    "perf:baseline:enforce": "pnpm run build && node --expose-gc scripts/performance-baseline.mjs --enforce",
     "test:integration": "node scripts/reject-live-alias.mjs integration",
     "test:contract:live": "node scripts/reject-live-alias.mjs contract",
     "test:integration:live": "node scripts/reject-live-alias.mjs integration",

--- a/performance-baseline.json
+++ b/performance-baseline.json
@@ -1,0 +1,173 @@
+{
+  "schemaVersion": 1,
+  "mode": "advisory",
+  "issue": {
+    "number": 199,
+    "url": "https://github.com/backblaze-labs/b2-mcp/issues/199",
+    "title": "[b2-mcp] Establish an advisory local performance regression baseline",
+    "priority": "P2"
+  },
+  "reviewedBaseline": {
+    "date": "2026-08-21",
+    "nodeVersions": ["22.3.0", "22.23.1", "24", "26"],
+    "toolProfiles": ["full", "phase1-default", "read-only"],
+    "artifact": "reports/performance/local-baseline.json",
+    "summary": "reports/performance/local-baseline-summary.md"
+  },
+  "runtimeApplicability": {
+    "node-stdio": {
+      "decision": "measured",
+      "budgetSet": "startup-to-ready",
+      "reason": "Local stdio is the packaged CLI path and has deterministic fake-credential startup."
+    },
+    "node-http": {
+      "decision": "measured",
+      "budgetSet": "tools-list-discovery-memory",
+      "reason": "The local Node HTTP server owns the shared MCP fetch pipeline used by standalone deployments."
+    },
+    "vercel-serverless": {
+      "decision": "shared-runtime-advisory",
+      "budgetSet": "oauth-jwks-fake-path",
+      "reason": "The Vercel adapter shares the OAuth and MCP fetch runtime; platform cold-start latency is not claimed by this local baseline."
+    },
+    "cloudflare-worker": {
+      "decision": "shared-runtime-advisory",
+      "budgetSet": "oauth-jwks-fake-path",
+      "reason": "The Worker adapter shares OAuth/JWKS verification; workerd startup and edge placement latency are outside this deterministic local check."
+    }
+  },
+  "measurementPlan": {
+    "localOnly": true,
+    "usesRealB2Credentials": false,
+    "usesLiveB2Network": false,
+    "modestConcurrency": 8,
+    "memoryRequestCount": 50,
+    "notes": [
+      "Budgets are advisory until reviewed main-branch runs prove stable.",
+      "Use --enforce only when promoting the baseline to a merge gate.",
+      "The check measures local protocol overhead and resource growth, not end-to-end Backblaze B2 latency."
+    ]
+  },
+  "budgets": {
+    "node-stdio.startupReadyMs": {
+      "label": "Node stdio startup to ready",
+      "unit": "ms",
+      "direction": "max",
+      "baseline": 180,
+      "tolerance": {
+        "percent": 100,
+        "absolute": 400
+      }
+    },
+    "node-http.full.toolsListMs": {
+      "label": "tools/list latency, full profile",
+      "unit": "ms",
+      "direction": "max",
+      "baseline": 60,
+      "tolerance": {
+        "percent": 100,
+        "absolute": 75
+      }
+    },
+    "node-http.full.toolsListBytes": {
+      "label": "tools/list serialized bytes, full profile",
+      "unit": "bytes",
+      "direction": "max",
+      "baseline": 47217,
+      "tolerance": {
+        "percent": 10,
+        "absolute": 4096
+      }
+    },
+    "node-http.phase1-default.toolsListMs": {
+      "label": "tools/list latency, phase1-default profile",
+      "unit": "ms",
+      "direction": "max",
+      "baseline": 20,
+      "tolerance": {
+        "percent": 100,
+        "absolute": 75
+      }
+    },
+    "node-http.phase1-default.toolsListBytes": {
+      "label": "tools/list serialized bytes, phase1-default profile",
+      "unit": "bytes",
+      "direction": "max",
+      "baseline": 43874,
+      "tolerance": {
+        "percent": 10,
+        "absolute": 4096
+      }
+    },
+    "node-http.read-only.toolsListMs": {
+      "label": "tools/list latency, read-only profile",
+      "unit": "ms",
+      "direction": "max",
+      "baseline": 15,
+      "tolerance": {
+        "percent": 100,
+        "absolute": 75
+      }
+    },
+    "node-http.read-only.toolsListBytes": {
+      "label": "tools/list serialized bytes, read-only profile",
+      "unit": "bytes",
+      "direction": "max",
+      "baseline": 17216,
+      "tolerance": {
+        "percent": 10,
+        "absolute": 4096
+      }
+    },
+    "node-http.discovery.concurrentP95Ms": {
+      "label": "Concurrent local server/discover p95",
+      "unit": "ms",
+      "direction": "max",
+      "baseline": 70,
+      "tolerance": {
+        "percent": 100,
+        "absolute": 75
+      }
+    },
+    "node-http.discovery.throughputRps": {
+      "label": "Concurrent local server/discover throughput",
+      "unit": "requests/sec",
+      "direction": "min",
+      "baseline": 100,
+      "tolerance": {
+        "percent": 50,
+        "absolute": 1
+      }
+    },
+    "node-http.memory.repeatedToolsListGrowthMiB": {
+      "label": "Heap growth after repeated local tools/list",
+      "unit": "MiB",
+      "direction": "max",
+      "baseline": 1.5,
+      "tolerance": {
+        "percent": 100,
+        "absolute": 2
+      }
+    },
+    "oauth-jwks.coldVerifyMs": {
+      "label": "OAuth/JWKS fake cold-cache verification",
+      "unit": "ms",
+      "direction": "max",
+      "baseline": 8,
+      "tolerance": {
+        "percent": 200,
+        "absolute": 10
+      }
+    },
+    "oauth-jwks.warmVerifyMs": {
+      "label": "OAuth/JWKS fake warm-cache verification",
+      "unit": "ms",
+      "direction": "max",
+      "baseline": 5,
+      "tolerance": {
+        "percent": 200,
+        "absolute": 5
+      }
+    }
+  }
+}

--- a/scripts/lib/local-network-guard.mjs
+++ b/scripts/lib/local-network-guard.mjs
@@ -15,13 +15,23 @@ function normalizedHost(host) {
     .toLowerCase();
 }
 
+function isLoopbackIpv4(host) {
+  return net.isIP(host) === 4 && host.split(".")[0] === "127";
+}
+
+function isMappedLoopbackIpv4(host) {
+  const mapped = host.match(/^::ffff:(?<ipv4>.+)$/u)?.groups?.ipv4;
+  return mapped ? isLoopbackIpv4(mapped) : false;
+}
+
 function isLocalHost(host) {
   const normalized = normalizedHost(host);
   return (
     normalized === "localhost" ||
     normalized === "::1" ||
     normalized === "0:0:0:0:0:0:0:1" ||
-    /^(?:::ffff:)?127(?:\.\d{1,3}){3}$/.test(normalized)
+    isLoopbackIpv4(normalized) ||
+    isMappedLoopbackIpv4(normalized)
   );
 }
 

--- a/scripts/lib/local-network-guard.mjs
+++ b/scripts/lib/local-network-guard.mjs
@@ -1,0 +1,114 @@
+import { createRequire } from "node:module";
+
+const require = createRequire(import.meta.url);
+const http = require("node:http");
+const https = require("node:https");
+const net = require("node:net");
+const tls = require("node:tls");
+const SIGNAL = "B2_MCP_LOCAL_NETWORK_GUARD_BLOCKED";
+
+function normalizedHost(host) {
+  return String(host ?? "localhost")
+    .trim()
+    .replace(/^\[/, "")
+    .replace(/\]$/, "")
+    .toLowerCase();
+}
+
+function isLocalHost(host) {
+  const normalized = normalizedHost(host);
+  return (
+    normalized === "localhost" ||
+    normalized === "::1" ||
+    normalized === "0:0:0:0:0:0:0:1" ||
+    /^(?:::ffff:)?127(?:\.\d{1,3}){3}$/.test(normalized)
+  );
+}
+
+function block(kind, host) {
+  const label = normalizedHost(host);
+  process.stderr.write(`${SIGNAL}:${kind}:${label}\n`);
+  throw new Error(`Non-local network access blocked during performance baseline: ${kind}`);
+}
+
+function assertLocal(kind, host) {
+  if (!isLocalHost(host)) block(kind, host);
+}
+
+function urlHost(value) {
+  if (value instanceof URL) return value.hostname;
+  if (typeof Request !== "undefined" && value instanceof Request) {
+    return new URL(value.url).hostname;
+  }
+  if (typeof value === "string") return new URL(value).hostname;
+  return undefined;
+}
+
+function requestHost(args) {
+  const [first, second] = args;
+  const directUrlHost = urlHost(first);
+  if (directUrlHost) return directUrlHost;
+  if (first && typeof first === "object") {
+    return first.hostname ?? first.host ?? "localhost";
+  }
+  if (second && typeof second === "object") {
+    return second.hostname ?? second.host ?? "localhost";
+  }
+  if (typeof second === "string") return second;
+  return "localhost";
+}
+
+function socketHost(args) {
+  const [first, second] = args;
+  if (first && typeof first === "object") {
+    if (first.path) return "localhost";
+    return first.host ?? first.hostname ?? "localhost";
+  }
+  if (second && typeof second === "object") {
+    if (second.path) return "localhost";
+    return second.host ?? second.hostname ?? "localhost";
+  }
+  if (typeof second === "string") return second;
+  return "localhost";
+}
+
+const originalFetch = globalThis.fetch?.bind(globalThis);
+if (originalFetch) {
+  globalThis.fetch = (input, init) => {
+    assertLocal("fetch", urlHost(input) ?? "localhost");
+    return originalFetch(input, init);
+  };
+}
+
+for (const [moduleName, module] of [
+  ["http", http],
+  ["https", https],
+]) {
+  const originalRequest = module.request;
+  const originalGet = module.get;
+  module.request = function guardedRequest(...args) {
+    assertLocal(`${moduleName}.request`, requestHost(args));
+    return originalRequest.apply(this, args);
+  };
+  module.get = function guardedGet(...args) {
+    assertLocal(`${moduleName}.get`, requestHost(args));
+    return originalGet.apply(this, args);
+  };
+}
+
+const originalNetConnect = net.connect;
+const originalNetCreateConnection = net.createConnection;
+net.connect = function guardedNetConnect(...args) {
+  assertLocal("net.connect", socketHost(args));
+  return originalNetConnect.apply(this, args);
+};
+net.createConnection = function guardedNetCreateConnection(...args) {
+  assertLocal("net.createConnection", socketHost(args));
+  return originalNetCreateConnection.apply(this, args);
+};
+
+const originalTlsConnect = tls.connect;
+tls.connect = function guardedTlsConnect(...args) {
+  assertLocal("tls.connect", socketHost(args));
+  return originalTlsConnect.apply(this, args);
+};

--- a/scripts/lib/local-network-guard.mjs
+++ b/scripts/lib/local-network-guard.mjs
@@ -44,8 +44,15 @@ function urlHost(value) {
   return undefined;
 }
 
+function explicitRequestOptionsHost(value) {
+  if (!value || typeof value !== "object") return undefined;
+  return value.hostname ?? value.host;
+}
+
 function requestHost(args) {
   const [first, second] = args;
+  const optionOverrideHost = explicitRequestOptionsHost(second);
+  if (optionOverrideHost) return optionOverrideHost;
   const directUrlHost = urlHost(first);
   if (directUrlHost) return directUrlHost;
   if (first && typeof first === "object") {

--- a/scripts/lib/local-network-guard.mjs
+++ b/scripts/lib/local-network-guard.mjs
@@ -1,4 +1,4 @@
-import { createRequire } from "node:module";
+import { createRequire, syncBuiltinESMExports } from "node:module";
 
 const require = createRequire(import.meta.url);
 const http = require("node:http");
@@ -105,6 +105,9 @@ for (const [moduleName, module] of [
 
 const originalNetConnect = net.connect;
 const originalNetCreateConnection = net.createConnection;
+const originalNetSocketConnect = net.Socket.prototype.connect;
+const originalTlsConnect = tls.connect;
+const originalTlsSocketConnect = tls.TLSSocket.prototype.connect;
 net.connect = function guardedNetConnect(...args) {
   assertLocal("net.connect", socketHost(args));
   return originalNetConnect.apply(this, args);
@@ -113,9 +116,18 @@ net.createConnection = function guardedNetCreateConnection(...args) {
   assertLocal("net.createConnection", socketHost(args));
   return originalNetCreateConnection.apply(this, args);
 };
+net.Socket.prototype.connect = function guardedNetSocketConnect(...args) {
+  assertLocal("net.Socket.connect", socketHost(args));
+  return originalNetSocketConnect.apply(this, args);
+};
 
-const originalTlsConnect = tls.connect;
 tls.connect = function guardedTlsConnect(...args) {
   assertLocal("tls.connect", socketHost(args));
   return originalTlsConnect.apply(this, args);
 };
+tls.TLSSocket.prototype.connect = function guardedTlsSocketConnect(...args) {
+  assertLocal("tls.TLSSocket.connect", socketHost(args));
+  return originalTlsSocketConnect.apply(this, args);
+};
+
+syncBuiltinESMExports();

--- a/scripts/lib/local-network-guard.mjs
+++ b/scripts/lib/local-network-guard.mjs
@@ -45,6 +45,14 @@ function assertLocal(kind, host) {
   if (!isLocalHost(host)) block(kind, host);
 }
 
+function assertNoCustomLookup(kind, args) {
+  for (const value of args) {
+    if (value && typeof value === "object" && typeof value.lookup === "function") {
+      block(kind, "custom-lookup");
+    }
+  }
+}
+
 function urlHost(value) {
   if (value instanceof URL) return value.hostname;
   if (typeof Request !== "undefined" && value instanceof Request) {
@@ -104,10 +112,12 @@ for (const [moduleName, module] of [
   const originalRequest = module.request;
   const originalGet = module.get;
   module.request = function guardedRequest(...args) {
+    assertNoCustomLookup(`${moduleName}.request`, args);
     assertLocal(`${moduleName}.request`, requestHost(args));
     return originalRequest.apply(this, args);
   };
   module.get = function guardedGet(...args) {
+    assertNoCustomLookup(`${moduleName}.get`, args);
     assertLocal(`${moduleName}.get`, requestHost(args));
     return originalGet.apply(this, args);
   };
@@ -119,23 +129,28 @@ const originalNetSocketConnect = net.Socket.prototype.connect;
 const originalTlsConnect = tls.connect;
 const originalTlsSocketConnect = tls.TLSSocket.prototype.connect;
 net.connect = function guardedNetConnect(...args) {
+  assertNoCustomLookup("net.connect", args);
   assertLocal("net.connect", socketHost(args));
   return originalNetConnect.apply(this, args);
 };
 net.createConnection = function guardedNetCreateConnection(...args) {
+  assertNoCustomLookup("net.createConnection", args);
   assertLocal("net.createConnection", socketHost(args));
   return originalNetCreateConnection.apply(this, args);
 };
 net.Socket.prototype.connect = function guardedNetSocketConnect(...args) {
+  assertNoCustomLookup("net.Socket.connect", args);
   assertLocal("net.Socket.connect", socketHost(args));
   return originalNetSocketConnect.apply(this, args);
 };
 
 tls.connect = function guardedTlsConnect(...args) {
+  assertNoCustomLookup("tls.connect", args);
   assertLocal("tls.connect", socketHost(args));
   return originalTlsConnect.apply(this, args);
 };
 tls.TLSSocket.prototype.connect = function guardedTlsSocketConnect(...args) {
+  assertNoCustomLookup("tls.TLSSocket.connect", args);
   assertLocal("tls.TLSSocket.connect", socketHost(args));
   return originalTlsSocketConnect.apply(this, args);
 };

--- a/scripts/lib/performance-baseline.cjs
+++ b/scripts/lib/performance-baseline.cjs
@@ -1,0 +1,134 @@
+const os = require("node:os");
+
+function round(value, digits = 2) {
+  const factor = 10 ** digits;
+  return Math.round(value * factor) / factor;
+}
+
+function displayValue(value, unit) {
+  return unit === "bytes" ? Math.round(value) : round(value);
+}
+
+function budgetLimit(budget) {
+  const percent = Number(budget.tolerance?.percent ?? 0);
+  const absolute = Number(budget.tolerance?.absolute ?? 0);
+  if (budget.direction === "min") {
+    return budget.baseline * (1 - percent / 100) - absolute;
+  }
+  return budget.baseline * (1 + percent / 100) + absolute;
+}
+
+function evaluateMetric(id, value, budget) {
+  const rawLimit = budgetLimit(budget);
+  const reportedValue = displayValue(value, budget.unit);
+  const reportedLimit = displayValue(rawLimit, budget.unit);
+  const pass =
+    budget.direction === "min" ? reportedValue >= reportedLimit : reportedValue <= reportedLimit;
+  return {
+    id,
+    label: budget.label,
+    unit: budget.unit,
+    value: reportedValue,
+    status: pass ? "pass" : "fail",
+    budget: {
+      direction: budget.direction,
+      baseline: budget.baseline,
+      tolerance: budget.tolerance,
+      limit: reportedLimit,
+      rawLimit,
+    },
+    rawValue: value,
+  };
+}
+
+function evaluateMeasurements(config, measurements, { requireAll = true } = {}) {
+  const byId = new Map(measurements.map((metric) => [metric.id, metric]));
+  return Object.entries(config.budgets).flatMap(([id, budget]) => {
+    const measured = byId.get(id);
+    if (!measured) {
+      if (!requireAll) return [];
+      throw new Error(`Performance budget ${id} has no measurement.`);
+    }
+    return [
+      {
+        ...evaluateMetric(id, measured.value, budget),
+        ...(measured.details && { details: measured.details }),
+      },
+    ];
+  });
+}
+
+function renderSummary(config, metrics, { enforce = false, failure = null } = {}) {
+  const failures = metrics.filter((metric) => metric.status !== "pass");
+  const mode = enforce ? "enforce" : "advisory";
+  const rows = metrics.map((metric) =>
+    [
+      metric.status === "pass" ? "PASS" : "FAIL",
+      metric.id,
+      `${metric.value} ${metric.unit}`,
+      `${metric.budget.direction} ${metric.budget.limit} ${metric.unit}`,
+    ].join(" | "),
+  );
+  return [
+    "# Local Performance Baseline",
+    "",
+    `Mode: ${mode}`,
+    `Issue: #${config.issue.number} ${config.issue.url}`,
+    failure
+      ? `Status: measurement failed (${failure.phase ?? failure.metricId ?? "unknown phase"})`
+      : `Status: ${failures.length === 0 ? "pass" : `${failures.length} budget violation(s)`}`,
+    ...(failure ? [`Error: ${failure.message}`] : []),
+    "",
+    "This local baseline uses fake deterministic fixtures and does not measure live Backblaze B2 latency.",
+    "",
+    "status | metric | measured | budget",
+    "--- | --- | --- | ---",
+    ...(rows.length > 0 ? rows : ["NO DATA | partial metrics | none | n/a"]),
+    "",
+    "Runtime applicability:",
+    ...Object.entries(config.runtimeApplicability).map(
+      ([runtime, decision]) => `- ${runtime}: ${decision.decision} (${decision.budgetSet})`,
+    ),
+    "",
+  ].join("\n");
+}
+
+function createArtifact({
+  config,
+  metrics,
+  measurements = [],
+  enforce = false,
+  failure = null,
+  generatedAt = new Date().toISOString(),
+}) {
+  return {
+    schemaVersion: 1,
+    generatedAt,
+    issue: config.issue,
+    mode: enforce ? "enforce" : "advisory",
+    advisory: !enforce,
+    liveB2CredentialsUsed: false,
+    liveB2NetworkMeasured: false,
+    node: process.version,
+    platform: {
+      os: os.platform(),
+      arch: os.arch(),
+    },
+    measurementPlan: config.measurementPlan,
+    runtimeApplicability: config.runtimeApplicability,
+    metrics,
+    partialMeasurements: measurements,
+    violations: metrics.filter((metric) => metric.status !== "pass").map((metric) => metric.id),
+    ...(failure && { failure }),
+  };
+}
+
+module.exports = {
+  budgetLimit,
+  createArtifact,
+  displayValue,
+  evaluateMeasurements,
+  evaluateMetric,
+  renderSummary,
+  round,
+};

--- a/scripts/no-network-guard.mjs
+++ b/scripts/no-network-guard.mjs
@@ -1,4 +1,4 @@
-import { createRequire } from "node:module";
+import { createRequire, syncBuiltinESMExports } from "node:module";
 
 const require = createRequire(import.meta.url);
 const http = require("node:http");
@@ -21,4 +21,8 @@ https.request = block("https.request");
 https.get = block("https.get");
 net.connect = block("net.connect");
 net.createConnection = block("net.createConnection");
+net.Socket.prototype.connect = block("net.Socket.connect");
 tls.connect = block("tls.connect");
+tls.TLSSocket.prototype.connect = block("tls.TLSSocket.connect");
+
+syncBuiltinESMExports();

--- a/scripts/performance-baseline.mjs
+++ b/scripts/performance-baseline.mjs
@@ -602,28 +602,46 @@ function syntheticBudgetViolationMeasurements(config) {
 async function runEnvProbe() {
   const { SignJWT } = await import("jose");
   const http = require("node:http");
+  const net = require("node:net");
+  const tls = require("node:tls");
+  const { connect: esmNetConnect, Socket: EsmSocket } = await import("node:net");
   const stdioEnv = fakeServerEnv();
   const observedSentinelNames = Object.entries(process.env)
     .filter(([, value]) => String(value).includes(parentSecretSentinel))
     .map(([name]) => name)
     .sort();
+  const isBlocked = (error) =>
+    /Non-local network access blocked/.test(error instanceof Error ? error.message : String(error));
+  const blockedNetworkCall = (call) => {
+    try {
+      const handle = call();
+      handle?.destroy?.();
+      return false;
+    } catch (error) {
+      return isBlocked(error);
+    }
+  };
   let nonLocalFetchBlocked = false;
   try {
     await fetch("https://example.com");
   } catch (error) {
-    nonLocalFetchBlocked = /Non-local network access blocked/.test(
-      error instanceof Error ? error.message : String(error),
-    );
+    nonLocalFetchBlocked = isBlocked(error);
   }
-  let requestOptionsOverrideBlocked = false;
-  try {
-    const request = http.request("http://127.0.0.1", { hostname: "example.com" });
-    request.destroy();
-  } catch (error) {
-    requestOptionsOverrideBlocked = /Non-local network access blocked/.test(
-      error instanceof Error ? error.message : String(error),
-    );
-  }
+  const requestOptionsOverrideBlocked = blockedNetworkCall(() =>
+    http.request("http://127.0.0.1", { hostname: "example.com" }),
+  );
+  const netSocketConnectBlocked = blockedNetworkCall(() =>
+    new net.Socket().connect({ host: "example.com", port: 443 }),
+  );
+  const tlsSocketConnectBlocked = blockedNetworkCall(() =>
+    new tls.TLSSocket(new net.Socket()).connect({ host: "example.com", port: 443 }),
+  );
+  const esmNetConnectBlocked = blockedNetworkCall(() =>
+    esmNetConnect({ host: "example.com", port: 443 }),
+  );
+  const esmSocketConnectBlocked = blockedNetworkCall(() =>
+    new EsmSocket().connect({ host: "example.com", port: 443 }),
+  );
   return {
     importedDependency: typeof SignJWT === "function",
     observedSentinelNames,
@@ -634,6 +652,10 @@ async function runEnvProbe() {
     stdioSecretSinkFileUnset: stdioEnv.B2_SECRET_SINK_FILE === undefined,
     nonLocalFetchBlocked,
     requestOptionsOverrideBlocked,
+    netSocketConnectBlocked,
+    tlsSocketConnectBlocked,
+    esmNetConnectBlocked,
+    esmSocketConnectBlocked,
   };
 }
 
@@ -729,7 +751,15 @@ function runSelfTestEnvSanitizer() {
     return 1;
   }
   console.log(JSON.stringify(payload.probe));
-  return payload.probe.sentinelValueVisible || !payload.probe.nonLocalFetchBlocked ? 1 : 0;
+  return payload.probe.sentinelValueVisible ||
+    !payload.probe.nonLocalFetchBlocked ||
+    !payload.probe.requestOptionsOverrideBlocked ||
+    !payload.probe.netSocketConnectBlocked ||
+    !payload.probe.tlsSocketConnectBlocked ||
+    !payload.probe.esmNetConnectBlocked ||
+    !payload.probe.esmSocketConnectBlocked
+    ? 1
+    : 0;
 }
 
 function runParent(enforce, workerExtraEnv = {}) {

--- a/scripts/performance-baseline.mjs
+++ b/scripts/performance-baseline.mjs
@@ -10,7 +10,9 @@ import { fileURLToPath, pathToFileURL } from "node:url";
 const require = createRequire(import.meta.url);
 const { sanitizedEnv } = require("./lib/sanitized-env.cjs");
 const {
+  budgetLimit,
   createArtifact,
+  displayValue,
   evaluateMeasurements,
   renderSummary,
   round,
@@ -27,6 +29,7 @@ const noNetworkGuardPath = path.join(root, "scripts/no-network-guard.mjs");
 const workerEnvFlag = "B2_MCP_PERFORMANCE_BASELINE_WORKER";
 const probeOnlyFlag = "B2_MCP_PERFORMANCE_BASELINE_PROBE_ONLY";
 const forceFailurePhaseFlag = "B2_MCP_PERFORMANCE_BASELINE_FORCE_FAILURE_PHASE";
+const forceBudgetViolationFlag = "B2_MCP_PERFORMANCE_BASELINE_FORCE_BUDGET_VIOLATION";
 const parentSecretSentinel = "sentinel-parent-secret";
 const workerTimeoutMs = 120_000;
 
@@ -41,6 +44,7 @@ const benchmarkWorkerEnv = {
   B2_MCP_RATE_LIMIT_BURST: "1000",
   B2_MCP_RATE_LIMIT_RPS: "1000",
   B2_REGISTER_ALL_TOOLS: "true",
+  B2_SECRET_SINK: "off",
   LOG_LEVEL: "fatal",
   NODE_ENV: "test",
   NODE_OPTIONS: `--import ${pathToFileURL(localNetworkGuardPath).href}`,
@@ -76,17 +80,20 @@ function parseArgs(argv) {
       worker: false,
       selfTestEnvSanitizer: false,
       selfTestMeasurementFailure: false,
+      selfTestBudgetViolation: false,
     };
   }
   const worker = args.has("--worker");
   const selfTestEnvSanitizer = args.has("--self-test-env-sanitizer");
   const selfTestMeasurementFailure = args.has("--self-test-measurement-failure");
+  const selfTestBudgetViolation = args.has("--self-test-budget-violation");
   const allowed = new Set([
     "--advisory",
     "--enforce",
     "--worker",
     "--self-test-env-sanitizer",
     "--self-test-measurement-failure",
+    "--self-test-budget-violation",
   ]);
   const unknown = argv.filter((arg) => !allowed.has(arg));
   if (unknown.length > 0) {
@@ -98,6 +105,7 @@ function parseArgs(argv) {
     worker,
     selfTestEnvSanitizer,
     selfTestMeasurementFailure,
+    selfTestBudgetViolation,
   };
 }
 
@@ -133,6 +141,7 @@ function fakeServerEnv() {
     B2_APPLICATION_KEY_ID: "performance-key-id",
     B2_APPLICATION_KEY: "performance-key-secret",
     B2_REGISTER_ALL_TOOLS: "true",
+    B2_SECRET_SINK: "off",
     LOG_LEVEL: "fatal",
     NODE_ENV: "test",
     NODE_OPTIONS: `--import ${pathToFileURL(noNetworkGuardPath).href}`,
@@ -528,6 +537,9 @@ async function recordPhase(measurements, phase, run) {
 }
 
 async function runMeasurements(config) {
+  if (process.env[forceBudgetViolationFlag] === "1") {
+    return syntheticBudgetViolationMeasurements(config);
+  }
   if (process.env[forceFailurePhaseFlag]) {
     const error = new Error("Forced measurement failure for performance artifact self-test.");
     error.phase = process.env[forceFailurePhaseFlag];
@@ -572,8 +584,24 @@ async function runMeasurements(config) {
   return measurements;
 }
 
+function syntheticBudgetViolationMeasurements(config) {
+  const maxViolationId = "node-http.full.toolsListBytes";
+  const minViolationId = "node-http.discovery.throughputRps";
+  return Object.entries(config.budgets).map(([id, budget]) => {
+    const displayedLimit = displayValue(budgetLimit(budget), budget.unit);
+    if (id === maxViolationId) {
+      return { id, value: displayedLimit + (budget.unit === "bytes" ? 1 : 0.01) };
+    }
+    if (id === minViolationId) {
+      return { id, value: displayedLimit - (budget.unit === "bytes" ? 1 : 0.01) };
+    }
+    return { id, value: budget.baseline };
+  });
+}
+
 async function runEnvProbe() {
   const { SignJWT } = await import("jose");
+  const stdioEnv = fakeServerEnv();
   const observedSentinelNames = Object.entries(process.env)
     .filter(([, value]) => String(value).includes(parentSecretSentinel))
     .map(([name]) => name)
@@ -591,6 +619,9 @@ async function runEnvProbe() {
     observedSentinelNames,
     sentinelValueVisible: observedSentinelNames.length > 0,
     benchmarkCredentialIsFake: process.env.B2_APPLICATION_KEY === "performance-key-secret",
+    benchmarkSecretSinkIsOff: process.env.B2_SECRET_SINK === "off",
+    stdioSecretSinkIsOff: stdioEnv.B2_SECRET_SINK === "off",
+    stdioSecretSinkFileUnset: stdioEnv.B2_SECRET_SINK_FILE === undefined,
     nonLocalFetchBlocked,
   };
 }
@@ -717,6 +748,10 @@ function runSelfTestMeasurementFailure() {
   return runParent(true, { [forceFailurePhaseFlag]: "self-test-measurement" });
 }
 
+function runSelfTestBudgetViolation() {
+  return runParent(true, { [forceBudgetViolationFlag]: "1" });
+}
+
 async function main(argv = process.argv.slice(2)) {
   const options = parseArgs(argv);
   if (options.help) {
@@ -734,6 +769,7 @@ async function main(argv = process.argv.slice(2)) {
   }
   if (options.selfTestEnvSanitizer) return runSelfTestEnvSanitizer();
   if (options.selfTestMeasurementFailure) return runSelfTestMeasurementFailure();
+  if (options.selfTestBudgetViolation) return runSelfTestBudgetViolation();
   return runParent(options.enforce);
 }
 

--- a/scripts/performance-baseline.mjs
+++ b/scripts/performance-baseline.mjs
@@ -1,0 +1,646 @@
+#!/usr/bin/env node
+
+import { existsSync, mkdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { createRequire } from "node:module";
+import os from "node:os";
+import path from "node:path";
+import { performance } from "node:perf_hooks";
+import { fileURLToPath, pathToFileURL } from "node:url";
+
+const require = createRequire(import.meta.url);
+const scriptPath = fileURLToPath(import.meta.url);
+const root = path.dirname(path.dirname(scriptPath));
+const configPath = path.join(root, "performance-baseline.json");
+const reportsDir = path.join(root, "reports", "performance");
+const artifactPath = path.join(reportsDir, "local-baseline.json");
+const summaryPath = path.join(reportsDir, "local-baseline-summary.md");
+const mcpRevision = "2026-07-28";
+const jsonHeaders = {
+  "content-type": "application/json",
+  accept: "application/json, text/event-stream",
+  "mcp-protocol-version": mcpRevision,
+};
+const benchmarkEnv = {
+  B2_ALLOWED_HOSTS: "",
+  B2_ALLOWED_ORIGINS: "",
+  B2_CAPABILITY_CACHE_TTL_MS: "0",
+  B2_MAX_SESSIONS: "1000",
+  B2_MAX_SESSIONS_PER_KEY: "1000",
+  B2_MCP_RATE_LIMIT_BURST: "1000",
+  B2_MCP_RATE_LIMIT_RPS: "1000",
+  LOG_LEVEL: "fatal",
+};
+
+function readJson(filePath) {
+  return JSON.parse(readFileSync(filePath, "utf8"));
+}
+
+function round(value, digits = 2) {
+  const factor = 10 ** digits;
+  return Math.round(value * factor) / factor;
+}
+
+export function budgetLimit(budget) {
+  const percent = Number(budget.tolerance?.percent ?? 0);
+  const absolute = Number(budget.tolerance?.absolute ?? 0);
+  if (budget.direction === "min") {
+    return budget.baseline * (1 - percent / 100) - absolute;
+  }
+  return budget.baseline * (1 + percent / 100) + absolute;
+}
+
+export function evaluateMetric(id, value, budget) {
+  const limit = budgetLimit(budget);
+  const pass = budget.direction === "min" ? value >= limit : value <= limit;
+  return {
+    id,
+    label: budget.label,
+    unit: budget.unit,
+    value: budget.unit === "bytes" ? Math.round(value) : round(value),
+    status: pass ? "pass" : "fail",
+    budget: {
+      direction: budget.direction,
+      baseline: budget.baseline,
+      tolerance: budget.tolerance,
+      limit: budget.unit === "bytes" ? Math.round(limit) : round(limit),
+    },
+  };
+}
+
+function usage() {
+  return [
+    "Usage: node --expose-gc scripts/performance-baseline.mjs [--enforce]",
+    "",
+    "Runs the advisory local performance baseline for issue #199.",
+    "Artifacts:",
+    `  ${path.relative(root, artifactPath)}`,
+    `  ${path.relative(root, summaryPath)}`,
+    "",
+    "Options:",
+    "  --advisory  Record failures but exit zero (default).",
+    "  --enforce   Exit nonzero when a budget is exceeded.",
+    "  --help      Show this help text.",
+  ].join("\n");
+}
+
+function parseArgs(argv) {
+  const args = new Set(argv);
+  if (args.has("--help") || args.has("-h")) return { help: true, enforce: false };
+  const unknown = argv.filter((arg) => arg !== "--advisory" && arg !== "--enforce");
+  if (unknown.length > 0) {
+    throw new Error(`Unknown argument(s): ${unknown.join(", ")}`);
+  }
+  return { help: false, enforce: args.has("--enforce") };
+}
+
+function assertBuiltArtifacts() {
+  const missing = [
+    "dist/index.js",
+    "dist/http-server.js",
+    "dist/oauth-resource-server.js",
+    "dist/tool-contract.js",
+  ].filter((relativePath) => !existsSync(path.join(root, relativePath)));
+  if (missing.length > 0) {
+    throw new Error(
+      `Missing built artifact(s): ${missing.join(
+        ", ",
+      )}. Run pnpm run build before the performance baseline.`,
+    );
+  }
+}
+
+function saveBenchmarkEnv() {
+  const saved = {};
+  for (const key of Object.keys(benchmarkEnv)) saved[key] = process.env[key];
+  return saved;
+}
+
+function applyBenchmarkEnv() {
+  for (const [key, value] of Object.entries(benchmarkEnv)) {
+    if (value === "") delete process.env[key];
+    else process.env[key] = value;
+  }
+}
+
+function restoreBenchmarkEnv(saved) {
+  for (const [key, value] of Object.entries(saved)) {
+    if (value === undefined) delete process.env[key];
+    else process.env[key] = value;
+  }
+}
+
+function safeChildEnv(extra) {
+  const inheritedNames = [
+    "PATH",
+    "Path",
+    "SystemRoot",
+    "COMSPEC",
+    "PATHEXT",
+    "HOME",
+    "USERPROFILE",
+    "TMPDIR",
+    "TMP",
+    "TEMP",
+  ];
+  const inherited = Object.fromEntries(
+    inheritedNames.flatMap((name) =>
+      process.env[name] === undefined ? [] : [[name, process.env[name]]],
+    ),
+  );
+  return {
+    ...inherited,
+    NODE_ENV: "test",
+    LOG_LEVEL: "fatal",
+    ...extra,
+  };
+}
+
+function fakeServerEnv() {
+  return safeChildEnv({
+    B2_APPLICATION_KEY_ID: "performance-key-id",
+    B2_APPLICATION_KEY: "performance-key-secret",
+    B2_REGISTER_ALL_TOOLS: "true",
+    NODE_OPTIONS: `--import ${pathToFileURL(path.join(root, "scripts/no-network-guard.mjs")).href}`,
+  });
+}
+
+async function measureStdioStartup() {
+  const [{ Client }, { StdioClientTransport }] = await Promise.all([
+    import("@modelcontextprotocol/client"),
+    import("@modelcontextprotocol/client/stdio"),
+  ]);
+  const transport = new StdioClientTransport({
+    command: process.execPath,
+    args: [path.join(root, "dist/index.js")],
+    cwd: root,
+    env: fakeServerEnv(),
+    stderr: "pipe",
+  });
+  let stderr = "";
+  transport.stderr?.on("data", (chunk) => {
+    stderr = `${stderr}${chunk.toString()}`.slice(-4096);
+  });
+  const client = new Client(
+    { name: "b2-mcp-performance-baseline", version: "1.0.0" },
+    {
+      versionNegotiation: { mode: { pin: mcpRevision } },
+      defaultCacheTtlMs: 0,
+    },
+  );
+  const started = performance.now();
+  let elapsed;
+  try {
+    await client.connect(transport, { timeoutMs: 10_000 });
+    elapsed = performance.now() - started;
+    const server = client.getServerVersion();
+    if (server?.name !== "backblaze-b2") {
+      throw new Error(`Unexpected stdio server name: ${server?.name ?? "missing"}`);
+    }
+  } finally {
+    await client.close().catch(() => undefined);
+  }
+  if (stderr.includes("MCP_CLIENT_SMOKE_NETWORK_BLOCKED")) {
+    throw new Error("Local stdio startup attempted network access under the no-network guard.");
+  }
+  return { id: "node-stdio.startupReadyMs", value: elapsed };
+}
+
+function loadDistModules() {
+  return {
+    httpServer: require(path.join(root, "dist/http-server.js")),
+    oauth: require(path.join(root, "dist/oauth-resource-server.js")),
+    toolContract: require(path.join(root, "dist/tool-contract.js")),
+  };
+}
+
+function profileProvider(profile, contractTestConfig) {
+  return {
+    name: `performance-${profile}`,
+    validateConfiguration() {
+      return undefined;
+    },
+    resolve() {
+      return {
+        config: {
+          ...contractTestConfig,
+          applicationKeyId: `performance-${profile}-key-id`,
+          applicationKey: `performance-${profile}-key-secret`,
+          appKeyId: `performance-${profile}-key-id`,
+          appKey: `performance-${profile}-key-secret`,
+          masterKeyId: `performance-${profile}-key-id`,
+          masterKey: `performance-${profile}-key-secret`,
+        },
+        cacheKey: `performance:${profile}`,
+        capabilityCacheKey: `performance:${profile}`,
+      };
+    },
+  };
+}
+
+async function listen(handle) {
+  await new Promise((resolve, reject) => {
+    const onError = (err) => {
+      handle.server.off("listening", onListening);
+      reject(err);
+    };
+    const onListening = () => {
+      handle.server.off("error", onError);
+      resolve();
+    };
+    handle.server.once("error", onError);
+    handle.server.once("listening", onListening);
+    handle.server.listen(0, "127.0.0.1");
+  });
+  const address = handle.server.address();
+  if (!address || typeof address === "string")
+    throw new Error("HTTP benchmark server did not bind");
+  return address.port;
+}
+
+async function closeHandle(handle) {
+  handle.drain();
+  await new Promise((resolve) => handle.server.close(() => resolve()));
+  await new Promise((resolve) => setImmediate(resolve));
+}
+
+async function withProfileServer(profile, modules, contract, run) {
+  const handle = modules.httpServer.buildHttpServer({
+    credentialProvider: profileProvider(profile, modules.toolContract.CONTRACT_TEST_CONFIG),
+    fetchCapabilities: async () => contract.profiles[profile].capabilities,
+    idleSweepMode: "request",
+  });
+  const port = await listen(handle);
+  try {
+    return await run(port);
+  } finally {
+    await closeHandle(handle);
+  }
+}
+
+function modernBody(method, params = {}, id = 1) {
+  return JSON.stringify({
+    jsonrpc: "2.0",
+    id,
+    method,
+    params: {
+      ...params,
+      _meta: {
+        "io.modelcontextprotocol/protocolVersion": mcpRevision,
+        "io.modelcontextprotocol/clientCapabilities": {},
+        "io.modelcontextprotocol/clientInfo": {
+          name: "b2-mcp-performance-baseline",
+          version: "1.0.0",
+        },
+      },
+    },
+  });
+}
+
+async function rawMcpRequest(port, method, id) {
+  const response = await fetch(`http://127.0.0.1:${port}/mcp`, {
+    method: "POST",
+    headers: {
+      ...jsonHeaders,
+      "mcp-method": method,
+    },
+    body: modernBody(method, {}, id),
+    signal: AbortSignal.timeout(10_000),
+  });
+  const text = await response.text();
+  if (!response.ok) {
+    throw new Error(`${method} returned HTTP ${response.status}: ${text.slice(0, 200)}`);
+  }
+  const parsed = JSON.parse(text);
+  if (parsed.error) {
+    throw new Error(`${method} returned JSON-RPC error: ${parsed.error.message}`);
+  }
+  return { text, result: parsed.result };
+}
+
+async function measureToolsList(profile, modules, contract) {
+  return withProfileServer(profile, modules, contract, async (port) => {
+    const started = performance.now();
+    const response = await rawMcpRequest(port, "tools/list", 1);
+    const elapsed = performance.now() - started;
+    const bytes = Buffer.byteLength(response.text, "utf8");
+    const expectedCount = contract.profiles[profile].counts.total;
+    const actualCount = response.result?.tools?.length;
+    if (actualCount !== expectedCount) {
+      throw new Error(
+        `tools/list for ${profile} returned ${actualCount ?? "unknown"} tools, expected ${expectedCount}`,
+      );
+    }
+    return [
+      { id: `node-http.${profile}.toolsListMs`, value: elapsed },
+      { id: `node-http.${profile}.toolsListBytes`, value: bytes },
+    ];
+  });
+}
+
+function percentile(values, p) {
+  if (values.length === 0) return 0;
+  const sorted = [...values].sort((a, b) => a - b);
+  const index = Math.min(sorted.length - 1, Math.ceil((p / 100) * sorted.length) - 1);
+  return sorted[index];
+}
+
+async function measureConcurrentDiscovery(modules, contract, concurrency) {
+  return withProfileServer("full", modules, contract, async (port) => {
+    const ids = Array.from({ length: concurrency }, (_, index) => index + 1);
+    const started = performance.now();
+    const latencies = await Promise.all(
+      ids.map(async (id) => {
+        const requestStarted = performance.now();
+        const response = await rawMcpRequest(port, "server/discover", id);
+        if (!response.result?.supportedVersions?.includes(mcpRevision)) {
+          throw new Error("server/discover did not advertise the target MCP revision");
+        }
+        return performance.now() - requestStarted;
+      }),
+    );
+    const totalMs = performance.now() - started;
+    return [
+      {
+        id: "node-http.discovery.concurrentP95Ms",
+        value: percentile(latencies, 95),
+      },
+      {
+        id: "node-http.discovery.throughputRps",
+        value: (concurrency / totalMs) * 1000,
+      },
+    ];
+  });
+}
+
+async function measureMemoryGrowth(modules, contract, requestCount) {
+  return withProfileServer("full", modules, contract, async (port) => {
+    globalThis.gc?.();
+    const before = process.memoryUsage().heapUsed;
+    for (let index = 0; index < requestCount; index++) {
+      await rawMcpRequest(port, "tools/list", index + 1);
+    }
+    globalThis.gc?.();
+    const after = process.memoryUsage().heapUsed;
+    return {
+      id: "node-http.memory.repeatedToolsListGrowthMiB",
+      value: Math.max(0, after - before) / 1024 / 1024,
+      details: {
+        requestCount,
+        gcAvailable: typeof globalThis.gc === "function",
+        heapBeforeMiB: round(before / 1024 / 1024),
+        heapAfterMiB: round(after / 1024 / 1024),
+      },
+    };
+  });
+}
+
+function oauthConfig() {
+  const issuer = "http://localhost:9000";
+  const resource = "http://localhost:9000/mcp";
+  return {
+    issuer,
+    resource,
+    audience: resource,
+    publicUrl: resource,
+    authorizationEndpoint: `${issuer}/oauth2/authorize`,
+    tokenEndpoint: `${issuer}/oauth2/token`,
+    requiredScopes: ["b2:read"],
+    allowedSubjects: ["performance-subject"],
+    allowedTokenTypes: ["bearer"],
+    allowedAlgorithms: ["RS256"],
+    allowedJwtAlgorithms: ["RS256"],
+    allowedJwtTypes: ["at+jwt"],
+    dangerouslyAllowInsecureIssuerUrl: true,
+    dangerouslyAllowUnauthenticatedIntrospection: false,
+    tokenCacheMaxEntries: 1000,
+    tokenCacheTtlSeconds: 300,
+    tokenCacheSkewSeconds: 30,
+    jwksUri: `${issuer}/oauth2/jwks`,
+    jwksCacheTtlSeconds: 300,
+    jwksCacheMinTtlSeconds: 30,
+    jwksTimeoutMs: 1000,
+    jwksMaxRetries: 0,
+    jwksRetryDelayMs: 0,
+    jwksCircuitFailures: 5,
+    jwksCircuitOpenMs: 30000,
+    jwksRefreshCooldownMs: 30000,
+    jwtClockSkewSeconds: 60,
+  };
+}
+
+async function signToken(privateKey, jti, nowSeconds, config) {
+  const { SignJWT } = await import("jose");
+  return new SignJWT({
+    aud: config.audience,
+    resource: config.resource,
+    scope: "b2:read",
+    token_type: "bearer",
+    jti,
+  })
+    .setProtectedHeader({ alg: "RS256", kid: "performance-key", typ: "at+jwt" })
+    .setIssuer(config.issuer)
+    .setSubject("performance-subject")
+    .setIssuedAt(nowSeconds)
+    .setNotBefore(nowSeconds - 1)
+    .setExpirationTime(nowSeconds + 300)
+    .sign(privateKey);
+}
+
+async function assertOAuthSuccess(result) {
+  if (!(result instanceof Response)) return result;
+  const text = await result.text();
+  throw new Error(`OAuth fake-path verification returned HTTP ${result.status}: ${text}`);
+}
+
+async function measureOAuthJwks(modules) {
+  const { exportJWK, generateKeyPair } = await import("jose");
+  const config = oauthConfig();
+  const nowSeconds = Math.floor(Date.now() / 1000);
+  const { privateKey, publicKey } = await generateKeyPair("RS256");
+  const publicJwk = {
+    ...(await exportJWK(publicKey)),
+    kid: "performance-key",
+    alg: "RS256",
+    use: "sig",
+  };
+  const tokens = await Promise.all([
+    signToken(privateKey, "cold", nowSeconds, config),
+    signToken(privateKey, "warm", nowSeconds, config),
+  ]);
+  let jwksFetches = 0;
+  const fetchImpl = async (url) => {
+    if (String(url) !== config.jwksUri) {
+      throw new Error(`Unexpected OAuth benchmark fetch URL: ${url}`);
+    }
+    jwksFetches++;
+    return new Response(JSON.stringify({ keys: [publicJwk] }), {
+      status: 200,
+      headers: {
+        "content-type": "application/json",
+        "cache-control": "max-age=60",
+      },
+    });
+  };
+  const requestFor = (token) =>
+    new Request("http://localhost:9000/mcp", {
+      headers: {
+        authorization: `Bearer ${token}`,
+      },
+    });
+
+  modules.oauth.resetOAuthVerifierCacheForTests();
+  const coldStarted = performance.now();
+  await assertOAuthSuccess(
+    await modules.oauth.authenticateOAuthRequest(requestFor(tokens[0]), config, {
+      fetch: fetchImpl,
+      nowSeconds: () => nowSeconds,
+    }),
+  );
+  const coldMs = performance.now() - coldStarted;
+
+  const warmStarted = performance.now();
+  await assertOAuthSuccess(
+    await modules.oauth.authenticateOAuthRequest(requestFor(tokens[1]), config, {
+      fetch: fetchImpl,
+      nowSeconds: () => nowSeconds,
+    }),
+  );
+  const warmMs = performance.now() - warmStarted;
+  if (jwksFetches !== 1) {
+    throw new Error(`Expected one JWKS fetch across cold/warm checks, observed ${jwksFetches}`);
+  }
+  return [
+    { id: "oauth-jwks.coldVerifyMs", value: coldMs, details: { jwksFetches: 1 } },
+    { id: "oauth-jwks.warmVerifyMs", value: warmMs, details: { jwksFetches: 0 } },
+  ];
+}
+
+async function runMeasurements(config) {
+  assertBuiltArtifacts();
+  const contract = readJson(path.join(root, "docs/tool-profile-contract.json"));
+  const measurements = [];
+  const saved = saveBenchmarkEnv();
+  let modules;
+  applyBenchmarkEnv();
+  try {
+    modules = loadDistModules();
+    measurements.push(await measureStdioStartup());
+    for (const profile of config.reviewedBaseline.toolProfiles) {
+      measurements.push(...(await measureToolsList(profile, modules, contract)));
+    }
+    measurements.push(
+      ...(await measureConcurrentDiscovery(
+        modules,
+        contract,
+        config.measurementPlan.modestConcurrency,
+      )),
+    );
+    measurements.push(
+      await measureMemoryGrowth(modules, contract, config.measurementPlan.memoryRequestCount),
+    );
+    measurements.push(...(await measureOAuthJwks(modules)));
+  } finally {
+    restoreBenchmarkEnv(saved);
+    modules?.oauth.resetOAuthVerifierCacheForTests();
+  }
+  return measurements;
+}
+
+function evaluateMeasurements(config, measurements) {
+  const byId = new Map(measurements.map((metric) => [metric.id, metric]));
+  return Object.entries(config.budgets).map(([id, budget]) => {
+    const measured = byId.get(id);
+    if (!measured) throw new Error(`Performance budget ${id} has no measurement.`);
+    return {
+      ...evaluateMetric(id, measured.value, budget),
+      ...(measured.details && { details: measured.details }),
+    };
+  });
+}
+
+function renderSummary(config, metrics, enforce) {
+  const failures = metrics.filter((metric) => metric.status !== "pass");
+  const mode = enforce ? "enforce" : "advisory";
+  const rows = metrics.map((metric) =>
+    [
+      metric.status === "pass" ? "PASS" : "FAIL",
+      metric.id,
+      `${metric.value} ${metric.unit}`,
+      `${metric.budget.direction} ${metric.budget.limit} ${metric.unit}`,
+    ].join(" | "),
+  );
+  return [
+    "# Local Performance Baseline",
+    "",
+    `Mode: ${mode}`,
+    `Issue: #${config.issue.number} ${config.issue.url}`,
+    `Status: ${failures.length === 0 ? "pass" : `${failures.length} budget violation(s)`}`,
+    "",
+    "This local baseline uses fake deterministic fixtures and does not measure live Backblaze B2 latency.",
+    "",
+    "status | metric | measured | budget",
+    "--- | --- | --- | ---",
+    ...rows,
+    "",
+    "Runtime applicability:",
+    ...Object.entries(config.runtimeApplicability).map(
+      ([runtime, decision]) => `- ${runtime}: ${decision.decision} (${decision.budgetSet})`,
+    ),
+    "",
+  ].join("\n");
+}
+
+function writeReports(config, metrics, summary, enforce) {
+  mkdirSync(reportsDir, { recursive: true });
+  rmSync(artifactPath, { force: true });
+  rmSync(summaryPath, { force: true });
+  const artifact = {
+    schemaVersion: 1,
+    generatedAt: new Date().toISOString(),
+    issue: config.issue,
+    mode: enforce ? "enforce" : "advisory",
+    advisory: !enforce,
+    liveB2CredentialsUsed: false,
+    liveB2NetworkMeasured: false,
+    node: process.version,
+    platform: {
+      os: os.platform(),
+      arch: os.arch(),
+    },
+    measurementPlan: config.measurementPlan,
+    runtimeApplicability: config.runtimeApplicability,
+    metrics,
+    violations: metrics.filter((metric) => metric.status !== "pass").map((metric) => metric.id),
+  };
+  writeFileSync(artifactPath, `${JSON.stringify(artifact, null, 2)}\n`);
+  writeFileSync(summaryPath, summary);
+  return artifact;
+}
+
+async function main(argv = process.argv.slice(2)) {
+  const options = parseArgs(argv);
+  if (options.help) {
+    console.log(usage());
+    return 0;
+  }
+  const config = readJson(configPath);
+  const measurements = await runMeasurements(config);
+  const metrics = evaluateMeasurements(config, measurements);
+  const summary = renderSummary(config, metrics, options.enforce);
+  const artifact = writeReports(config, metrics, summary, options.enforce);
+  console.log(summary);
+  if (options.enforce && artifact.violations.length > 0) return 1;
+  return 0;
+}
+
+if (import.meta.url === pathToFileURL(process.argv[1] ?? "").href) {
+  main().then(
+    (code) => {
+      process.exitCode = code;
+    },
+    (err) => {
+      console.error(err instanceof Error ? err.message : String(err));
+      process.exitCode = 1;
+    },
+  );
+}

--- a/scripts/performance-baseline.mjs
+++ b/scripts/performance-baseline.mjs
@@ -601,6 +601,7 @@ function syntheticBudgetViolationMeasurements(config) {
 
 async function runEnvProbe() {
   const { SignJWT } = await import("jose");
+  const http = require("node:http");
   const stdioEnv = fakeServerEnv();
   const observedSentinelNames = Object.entries(process.env)
     .filter(([, value]) => String(value).includes(parentSecretSentinel))
@@ -614,6 +615,15 @@ async function runEnvProbe() {
       error instanceof Error ? error.message : String(error),
     );
   }
+  let requestOptionsOverrideBlocked = false;
+  try {
+    const request = http.request("http://127.0.0.1", { hostname: "example.com" });
+    request.destroy();
+  } catch (error) {
+    requestOptionsOverrideBlocked = /Non-local network access blocked/.test(
+      error instanceof Error ? error.message : String(error),
+    );
+  }
   return {
     importedDependency: typeof SignJWT === "function",
     observedSentinelNames,
@@ -623,6 +633,7 @@ async function runEnvProbe() {
     stdioSecretSinkIsOff: stdioEnv.B2_SECRET_SINK === "off",
     stdioSecretSinkFileUnset: stdioEnv.B2_SECRET_SINK_FILE === undefined,
     nonLocalFetchBlocked,
+    requestOptionsOverrideBlocked,
   };
 }
 

--- a/scripts/performance-baseline.mjs
+++ b/scripts/performance-baseline.mjs
@@ -642,6 +642,12 @@ async function runEnvProbe() {
   const esmSocketConnectBlocked = blockedNetworkCall(() =>
     new EsmSocket().connect({ host: "example.com", port: 443 }),
   );
+  const malformedLoopbackBlocked = blockedNetworkCall(() =>
+    new net.Socket().connect({ host: "127.999.999.999", port: 443 }),
+  );
+  const zeroPaddedLoopbackBlocked = blockedNetworkCall(() =>
+    new net.Socket().connect({ host: "127.000.000.001", port: 443 }),
+  );
   return {
     importedDependency: typeof SignJWT === "function",
     observedSentinelNames,
@@ -656,6 +662,8 @@ async function runEnvProbe() {
     tlsSocketConnectBlocked,
     esmNetConnectBlocked,
     esmSocketConnectBlocked,
+    malformedLoopbackBlocked,
+    zeroPaddedLoopbackBlocked,
   };
 }
 
@@ -757,7 +765,9 @@ function runSelfTestEnvSanitizer() {
     !payload.probe.netSocketConnectBlocked ||
     !payload.probe.tlsSocketConnectBlocked ||
     !payload.probe.esmNetConnectBlocked ||
-    !payload.probe.esmSocketConnectBlocked
+    !payload.probe.esmSocketConnectBlocked ||
+    !payload.probe.malformedLoopbackBlocked ||
+    !payload.probe.zeroPaddedLoopbackBlocked
     ? 1
     : 0;
 }

--- a/scripts/performance-baseline.mjs
+++ b/scripts/performance-baseline.mjs
@@ -648,6 +648,52 @@ async function runEnvProbe() {
   const zeroPaddedLoopbackBlocked = blockedNetworkCall(() =>
     new net.Socket().connect({ host: "127.000.000.001", port: 443 }),
   );
+  const customLookupBlocked = blockedNetworkCall(() =>
+    net.connect({
+      host: "localhost",
+      port: 443,
+      lookup: (_host, _options, callback) => callback(null, "1.1.1.1", 4),
+    }),
+  );
+  const stdioGuardProbe = spawnSync(
+    process.execPath,
+    [
+      "--input-type=module",
+      "--eval",
+      [
+        'import net, { connect, Socket } from "node:net";',
+        'import tls from "node:tls";',
+        "const blocked = (call) => {",
+        "  try {",
+        "    const handle = call();",
+        "    handle?.destroy?.();",
+        "    return false;",
+        "  } catch {",
+        "    return true;",
+        "  }",
+        "};",
+        "const results = {",
+        '  netSocket: blocked(() => new net.Socket().connect({ host: "example.com", port: 443 })),',
+        '  tlsSocket: blocked(() => new tls.TLSSocket(new net.Socket()).connect({ host: "example.com", port: 443 })),',
+        '  esmConnect: blocked(() => connect({ host: "example.com", port: 443 })),',
+        '  esmSocket: blocked(() => new Socket().connect({ host: "example.com", port: 443 })),',
+        "};",
+        "console.log(JSON.stringify(results));",
+        "process.exitCode = Object.values(results).every(Boolean) ? 0 : 1;",
+      ].join("\n"),
+    ],
+    {
+      cwd: root,
+      env: stdioEnv,
+      encoding: "utf8",
+      timeout: 10_000,
+    },
+  );
+  const stdioGuardProbeBlocked =
+    stdioGuardProbe.status === 0 &&
+    Object.values(JSON.parse(stdioGuardProbe.stdout.trim().split(/\r?\n/).at(-1) ?? "{}")).every(
+      Boolean,
+    );
   return {
     importedDependency: typeof SignJWT === "function",
     observedSentinelNames,
@@ -664,6 +710,8 @@ async function runEnvProbe() {
     esmSocketConnectBlocked,
     malformedLoopbackBlocked,
     zeroPaddedLoopbackBlocked,
+    customLookupBlocked,
+    stdioGuardProbeBlocked,
   };
 }
 
@@ -767,7 +815,9 @@ function runSelfTestEnvSanitizer() {
     !payload.probe.esmNetConnectBlocked ||
     !payload.probe.esmSocketConnectBlocked ||
     !payload.probe.malformedLoopbackBlocked ||
-    !payload.probe.zeroPaddedLoopbackBlocked
+    !payload.probe.zeroPaddedLoopbackBlocked ||
+    !payload.probe.customLookupBlocked ||
+    !payload.probe.stdioGuardProbeBlocked
     ? 1
     : 0;
 }

--- a/scripts/performance-baseline.mjs
+++ b/scripts/performance-baseline.mjs
@@ -1,70 +1,54 @@
 #!/usr/bin/env node
 
+import { spawnSync } from "node:child_process";
 import { existsSync, mkdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { createRequire } from "node:module";
-import os from "node:os";
 import path from "node:path";
 import { performance } from "node:perf_hooks";
 import { fileURLToPath, pathToFileURL } from "node:url";
 
 const require = createRequire(import.meta.url);
+const { sanitizedEnv } = require("./lib/sanitized-env.cjs");
+const {
+  createArtifact,
+  evaluateMeasurements,
+  renderSummary,
+  round,
+} = require("./lib/performance-baseline.cjs");
+
 const scriptPath = fileURLToPath(import.meta.url);
 const root = path.dirname(path.dirname(scriptPath));
 const configPath = path.join(root, "performance-baseline.json");
 const reportsDir = path.join(root, "reports", "performance");
 const artifactPath = path.join(reportsDir, "local-baseline.json");
 const summaryPath = path.join(reportsDir, "local-baseline-summary.md");
-const mcpRevision = "2026-07-28";
-const jsonHeaders = {
-  "content-type": "application/json",
-  accept: "application/json, text/event-stream",
-  "mcp-protocol-version": mcpRevision,
-};
-const benchmarkEnv = {
+const localNetworkGuardPath = path.join(root, "scripts/lib/local-network-guard.mjs");
+const noNetworkGuardPath = path.join(root, "scripts/no-network-guard.mjs");
+const workerEnvFlag = "B2_MCP_PERFORMANCE_BASELINE_WORKER";
+const probeOnlyFlag = "B2_MCP_PERFORMANCE_BASELINE_PROBE_ONLY";
+const forceFailurePhaseFlag = "B2_MCP_PERFORMANCE_BASELINE_FORCE_FAILURE_PHASE";
+const parentSecretSentinel = "sentinel-parent-secret";
+const workerTimeoutMs = 120_000;
+
+const benchmarkWorkerEnv = {
   B2_ALLOWED_HOSTS: "",
   B2_ALLOWED_ORIGINS: "",
+  B2_APPLICATION_KEY_ID: "performance-key-id",
+  B2_APPLICATION_KEY: "performance-key-secret",
   B2_CAPABILITY_CACHE_TTL_MS: "0",
   B2_MAX_SESSIONS: "1000",
   B2_MAX_SESSIONS_PER_KEY: "1000",
   B2_MCP_RATE_LIMIT_BURST: "1000",
   B2_MCP_RATE_LIMIT_RPS: "1000",
+  B2_REGISTER_ALL_TOOLS: "true",
   LOG_LEVEL: "fatal",
+  NODE_ENV: "test",
+  NODE_OPTIONS: `--import ${pathToFileURL(localNetworkGuardPath).href}`,
+  [workerEnvFlag]: "1",
 };
 
 function readJson(filePath) {
   return JSON.parse(readFileSync(filePath, "utf8"));
-}
-
-function round(value, digits = 2) {
-  const factor = 10 ** digits;
-  return Math.round(value * factor) / factor;
-}
-
-export function budgetLimit(budget) {
-  const percent = Number(budget.tolerance?.percent ?? 0);
-  const absolute = Number(budget.tolerance?.absolute ?? 0);
-  if (budget.direction === "min") {
-    return budget.baseline * (1 - percent / 100) - absolute;
-  }
-  return budget.baseline * (1 + percent / 100) + absolute;
-}
-
-export function evaluateMetric(id, value, budget) {
-  const limit = budgetLimit(budget);
-  const pass = budget.direction === "min" ? value >= limit : value <= limit;
-  return {
-    id,
-    label: budget.label,
-    unit: budget.unit,
-    value: budget.unit === "bytes" ? Math.round(value) : round(value),
-    status: pass ? "pass" : "fail",
-    budget: {
-      direction: budget.direction,
-      baseline: budget.baseline,
-      tolerance: budget.tolerance,
-      limit: budget.unit === "bytes" ? Math.round(limit) : round(limit),
-    },
-  };
 }
 
 function usage() {
@@ -85,12 +69,36 @@ function usage() {
 
 function parseArgs(argv) {
   const args = new Set(argv);
-  if (args.has("--help") || args.has("-h")) return { help: true, enforce: false };
-  const unknown = argv.filter((arg) => arg !== "--advisory" && arg !== "--enforce");
+  if (args.has("--help") || args.has("-h")) {
+    return {
+      help: true,
+      enforce: false,
+      worker: false,
+      selfTestEnvSanitizer: false,
+      selfTestMeasurementFailure: false,
+    };
+  }
+  const worker = args.has("--worker");
+  const selfTestEnvSanitizer = args.has("--self-test-env-sanitizer");
+  const selfTestMeasurementFailure = args.has("--self-test-measurement-failure");
+  const allowed = new Set([
+    "--advisory",
+    "--enforce",
+    "--worker",
+    "--self-test-env-sanitizer",
+    "--self-test-measurement-failure",
+  ]);
+  const unknown = argv.filter((arg) => !allowed.has(arg));
   if (unknown.length > 0) {
     throw new Error(`Unknown argument(s): ${unknown.join(", ")}`);
   }
-  return { help: false, enforce: args.has("--enforce") };
+  return {
+    help: false,
+    enforce: args.has("--enforce"),
+    worker,
+    selfTestEnvSanitizer,
+    selfTestMeasurementFailure,
+  };
 }
 
 function assertBuiltArtifacts() {
@@ -109,62 +117,41 @@ function assertBuiltArtifacts() {
   }
 }
 
-function saveBenchmarkEnv() {
-  const saved = {};
-  for (const key of Object.keys(benchmarkEnv)) saved[key] = process.env[key];
-  return saved;
-}
-
-function applyBenchmarkEnv() {
-  for (const [key, value] of Object.entries(benchmarkEnv)) {
-    if (value === "") delete process.env[key];
-    else process.env[key] = value;
-  }
-}
-
-function restoreBenchmarkEnv(saved) {
-  for (const [key, value] of Object.entries(saved)) {
-    if (value === undefined) delete process.env[key];
-    else process.env[key] = value;
-  }
-}
-
-function safeChildEnv(extra) {
-  const inheritedNames = [
-    "PATH",
-    "Path",
-    "SystemRoot",
-    "COMSPEC",
-    "PATHEXT",
-    "HOME",
-    "USERPROFILE",
-    "TMPDIR",
-    "TMP",
-    "TEMP",
-  ];
-  const inherited = Object.fromEntries(
-    inheritedNames.flatMap((name) =>
-      process.env[name] === undefined ? [] : [[name, process.env[name]]],
-    ),
-  );
-  return {
-    ...inherited,
-    NODE_ENV: "test",
-    LOG_LEVEL: "fatal",
+function createWorkerEnv(extra = {}, sourceEnv = process.env) {
+  const merged = {
+    ...benchmarkWorkerEnv,
     ...extra,
   };
-}
-
-function fakeServerEnv() {
-  return safeChildEnv({
-    B2_APPLICATION_KEY_ID: "performance-key-id",
-    B2_APPLICATION_KEY: "performance-key-secret",
-    B2_REGISTER_ALL_TOOLS: "true",
-    NODE_OPTIONS: `--import ${pathToFileURL(path.join(root, "scripts/no-network-guard.mjs")).href}`,
+  return sanitizedEnv(merged, {
+    sourceEnv,
+    nonSecretEnvNames: Object.keys(merged),
   });
 }
 
-async function measureStdioStartup() {
+function fakeServerEnv() {
+  const extra = {
+    B2_APPLICATION_KEY_ID: "performance-key-id",
+    B2_APPLICATION_KEY: "performance-key-secret",
+    B2_REGISTER_ALL_TOOLS: "true",
+    LOG_LEVEL: "fatal",
+    NODE_ENV: "test",
+    NODE_OPTIONS: `--import ${pathToFileURL(noNetworkGuardPath).href}`,
+  };
+  return sanitizedEnv(extra, {
+    sourceEnv: process.env,
+    nonSecretEnvNames: Object.keys(extra),
+  });
+}
+
+function jsonHeaders(mcpRevision) {
+  return {
+    "content-type": "application/json",
+    accept: "application/json, text/event-stream",
+    "mcp-protocol-version": mcpRevision,
+  };
+}
+
+async function measureStdioStartup(mcpRevision) {
   const [{ Client }, { StdioClientTransport }] = await Promise.all([
     import("@modelcontextprotocol/client"),
     import("@modelcontextprotocol/client/stdio"),
@@ -277,7 +264,7 @@ async function withProfileServer(profile, modules, contract, run) {
   }
 }
 
-function modernBody(method, params = {}, id = 1) {
+function modernBody(method, mcpRevision, params = {}, id = 1) {
   return JSON.stringify({
     jsonrpc: "2.0",
     id,
@@ -296,14 +283,14 @@ function modernBody(method, params = {}, id = 1) {
   });
 }
 
-async function rawMcpRequest(port, method, id) {
+async function rawMcpRequest(port, method, id, mcpRevision) {
   const response = await fetch(`http://127.0.0.1:${port}/mcp`, {
     method: "POST",
     headers: {
-      ...jsonHeaders,
+      ...jsonHeaders(mcpRevision),
       "mcp-method": method,
     },
-    body: modernBody(method, {}, id),
+    body: modernBody(method, mcpRevision, {}, id),
     signal: AbortSignal.timeout(10_000),
   });
   const text = await response.text();
@@ -317,10 +304,10 @@ async function rawMcpRequest(port, method, id) {
   return { text, result: parsed.result };
 }
 
-async function measureToolsList(profile, modules, contract) {
+async function measureToolsList(profile, modules, contract, mcpRevision) {
   return withProfileServer(profile, modules, contract, async (port) => {
     const started = performance.now();
-    const response = await rawMcpRequest(port, "tools/list", 1);
+    const response = await rawMcpRequest(port, "tools/list", 1, mcpRevision);
     const elapsed = performance.now() - started;
     const bytes = Buffer.byteLength(response.text, "utf8");
     const expectedCount = contract.profiles[profile].counts.total;
@@ -344,14 +331,14 @@ function percentile(values, p) {
   return sorted[index];
 }
 
-async function measureConcurrentDiscovery(modules, contract, concurrency) {
+async function measureConcurrentDiscovery(modules, contract, concurrency, mcpRevision) {
   return withProfileServer("full", modules, contract, async (port) => {
     const ids = Array.from({ length: concurrency }, (_, index) => index + 1);
     const started = performance.now();
     const latencies = await Promise.all(
       ids.map(async (id) => {
         const requestStarted = performance.now();
-        const response = await rawMcpRequest(port, "server/discover", id);
+        const response = await rawMcpRequest(port, "server/discover", id, mcpRevision);
         if (!response.result?.supportedVersions?.includes(mcpRevision)) {
           throw new Error("server/discover did not advertise the target MCP revision");
         }
@@ -372,12 +359,12 @@ async function measureConcurrentDiscovery(modules, contract, concurrency) {
   });
 }
 
-async function measureMemoryGrowth(modules, contract, requestCount) {
+async function measureMemoryGrowth(modules, contract, requestCount, mcpRevision) {
   return withProfileServer("full", modules, contract, async (port) => {
     globalThis.gc?.();
     const before = process.memoryUsage().heapUsed;
     for (let index = 0; index < requestCount; index++) {
-      await rawMcpRequest(port, "tools/list", index + 1);
+      await rawMcpRequest(port, "tools/list", index + 1, mcpRevision);
     }
     globalThis.gc?.();
     const after = process.memoryUsage().heapUsed;
@@ -515,106 +502,219 @@ async function measureOAuthJwks(modules) {
   ];
 }
 
+function serializeError(error, phase, partialMeasurements) {
+  return {
+    phase,
+    message: error instanceof Error ? error.message : String(error),
+    name: error instanceof Error ? error.name : "Error",
+    ...(partialMeasurements && {
+      partialMetricIds: partialMeasurements.map((metric) => metric.id),
+    }),
+  };
+}
+
+async function recordPhase(measurements, phase, run) {
+  try {
+    const result = await run();
+    const entries = Array.isArray(result) ? result : [result];
+    measurements.push(...entries);
+  } catch (error) {
+    const wrapped = new Error(error instanceof Error ? error.message : String(error));
+    wrapped.name = error instanceof Error ? error.name : "Error";
+    wrapped.phase = phase;
+    wrapped.partialMeasurements = [...measurements];
+    throw wrapped;
+  }
+}
+
 async function runMeasurements(config) {
+  if (process.env[forceFailurePhaseFlag]) {
+    const error = new Error("Forced measurement failure for performance artifact self-test.");
+    error.phase = process.env[forceFailurePhaseFlag];
+    error.partialMeasurements = [];
+    throw error;
+  }
   assertBuiltArtifacts();
   const contract = readJson(path.join(root, "docs/tool-profile-contract.json"));
+  const mcpRevision = contract.mcpRevision;
+  const modules = loadDistModules();
   const measurements = [];
-  const saved = saveBenchmarkEnv();
-  let modules;
-  applyBenchmarkEnv();
+
   try {
-    modules = loadDistModules();
-    measurements.push(await measureStdioStartup());
+    await recordPhase(measurements, "node-stdio.startupReadyMs", () =>
+      measureStdioStartup(mcpRevision),
+    );
     for (const profile of config.reviewedBaseline.toolProfiles) {
-      measurements.push(...(await measureToolsList(profile, modules, contract)));
+      await recordPhase(measurements, `node-http.${profile}.toolsList`, () =>
+        measureToolsList(profile, modules, contract, mcpRevision),
+      );
     }
-    measurements.push(
-      ...(await measureConcurrentDiscovery(
+    await recordPhase(measurements, "node-http.discovery", () =>
+      measureConcurrentDiscovery(
         modules,
         contract,
         config.measurementPlan.modestConcurrency,
-      )),
+        mcpRevision,
+      ),
     );
-    measurements.push(
-      await measureMemoryGrowth(modules, contract, config.measurementPlan.memoryRequestCount),
+    await recordPhase(measurements, "node-http.memory.repeatedToolsListGrowthMiB", () =>
+      measureMemoryGrowth(
+        modules,
+        contract,
+        config.measurementPlan.memoryRequestCount,
+        mcpRevision,
+      ),
     );
-    measurements.push(...(await measureOAuthJwks(modules)));
+    await recordPhase(measurements, "oauth-jwks", () => measureOAuthJwks(modules));
   } finally {
-    restoreBenchmarkEnv(saved);
-    modules?.oauth.resetOAuthVerifierCacheForTests();
+    modules.oauth.resetOAuthVerifierCacheForTests();
   }
   return measurements;
 }
 
-function evaluateMeasurements(config, measurements) {
-  const byId = new Map(measurements.map((metric) => [metric.id, metric]));
-  return Object.entries(config.budgets).map(([id, budget]) => {
-    const measured = byId.get(id);
-    if (!measured) throw new Error(`Performance budget ${id} has no measurement.`);
+async function runEnvProbe() {
+  const { SignJWT } = await import("jose");
+  const observedSentinelNames = Object.entries(process.env)
+    .filter(([, value]) => String(value).includes(parentSecretSentinel))
+    .map(([name]) => name)
+    .sort();
+  let nonLocalFetchBlocked = false;
+  try {
+    await fetch("https://example.com");
+  } catch (error) {
+    nonLocalFetchBlocked = /Non-local network access blocked/.test(
+      error instanceof Error ? error.message : String(error),
+    );
+  }
+  return {
+    importedDependency: typeof SignJWT === "function",
+    observedSentinelNames,
+    sentinelValueVisible: observedSentinelNames.length > 0,
+    benchmarkCredentialIsFake: process.env.B2_APPLICATION_KEY === "performance-key-secret",
+    nonLocalFetchBlocked,
+  };
+}
+
+async function workerMain() {
+  if (process.env[probeOnlyFlag] === "1") {
+    return { ok: true, probe: await runEnvProbe() };
+  }
+  const config = readJson(configPath);
+  try {
+    return { ok: true, measurements: await runMeasurements(config) };
+  } catch (error) {
     return {
-      ...evaluateMetric(id, measured.value, budget),
-      ...(measured.details && { details: measured.details }),
+      ok: false,
+      error: serializeError(error, error?.phase ?? "measurement", error?.partialMeasurements),
+      partialMeasurements: error?.partialMeasurements ?? [],
     };
+  }
+}
+
+function parseWorkerPayload(stdout) {
+  const line = stdout
+    .split(/\r?\n/)
+    .map((candidate) => candidate.trim())
+    .filter(Boolean)
+    .at(-1);
+  if (!line) throw new Error("Performance worker wrote no JSON payload.");
+  return JSON.parse(line);
+}
+
+function runWorkerProcess(extraEnv = {}) {
+  const result = spawnSync(process.execPath, ["--expose-gc", scriptPath, "--worker"], {
+    cwd: root,
+    env: createWorkerEnv(extraEnv),
+    encoding: "utf8",
+    maxBuffer: 16 * 1024 * 1024,
+    timeout: workerTimeoutMs,
   });
+  let payload = null;
+  try {
+    payload = result.stdout ? parseWorkerPayload(result.stdout) : null;
+  } catch {
+    payload = null;
+  }
+  if (result.error) {
+    return {
+      ok: false,
+      error: {
+        phase: "worker",
+        message:
+          result.error.code === "ETIMEDOUT"
+            ? `Performance worker timed out after ${workerTimeoutMs} ms`
+            : result.error.message,
+        name: result.error.name,
+      },
+      partialMeasurements: payload?.partialMeasurements ?? [],
+    };
+  }
+  if (payload?.ok === true && result.status === 0) return payload;
+  return {
+    ok: false,
+    error: payload?.error ?? {
+      phase: "worker",
+      message:
+        result.stderr?.trim().split(/\r?\n/).at(-1) ||
+        `Performance worker exited with status ${result.status ?? "unknown"}`,
+      name: "WorkerError",
+    },
+    partialMeasurements: payload?.partialMeasurements ?? [],
+  };
 }
 
-function renderSummary(config, metrics, enforce) {
-  const failures = metrics.filter((metric) => metric.status !== "pass");
-  const mode = enforce ? "enforce" : "advisory";
-  const rows = metrics.map((metric) =>
-    [
-      metric.status === "pass" ? "PASS" : "FAIL",
-      metric.id,
-      `${metric.value} ${metric.unit}`,
-      `${metric.budget.direction} ${metric.budget.limit} ${metric.unit}`,
-    ].join(" | "),
-  );
-  return [
-    "# Local Performance Baseline",
-    "",
-    `Mode: ${mode}`,
-    `Issue: #${config.issue.number} ${config.issue.url}`,
-    `Status: ${failures.length === 0 ? "pass" : `${failures.length} budget violation(s)`}`,
-    "",
-    "This local baseline uses fake deterministic fixtures and does not measure live Backblaze B2 latency.",
-    "",
-    "status | metric | measured | budget",
-    "--- | --- | --- | ---",
-    ...rows,
-    "",
-    "Runtime applicability:",
-    ...Object.entries(config.runtimeApplicability).map(
-      ([runtime, decision]) => `- ${runtime}: ${decision.decision} (${decision.budgetSet})`,
-    ),
-    "",
-  ].join("\n");
-}
-
-function writeReports(config, metrics, summary, enforce) {
+function writeReports(config, metrics, measurements, enforce, failure = null) {
   mkdirSync(reportsDir, { recursive: true });
   rmSync(artifactPath, { force: true });
   rmSync(summaryPath, { force: true });
-  const artifact = {
-    schemaVersion: 1,
-    generatedAt: new Date().toISOString(),
-    issue: config.issue,
-    mode: enforce ? "enforce" : "advisory",
-    advisory: !enforce,
-    liveB2CredentialsUsed: false,
-    liveB2NetworkMeasured: false,
-    node: process.version,
-    platform: {
-      os: os.platform(),
-      arch: os.arch(),
-    },
-    measurementPlan: config.measurementPlan,
-    runtimeApplicability: config.runtimeApplicability,
+  const summary = renderSummary(config, metrics, { enforce, failure });
+  const artifact = createArtifact({
+    config,
     metrics,
-    violations: metrics.filter((metric) => metric.status !== "pass").map((metric) => metric.id),
-  };
+    measurements,
+    enforce,
+    failure,
+  });
   writeFileSync(artifactPath, `${JSON.stringify(artifact, null, 2)}\n`);
   writeFileSync(summaryPath, summary);
-  return artifact;
+  return { artifact, summary };
+}
+
+function runSelfTestEnvSanitizer() {
+  const payload = runWorkerProcess({ [probeOnlyFlag]: "1" });
+  if (!payload.ok) {
+    console.error(payload.error?.message ?? "Environment sanitizer self-test failed");
+    return 1;
+  }
+  console.log(JSON.stringify(payload.probe));
+  return payload.probe.sentinelValueVisible || !payload.probe.nonLocalFetchBlocked ? 1 : 0;
+}
+
+function runParent(enforce, workerExtraEnv = {}) {
+  const config = readJson(configPath);
+  const payload = runWorkerProcess(workerExtraEnv);
+  if (!payload.ok) {
+    const measurements = payload.partialMeasurements ?? [];
+    const metrics = evaluateMeasurements(config, measurements, { requireAll: false });
+    const failure = payload.error ?? {
+      phase: "worker",
+      message: "Performance worker failed before returning an error payload.",
+    };
+    const { summary } = writeReports(config, metrics, measurements, enforce, failure);
+    console.log(summary);
+    return enforce ? 1 : 0;
+  }
+
+  const measurements = payload.measurements ?? [];
+  const metrics = evaluateMeasurements(config, measurements);
+  const { artifact, summary } = writeReports(config, metrics, measurements, enforce);
+  console.log(summary);
+  if (enforce && artifact.violations.length > 0) return 1;
+  return 0;
+}
+
+function runSelfTestMeasurementFailure() {
+  return runParent(true, { [forceFailurePhaseFlag]: "self-test-measurement" });
 }
 
 async function main(argv = process.argv.slice(2)) {
@@ -623,14 +723,18 @@ async function main(argv = process.argv.slice(2)) {
     console.log(usage());
     return 0;
   }
-  const config = readJson(configPath);
-  const measurements = await runMeasurements(config);
-  const metrics = evaluateMeasurements(config, measurements);
-  const summary = renderSummary(config, metrics, options.enforce);
-  const artifact = writeReports(config, metrics, summary, options.enforce);
-  console.log(summary);
-  if (options.enforce && artifact.violations.length > 0) return 1;
-  return 0;
+  if (options.worker) {
+    if (process.env[workerEnvFlag] !== "1") {
+      console.error("Performance baseline worker mode requires a sanitized launcher.");
+      return 1;
+    }
+    const payload = await workerMain();
+    process.stdout.write(`${JSON.stringify(payload)}\n`);
+    return payload.ok ? 0 : 1;
+  }
+  if (options.selfTestEnvSanitizer) return runSelfTestEnvSanitizer();
+  if (options.selfTestMeasurementFailure) return runSelfTestMeasurementFailure();
+  return runParent(options.enforce);
 }
 
 if (import.meta.url === pathToFileURL(process.argv[1] ?? "").href) {

--- a/tests/unit/performance-baseline.unit.test.ts
+++ b/tests/unit/performance-baseline.unit.test.ts
@@ -238,6 +238,7 @@ describe("local performance baseline", () => {
     expect(probe.stdioSecretSinkIsOff).toBe(true);
     expect(probe.stdioSecretSinkFileUnset).toBe(true);
     expect(probe.nonLocalFetchBlocked).toBe(true);
+    expect(probe.requestOptionsOverrideBlocked).toBe(true);
   });
 
   it("rejects direct worker mode without sanitized launcher state", () => {

--- a/tests/unit/performance-baseline.unit.test.ts
+++ b/tests/unit/performance-baseline.unit.test.ts
@@ -1,0 +1,87 @@
+import { spawnSync } from "child_process";
+import { readFileSync } from "fs";
+import { join } from "path";
+
+const root = join(__dirname, "../..");
+
+function readJson<T>(relativePath: string): T {
+  return JSON.parse(readFileSync(join(root, relativePath), "utf8")) as T;
+}
+
+describe("local performance baseline", () => {
+  it("is advisory and traceable to issue 199", () => {
+    const config = readJson<{
+      mode: string;
+      issue: { number: number; url: string };
+      measurementPlan: { localOnly: boolean; usesRealB2Credentials: boolean };
+      reviewedBaseline: { toolProfiles: string[] };
+      runtimeApplicability: Record<string, { decision: string; budgetSet: string }>;
+      budgets: Record<
+        string,
+        {
+          baseline: number;
+          tolerance: { percent: number; absolute: number };
+          direction: "min" | "max";
+        }
+      >;
+    }>("performance-baseline.json");
+
+    expect(config.mode).toBe("advisory");
+    expect(config.issue.number).toBe(199);
+    expect(config.issue.url).toBe("https://github.com/backblaze-labs/b2-mcp/issues/199");
+    expect(config.measurementPlan.localOnly).toBe(true);
+    expect(config.measurementPlan.usesRealB2Credentials).toBe(false);
+    expect(config.reviewedBaseline.toolProfiles).toEqual(["full", "phase1-default", "read-only"]);
+    expect(Object.keys(config.runtimeApplicability).sort()).toEqual([
+      "cloudflare-worker",
+      "node-http",
+      "node-stdio",
+      "vercel-serverless",
+    ]);
+    for (const [id, budget] of Object.entries(config.budgets)) {
+      expect(budget.baseline, id).toBeGreaterThan(0);
+      expect(budget.tolerance.percent, id).toBeGreaterThanOrEqual(0);
+      expect(budget.tolerance.absolute, id).toBeGreaterThanOrEqual(0);
+      expect(["min", "max"]).toContain(budget.direction);
+    }
+  });
+
+  it("budgets tools/list latency and size for each supported profile", () => {
+    const config = readJson<{
+      reviewedBaseline: { toolProfiles: string[] };
+      budgets: Record<string, unknown>;
+    }>("performance-baseline.json");
+    const contract = readJson<{ profiles: Record<string, unknown> }>(
+      "docs/tool-profile-contract.json",
+    );
+
+    expect(config.reviewedBaseline.toolProfiles).toEqual(Object.keys(contract.profiles));
+    for (const profile of config.reviewedBaseline.toolProfiles) {
+      expect(config.budgets).toHaveProperty(`node-http.${profile}.toolsListMs`);
+      expect(config.budgets).toHaveProperty(`node-http.${profile}.toolsListBytes`);
+    }
+  });
+
+  it("exposes advisory and enforce scripts without wiring them into verify", () => {
+    const packageJson = readJson<{ scripts: Record<string, string> }>("package.json");
+
+    expect(packageJson.scripts["perf:baseline"]).toBe(
+      "pnpm run build && node --expose-gc scripts/performance-baseline.mjs",
+    );
+    expect(packageJson.scripts["perf:baseline:enforce"]).toBe(
+      "pnpm run build && node --expose-gc scripts/performance-baseline.mjs --enforce",
+    );
+    expect(packageJson.scripts.verify).not.toContain("perf:baseline");
+  });
+
+  it("prints help without requiring built artifacts", () => {
+    const result = spawnSync(process.execPath, ["scripts/performance-baseline.mjs", "--help"], {
+      cwd: root,
+      encoding: "utf8",
+    });
+
+    expect(result.status).toBe(0);
+    expect(result.stdout).toContain("issue #199");
+    expect(result.stdout).toContain("--enforce");
+  });
+});

--- a/tests/unit/performance-baseline.unit.test.ts
+++ b/tests/unit/performance-baseline.unit.test.ts
@@ -245,6 +245,8 @@ describe("local performance baseline", () => {
     expect(probe.esmSocketConnectBlocked).toBe(true);
     expect(probe.malformedLoopbackBlocked).toBe(true);
     expect(probe.zeroPaddedLoopbackBlocked).toBe(true);
+    expect(probe.customLookupBlocked).toBe(true);
+    expect(probe.stdioGuardProbeBlocked).toBe(true);
   });
 
   it("rejects direct worker mode without sanitized launcher state", () => {

--- a/tests/unit/performance-baseline.unit.test.ts
+++ b/tests/unit/performance-baseline.unit.test.ts
@@ -86,7 +86,7 @@ describe("local performance baseline", () => {
     expect(result.stdout).toContain("--enforce");
   });
 
-  it("uses displayed precision for byte budget boundaries", () => {
+  it("uses displayed precision for max byte budget boundaries", () => {
     const config = readJson<{
       budgets: Record<string, { unit: string; direction: string; baseline: number }>;
     }>("performance-baseline.json");
@@ -100,6 +100,50 @@ describe("local performance baseline", () => {
     expect(metric.value).toBe(56035);
     expect(metric.budget.limit).toBe(56035);
     expect(metric.status).toBe("pass");
+  });
+
+  it("uses displayed precision for min throughput budget boundaries", () => {
+    const config = readJson<{
+      budgets: Record<string, { unit: string; direction: string; baseline: number }>;
+    }>("performance-baseline.json");
+
+    const metric = helpers.evaluateMetric(
+      "node-http.discovery.throughputRps",
+      49,
+      config.budgets["node-http.discovery.throughputRps"],
+    );
+
+    expect(metric.value).toBe(49);
+    expect(metric.budget.limit).toBe(49);
+    expect(metric.status).toBe("pass");
+  });
+
+  it("fails enforce mode for deterministic budget violations", () => {
+    const result = spawnSync(
+      process.execPath,
+      ["scripts/performance-baseline.mjs", "--self-test-budget-violation"],
+      {
+        cwd: root,
+        encoding: "utf8",
+      },
+    );
+
+    expect(result.status).toBe(1);
+    const artifact = readJson<{
+      mode: string;
+      violations: string[];
+    }>("reports/performance/local-baseline.json");
+    const summary = readFileSync(
+      join(root, "reports/performance/local-baseline-summary.md"),
+      "utf8",
+    );
+
+    expect(artifact.mode).toBe("enforce");
+    expect(artifact.violations).toEqual([
+      "node-http.full.toolsListBytes",
+      "node-http.discovery.throughputRps",
+    ]);
+    expect(summary).toContain("Status: 2 budget violation(s)");
   });
 
   it("renders failure artifacts with partial metrics", () => {
@@ -190,6 +234,9 @@ describe("local performance baseline", () => {
     expect(probe.observedSentinelNames).toEqual([]);
     expect(probe.sentinelValueVisible).toBe(false);
     expect(probe.benchmarkCredentialIsFake).toBe(true);
+    expect(probe.benchmarkSecretSinkIsOff).toBe(true);
+    expect(probe.stdioSecretSinkIsOff).toBe(true);
+    expect(probe.stdioSecretSinkFileUnset).toBe(true);
     expect(probe.nonLocalFetchBlocked).toBe(true);
   });
 

--- a/tests/unit/performance-baseline.unit.test.ts
+++ b/tests/unit/performance-baseline.unit.test.ts
@@ -243,6 +243,8 @@ describe("local performance baseline", () => {
     expect(probe.tlsSocketConnectBlocked).toBe(true);
     expect(probe.esmNetConnectBlocked).toBe(true);
     expect(probe.esmSocketConnectBlocked).toBe(true);
+    expect(probe.malformedLoopbackBlocked).toBe(true);
+    expect(probe.zeroPaddedLoopbackBlocked).toBe(true);
   });
 
   it("rejects direct worker mode without sanitized launcher state", () => {

--- a/tests/unit/performance-baseline.unit.test.ts
+++ b/tests/unit/performance-baseline.unit.test.ts
@@ -239,6 +239,10 @@ describe("local performance baseline", () => {
     expect(probe.stdioSecretSinkFileUnset).toBe(true);
     expect(probe.nonLocalFetchBlocked).toBe(true);
     expect(probe.requestOptionsOverrideBlocked).toBe(true);
+    expect(probe.netSocketConnectBlocked).toBe(true);
+    expect(probe.tlsSocketConnectBlocked).toBe(true);
+    expect(probe.esmNetConnectBlocked).toBe(true);
+    expect(probe.esmSocketConnectBlocked).toBe(true);
   });
 
   it("rejects direct worker mode without sanitized launcher state", () => {

--- a/tests/unit/performance-baseline.unit.test.ts
+++ b/tests/unit/performance-baseline.unit.test.ts
@@ -3,6 +3,7 @@ import { readFileSync } from "fs";
 import { join } from "path";
 
 const root = join(__dirname, "../..");
+const helpers = require("../../scripts/lib/performance-baseline.cjs");
 
 function readJson<T>(relativePath: string): T {
   return JSON.parse(readFileSync(join(root, relativePath), "utf8")) as T;
@@ -83,5 +84,127 @@ describe("local performance baseline", () => {
     expect(result.status).toBe(0);
     expect(result.stdout).toContain("issue #199");
     expect(result.stdout).toContain("--enforce");
+  });
+
+  it("uses displayed precision for byte budget boundaries", () => {
+    const config = readJson<{
+      budgets: Record<string, { unit: string; direction: string; baseline: number }>;
+    }>("performance-baseline.json");
+
+    const metric = helpers.evaluateMetric(
+      "node-http.full.toolsListBytes",
+      56035,
+      config.budgets["node-http.full.toolsListBytes"],
+    );
+
+    expect(metric.value).toBe(56035);
+    expect(metric.budget.limit).toBe(56035);
+    expect(metric.status).toBe("pass");
+  });
+
+  it("renders failure artifacts with partial metrics", () => {
+    const config = readJson<{
+      issue: { number: number; url: string };
+      measurementPlan: Record<string, unknown>;
+      runtimeApplicability: Record<string, unknown>;
+      budgets: Record<string, unknown>;
+    }>("performance-baseline.json");
+    const measurements = [{ id: "node-http.full.toolsListBytes", value: 47217 }];
+    const metrics = helpers.evaluateMeasurements(config, measurements, { requireAll: false });
+    const failure = {
+      phase: "oauth-jwks",
+      message: "simulated failure",
+      partialMetricIds: measurements.map((metric) => metric.id),
+    };
+
+    const artifact = helpers.createArtifact({
+      config,
+      metrics,
+      measurements,
+      enforce: true,
+      failure,
+      generatedAt: "2026-08-21T00:00:00.000Z",
+    });
+    const summary = helpers.renderSummary(config, metrics, { enforce: true, failure });
+
+    expect(artifact.failure).toEqual(failure);
+    expect(artifact.partialMeasurements).toEqual(measurements);
+    expect(summary).toContain("Status: measurement failed (oauth-jwks)");
+    expect(summary).toContain("Error: simulated failure");
+  });
+
+  it("writes reports when measurement execution fails", () => {
+    const result = spawnSync(
+      process.execPath,
+      ["scripts/performance-baseline.mjs", "--self-test-measurement-failure"],
+      {
+        cwd: root,
+        encoding: "utf8",
+      },
+    );
+
+    expect(result.status).toBe(1);
+    const artifact = readJson<{
+      mode: string;
+      node: string;
+      platform: { os: string; arch: string };
+      failure: { phase: string; message: string; partialMetricIds: string[] };
+      partialMeasurements: unknown[];
+    }>("reports/performance/local-baseline.json");
+    const summary = readFileSync(
+      join(root, "reports/performance/local-baseline-summary.md"),
+      "utf8",
+    );
+
+    expect(artifact.mode).toBe("enforce");
+    expect(artifact.node).toMatch(/^v\d+/);
+    expect(artifact.platform.os).toBeTruthy();
+    expect(artifact.platform.arch).toBeTruthy();
+    expect(artifact.failure.phase).toBe("self-test-measurement");
+    expect(artifact.failure.message).toContain("Forced measurement failure");
+    expect(artifact.failure.partialMetricIds).toEqual([]);
+    expect(artifact.partialMeasurements).toEqual([]);
+    expect(summary).toContain("Status: measurement failed (self-test-measurement)");
+  });
+
+  it("sanitizes benchmark worker secrets and blocks non-local egress", () => {
+    const result = spawnSync(
+      process.execPath,
+      ["scripts/performance-baseline.mjs", "--self-test-env-sanitizer"],
+      {
+        cwd: root,
+        encoding: "utf8",
+        env: {
+          ...process.env,
+          AWS_SECRET_ACCESS_KEY: "sentinel-parent-secret",
+          B2_APPLICATION_KEY: "sentinel-parent-secret",
+          GITHUB_TOKEN: "sentinel-parent-secret",
+          NPM_TOKEN: "sentinel-parent-secret",
+        },
+      },
+    );
+
+    expect(result.status).toBe(0);
+    const probe = JSON.parse(result.stdout);
+    expect(probe.importedDependency).toBe(true);
+    expect(probe.observedSentinelNames).toEqual([]);
+    expect(probe.sentinelValueVisible).toBe(false);
+    expect(probe.benchmarkCredentialIsFake).toBe(true);
+    expect(probe.nonLocalFetchBlocked).toBe(true);
+  });
+
+  it("rejects direct worker mode without sanitized launcher state", () => {
+    const result = spawnSync(process.execPath, ["scripts/performance-baseline.mjs", "--worker"], {
+      cwd: root,
+      encoding: "utf8",
+      env: {
+        ...process.env,
+        B2_APPLICATION_KEY: "sentinel-parent-secret",
+      },
+    });
+
+    expect(result.status).toBe(1);
+    expect(result.stderr).toContain("requires a sanitized launcher");
+    expect(result.stdout).not.toContain("sentinel-parent-secret");
   });
 });


### PR DESCRIPTION
## Summary
- Add `performance-baseline.json`, `perf:baseline`, and `perf:baseline:enforce` for the advisory local regression baseline tied to issue #199.
- Measure local-only protocol overhead for stdio startup, HTTP `tools/list`, concurrent discovery, repeated-request memory growth, and fake OAuth/JWKS cache paths without live B2 credentials or live B2 latency.
- Run measurements in a sanitized worker with deterministic fake credentials, `B2_SECRET_SINK=off`, and hardened local-only/no-network guards.
- Harden guard coverage for request option host overrides, socket prototype and ESM import paths, malformed loopback literals, custom lookup callbacks, and the stdio child process guard.
- Emit machine-readable JSON and Markdown summaries for successful runs, budget violations, and measurement failures with failed phase metadata plus partial metrics.
- Move budget evaluation/reporting into a focused helper module with tests for max/min boundary precision and enforce-mode failures.
- Document runtime applicability decisions, artifact paths, and the advisory-to-enforce promotion path.

## Linked issue
Closes #199

## Tests run
- pnpm run build
- pnpm run typecheck
- pnpm run lint
- pnpm run format:check
- pnpm run lint:docs
- pnpm run lint:links
- pnpm run spell
- pnpm run test:unit
- pnpm exec vitest run --config vitest.config.mts --project=unit tests/unit/performance-baseline.unit.test.ts --coverage=false
- node scripts/performance-baseline.mjs --self-test-env-sanitizer
- node scripts/performance-baseline.mjs --self-test-budget-violation
- pnpm run perf:baseline
- pnpm run perf:baseline:enforce

## Follow-up notes
- The baseline is advisory by default and is not wired into verify or required CI gates until reviewed main-branch runs prove stable.
