### PR TITLE
Add deterministic dependency failure and recovery tests

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -30,6 +30,7 @@ Required CI check names for `main` protection:
 - [ ] `format/lint/typecheck`
 - [ ] `docs/spelling/links`
 - [ ] `unit/coverage`
+- [ ] `reliability/resilience`
 - [ ] `MCP contract`
 - [ ] `modern and legacy protocol/transport`
 - [ ] `observability/logging behavior`

--- a/.github/branch-protection-main.json
+++ b/.github/branch-protection-main.json
@@ -5,6 +5,7 @@
       "format/lint/typecheck",
       "docs/spelling/links",
       "unit/coverage",
+      "reliability/resilience",
       "MCP contract",
       "modern and legacy protocol/transport",
       "observability/logging behavior",

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -166,6 +166,39 @@ jobs:
             exit 1
           fi
 
+  reliability-resilience:
+    name: reliability/resilience
+    needs: runtime-policy
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      # actions/checkout v6, reviewed 2026-08-06.
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803
+        with:
+          persist-credentials: false
+      # pnpm/action-setup v6.0.10, reviewed 2026-08-06.
+      - uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86
+        with:
+          run_install: false
+      # actions/setup-node v7, reviewed 2026-08-06.
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020
+        with:
+          node-version: 22.23.1
+          cache: pnpm
+      - run: pnpm install --frozen-lockfile
+      - run: pnpm run test:reliability
+      # actions/upload-artifact v6, reviewed 2026-08-06.
+      - name: Upload reliability reports
+        if: always()
+        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f
+        with:
+          name: reliability-resilience-node-22.23.1
+          path: |
+            reports/junit/reliability.xml
+            reports/vitest/reliability.json
+          if-no-files-found: error
+          retention-days: 7
+
   mcp-contract:
     name: MCP contract
     needs: runtime-policy
@@ -663,6 +696,7 @@ jobs:
       - format-lint-typecheck
       - docs-spelling-links
       - unit-coverage
+      - reliability-resilience
       - mcp-contract
       - protocol-transport
       - observability-logging
@@ -695,6 +729,7 @@ jobs:
           | Legacy MCP fallback | 2025-era stateless initialize compatibility |
           | Observability logging | Structured lifecycle, warning, failure, redaction, and stream-separation canaries |
           | Linux deterministic Node matrix | 22.23.1, 24, 26 |
+          | Deterministic dependency failures | B2/S3/OAuth outage suite |
           | Runtime engine floor | Node.js 22.3.0 package install smoke |
           | Cross-platform fast suite | Linux, Windows, macOS on Node.js 22.23.1 |
           | Package budget metrics | Uploaded as package-budget artifact |
@@ -711,6 +746,7 @@ jobs:
       - format-lint-typecheck
       - docs-spelling-links
       - unit-coverage
+      - reliability-resilience
       - mcp-contract
       - protocol-transport
       - observability-logging

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "dev": "tsx src/index.ts",
     "test": "pnpm run typecheck && pnpm run test:unit",
     "test:unit": "node scripts/run-vitest-layer.mjs unit",
+    "test:reliability": "node scripts/run-vitest-layer.mjs reliability",
     "test:contract": "node scripts/run-vitest-layer.mjs contract",
     "test:protocol:modern": "node scripts/run-vitest-layer.mjs protocol-modern",
     "test:protocol:legacy": "node scripts/run-vitest-layer.mjs protocol-legacy",

--- a/scripts/vitest-layer-registry.mjs
+++ b/scripts/vitest-layer-registry.mjs
@@ -7,6 +7,13 @@ export const vitestLayerProjects = {
     public: true,
     coverage: true,
   },
