### PR TITLE
feat: emit b2-mcp product token on outbound user-agent

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+- Renamed the outbound User-Agent product token from `backblaze-b2-mcp` to
+  `b2-mcp` (`b2-mcp/<version>` on a published release, `b2-mcp/dev` otherwise)
+  across every SDK that talks to the B2 API. **Operators must sequence this
+  with the analytics side:** expand any Backblaze-side dashboards, alerts, and
+  token-keyed rate-limiting to accept BOTH `backblaze-b2-mcp` and `b2-mcp`
+  before rolling the fleet, then retire the old token only after every pod has
+  cycled onto `b2-mcp`. During a rolling deploy both tokens are emitted
+  simultaneously, so a dashboard keyed solely on the old token would otherwise
+  decay toward zero and page as a false partial outage. (#236)
+
 ### Fixed
 - `s3_put_bucket_lifecycle` now clears the bucket's S3 lifecycle configuration
   when passed an empty `rules` array, routing the clear through the destructive

--- a/README.md
+++ b/README.md
@@ -203,7 +203,7 @@ the healthcheck probes the same port the server binds.
 | `B2_APPLICATION_KEY`                                          | stdio / HTTP `server` | —                     | Application key secret                                                                                                     |
 | `B2_MASTER_KEY_ID` / `B2_MASTER_KEY`                          | —                     | falls back to app key | Master credential for SDK-backed Partner/Groups tools; required with Partner API entitlement for those operations          |
 | `B2_REGION`                                                   | —                     | `us-west-004`         | Fallback/default S3-compatible endpoint region; authorized B2 responses override this for S3/report tools                    |
-| `B2_MCP_UA_SUFFIX`                                            | —                     | —                     | Token appended to the outbound User-Agent (tag a deployment)                                                               |
+| `B2_MCP_UA_SUFFIX`                                            | —                     | —                     | Optional operator token appended _after_ the built-in `b2-mcp/<version>` product token on the outbound User-Agent (tag a deployment) |
 | `B2_MCP_OUTPUT_FORMAT`                                        | —                     | `json`                | LLM-facing `TextContent.text` format for structured successes: compact `json` or opt-in `toon`                             |
 | `B2_MCP_TRANSPORT`                                            | —                     | `stdio`               | CLI default transport when no `stdio` / `http` argument or `--transport` flag is passed; Docker images set this to `http`  |
 | `B2_LOG_FILE`                                                 | —                     | stderr                | Optional path for redacted structured JSON logs. When set, the file replaces stderr; stdout is never used for logs          |
@@ -214,6 +214,13 @@ the healthcheck probes the same port the server binds.
 | `B2_HTTP_CREDENTIAL_MODE`                                     | HTTP only             | `headers`             | `headers`, `server`, or `principal`; unset preserves existing header-based clients. Set explicitly for hosted deployments  |
 | `B2_PRINCIPAL_CREDENTIAL_MAP`                                 | HTTP `principal`      | —                     | JSON map from verified MCP principal to a customer-managed credential reference                                            |
 | `B2_CREDENTIAL_<REF>_APPLICATION_KEY_ID` / `_APPLICATION_KEY` | HTTP `principal`      | —                     | Env-backed secret-broker material for the mapped reference                                                                 |
+
+Every outbound B2 API call (native B2 SDK and the S3-compatible data plane) carries
+a `b2-mcp` product token on its User-Agent so the traffic is attributable to this
+server. A published release emits `b2-mcp/<version>` (for example `b2-mcp/0.1.2`);
+a source checkout, CI, or a dev/prerelease build emits `b2-mcp/dev`. `B2_MCP_UA_SUFFIX`
+appends an optional operator token _after_ that built-in product token and does not
+replace it.
 
 S3-compatible and report tools use the `s3ApiUrl` returned by `b2_authorize_account` when a tool call authorizes; setting `B2_REGION` does not override that authorized region. On a cold authorization cache, the first S3/report call attempts B2 authorization to learn the authoritative region. That wait is bounded, and if authorization is temporarily unavailable, S3 tools fall back to the `B2_REGION` endpoint for that operation so the S3 data plane can still be attempted with the configured default. Once authorization succeeds, the derived S3 endpoint is cached for the server process lifetime; restart the process to pick up a later account-region migration. Authorized S3 endpoints remain restricted to HTTPS `s3.<region>.backblazeb2.com` hosts with no credentials, custom port, path, query, or fragment.
 

--- a/package-budget.json
+++ b/package-budget.json
@@ -11,16 +11,16 @@
     "directProductionDependencyCount": 9,
     "totalProductionPackageCount": 48,
     "transitiveProductionPackageCount": 38,
-    "packedTarballBytes": 490530,
-    "unpackedPackageBytes": 2259297,
+    "packedTarballBytes": 491529,
+    "unpackedPackageBytes": 2261880,
     "packedEntryCount": 251,
     "cleanConsumerInstallFootprintBytes": 30975939
   },
   "limits": {
     "directProductionDependencyCount": 9,
     "totalProductionPackageCount": 48,
-    "packedTarballBytes": 491500,
-    "unpackedPackageBytes": 2260000,
+    "packedTarballBytes": 492500,
+    "unpackedPackageBytes": 2262600,
     "packedEntryCount": 251,
     "cleanConsumerInstallFootprintBytes": 31000000
   },

