### PR TITLE
fix: trusted checkout in privileged container-image publish job (CodeQL #42)

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -473,11 +473,30 @@ jobs:
       id-token: write
       packages: write
     steps:
+      # Check out the protected `ci-green` ref (a trusted constant, like the
+      # prepare job) rather than a dynamic sha in this write-privileged job, then
+      # hard-pin to the validated release commit below. This keeps the checkout
+      # off attacker-influenced refs in a packages:write/id-token:write context.
       # actions/checkout v6, reviewed 2026-08-06.
       - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803
         with:
-          ref: ${{ needs.prepare.outputs.checkout-sha }}
+          ref: refs/heads/ci-green
+          fetch-depth: 0
           persist-credentials: false
+      - name: Pin to the validated release commit
+        env:
+          CHECKOUT_SHA: ${{ needs.prepare.outputs.checkout-sha }}
+        run: |
+          set -euo pipefail
+          # `ci-green` is the protected ref prepare already validated the tag
+          # against; fail closed if the validated release sha is not contained in
+          # it, then detach to that exact commit so the image is built from the
+          # reproducible release source.
+          if ! git merge-base --is-ancestor "${CHECKOUT_SHA}" HEAD; then
+            echo "::error::${CHECKOUT_SHA} is not contained in protected ci-green"
+            exit 1
+          fi
+          git checkout --detach "${CHECKOUT_SHA}"
       # docker/setup-qemu-action v3.6.0, reviewed 2026-08-07.
       - uses: docker/setup-qemu-action@29109295f81e9208d7d86ff1c6c12d2833863392
       # docker/setup-buildx-action v3.11.1, reviewed 2026-08-07.


### PR DESCRIPTION
## Summary

Fixes CodeQL code-scanning alert #42 — `actions/untrusted-checkout/high` ("Checkout of untrusted code in a privileged context") in the `container-image` job of `.github/workflows/publish.yml`.

That job is privileged (`packages: write` + `id-token: write`, to publish and cosign-sign the GHCR image) and previously checked out `needs.prepare.outputs.checkout-sha` — a dynamic ref — then executed it via `docker build`. Even though the sha is validated upstream by `resolve-publish-ref.mjs` against the protected `ci-green` ref (and `persist-credentials: false` was already set), CodeQL cannot see that runtime validation and flags the dynamic checkout in a write-privileged `workflow_run` job.

## Why not a privilege split

The usual fix (build in an unprivileged job, push in a privileged one) is not feasible here: `publish-container-image.mjs` builds the multi-arch image with `docker buildx build --platform … --push`, so build and push are a single command that inherently needs `packages: write`. The build cannot be moved to an unprivileged job.

## Fix

Check out the protected `ci-green` ref (a trusted constant — the exact pattern the `prepare` job already uses and which CodeQL does not flag), then hard-pin to the validated release commit:

- `actions/checkout` now uses `ref: refs/heads/ci-green` with `fetch-depth: 0`.
- A new step fails closed if `checkout-sha` is not reachable from `ci-green`, then `git checkout --detach`es to that exact sha.

This removes the dynamic/attacker-influenceable ref from the privileged checkout (clearing the alert) while preserving — arguably strengthening — the guarantee that the image is built from the exact, `ci-green`-validated release commit. Behavior is unchanged in the normal case (at release time `ci-green` head is the release commit; releases are serialized by the `npm-publish-*` concurrency group), and any drift now fails closed instead of building an unvalidated sha.

## Tests run

- `pnpm run test:contract` (includes `ci-workflow-policy` and `supply-chain-policy`, which inspect `publish.yml`)
- `pnpm run verify`

## Note

The publish/GHCR/cosign flow can't be exercised locally, which is why this is a PR (not a direct push to `main`): please let CI + review validate the workflow change before merge. The CodeQL re-scan on this PR will confirm alert #42 clears.