+  reliability: {
+    include: ["tests/reliability/**/*.reliability.test.ts"],
+    live: false,
+    public: true,
+    coverage: true,
+    serial: true,
+  },
   contract: {
     include: ["tests/contract/**/*.contract.test.ts"],
     live: false,

--- a/src/utils/circuit-breaker.ts
+++ b/src/utils/circuit-breaker.ts
@@ -50,12 +50,10 @@ export function isClientError(err: unknown): boolean {
  */
 type CircuitBreakerInstance = InstanceType<typeof CircuitBreaker>;
 
-let breaker: CircuitBreakerInstance | null = null;
-let longBreaker: CircuitBreakerInstance | null = null;
-let reportBreaker: CircuitBreakerInstance | null = null;
-let s3Breaker: CircuitBreakerInstance | null = null;
-let s3LongBreaker: CircuitBreakerInstance | null = null;
-let partnerBreaker: CircuitBreakerInstance | null = null;
+interface CircuitBreakerSlot {
+  instance: CircuitBreakerInstance | null;
+  create: () => CircuitBreakerInstance;
+}
 
 function createBreaker(
   name: string,
@@ -82,13 +80,62 @@ function createBreaker(
   return instance;
 }
 
+function breakerSlot(create: () => CircuitBreakerInstance): CircuitBreakerSlot {
+  return { instance: null, create };
+}
+
+const breakerSlots = {
+  native: breakerSlot(() =>
+    createBreaker("b2-api", CIRCUIT_TIMEOUT_MS, {
+      open: "circuit.open",
+      halfOpen: "circuit.halfOpen",
+      close: "circuit.close",
+    }),
+  ),
+  transfer: breakerSlot(() =>
+    createBreaker("b2-transfer", false, {
+      open: "circuit.transfer.open",
+      halfOpen: "circuit.transfer.halfOpen",
+      close: "circuit.transfer.close",
+    }),
+  ),
+  report: breakerSlot(() =>
+    createBreaker("b2-report-s3", CIRCUIT_TIMEOUT_MS, {
+      open: "circuit.reportS3.open",
+      halfOpen: "circuit.reportS3.halfOpen",
+      close: "circuit.reportS3.close",
+    }),
+  ),
+  s3: breakerSlot(() =>
+    createBreaker("b2-s3-api", CIRCUIT_TIMEOUT_MS, {
+      open: "circuit.s3.open",
+      halfOpen: "circuit.s3.halfOpen",
+      close: "circuit.s3.close",
+    }),
+  ),
+  s3Transfer: breakerSlot(() =>
+    createBreaker("b2-s3-transfer", false, {
+      open: "circuit.s3Transfer.open",
+      halfOpen: "circuit.s3Transfer.halfOpen",
+      close: "circuit.s3Transfer.close",
+    }),
+  ),
+  partner: breakerSlot(() =>
+    createBreaker("b2-partner-api", CIRCUIT_TIMEOUT_MS, {
+      open: "circuit.partner.open",
+      halfOpen: "circuit.partner.halfOpen",
+      close: "circuit.partner.close",
+    }),
+  ),
+} satisfies Record<string, CircuitBreakerSlot>;
+
+function getBreaker(slot: CircuitBreakerSlot): CircuitBreakerInstance {
+  slot.instance ??= slot.create();
+  return slot.instance;
+}
+
 function defaultBreaker(): CircuitBreakerInstance {
-  breaker ??= createBreaker("b2-api", CIRCUIT_TIMEOUT_MS, {
-    open: "circuit.open",
-    halfOpen: "circuit.halfOpen",
-    close: "circuit.close",
-  });
-  return breaker;
+  return getBreaker(breakerSlots.native);
 }
 
 /**
@@ -101,12 +148,7 @@ function defaultBreaker(): CircuitBreakerInstance {
  * Transfer health is governed by SDK/request timeouts and the retry layer instead.
  */
 function transferBreaker(): CircuitBreakerInstance {
-  longBreaker ??= createBreaker("b2-transfer", false, {
-    open: "circuit.transfer.open",
-    halfOpen: "circuit.transfer.halfOpen",
-    close: "circuit.transfer.close",
-  });
-  return longBreaker;
+  return getBreaker(breakerSlots.transfer);
 }
 
 /**
@@ -117,12 +159,7 @@ function transferBreaker(): CircuitBreakerInstance {
  * opening the native control-plane breaker used by bucket/key/Object Lock tools.
  */
 function usageReportBreaker(): CircuitBreakerInstance {
-  reportBreaker ??= createBreaker("b2-report-s3", CIRCUIT_TIMEOUT_MS, {
-    open: "circuit.reportS3.open",
-    halfOpen: "circuit.reportS3.halfOpen",
-    close: "circuit.reportS3.close",
-  });
-  return reportBreaker;
+  return getBreaker(breakerSlots.report);
 }
 
 /**
@@ -135,12 +172,7 @@ function usageReportBreaker(): CircuitBreakerInstance {
  * mitigate the incident.
  */
 function s3ApiBreaker(): CircuitBreakerInstance {
-  s3Breaker ??= createBreaker("b2-s3-api", CIRCUIT_TIMEOUT_MS, {
-    open: "circuit.s3.open",
-    halfOpen: "circuit.s3.halfOpen",
-    close: "circuit.s3.close",
-  });
-  return s3Breaker;
+  return getBreaker(breakerSlots.s3);
 }
 
 /**
@@ -149,12 +181,7 @@ function s3ApiBreaker(): CircuitBreakerInstance {
  * or SDK socket deadlines where an operation can stall after response headers.
  */
 function s3TransferBreaker(): CircuitBreakerInstance {
-  s3LongBreaker ??= createBreaker("b2-s3-transfer", false, {
-    open: "circuit.s3Transfer.open",
-    halfOpen: "circuit.s3Transfer.halfOpen",
-    close: "circuit.s3Transfer.close",
-  });
-  return s3LongBreaker;
+  return getBreaker(breakerSlots.s3Transfer);
 }
 
 /**
@@ -165,12 +192,7 @@ function s3TransferBreaker(): CircuitBreakerInstance {
  * native breaker operators use for storage administration.
  */
 function partnerApiBreaker(): CircuitBreakerInstance {
-  partnerBreaker ??= createBreaker("b2-partner-api", CIRCUIT_TIMEOUT_MS, {
-    open: "circuit.partner.open",
-    halfOpen: "circuit.partner.halfOpen",
-    close: "circuit.partner.close",
-  });
-  return partnerBreaker;
+  return getBreaker(breakerSlots.partner);
 }
 
 function unrefTimer(timer: ReturnType<typeof setTimeout>): void {
@@ -281,20 +303,8 @@ export function resetCircuitBreakersForTests(): void {
   if (!isTestRuntime()) {
     throw new Error("Circuit breaker reset is only available in tests.");
   }
-  for (const instance of [
-    breaker,
-    longBreaker,
-    reportBreaker,
-    s3Breaker,
-    s3LongBreaker,
-    partnerBreaker,
-  ]) {
-    instance?.shutdown();
+  for (const slot of Object.values(breakerSlots)) {
+    slot.instance?.shutdown();
+    slot.instance = null;
   }
-  breaker = null;
-  longBreaker = null;
-  reportBreaker = null;
-  s3Breaker = null;
-  s3LongBreaker = null;
-  partnerBreaker = null;
 }

--- a/src/utils/circuit-breaker.ts
+++ b/src/utils/circuit-breaker.ts
@@ -2,6 +2,7 @@ import CircuitBreaker from "opossum";
 import { logger } from "./logger.js";
 import { abortError, timeoutError } from "./named-error.js";
 import { currentMcpRequestSignal, runWithMcpRequestSignal } from "../request-context.js";
+import { isTestRuntime } from "./runtime.js";
 
 export const CIRCUIT_TIMEOUT_MS = 150_000;
 
@@ -275,3 +276,25 @@ export const reportCircuitBreaker = breakerProxy(usageReportBreaker);
 export const s3CircuitBreaker = breakerProxy(s3ApiBreaker);
 export const s3TransferCircuitBreaker = breakerProxy(s3TransferBreaker);
 export const partnerCircuitBreaker = breakerProxy(partnerApiBreaker);
+
+export function resetCircuitBreakersForTests(): void {
+  if (!isTestRuntime()) {
+    throw new Error("Circuit breaker reset is only available in tests.");
+  }
+  for (const instance of [
+    breaker,
+    longBreaker,
+    reportBreaker,
+    s3Breaker,
+    s3LongBreaker,
+    partnerBreaker,
+  ]) {
+    instance?.shutdown();
+  }
+  breaker = null;
+  longBreaker = null;
+  reportBreaker = null;
+  s3Breaker = null;
+  s3LongBreaker = null;
+  partnerBreaker = null;
+}

--- a/tests/contract/ci-workflow-policy.contract.test.ts
+++ b/tests/contract/ci-workflow-policy.contract.test.ts
@@ -40,6 +40,7 @@ const requiredJobNames = [
   "format/lint/typecheck",
   "docs/spelling/links",
   "unit/coverage",
+  "reliability/resilience",
   "MCP contract",
   "modern and legacy protocol/transport",
   "observability/logging behavior",
@@ -123,6 +124,7 @@ describe("CI workflow policy", () => {
       "format-lint-typecheck",
       "docs-spelling-links",
       "unit-coverage",
+      "reliability-resilience",
       "mcp-contract",
       "protocol-transport",
       "observability-logging",
@@ -182,6 +184,7 @@ describe("CI workflow policy", () => {
     const docsJob = workflowJob("docs-spelling-links");
     const coverageJob = workflowJob("unit-coverage-matrix");
     const coverageAggregateJob = workflowJob("unit-coverage");
+    const reliabilityJob = workflowJob("reliability-resilience");
     const contractJob = workflowJob("mcp-contract");
     const protocolJob = workflowJob("protocol-transport");
     const observabilityJob = workflowJob("observability-logging");
@@ -205,6 +208,9 @@ describe("CI workflow policy", () => {
     expect(coverageJob).toContain("retention-days: 7");
     expect(coverageAggregateJob).toContain("name: unit/coverage");
     expect(coverageAggregateJob).toContain("needs: unit-coverage-matrix");
+    expect(reliabilityJob).toContain("pnpm run test:reliability");
+    expect(reliabilityJob).toContain("reports/junit/reliability.xml");
+    expect(reliabilityJob).toContain("reports/vitest/reliability.json");
     expect(contractJob).toContain("pnpm run test:contract");
     expect(contractJob).toContain("docs/tool-profile-contract.json");
     expect(protocolJob).toContain("pnpm run test:protocol");
@@ -271,6 +277,7 @@ describe("CI workflow policy", () => {
       "Observability logging | Structured lifecycle, warning, failure, redaction, and stream-separation canaries",
     );
     expect(summaryJob).toContain("Linux deterministic Node matrix | 22.23.1, 24, 26");
+    expect(summaryJob).toContain("Deterministic dependency failures | B2/S3/OAuth outage suite");
     expect(summaryJob).toContain("Runtime engine floor | Node.js 22.3.0 package install smoke");
     expect(summaryJob).toContain("Package budget metrics | Uploaded as package-budget artifact");
     expect(summaryJob).toContain("Vercel adapter budget | Uploaded as vercel-bundle artifact path");

--- a/tests/contract/test-layering.contract.test.ts
+++ b/tests/contract/test-layering.contract.test.ts
@@ -106,6 +106,7 @@ describe("test layer naming", () => {
     const invalid = testFiles.filter(
       (path) =>
         !/^tests\/unit\/.+\.unit\.test\.ts$/.test(path) &&
+        !/^tests\/reliability\/.+\.reliability\.test\.ts$/.test(path) &&
         !/^tests\/contract\/.+\.contract\.test\.ts$/.test(path) &&
         !/^tests\/protocol\/.+\.(modern|legacy)-protocol\.test\.ts$/.test(path) &&
         !/^tests\/runtime-security\/.+\.runtime-security\.test\.ts$/.test(path) &&

--- a/tests/reliability/dependency-failures.reliability.test.ts
+++ b/tests/reliability/dependency-failures.reliability.test.ts
@@ -172,11 +172,16 @@ function s3XmlErrorResponse(status: number, code: string, message: string) {
   };
 }
 
+const OAUTH_ISSUER = "http://localhost:9000/";
+const OAUTH_RESOURCE = "http://localhost:3000/mcp";
+const OAUTH_AUDIENCE = "http://localhost:3000/mcp";
+const OAUTH_PUBLIC_URL = "http://localhost:3000/mcp";
+
 const oauthJwksConfig = {
-  issuer: "http://localhost:9000/",
-  resource: "http://localhost:3000/mcp",
-  audience: "http://localhost:3000/mcp",
-  publicUrl: "http://localhost:3000/mcp",
+  issuer: OAUTH_ISSUER,
+  resource: OAUTH_RESOURCE,
+  audience: OAUTH_AUDIENCE,
+  publicUrl: OAUTH_PUBLIC_URL,
   authorizationEndpoint: "http://localhost:9000/oauth2/authorize",
   tokenEndpoint: "http://localhost:9000/oauth2/token",
   jwksUri: "http://localhost:9000/oauth2/jwks",
@@ -204,9 +209,9 @@ const oauthJwksConfig = {
 
 function oauthRequest(): Request {
   const token = signedJwt({
-    iss: oauthJwksConfig.issuer,
-    aud: oauthJwksConfig.audience,
-    resource: oauthJwksConfig.resource,
+    iss: OAUTH_ISSUER,
+    aud: OAUTH_AUDIENCE,
+    resource: OAUTH_RESOURCE,
     exp: 2_000_000_000,
     nbf: 900,
     token_type: "bearer",
@@ -214,7 +219,7 @@ function oauthRequest(): Request {
     client_id: "reliability-client",
     sub: "user-123",
   });
-  return new Request(oauthJwksConfig.publicUrl, {
+  return new Request(OAUTH_PUBLIC_URL, {
     headers: { Authorization: `Bearer ${token}` },
   });
 }

--- a/tests/reliability/dependency-failures.reliability.test.ts
+++ b/tests/reliability/dependency-failures.reliability.test.ts
@@ -16,6 +16,7 @@ import { registerS3ObjectTools } from "../../src/s3/objects";
 import {
   circuitBreaker,
   resetCircuitBreakersForTests,
+  s3CircuitBreaker,
   withCircuit,
 } from "../../src/utils/circuit-breaker";
 import { parseErrorText } from "../../src/utils/errors";
@@ -31,7 +32,7 @@ import {
   testConfig,
   ToolHarness,
 } from "../support/deterministic-fakes";
-import { signedJwt } from "../support/oauth-jwks";
+import { jwksResponse, signedJwt } from "../support/oauth-jwks";
 import { installSdkTransport, StaticHttpResponse } from "../support/sdk-test-helpers";
 import {
   restoreB2SdkTransportForTests,
@@ -123,12 +124,16 @@ async function waitForB2Requests(
   expect(transport.requestsFor(endpoint)).toHaveLength(count);
 }
 
-function s3ClientWithHandler(handle: ReturnType<typeof vi.fn>): B2S3PeerClient {
+function s3ClientWithHandler(
+  handle: ReturnType<typeof vi.fn>,
+  options: { maxAttempts?: number } = {},
+): B2S3PeerClient {
   return new B2S3PeerClient({
     region: "us-west-004",
     endpoint: "https://s3.us-west-004.backblazeb2.com",
     credentials: { accessKeyId: "key-id", secretAccessKey: "key-secret" },
     forcePathStyle: true,
+    ...(options.maxAttempts === undefined ? {} : { maxAttempts: options.maxAttempts }),
     requestHandler: {
       handle,
       updateHttpClientConfig() {
@@ -176,7 +181,7 @@ function oauthRequest(): Request {
     iss: oauthJwksConfig.issuer,
     aud: oauthJwksConfig.audience,
     resource: oauthJwksConfig.resource,
-    exp: 2_000,
+    exp: 2_000_000_000,
     nbf: 900,
     token_type: "bearer",
     scope: "b2:read",
@@ -350,6 +355,58 @@ describe("deterministic dependency failure and recovery suite", () => {
     expect(transport.requestsFor("b2_list_buckets")).toHaveLength(3);
   });
 
+  it("opens, short-circuits, and recovers the S3 dependency circuit", async () => {
+    vi.useFakeTimers();
+    let handlerCalls = 0;
+    const handle = vi.fn(async () => {
+      handlerCalls += 1;
+      if (handlerCalls <= 10) {
+        throw s3ServiceError(
+          "InternalError",
+          "S3 transient outage",
+          500,
+          `s3-outage-${handlerCalls}`,
+        );
+      }
+      return { response: { statusCode: 200, headers: {}, body: Readable.from([]) } };
+    });
+    const s3 = s3ClientWithHandler(handle, { maxAttempts: 1 });
+    const tools = new ToolHarness();
+    registerS3BucketTools(tools, s3, reliabilityConfig);
+
+    try {
+      for (let i = 0; i < 10; i++) {
+        const result = await tools.call("s3_head_bucket", { bucket: "reliability-bucket" });
+        const text = expectMcpError(result, { status: 500, code: "InternalError" });
+        expect(text).toMatch(/S3 transient outage/);
+      }
+      expect(handle).toHaveBeenCalledTimes(10);
+      expect(s3CircuitBreaker.opened).toBe(true);
+
+      const shortCircuited = await tools.call("s3_head_bucket", {
+        bucket: "reliability-bucket",
+      });
+      const shortCircuitText = expectMcpError(shortCircuited, {
+        status: 500,
+        code: "EOPENBREAKER",
+      });
+      expect(shortCircuitText).toMatch(/Breaker is open/);
+      expect(handle).toHaveBeenCalledTimes(10);
+
+      await vi.advanceTimersByTimeAsync(30_001);
+      expect(s3CircuitBreaker.halfOpen).toBe(true);
+      const recovered = await tools.call("s3_head_bucket", { bucket: "reliability-bucket" });
+
+      expect(parseResult(recovered)).toBe("Bucket 'reliability-bucket' exists and is accessible.");
+      expect(handle).toHaveBeenCalledTimes(11);
+      expect(handlerCalls).toBe(11);
+      expect(s3CircuitBreaker.closed).toBe(true);
+    } finally {
+      s3.destroy();
+      s3CircuitBreaker.close();
+    }
+  });
+
   it("does not replay unsafe B2 or S3 mutations after a lost response", async () => {
     const native = new DeterministicB2NativeFake({ capabilities: ["writeBuckets"] }).respond(
       "b2_create_bucket",
@@ -371,7 +428,7 @@ describe("deterministic dependency failure and recovery suite", () => {
     expect(b2Text).toMatch(/lost response/i);
     const createRequests = native.requestsFor("b2_create_bucket");
     expect(createRequests).toHaveLength(1);
-    expect(createRequests[0].request.retry?.maxRetries).toBe(0);
+    expect(createRequests[0].attempt).toBe(1);
 
     const handle = vi.fn().mockResolvedValue({
       response: { statusCode: 500, headers: {}, body: Readable.from([]) },
@@ -492,7 +549,16 @@ describe("deterministic dependency failure and recovery suite", () => {
       b2ErrorResponse(500, "tenant_b_down", "tenant B dependency failed"),
     );
     setB2SdkClientFactoryForTests((config) => {
-      const transport = config.applicationKeyId === tenantA.applicationKeyId ? fakeA : fakeB;
+      let transport: DeterministicB2NativeFake;
+      if (config.applicationKeyId === tenantA.applicationKeyId) {
+        transport = fakeA;
+      } else if (config.applicationKeyId === tenantB.applicationKeyId) {
+        transport = fakeB;
+      } else {
+        throw new Error(
+          `Unexpected reliability tenant applicationKeyId: ${config.applicationKeyId}`,
+        );
+      }
       return {
         client: new SdkB2Client({
           applicationKeyId: config.applicationKeyId,
@@ -526,15 +592,19 @@ describe("deterministic dependency failure and recovery suite", () => {
     expect(fakeB.requestsFor("b2_list_buckets")).toHaveLength(1);
   });
 
-  it("fails closed and opens the JWKS circuit without exhausting fetches", async () => {
+  it("fails closed, short-circuits, and recovers the JWKS verifier", async () => {
     resetOAuthVerifierCacheForTests();
-    const fetchMock = vi.fn(async () =>
-      Response.json({ error: "jwks unavailable" }, { status: 503 }),
-    );
+    let now = 1_000;
+    const fetchMock = vi.fn(async () => {
+      if (fetchMock.mock.calls.length <= 2) {
+        return Response.json({ error: "jwks unavailable" }, { status: 503 });
+      }
+      return jwksResponse();
+    });
 
     const first = await authenticateOAuthRequest(oauthRequest(), oauthJwksConfig, {
       fetch: fetchMock as typeof fetch,
-      nowSeconds: () => 1000,
+      nowSeconds: () => now,
     });
 
     expect(first).toBeInstanceOf(Response);
@@ -547,12 +617,25 @@ describe("deterministic dependency failure and recovery suite", () => {
 
     const second = await authenticateOAuthRequest(oauthRequest(), oauthJwksConfig, {
       fetch: fetchMock as typeof fetch,
-      nowSeconds: () => 1000,
+      nowSeconds: () => now,
     });
 
     expect(second).toBeInstanceOf(Response);
     expect((second as Response).status).toBe(503);
     expect((second as Response).headers.get("retry-after")).toBe("2");
     expect(fetchMock).toHaveBeenCalledTimes(2);
+
+    now = 1_003;
+    const recovered = await authenticateOAuthRequest(oauthRequest(), oauthJwksConfig, {
+      fetch: fetchMock as typeof fetch,
+      nowSeconds: () => now,
+    });
+
+    expect(recovered).not.toBeInstanceOf(Response);
+    expect(recovered).toMatchObject({
+      clientId: "reliability-client",
+      scopes: ["b2:read"],
+    });
+    expect(fetchMock).toHaveBeenCalledTimes(3);
   });
 });

--- a/tests/reliability/dependency-failures.reliability.test.ts
+++ b/tests/reliability/dependency-failures.reliability.test.ts
@@ -172,16 +172,11 @@ function s3XmlErrorResponse(status: number, code: string, message: string) {
   };
 }
 
-const OAUTH_ISSUER = "http://localhost:9000/";
-const OAUTH_RESOURCE = "http://localhost:3000/mcp";
-const OAUTH_AUDIENCE = "http://localhost:3000/mcp";
-const OAUTH_PUBLIC_URL = "http://localhost:3000/mcp";
-
 const oauthJwksConfig = {
-  issuer: OAUTH_ISSUER,
-  resource: OAUTH_RESOURCE,
-  audience: OAUTH_AUDIENCE,
-  publicUrl: OAUTH_PUBLIC_URL,
+  issuer: "http://localhost:9000/",
+  resource: "http://localhost:3000/mcp",
+  audience: "http://localhost:3000/mcp",
+  publicUrl: "http://localhost:3000/mcp",
   authorizationEndpoint: "http://localhost:9000/oauth2/authorize",
   tokenEndpoint: "http://localhost:9000/oauth2/token",
   jwksUri: "http://localhost:9000/oauth2/jwks",
@@ -209,9 +204,9 @@ const oauthJwksConfig = {
 
 function oauthRequest(): Request {
   const token = signedJwt({
-    iss: OAUTH_ISSUER,
-    aud: OAUTH_AUDIENCE,
-    resource: OAUTH_RESOURCE,
+    iss: oauthJwksConfig.issuer,
+    aud: oauthJwksConfig.audience,
+    resource: oauthJwksConfig.resource,
     exp: 2_000_000_000,
     nbf: 900,
     token_type: "bearer",
@@ -219,7 +214,7 @@ function oauthRequest(): Request {
     client_id: "reliability-client",
     sub: "user-123",
   });
-  return new Request(OAUTH_PUBLIC_URL, {
+  return new Request(oauthJwksConfig.publicUrl, {
     headers: { Authorization: `Bearer ${token}` },
   });
 }

--- a/tests/reliability/dependency-failures.reliability.test.ts
+++ b/tests/reliability/dependency-failures.reliability.test.ts
@@ -124,6 +124,18 @@ async function waitForB2Requests(
   expect(transport.requestsFor(endpoint)).toHaveLength(count);
 }
 
+async function waitForS3HandlerCalls(
+  handle: ReturnType<typeof vi.fn>,
+  count: number,
+): Promise<void> {
+  for (let i = 0; i < 20; i++) {
+    await vi.advanceTimersByTimeAsync(0);
+    if (handle.mock.calls.length >= count) return;
+    await Promise.resolve();
+  }
+  expect(handle).toHaveBeenCalledTimes(count);
+}
+
 function s3ClientWithHandler(
   handle: ReturnType<typeof vi.fn>,
   options: { maxAttempts?: number } = {},
@@ -144,6 +156,20 @@ function s3ClientWithHandler(
       },
     } as any,
   });
+}
+
+function s3XmlErrorResponse(status: number, code: string, message: string) {
+  const body = `<Error><Code>${code}</Code><Message>${message}</Message></Error>`;
+  return {
+    response: {
+      statusCode: status,
+      headers: {
+        "content-type": "application/xml",
+        "x-amz-request-id": `${code}-request`,
+      },
+      body: Readable.from([body]),
+    },
+  };
 }
 
 const oauthJwksConfig = {
@@ -251,50 +277,69 @@ describe("deterministic dependency failure and recovery suite", () => {
   it.each([
     {
       name: "429",
-      operation: "headBucket",
-      tool: "s3_head_bucket",
-      args: { bucket: "reliability-bucket" },
-      error: s3ServiceError("SlowDown", "S3 rate limited", 429),
+      reply: () => s3XmlErrorResponse(429, "SlowDown", "S3 rate limited"),
       expected: { status: 429, code: "SlowDown" },
       message: /rate limited/i,
+      retryDelaysMs: [250, 500],
     },
     {
       name: "500",
-      operation: "headBucket",
-      tool: "s3_head_bucket",
-      args: { bucket: "reliability-bucket" },
-      error: s3ServiceError("InternalError", "S3 unavailable", 500),
+      reply: () => s3XmlErrorResponse(500, "InternalError", "S3 unavailable"),
       expected: { status: 500, code: "InternalError" },
       message: /unavailable/i,
+      retryDelaysMs: [50, 100],
     },
     {
       name: "timeout",
-      operation: "headBucket",
-      tool: "s3_head_bucket",
-      args: { bucket: "reliability-bucket" },
-      error: timeoutFailure(),
-      expected: { status: 500, code: "internal_error" },
+      reply: () => {
+        throw timeoutFailure();
+      },
+      expected: { status: 500, code: "TimeoutError" },
       message: /timed out/i,
+      retryDelaysMs: [50, 100],
     },
     {
       name: "connection reset",
-      operation: "headBucket",
-      tool: "s3_head_bucket",
-      args: { bucket: "reliability-bucket" },
-      error: connectionResetFailure(),
+      reply: () => {
+        throw Object.assign(connectionResetFailure(), { name: "ECONNRESET" });
+      },
       expected: { status: 500, code: "ECONNRESET" },
       message: /ECONNRESET/i,
+      retryDelaysMs: [50, 100],
     },
-  ])("returns controlled MCP errors for S3 $name failures", async (testCase) => {
-    const s3 = new DeterministicS3ClientFake().fail(testCase.operation, testCase.error);
-    const tools = registerS3Harness(s3);
+  ])(
+    "bounds adapter retries and returns controlled MCP errors for S3 $name failures",
+    async (testCase) => {
+      vi.useFakeTimers();
+      vi.spyOn(Math, "random").mockReturnValue(0.5);
+      const handle = vi.fn(async () => testCase.reply());
+      const s3 = s3ClientWithHandler(handle, { maxAttempts: 3 });
+      const tools = new ToolHarness();
+      registerS3BucketTools(tools, s3, reliabilityConfig);
 
-    const result = await tools.call(testCase.tool, testCase.args);
+      try {
+        const pending = tools.call("s3_head_bucket", { bucket: "reliability-bucket" });
+        await waitForS3HandlerCalls(handle, 1);
+        expect(handle).toHaveBeenCalledTimes(1);
 
-    const text = expectMcpError(result, testCase.expected);
-    expect(text).toMatch(testCase.message);
-    expect(s3.requestsFor(testCase.operation)).toHaveLength(1);
-  });
+        await vi.advanceTimersByTimeAsync(testCase.retryDelaysMs[0] - 1);
+        expect(handle).toHaveBeenCalledTimes(1);
+        await vi.advanceTimersByTimeAsync(1);
+        await waitForS3HandlerCalls(handle, 2);
+
+        await vi.advanceTimersByTimeAsync(testCase.retryDelaysMs[1] - 1);
+        expect(handle).toHaveBeenCalledTimes(2);
+        await vi.advanceTimersByTimeAsync(1);
+        await waitForS3HandlerCalls(handle, 3);
+
+        const text = expectMcpError(await pending, testCase.expected);
+        expect(text).toMatch(testCase.message);
+        expect(handle).toHaveBeenCalledTimes(3);
+      } finally {
+        s3.destroy();
+      }
+    },
+  );
 
   it("returns a controlled MCP error for malformed S3 object metadata", async () => {
     const s3 = new DeterministicS3ClientFake().respond("getObject", {

--- a/tests/reliability/dependency-failures.reliability.test.ts
+++ b/tests/reliability/dependency-failures.reliability.test.ts
@@ -1,15 +1,15 @@
+import * as http from "node:http";
 import { Readable } from "node:stream";
-import { ReadableStream } from "node:stream/web";
 import { B2Client as SdkB2Client } from "@backblaze-labs/b2-sdk";
 import { B2AuthManager, createMcpHttpTransport } from "../../src/auth";
 import { B2Client } from "../../src/b2/client";
 import { registerBucketTools } from "../../src/b2/buckets";
+import { buildHttpServer } from "../../src/http-server";
 import {
   authenticateOAuthRequest,
   resetOAuthVerifierCacheForTests,
 } from "../../src/oauth-resource-server";
 import type { OAuthJwtVerifierConfig } from "../../src/oauth-resource-server";
-import { runWithMcpRequestSignal } from "../../src/request-context";
 import { B2S3PeerClient } from "../../src/s3/aws-sdk-adapter";
 import { registerS3BucketTools } from "../../src/s3/buckets";
 import { registerS3ObjectTools } from "../../src/s3/objects";
@@ -26,13 +26,14 @@ import type { B2Config, B2S3VersionGuard } from "../../src/utils/types";
 import {
   b2ErrorResponse,
   DeterministicB2NativeFake,
-  DeterministicS3ClientFake,
   parseResult,
   s3ServiceError,
   testConfig,
   ToolHarness,
 } from "../support/deterministic-fakes";
+import { closeHttpServer, creds, JSON_HEADERS, listenOnLocalhost } from "../support/http";
 import { jwksResponse, signedJwt } from "../support/oauth-jwks";
+import { MODERN_META, MODERN_PROTOCOL_VERSION } from "../support/protocol";
 import { installSdkTransport, StaticHttpResponse } from "../support/sdk-test-helpers";
 import {
   restoreB2SdkTransportForTests,
@@ -73,14 +74,6 @@ function registerB2BucketHarness(
   return tools;
 }
 
-function registerS3Harness(s3: DeterministicS3ClientFake): ToolHarness {
-  const tools = new ToolHarness();
-  const peer = s3.asPeerClient();
-  registerS3BucketTools(tools, peer, reliabilityConfig);
-  registerS3ObjectTools(tools, peer, noopVersionGuard, reliabilityConfig);
-  return tools;
-}
-
 function expectMcpError(result: unknown, expected: { status: number; code: string }): string {
   expect(result).toMatchObject({ isError: true });
   const text = parseResult(result);
@@ -101,14 +94,6 @@ class MalformedJsonResponse extends StaticHttpResponse {
   async json<T>(): Promise<T> {
     throw new SyntaxError("Malformed JSON from B2 dependency");
   }
-}
-
-function emptyWebBody(): ReadableStream<Uint8Array> {
-  return new ReadableStream<Uint8Array>({
-    start(controller) {
-      controller.close();
-    },
-  });
 }
 
 async function waitForB2Requests(
@@ -170,6 +155,66 @@ function s3XmlErrorResponse(status: number, code: string, message: string) {
       body: Readable.from([body]),
     },
   };
+}
+
+function mcpToolCallBody(name: string, args: Record<string, unknown>, id = 1): string {
+  return JSON.stringify({
+    jsonrpc: "2.0",
+    id,
+    method: "tools/call",
+    params: { name, arguments: args, _meta: MODERN_META },
+  });
+}
+
+function mcpToolCallHeaders(name: string, body: string): Record<string, string | number> {
+  return {
+    ...creds,
+    ...JSON_HEADERS,
+    "content-length": Buffer.byteLength(body),
+    "mcp-protocol-version": MODERN_PROTOCOL_VERSION,
+    "mcp-method": "tools/call",
+    "mcp-name": name,
+  };
+}
+
+function startDisconnectableMcpRequest(
+  port: number,
+  name: string,
+  args: Record<string, unknown>,
+): {
+  req: http.ClientRequest;
+  bodyChunks: string[];
+  done: Promise<{ status?: number; body: string; error?: Error }>;
+} {
+  const body = mcpToolCallBody(name, args);
+  const bodyChunks: string[] = [];
+  let req!: http.ClientRequest;
+  const done = new Promise<{ status?: number; body: string; error?: Error }>((resolve) => {
+    let settled = false;
+    const finish = (result: { status?: number; body: string; error?: Error }) => {
+      if (settled) return;
+      settled = true;
+      resolve(result);
+    };
+    req = http.request(
+      {
+        host: "127.0.0.1",
+        port,
+        method: "POST",
+        path: "/mcp",
+        headers: mcpToolCallHeaders(name, body),
+      },
+      (res) => {
+        res.setEncoding("utf8");
+        res.on("data", (chunk) => bodyChunks.push(String(chunk)));
+        res.on("end", () => finish({ status: res.statusCode, body: bodyChunks.join("") }));
+        res.on("close", () => finish({ status: res.statusCode, body: bodyChunks.join("") }));
+      },
+    );
+    req.on("error", (error) => finish({ error, body: bodyChunks.join("") }));
+    req.end(body);
+  });
+  return { req, bodyChunks, done };
 }
 
 const oauthJwksConfig = {
@@ -341,24 +386,34 @@ describe("deterministic dependency failure and recovery suite", () => {
     },
   );
 
-  it("returns a controlled MCP error for malformed S3 object metadata", async () => {
-    const s3 = new DeterministicS3ClientFake().respond("getObject", {
-      key: "bad-object.txt",
-      contentType: "text/plain",
-      contentLength: Number.NaN,
-      metadata: {},
-      body: emptyWebBody(),
-    });
-    const tools = registerS3Harness(s3);
+  it("returns a controlled MCP error for malformed S3 dependency response data", async () => {
+    const handle = vi.fn(async () => ({
+      response: {
+        statusCode: 200,
+        headers: {
+          "content-type": "text/plain",
+          "content-length": "not-a-number",
+          "x-amz-request-id": "malformed-get-object",
+        },
+        body: Readable.from(["malformed provider body"]),
+      },
+    }));
+    const s3 = s3ClientWithHandler(handle, { maxAttempts: 1 });
+    const tools = new ToolHarness();
+    registerS3ObjectTools(tools, s3, noopVersionGuard, reliabilityConfig);
 
-    const result = await tools.call("s3_get_object", {
-      bucket: "reliability-bucket",
-      key: "bad-object.txt",
-    });
+    try {
+      const result = await tools.call("s3_get_object", {
+        bucket: "reliability-bucket",
+        key: "bad-object.txt",
+      });
 
-    const text = expectMcpError(result, { status: 500, code: "internal_error" });
-    expect(text).toMatch(/invalid content length/i);
-    expect(s3.requestsFor("getObject")).toHaveLength(1);
+      const text = expectMcpError(result, { status: 500, code: "internal_error" });
+      expect(text).toMatch(/invalid content length|not-a-number|malformed/i);
+      expect(handle).toHaveBeenCalledTimes(1);
+    } finally {
+      s3.destroy();
+    }
   });
 
   it("bounds B2 retries and resumes after transient 429 responses", async () => {
@@ -525,7 +580,7 @@ describe("deterministic dependency failure and recovery suite", () => {
     }
   });
 
-  it("cancels a downstream B2 request and keeps late provider work from changing the result", async () => {
+  it("cancels a disconnected HTTP/MCP B2 request and emits no late response frame", async () => {
     let releaseProviderSuccess!: () => void;
     let downstreamAborted = false;
     const transport = new DeterministicB2NativeFake({ capabilities: ["listBuckets"] }).respond(
@@ -543,23 +598,29 @@ describe("deterministic dependency failure and recovery suite", () => {
           );
         }),
     );
-    const tools = registerB2BucketHarness(transport);
-    const controller = new AbortController();
+    installSdkTransport(transport);
+    const handle = buildHttpServer();
+    const port = await listenOnLocalhost(handle);
+    const client = startDisconnectableMcpRequest(port, "b2_list_buckets", {});
 
-    const pending = runWithMcpRequestSignal(controller.signal, () =>
-      tools.call("b2_list_buckets", {}),
-    );
-    await vi.waitFor(() => expect(transport.requestsFor("b2_list_buckets")).toHaveLength(1));
-    controller.abort(abortError("caller cancelled"));
+    try {
+      await vi.waitFor(() => expect(transport.requestsFor("b2_list_buckets")).toHaveLength(1));
+      client.req.destroy(abortError("client disconnected"));
 
-    const result = await pending;
-    const text = expectMcpError(result, { status: 500, code: "internal_error" });
-    expect(text).toMatch(/cancel|abort/i);
-    expect(downstreamAborted).toBe(true);
+      const disconnected = await client.done;
+      expect(disconnected.error?.message ?? disconnected.body).toMatch(
+        /disconnect|socket hang up/i,
+      );
+      expect(disconnected.body).toBe("");
+      await vi.waitFor(() => expect(downstreamAborted).toBe(true));
 
-    releaseProviderSuccess();
-    await Promise.resolve();
-    expect(transport.requestsFor("b2_list_buckets")).toHaveLength(1);
+      releaseProviderSuccess();
+      await new Promise((resolve) => setImmediate(resolve));
+      expect(client.bodyChunks.join("")).toBe("");
+      expect(transport.requestsFor("b2_list_buckets")).toHaveLength(1);
+    } finally {
+      await closeHttpServer(handle);
+    }
   });
 
   it("isolates concurrent dependency failures by credential", async () => {

--- a/tests/reliability/dependency-failures.reliability.test.ts
+++ b/tests/reliability/dependency-failures.reliability.test.ts
@@ -1,0 +1,558 @@
+import { Readable } from "node:stream";
+import { ReadableStream } from "node:stream/web";
+import { B2Client as SdkB2Client } from "@backblaze-labs/b2-sdk";
+import { B2AuthManager, createMcpHttpTransport } from "../../src/auth";
+import { B2Client } from "../../src/b2/client";
+import { registerBucketTools } from "../../src/b2/buckets";
+import {
+  authenticateOAuthRequest,
+  resetOAuthVerifierCacheForTests,
+} from "../../src/oauth-resource-server";
+import type { OAuthJwtVerifierConfig } from "../../src/oauth-resource-server";
+import { runWithMcpRequestSignal } from "../../src/request-context";
+import { B2S3PeerClient } from "../../src/s3/aws-sdk-adapter";
+import { registerS3BucketTools } from "../../src/s3/buckets";
+import { registerS3ObjectTools } from "../../src/s3/objects";
+import {
+  circuitBreaker,
+  resetCircuitBreakersForTests,
+  withCircuit,
+} from "../../src/utils/circuit-breaker";
+import { parseErrorText } from "../../src/utils/errors";
+import { abortError } from "../../src/utils/named-error";
+import { _resetRetryBudget } from "../../src/utils/retry";
+import type { B2Config, B2S3VersionGuard } from "../../src/utils/types";
+import {
+  b2ErrorResponse,
+  DeterministicB2NativeFake,
+  DeterministicS3ClientFake,
+  parseResult,
+  s3ServiceError,
+  testConfig,
+  ToolHarness,
+} from "../support/deterministic-fakes";
+import { signedJwt } from "../support/oauth-jwks";
+import { installSdkTransport, StaticHttpResponse } from "../support/sdk-test-helpers";
+import {
+  restoreB2SdkTransportForTests,
+  setB2SdkClientFactoryForTests,
+} from "../support/sdk-factory-hook";
+
+const retryDisabled = {
+  maxRetries: 0,
+  initialRetryDelayMs: 1,
+  maxRetryDelayMs: 1,
+  requestTimeoutMs: 30_000,
+};
+
+const reliabilityConfig = {
+  ...testConfig,
+  destructivePolicy: "allow",
+} satisfies B2Config;
+
+const noopVersionGuard: B2S3VersionGuard = {
+  async resolveS3FileVersion() {
+    throw new Error("version lookup should not run for unversioned reliability fixtures");
+  },
+  async resolveS3FileVersions({ objects }) {
+    return objects.map((object) => ({ object, version: null }));
+  },
+  async getCurrentS3FileVersion() {
+    return null;
+  },
+};
+
+function registerB2BucketHarness(
+  transport: DeterministicB2NativeFake,
+  retry = retryDisabled,
+): ToolHarness {
+  installSdkTransport(transport, retry);
+  const tools = new ToolHarness();
+  registerBucketTools(tools, new B2Client(new B2AuthManager(reliabilityConfig)), reliabilityConfig);
+  return tools;
+}
+
+function registerS3Harness(s3: DeterministicS3ClientFake): ToolHarness {
+  const tools = new ToolHarness();
+  const peer = s3.asPeerClient();
+  registerS3BucketTools(tools, peer, reliabilityConfig);
+  registerS3ObjectTools(tools, peer, noopVersionGuard, reliabilityConfig);
+  return tools;
+}
+
+function expectMcpError(result: unknown, expected: { status: number; code: string }): string {
+  expect(result).toMatchObject({ isError: true });
+  const text = parseResult(result);
+  expect(text).toEqual(expect.any(String));
+  expect(parseErrorText(text as string)).toMatchObject(expected);
+  return text as string;
+}
+
+function timeoutFailure(): Error {
+  return Object.assign(new Error("upstream timed out"), { name: "TimeoutError" });
+}
+
+function connectionResetFailure(): Error {
+  return Object.assign(new Error("read ECONNRESET"), { code: "ECONNRESET" });
+}
+
+class MalformedJsonResponse extends StaticHttpResponse {
+  async json<T>(): Promise<T> {
+    throw new SyntaxError("Malformed JSON from B2 dependency");
+  }
+}
+
+function emptyWebBody(): ReadableStream<Uint8Array> {
+  return new ReadableStream<Uint8Array>({
+    start(controller) {
+      controller.close();
+    },
+  });
+}
+
+async function waitForB2Requests(
+  transport: DeterministicB2NativeFake,
+  endpoint: string,
+  count: number,
+): Promise<void> {
+  for (let i = 0; i < 20; i++) {
+    await vi.advanceTimersByTimeAsync(0);
+    if (transport.requestsFor(endpoint).length >= count) return;
+    await Promise.resolve();
+  }
+  expect(transport.requestsFor(endpoint)).toHaveLength(count);
+}
+
+function s3ClientWithHandler(handle: ReturnType<typeof vi.fn>): B2S3PeerClient {
+  return new B2S3PeerClient({
+    region: "us-west-004",
+    endpoint: "https://s3.us-west-004.backblazeb2.com",
+    credentials: { accessKeyId: "key-id", secretAccessKey: "key-secret" },
+    forcePathStyle: true,
+    requestHandler: {
+      handle,
+      updateHttpClientConfig() {
+        return undefined;
+      },
+      httpHandlerConfigs() {
+        return {};
+      },
+    } as any,
+  });
+}
+
+const oauthJwksConfig = {
+  issuer: "http://localhost:9000/",
+  resource: "http://localhost:3000/mcp",
+  audience: "http://localhost:3000/mcp",
+  publicUrl: "http://localhost:3000/mcp",
+  authorizationEndpoint: "http://localhost:9000/oauth2/authorize",
+  tokenEndpoint: "http://localhost:9000/oauth2/token",
+  jwksUri: "http://localhost:9000/oauth2/jwks",
+  requiredScopes: [],
+  allowedSubjects: [],
+  allowedTokenTypes: ["bearer"],
+  allowedAlgorithms: ["RS256"],
+  allowedJwtAlgorithms: ["RS256"],
+  allowedJwtTypes: ["at+jwt", "application/at+jwt"],
+  dangerouslyAllowInsecureIssuerUrl: true,
+  dangerouslyAllowUnauthenticatedIntrospection: false,
+  tokenCacheMaxEntries: 100,
+  tokenCacheTtlSeconds: 300,
+  tokenCacheSkewSeconds: 0,
+  jwksCacheTtlSeconds: 300,
+  jwksCacheMinTtlSeconds: 30,
+  jwksTimeoutMs: 50,
+  jwksMaxRetries: 1,
+  jwksRetryDelayMs: 0,
+  jwksCircuitFailures: 1,
+  jwksCircuitOpenMs: 2_000,
+  jwksRefreshCooldownMs: 30_000,
+  jwtClockSkewSeconds: 60,
+} satisfies OAuthJwtVerifierConfig;
+
+function oauthRequest(): Request {
+  const token = signedJwt({
+    iss: oauthJwksConfig.issuer,
+    aud: oauthJwksConfig.audience,
+    resource: oauthJwksConfig.resource,
+    exp: 2_000,
+    nbf: 900,
+    token_type: "bearer",
+    scope: "b2:read",
+    client_id: "reliability-client",
+    sub: "user-123",
+  });
+  return new Request(oauthJwksConfig.publicUrl, {
+    headers: { Authorization: `Bearer ${token}` },
+  });
+}
+
+afterEach(() => {
+  vi.useRealTimers();
+  vi.restoreAllMocks();
+  restoreB2SdkTransportForTests();
+  resetOAuthVerifierCacheForTests();
+  _resetRetryBudget();
+  resetCircuitBreakersForTests();
+});
+
+describe("deterministic dependency failure and recovery suite", () => {
+  it.each([
+    {
+      name: "429",
+      reply: b2ErrorResponse(429, "too_many_requests", "slow down"),
+      expected: { status: 429, code: "too_many_requests" },
+      message: /slow down/i,
+    },
+    {
+      name: "500",
+      reply: b2ErrorResponse(500, "internal_error", "B2 is unavailable"),
+      expected: { status: 500, code: "internal_error" },
+      message: /unavailable/i,
+    },
+    {
+      name: "timeout",
+      reply: timeoutFailure(),
+      expected: { status: 500, code: "internal_error" },
+      message: /timed out/i,
+    },
+    {
+      name: "connection reset",
+      reply: connectionResetFailure(),
+      expected: { status: 500, code: "internal_error" },
+      message: /ECONNRESET/i,
+    },
+    {
+      name: "malformed response",
+      reply: new MalformedJsonResponse(200, null),
+      expected: { status: 500, code: "internal_error" },
+      message: /malformed JSON/i,
+    },
+  ])("returns controlled MCP errors for B2 $name failures", async (testCase) => {
+    const transport = new DeterministicB2NativeFake({ capabilities: ["listBuckets"] }).respond(
+      "b2_list_buckets",
+      testCase.reply,
+    );
+    const tools = registerB2BucketHarness(transport);
+
+    const result = await tools.call("b2_list_buckets", {});
+
+    const text = expectMcpError(result, testCase.expected);
+    expect(text).toMatch(testCase.message);
+    expect(transport.requestsFor("b2_list_buckets")).toHaveLength(1);
+  });
+
+  it.each([
+    {
+      name: "429",
+      operation: "headBucket",
+      tool: "s3_head_bucket",
+      args: { bucket: "reliability-bucket" },
+      error: s3ServiceError("SlowDown", "S3 rate limited", 429),
+      expected: { status: 429, code: "SlowDown" },
+      message: /rate limited/i,
+    },
+    {
+      name: "500",
+      operation: "headBucket",
+      tool: "s3_head_bucket",
+      args: { bucket: "reliability-bucket" },
+      error: s3ServiceError("InternalError", "S3 unavailable", 500),
+      expected: { status: 500, code: "InternalError" },
+      message: /unavailable/i,
+    },
+    {
+      name: "timeout",
+      operation: "headBucket",
+      tool: "s3_head_bucket",
+      args: { bucket: "reliability-bucket" },
+      error: timeoutFailure(),
+      expected: { status: 500, code: "internal_error" },
+      message: /timed out/i,
+    },
+    {
+      name: "connection reset",
+      operation: "headBucket",
+      tool: "s3_head_bucket",
+      args: { bucket: "reliability-bucket" },
+      error: connectionResetFailure(),
+      expected: { status: 500, code: "ECONNRESET" },
+      message: /ECONNRESET/i,
+    },
+  ])("returns controlled MCP errors for S3 $name failures", async (testCase) => {
+    const s3 = new DeterministicS3ClientFake().fail(testCase.operation, testCase.error);
+    const tools = registerS3Harness(s3);
+
+    const result = await tools.call(testCase.tool, testCase.args);
+
+    const text = expectMcpError(result, testCase.expected);
+    expect(text).toMatch(testCase.message);
+    expect(s3.requestsFor(testCase.operation)).toHaveLength(1);
+  });
+
+  it("returns a controlled MCP error for malformed S3 object metadata", async () => {
+    const s3 = new DeterministicS3ClientFake().respond("getObject", {
+      key: "bad-object.txt",
+      contentType: "text/plain",
+      contentLength: Number.NaN,
+      metadata: {},
+      body: emptyWebBody(),
+    });
+    const tools = registerS3Harness(s3);
+
+    const result = await tools.call("s3_get_object", {
+      bucket: "reliability-bucket",
+      key: "bad-object.txt",
+    });
+
+    const text = expectMcpError(result, { status: 500, code: "internal_error" });
+    expect(text).toMatch(/invalid content length/i);
+    expect(s3.requestsFor("getObject")).toHaveLength(1);
+  });
+
+  it("bounds B2 retries and resumes after transient 429 responses", async () => {
+    vi.useFakeTimers();
+    vi.spyOn(Math, "random").mockReturnValue(0);
+    _resetRetryBudget();
+    const transport = new DeterministicB2NativeFake({ capabilities: ["listBuckets"] }).respond(
+      "b2_list_buckets",
+      b2ErrorResponse(429, "too_many_requests", "slow down once"),
+      b2ErrorResponse(429, "too_many_requests", "slow down twice"),
+      new StaticHttpResponse(200, { buckets: [] }),
+    );
+    const tools = registerB2BucketHarness(transport, {
+      maxRetries: 2,
+      initialRetryDelayMs: 50,
+      maxRetryDelayMs: 100,
+      requestTimeoutMs: 30_000,
+    });
+
+    const pending = tools.call("b2_list_buckets", {});
+    await waitForB2Requests(transport, "b2_list_buckets", 1);
+    expect(transport.requestsFor("b2_list_buckets")).toHaveLength(1);
+
+    await vi.advanceTimersByTimeAsync(49);
+    expect(transport.requestsFor("b2_list_buckets")).toHaveLength(1);
+    await vi.advanceTimersByTimeAsync(1);
+    await waitForB2Requests(transport, "b2_list_buckets", 2);
+
+    await vi.advanceTimersByTimeAsync(99);
+    expect(transport.requestsFor("b2_list_buckets")).toHaveLength(2);
+    await vi.advanceTimersByTimeAsync(1);
+    await waitForB2Requests(transport, "b2_list_buckets", 3);
+
+    expect(parseResult(await pending)).toMatchObject({
+      buckets: [],
+      bucket_count: 0,
+      total_bucket_count: 0,
+    });
+    expect(transport.requestsFor("b2_list_buckets")).toHaveLength(3);
+  });
+
+  it("does not replay unsafe B2 or S3 mutations after a lost response", async () => {
+    const native = new DeterministicB2NativeFake({ capabilities: ["writeBuckets"] }).respond(
+      "b2_create_bucket",
+      new Error("lost response after createBucket"),
+    );
+    const b2Tools = registerB2BucketHarness(native, {
+      maxRetries: 3,
+      initialRetryDelayMs: 1,
+      maxRetryDelayMs: 1,
+      requestTimeoutMs: 30_000,
+    });
+
+    const b2Result = await b2Tools.call("b2_create_bucket", {
+      bucketName: "created-once",
+      bucketType: "allPrivate",
+    });
+
+    const b2Text = expectMcpError(b2Result, { status: 500, code: "internal_error" });
+    expect(b2Text).toMatch(/lost response/i);
+    const createRequests = native.requestsFor("b2_create_bucket");
+    expect(createRequests).toHaveLength(1);
+    expect(createRequests[0].request.retry?.maxRetries).toBe(0);
+
+    const handle = vi.fn().mockResolvedValue({
+      response: { statusCode: 500, headers: {}, body: Readable.from([]) },
+    });
+    const s3 = s3ClientWithHandler(handle);
+    const s3Tools = new ToolHarness();
+    registerS3ObjectTools(s3Tools, s3, noopVersionGuard, reliabilityConfig);
+    try {
+      const s3Result = await s3Tools.call("s3_put_object", {
+        bucket: "reliability-bucket",
+        key: "created-once.txt",
+        content: Buffer.from("hello").toString("base64"),
+        contentType: "text/plain",
+      });
+
+      expect(s3Result).toMatchObject({ isError: true });
+      expect(handle).toHaveBeenCalledTimes(1);
+    } finally {
+      s3.destroy();
+    }
+  });
+
+  it("opens, short-circuits, and recovers the native circuit breaker", async () => {
+    vi.useFakeTimers();
+    try {
+      resetCircuitBreakersForTests();
+      for (let i = 0; i < 10; i++) {
+        await expect(
+          withCircuit(async () => {
+            throw Object.assign(new Error("B2 dependency returned 500"), {
+              status: 500,
+              code: "internal_error",
+            });
+          }),
+        ).rejects.toThrow(/500/);
+      }
+
+      expect(circuitBreaker.opened).toBe(true);
+      const shortCircuited = withCircuit(async () => "should not run");
+      await expect(shortCircuited).rejects.toMatchObject({ code: "EOPENBREAKER" });
+      expect(circuitBreaker.status.stats.rejects).toBeGreaterThanOrEqual(1);
+
+      await vi.advanceTimersByTimeAsync(30_001);
+      expect(circuitBreaker.halfOpen).toBe(true);
+      await expect(withCircuit(async () => "recovered")).resolves.toBe("recovered");
+      expect(circuitBreaker.closed).toBe(true);
+    } finally {
+      circuitBreaker.close();
+    }
+  });
+
+  it("cancels a downstream B2 request and keeps late provider work from changing the result", async () => {
+    let releaseProviderSuccess!: () => void;
+    let downstreamAborted = false;
+    const transport = new DeterministicB2NativeFake({ capabilities: ["listBuckets"] }).respond(
+      "b2_list_buckets",
+      (captured) =>
+        new Promise<StaticHttpResponse>((resolve, reject) => {
+          releaseProviderSuccess = () => resolve(new StaticHttpResponse(200, { buckets: [] }));
+          captured.request.signal?.addEventListener(
+            "abort",
+            () => {
+              downstreamAborted = true;
+              reject(captured.request.signal?.reason ?? abortError());
+            },
+            { once: true },
+          );
+        }),
+    );
+    const tools = registerB2BucketHarness(transport);
+    const controller = new AbortController();
+
+    const pending = runWithMcpRequestSignal(controller.signal, () =>
+      tools.call("b2_list_buckets", {}),
+    );
+    await vi.waitFor(() => expect(transport.requestsFor("b2_list_buckets")).toHaveLength(1));
+    controller.abort(abortError("caller cancelled"));
+
+    const result = await pending;
+    const text = expectMcpError(result, { status: 500, code: "internal_error" });
+    expect(text).toMatch(/cancel|abort/i);
+    expect(downstreamAborted).toBe(true);
+
+    releaseProviderSuccess();
+    await Promise.resolve();
+    expect(transport.requestsFor("b2_list_buckets")).toHaveLength(1);
+  });
+
+  it("isolates concurrent dependency failures by credential", async () => {
+    const tenantA = {
+      ...reliabilityConfig,
+      applicationKeyId: "tenant-a-key-id",
+      applicationKey: "tenant-a-key-secret",
+      appKeyId: "tenant-a-key-id",
+      appKey: "tenant-a-key-secret",
+      credentialFingerprint: "tenant-a",
+    } satisfies B2Config;
+    const tenantB = {
+      ...reliabilityConfig,
+      applicationKeyId: "tenant-b-key-id",
+      applicationKey: "tenant-b-key-secret",
+      appKeyId: "tenant-b-key-id",
+      appKey: "tenant-b-key-secret",
+      credentialFingerprint: "tenant-b",
+    } satisfies B2Config;
+    const fakeA = new DeterministicB2NativeFake({
+      accountId: "tenant-a-account",
+      capabilities: ["listBuckets"],
+    }).respond(
+      "b2_list_buckets",
+      b2ErrorResponse(500, "tenant_a_down", "tenant A dependency failed"),
+    );
+    const fakeB = new DeterministicB2NativeFake({
+      accountId: "tenant-b-account",
+      capabilities: ["listBuckets"],
+    }).respond(
+      "b2_list_buckets",
+      b2ErrorResponse(500, "tenant_b_down", "tenant B dependency failed"),
+    );
+    setB2SdkClientFactoryForTests((config) => {
+      const transport = config.applicationKeyId === tenantA.applicationKeyId ? fakeA : fakeB;
+      return {
+        client: new SdkB2Client({
+          applicationKeyId: config.applicationKeyId,
+          applicationKey: config.applicationKey,
+          transport: createMcpHttpTransport(transport, retryDisabled),
+          retry: retryDisabled,
+        }),
+      };
+    });
+    const toolsA = new ToolHarness();
+    const toolsB = new ToolHarness();
+    registerBucketTools(toolsA, new B2Client(new B2AuthManager(tenantA)), tenantA);
+    registerBucketTools(toolsB, new B2Client(new B2AuthManager(tenantB)), tenantB);
+
+    const [resultA, resultB] = await Promise.all([
+      toolsA.call("b2_list_buckets", {}),
+      toolsB.call("b2_list_buckets", {}),
+    ]);
+
+    const textA = expectMcpError(resultA, { status: 500, code: "tenant_a_down" });
+    const textB = expectMcpError(resultB, { status: 500, code: "tenant_b_down" });
+    expect(textA).toContain("tenant A dependency failed");
+    expect(textA).not.toContain("tenant_b_down");
+    expect(textA).not.toContain("tenant-b-key-secret");
+    expect(textB).toContain("tenant B dependency failed");
+    expect(textB).not.toContain("tenant_a_down");
+    expect(textB).not.toContain("tenant-a-key-secret");
+    expect(fakeA.requestsFor("b2_authorize_account")).toHaveLength(1);
+    expect(fakeB.requestsFor("b2_authorize_account")).toHaveLength(1);
+    expect(fakeA.requestsFor("b2_list_buckets")).toHaveLength(1);
+    expect(fakeB.requestsFor("b2_list_buckets")).toHaveLength(1);
+  });
+
+  it("fails closed and opens the JWKS circuit without exhausting fetches", async () => {
+    resetOAuthVerifierCacheForTests();
+    const fetchMock = vi.fn(async () =>
+      Response.json({ error: "jwks unavailable" }, { status: 503 }),
+    );
+
+    const first = await authenticateOAuthRequest(oauthRequest(), oauthJwksConfig, {
+      fetch: fetchMock as typeof fetch,
+      nowSeconds: () => 1000,
+    });
+
+    expect(first).toBeInstanceOf(Response);
+    expect((first as Response).status).toBe(503);
+    expect((first as Response).headers.get("cache-control")).toBe("no-store");
+    await expect((first as Response).json()).resolves.toEqual({
+      error: "OAuth authorization server unavailable",
+    });
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+
+    const second = await authenticateOAuthRequest(oauthRequest(), oauthJwksConfig, {
+      fetch: fetchMock as typeof fetch,
+      nowSeconds: () => 1000,
+    });
+
+    expect(second).toBeInstanceOf(Response);
+    expect((second as Response).status).toBe(503);
+    expect((second as Response).headers.get("retry-after")).toBe("2");
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
+});


### PR DESCRIPTION
## Summary

- Adds a deterministic reliability Vitest layer for B2, S3, and OAuth/JWKS dependency failures with no real B2 credentials required.
- Covers controlled MCP error shapes for B2/S3 429, 500, timeout, connection reset, and malformed-response paths.
- Asserts bounded retry attempts and backoff timing, including adapter-backed S3 read retries through `B2S3PeerClient` with a controllable request handler.
- Exercises malformed S3 provider HTTP response data through `B2S3PeerClient`, including handler-count assertions and controlled MCP error normalization.
- Proves unsafe mutation no-replay behavior, HTTP/MCP request cancellation with no late response frame, native and S3 circuit open/short-circuit/recovery, JWKS fail-closed/short-circuit/recovery, and concurrent credential isolation.
- Maps the suite to `pnpm run test:reliability` and a required CI `reliability/resilience` job with JUnit/Vitest artifacts.

## Linked Issue

Closes #198

## Tests Run

- `pnpm run test:reliability`
- `pnpm run typecheck`
- `pnpm run lint`
- `pnpm run format:check`
- `pnpm run test:contract`
- `pnpm run verify`

## Follow-up Notes

- The suite uses deterministic fakes and controllable local handlers only.
- Review fixes route S3 malformed-response coverage through the AWS adapter and cancellation coverage through the HTTP/MCP response boundary.