--- a/scripts/lib/local-import-graph.cjs
+++ b/scripts/lib/local-import-graph.cjs
@@ -2,7 +2,7 @@ const { existsSync, readFileSync, statSync } = require("fs");
 const { dirname, extname, resolve } = require("path");
 
 const WORKER_SOURCE_GRAPH_FILES_BUDGET = 75;
-const WORKER_SOURCE_GRAPH_BYTES_BUDGET = 625_400;
+const WORKER_SOURCE_GRAPH_BYTES_BUDGET = 626_800;
 const WORKER_EMITTED_FILES_BUDGET = 8;
 const WORKER_EMITTED_TOTAL_BYTES_BUDGET = 9_150_000;
 const WORKER_UPLOAD_SCRIPT_BYTES_BUDGET = 3_000_000;

--- a/src/s3/client.ts
+++ b/src/s3/client.ts
@@ -124,6 +124,9 @@ function customUserAgent(
   surface?: string,
 ): B2S3PeerClientConfig["customUserAgent"] {
   const entries: Array<[string, string]> = [
+    // AWS's customUserAgent expects [name, version] tuples, so this path can't
+    // consume the joined productToken(); both sites still single-source
+    // PRODUCT_NAME, so a name change stays in one place.
     [PRODUCT_NAME, productVersion()],
     ["transport", config.transport ?? "stdio"],
   ];

--- a/src/s3/client.ts
+++ b/src/s3/client.ts
@@ -4,7 +4,7 @@ import type { B2AuthResponse, B2Config } from "../utils/types.js";
 import { runWithMcpRequestSignal } from "../request-context.js";
 import { logger } from "../utils/logger.js";
 import { timeoutError } from "../utils/named-error.js";
-import { productVersion } from "../version.js";
+import { PRODUCT_NAME, productVersion } from "../version.js";
 import {
   createB2S3PeerClient,
   type B2S3PeerClient,
@@ -124,7 +124,7 @@ function customUserAgent(
   surface?: string,
 ): B2S3PeerClientConfig["customUserAgent"] {
   const entries: Array<[string, string]> = [
-    ["backblaze-b2-mcp", productVersion()],
+    [PRODUCT_NAME, productVersion()],
     ["transport", config.transport ?? "stdio"],
   ];
   if (surface) entries.push(["surface", surface]);

--- a/src/utils/user-agent.ts
+++ b/src/utils/user-agent.ts
@@ -1,4 +1,4 @@
-import { productVersion } from "../version.js";
+import { productToken } from "../version.js";
 import { B2Config } from "./types.js";
 
 /**
@@ -10,7 +10,7 @@ import { B2Config } from "./types.js";
  */
 export function buildUserAgent(config: B2Config): string {
   const transport = config.transport ?? "stdio";
-  const product = `backblaze-b2-mcp/${productVersion()} (${transport})`;
+  const product = `${productToken()} (${transport})`;
   const suffix = process.env.B2_MCP_UA_SUFFIX?.trim();
   return [product, suffix].filter(Boolean).join(" ");
 }

--- a/src/version.ts
+++ b/src/version.ts
@@ -71,3 +71,19 @@ export function productVersion(): string {
   if (isPublishedRelease) return VERSION;
   return "dev";
 }
+
+/**
+ * The binary/package product name emitted on outbound User-Agent headers.
+ * Kept here so every SDK's UA construction derives the token from one place.
+ */
+export const PRODUCT_NAME = "b2-mcp";
+
+/**
+ * The outbound product token identifying this server to Backblaze:
+ * `b2-mcp/<version>` on a published release, `b2-mcp/dev` otherwise.
+ *
+ * @returns The single product token shared by every SDK User-Agent.
+ */
+export function productToken(): string {
+  return `${PRODUCT_NAME}/${productVersion()}`;
+}

--- a/tests/contract/doc-examples-policy.contract.test.ts
+++ b/tests/contract/doc-examples-policy.contract.test.ts
@@ -79,7 +79,7 @@ describe("documentation example validator policy", () => {
     const result = runDocExamplesWithOverrides({ "README.md": readme });
 
     expect(result.status).not.toBe(0);
-    expect(result.stderr).toContain("README.md:489");
+    expect(result.stderr).toContain("README.md:496");
     expect(result.stderr).toContain("has an unclosed Markdown code fence");
   });
 
@@ -97,7 +97,7 @@ describe("documentation example validator policy", () => {
     const result = runDocExamplesWithOverrides({ "README.md": readme });
 
     expect(result.status).not.toBe(0);
-    expect(result.stderr).toContain("README.md:492");
+    expect(result.stderr).toContain("README.md:499");
     expect(result.stderr).toContain("references missing package script missing-script");
   });
 });

--- a/tests/unit/s3-client-config.unit.test.ts
+++ b/tests/unit/s3-client-config.unit.test.ts
@@ -109,7 +109,7 @@ describe("B2 S3 client configuration", () => {
     ]);
   });
 
-  it("emits [\"b2-mcp\", \"<semver>\"] for a published release build", async () => {
+  it('emits ["b2-mcp", "<semver>"] for a published release build', async () => {
     vi.resetModules();
     vi.doMock("../../src/version.js", async (importOriginal) => ({
       ...(await importOriginal<typeof import("../../src/version.js")>()),

--- a/tests/unit/s3-client-config.unit.test.ts
+++ b/tests/unit/s3-client-config.unit.test.ts
@@ -109,6 +109,27 @@ describe("B2 S3 client configuration", () => {
     ]);
   });
 
+  it("emits [\"b2-mcp\", \"<semver>\"] for a published release build", async () => {
+    vi.resetModules();
+    vi.doMock("../../src/version.js", async (importOriginal) => ({
+      ...(await importOriginal<typeof import("../../src/version.js")>()),
+      PRODUCT_NAME: "b2-mcp",
+      productVersion: () => "1.2.3",
+    }));
+    try {
+      const { buildB2S3ClientConfig: released } = await import("../../src/s3/client");
+      const s3 = released(config, { surface: "s3-object-tools" });
+      expect(s3.customUserAgent).toEqual([
+        ["b2-mcp", "1.2.3"],
+        ["transport", "stdio"],
+        ["surface", "s3-object-tools"],
+      ]);
+    } finally {
+      vi.doUnmock("../../src/version.js");
+      vi.resetModules();
+    }
+  });
+
   it("adds the optional user-agent suffix after the surface tag", () => {
     const previous = process.env.B2_MCP_UA_SUFFIX;
     process.env.B2_MCP_UA_SUFFIX = " tenant-a ";

--- a/tests/unit/s3-client-config.unit.test.ts
+++ b/tests/unit/s3-client-config.unit.test.ts
@@ -103,7 +103,7 @@ describe("B2 S3 client configuration", () => {
       secretAccessKey: "principal-secret",
     });
     expect(s3.customUserAgent).toEqual([
-      ["backblaze-b2-mcp", "dev"],
+      ["b2-mcp", "dev"],
       ["transport", "stdio"],
       ["surface", "s3-object-tools"],
     ]);
@@ -119,7 +119,7 @@ describe("B2 S3 client configuration", () => {
       );
 
       expect(s3.customUserAgent).toEqual([
-        ["backblaze-b2-mcp", "dev"],
+        ["b2-mcp", "dev"],
         ["transport", "http"],
         ["surface", "s3-object-tools"],
         ["suffix", "tenant-a"],

--- a/tests/unit/user-agent.unit.test.ts
+++ b/tests/unit/user-agent.unit.test.ts
@@ -13,6 +13,21 @@ describe("buildUserAgent", () => {
     expect(ua).toBe("b2-mcp/dev (http)");
   });
 
+  it("emits b2-mcp/<semver> for a published release build", async () => {
+    vi.resetModules();
+    vi.doMock("../../src/version.js", async (importOriginal) => ({
+      ...(await importOriginal<typeof import("../../src/version.js")>()),
+      productToken: () => "b2-mcp/1.2.3",
+    }));
+    try {
+      const { buildUserAgent: released } = await import("../../src/utils/user-agent");
+      expect(released(cfg({ transport: "http" }))).toBe("b2-mcp/1.2.3 (http)");
+    } finally {
+      vi.doUnmock("../../src/version.js");
+      vi.resetModules();
+    }
+  });
+
   it("does not rebuild the SDK transport stack identity", () => {
     const ua = buildUserAgent(cfg());
     expect(ua).not.toContain("axios/");

--- a/tests/unit/user-agent.unit.test.ts
+++ b/tests/unit/user-agent.unit.test.ts
@@ -10,7 +10,7 @@ describe("buildUserAgent", () => {
 
   it("includes product, release channel, and transport", () => {
     const ua = buildUserAgent(cfg({ transport: "http" }));
-    expect(ua).toBe("backblaze-b2-mcp/dev (http)");
+    expect(ua).toBe("b2-mcp/dev (http)");
   });
 
   it("does not rebuild the SDK transport stack identity", () => {


### PR DESCRIPTION
## Summary

Emit a single, consistent outbound product token — `b2-mcp/<version>` on a published release and `b2-mcp/dev` for source/CI/dev builds — on the User-Agent of every SDK that talks to the B2 API.

- Added `PRODUCT_NAME` (`"b2-mcp"`) and `productToken()` to `src/version.ts` so the token is derived from one place, built on the `productVersion()` release/channel resolver from #237 (`b2-mcp/<version>` on a release, `b2-mcp/dev` otherwise).
- `buildUserAgent()` (native B2 SDK, `src/utils/user-agent.ts`) now consumes `productToken()`, keeping the transport tag and optional `B2_MCP_UA_SUFFIX`.
- `customUserAgent()` (AWS S3 SDK, `src/s3/client.ts`) now uses the shared `PRODUCT_NAME`, keeping transport/surface/suffix metadata.
- Renamed the outbound product token from `backblaze-b2-mcp` to `b2-mcp`.

Internal identifiers not on the outbound wire (the `/health` `server` field and the logger `service` name) are intentionally left unchanged; this issue is scoped to the outbound User-Agent.

> Note: any Backblaze-side analytics keyed on the old `backblaze-b2-mcp` product token must move to `b2-mcp`.

## Linked issue

Closes #236

## Commits

- `feat: emit b2-mcp product token on outbound user-agent` — shared `PRODUCT_NAME`/`productToken()` in `src/version.ts`, consumed by the native and S3 user-agent builders; renames the outbound token to `b2-mcp`.
- `docs: sequence product-token rename and document divergence` — README documents the `b2-mcp/<version>` vs `b2-mcp/dev` token, the `B2_MCP_UA_SUFFIX` append semantics, and the analytics-rename divergence note.
- `test: cover published product token and document it` — unit coverage for the published-release token and the dev fallback.
- `fix: align CI budgets and doc-example refs for b2-mcp token` — the new README paragraph and source shifted content past the repo's brittle guards, so this realigns them: doc-example line refs in `doc-examples-policy.contract.test.ts` (fence 489→496, `pnpm test` 492→499), the Cloudflare worker source-graph byte budget in `scripts/lib/local-import-graph.cjs` (625,400→626,800), the packed/unpacked budgets and baseline in `package-budget.json`, and a Biome quote-style reformat of `s3-client-config.unit.test.ts`.

## Tests run

- `pnpm run typecheck` — clean
- `pnpm run verify` (typecheck, build, doc-examples, deployment-contracts, lint, doc-lint, links, skills, format, spell, runtime-security, diagnostics) — clean
- `pnpm run test:contract` — 266 passed
- `pnpm run test:coverage` — 1661 passed; statements 91.13% / branches 82.92% / functions 95.72% / lines 94.11% (all above thresholds)
- Updated `tests/unit/user-agent.unit.test.ts` and `tests/unit/s3-client-config.unit.test.ts` to assert the new `b2-mcp` token.
- All CI checks green on the latest commit.

## Follow-up notes

- Depends on #237 (merged via #238), whose `productVersion()` resolver drives the `<version>`-vs-`dev` segment.
