### PR TITLE
fix: resolve insights bucket via authorized scope (#212)

### DIFF
--- a/docs/TOOL_PROFILES.md
+++ b/docs/TOOL_PROFILES.md
@@ -8,16 +8,16 @@ Approved modern cache hint: `ttlMs=30000`, `cacheScope=private`
 
 | Profile | Total | `b2_*` | `s3_*` | `bz_*` | Hash prefix |
 | --- | ---: | ---: | ---: | ---: | --- |
-| `full` | 40 | 21 | 19 | 0 | `023b2a4c819f` |
-| `live-b2-contract` | 39 | 20 | 19 | 0 | `4d5c97ef2a70` |
-| `phase1-default` | 37 | 18 | 19 | 0 | `11be52cf8f07` |
-| `read-only` | 20 | 11 | 9 | 0 | `23a707ac7b59` |
+| `full` | 40 | 21 | 19 | 0 | `d2303ac12643` |
+| `live-b2-contract` | 39 | 20 | 19 | 0 | `069b5c0910b3` |
+| `phase1-default` | 37 | 18 | 19 | 0 | `c5aeb288ab6e` |
+| `read-only` | 20 | 11 | 9 | 0 | `9873510da79d` |
 
 ## `full`
 
 Complete tool superset for contract review and regression detection across all backing categories; durable-secret producers are sink-backed when a secret sink is active and otherwise remain availability-annotated stubs.
 
-Profile hash: `023b2a4c819f53a8ecbf3a0daca9d65a3d361bb0b0c8a81cd8afa3945d9c09fe`
+Profile hash: `d2303ac126434295689e1bc06d2adb7d07441e96f53e88f0813594bdfe5b4a71`
 
 ### Capability Input
 
@@ -79,7 +79,7 @@ Profile hash: `023b2a4c819f53a8ecbf3a0daca9d65a3d361bb0b0c8a81cd8afa3945d9c09fe`
 
 Protected live B2 contract profile: non-master application key with release-evidence capabilities, no key-management grants, and a distinct master key only for Partner/Groups API surface discovery.
 
-Profile hash: `4d5c97ef2a70f3c45c5084dd9054b59e685b178d9240c177bac2162c1d967136`
+Profile hash: `069b5c0910b3262e56fb821b1a8e1945c805689b67b4ebcf200f7f0ff9cad18c`
 
 ### Capability Input
 
@@ -158,7 +158,7 @@ Profile hash: `4d5c97ef2a70f3c45c5084dd9054b59e685b178d9240c177bac2162c1d967136`
 
 Default customer-hosted Phase 1 profile: standard B2 application key, no distinct Partner/master credential, and durable-secret producers exposed as sink-backed tools on local stdio or unavailable stubs when the sink is off.
 
-Profile hash: `11be52cf8f077a208b7f6ecaa7335323f03a01360a8ce377f6e8d531498d10f4`
+Profile hash: `c5aeb288ab6e0377d7c2da3582caadd0b3312c7bd8a27cb4a06adbc7c6f539ca`
 
 ### Capability Input
 
@@ -229,7 +229,7 @@ Profile hash: `11be52cf8f077a208b7f6ecaa7335323f03a01360a8ce377f6e8d531498d10f4`
 
 Deterministic read/list profile for safe production use and contract tests; write/delete/admin handlers are omitted while durable-secret producer names remain unavailable stubs unless a sink-backed admin profile is configured.
 
-Profile hash: `23a707ac7b596db31e641e7b4b670d05b7a1314d2c0d4cbc24639721987f0228`
+Profile hash: `9873510da79d6862df6aa9b9d0bb55d4646f09b6daf6d89646f197b3845411c0`
 
 ### Capability Input
 

--- a/docs/tool-profile-contract.json
+++ b/docs/tool-profile-contract.json
@@ -204,7 +204,7 @@
         "s3_get_presigned_url",
         "s3_put_bucket_lifecycle"
       ],
-      "hash": "023b2a4c819f53a8ecbf3a0daca9d65a3d361bb0b0c8a81cd8afa3945d9c09fe",
+      "hash": "d2303ac126434295689e1bc06d2adb7d07441e96f53e88f0813594bdfe5b4a71",
       "fixtures": {
         "modern": "tests/fixtures/tool-contract/full.modern.json",
         "legacy": "tests/fixtures/tool-contract/full.legacy.json"
@@ -358,7 +358,7 @@
         "s3_get_presigned_url",
         "s3_put_bucket_lifecycle"
       ],
-      "hash": "4d5c97ef2a70f3c45c5084dd9054b59e685b178d9240c177bac2162c1d967136",
+      "hash": "069b5c0910b3262e56fb821b1a8e1945c805689b67b4ebcf200f7f0ff9cad18c",
       "fixtures": {
         "modern": "tests/fixtures/tool-contract/live-b2-contract.modern.json",
         "legacy": "tests/fixtures/tool-contract/live-b2-contract.legacy.json"
@@ -502,7 +502,7 @@
         "s3_get_presigned_url",
         "s3_put_bucket_lifecycle"
       ],
-      "hash": "11be52cf8f077a208b7f6ecaa7335323f03a01360a8ce377f6e8d531498d10f4",
+      "hash": "c5aeb288ab6e0377d7c2da3582caadd0b3312c7bd8a27cb4a06adbc7c6f539ca",
       "fixtures": {
         "modern": "tests/fixtures/tool-contract/phase1-default.modern.json",
         "legacy": "tests/fixtures/tool-contract/phase1-default.legacy.json"
@@ -582,7 +582,7 @@
         "b2_create_key",
         "b2_reserve_trial_create_account"
       ],
-      "hash": "23a707ac7b596db31e641e7b4b670d05b7a1314d2c0d4cbc24639721987f0228",
+      "hash": "9873510da79d6862df6aa9b9d0bb55d4646f09b6daf6d89646f197b3845411c0",
       "fixtures": {
         "modern": "tests/fixtures/tool-contract/read-only.modern.json",
         "legacy": "tests/fixtures/tool-contract/read-only.legacy.json"

--- a/package-budget.json
+++ b/package-budget.json
@@ -11,16 +11,16 @@
     "directProductionDependencyCount": 9,
     "totalProductionPackageCount": 48,
     "transitiveProductionPackageCount": 38,
-    "packedTarballBytes": 491529,
-    "unpackedPackageBytes": 2261880,
+    "packedTarballBytes": 492507,
+    "unpackedPackageBytes": 2266060,
     "packedEntryCount": 251,
-    "cleanConsumerInstallFootprintBytes": 30975939
+    "cleanConsumerInstallFootprintBytes": 30982702
   },
   "limits": {
     "directProductionDependencyCount": 9,
     "totalProductionPackageCount": 48,
-    "packedTarballBytes": 492500,
-    "unpackedPackageBytes": 2262600,
+    "packedTarballBytes": 493500,
+    "unpackedPackageBytes": 2268000,
     "packedEntryCount": 251,
     "cleanConsumerInstallFootprintBytes": 31000000
   },

--- a/scripts/lib/local-import-graph.cjs
+++ b/scripts/lib/local-import-graph.cjs
@@ -2,7 +2,7 @@ const { existsSync, readFileSync, statSync } = require("fs");
 const { dirname, extname, resolve } = require("path");
 
 const WORKER_SOURCE_GRAPH_FILES_BUDGET = 75;
-const WORKER_SOURCE_GRAPH_BYTES_BUDGET = 626_800;
+const WORKER_SOURCE_GRAPH_BYTES_BUDGET = 630_000;
 const WORKER_EMITTED_FILES_BUDGET = 8;
 const WORKER_EMITTED_TOTAL_BYTES_BUDGET = 9_150_000;
 const WORKER_UPLOAD_SCRIPT_BYTES_BUDGET = 3_000_000;

--- a/src/b2/insights.ts
+++ b/src/b2/insights.ts
@@ -713,6 +713,10 @@ async function resolveFromAuthorizedScope(
 ): Promise<{ name?: string; id?: string; candidates?: string[]; outOfScope?: boolean } | null> {
   const { allowedBuckets } = await auth.getAuth();
   if (!allowedBuckets || allowedBuckets.length === 0) return null;
+  // An empty/blank input substring-matches every bucket, so treat it as a miss
+  // rather than let `includes("")` enumerate the whole scope. The tool schemas
+  // reject empty bucket values too; this is defense in depth for the guarantee.
+  if (input.trim() === "") return { outOfScope: true };
   const exact = allowedBuckets.find((b) => b.name === input || b.id === input);
   // A key restricted by name (not id) may report a null name; matched by id we
   // still have a usable id and fall back to the supplied input for display.
@@ -1015,7 +1019,7 @@ export function registerInsightTools(
       description:
         "List a bucket's largest objects by size via a live listing. For 'largest files', 'what's taking up space in <bucket>'. Give the bucket by name or bucketId; optional path prefix. Sorting by size requires a full listing, so on very large buckets the scan is bounded by max_scan and a time budget — it then returns the largest among the objects scanned with truncated=true; pass a prefix to focus on a subtree for a complete ranking. Returns name, size, and upload time — never contents.",
       inputSchema: {
-        bucket: z.string().describe("Bucket name or bucketId to inspect."),
+        bucket: z.string().min(1).describe("Bucket name or bucketId to inspect."),
         limit: z
           .number()
           .int()
@@ -1142,7 +1146,7 @@ export function registerInsightTools(
       description:
         "Find abandoned multipart uploads that silently consume storage in a bucket. For 'bucket bloat', 'stuck/incomplete uploads', 'wasted storage'. Returns count, oldest upload age, and wasted bytes. Give the bucket by name or bucketId. Live listing, bounded by max_uploads and an internal time budget — on a very bloated bucket it returns a truncated result (and wasted_gb may be a lower bound) and recommends a lifecycle rule.",
       inputSchema: {
-        bucket: z.string().describe("Bucket name or bucketId to inspect."),
+        bucket: z.string().min(1).describe("Bucket name or bucketId to inspect."),
         older_than_days: z
           .number()
           .int()

--- a/src/b2/insights.ts
+++ b/src/b2/insights.ts
@@ -686,24 +686,18 @@ export function computeSnapshotGrowth(
 // ── Phase 2 helpers ─────────────────────────────────────────────────────────
 
 /**
- * Resolve the caller's authorized bucket scope directly from the authorize
- * response. A bucket-scoped key cannot call the unfiltered `listBuckets()`
- * (it lacks the `listBuckets` capability and B2 answers 401), yet the authorized
- * bucket's id — and usually its name — is already present in `allowedBuckets`.
- * Returns null when the key is unrestricted (no recorded scope), so the caller
- * falls back to a live listing.
+ * Resolve a bucket from the authorize response's `allowedBuckets` scope. A
+ * bucket-scoped key cannot call the unfiltered `listBuckets()` (no `listBuckets`
+ * capability -> 401), but its id (and usually name) is already in that scope.
+ * Returns null for unrestricted keys so the caller falls back to a live listing.
  *
- * Resolution reads the authorize scope cached by `B2AuthManager` (~23h TTL), so
- * after a bucket rename a lookup by the new name can briefly miss (falling to the
- * "no match" path) and a lookup by id can display the stale cached name. This is
- * self-healing within the token TTL and never targets the wrong bucket — object
- * operations always use the resolved `id`, which a rename does not change.
+ * The scope is read from `B2AuthManager`'s ~23h cache, so a rename can briefly
+ * miss by new name or display a stale name by id. This self-heals within the
+ * token TTL and never targets the wrong bucket (object ops use the resolved id).
  *
- * Matching mirrors the unrestricted `resolveBucketName()` path exactly: an exact
- * name/id hit, else a substring match against in-scope names. It never echoes the
- * whole scope on a miss — on the `server`/`principal` HTTP modes the remote caller
- * does not hold the key, so dumping every in-scope bucket name for an arbitrary
- * bogus input would let them enumerate the credential's full bucket namespace.
+ * Matching mirrors `resolveBucketName()`: exact name/id, else substring. It never
+ * echoes the whole scope on a miss, since a `server`/`principal` HTTP caller does
+ * not hold the key and could otherwise enumerate its full bucket namespace.
  *
  * @returns The resolved bucket, in-scope candidates, or null for unrestricted keys.
  */
@@ -713,18 +707,14 @@ async function resolveFromAuthorizedScope(
 ): Promise<{ name?: string; id?: string; candidates?: string[]; outOfScope?: boolean } | null> {
   const { allowedBuckets } = await auth.getAuth();
   if (!allowedBuckets || allowedBuckets.length === 0) return null;
-  // An empty/blank input substring-matches every bucket, so treat it as a miss
-  // rather than let `includes("")` enumerate the whole scope. The tool schemas
-  // reject empty bucket values too; this is defense in depth for the guarantee.
+  // Blank input substring-matches every bucket; treat it as a miss so
+  // `includes("")` cannot enumerate the scope (schemas also reject empty input).
   if (input.trim() === "") return { outOfScope: true };
   const exact = allowedBuckets.find((b) => b.name === input || b.id === input);
-  // A key restricted by name (not id) may report a null name; matched by id we
-  // still have a usable id and fall back to the supplied input for display.
+  // A name-restricted key may report a null name; matched by id, display the input.
   if (exact) return { name: exact.name ?? input, id: exact.id };
-  // No exact hit: surface only in-scope names that partially match the input,
-  // never the full scope. A fully-unrelated input flags outOfScope so the error
-  // explains the bucket is outside the key's authorized scope, without leaking
-  // any in-scope names — while a genuine substring ambiguity still lists matches.
+  // No exact hit: surface only partially-matching names, never the full scope. A
+  // fully-unrelated input flags outOfScope so the error says so without leaking names.
   const subs = allowedBuckets.filter((b) => b.name?.includes(input));
   if (subs.length === 1 && subs[0].name) return { name: subs[0].name, id: subs[0].id };
   if (subs.length > 1) {

--- a/src/b2/insights.ts
+++ b/src/b2/insights.ts
@@ -688,7 +688,7 @@ export function computeSnapshotGrowth(
 /**
  * Resolve a bucket from the authorize response's `allowedBuckets` scope. A
  * bucket-scoped key cannot call the unfiltered `listBuckets()` (no `listBuckets`
- * capability -> 401), but its id (and usually name) is already in that scope.
+ * capability, so B2 answers 401), but its id (and usually name) is in scope.
  * Returns null for unrestricted keys so the caller falls back to a live listing.
  *
  * The scope is read from `B2AuthManager`'s ~23h cache, so a rename can briefly

--- a/src/b2/insights.ts
+++ b/src/b2/insights.ts
@@ -710,7 +710,7 @@ export function computeSnapshotGrowth(
 async function resolveFromAuthorizedScope(
   auth: B2AuthManager,
   input: string,
-): Promise<{ name?: string; id?: string; candidates?: string[] } | null> {
+): Promise<{ name?: string; id?: string; candidates?: string[]; outOfScope?: boolean } | null> {
   const { allowedBuckets } = await auth.getAuth();
   if (!allowedBuckets || allowedBuckets.length === 0) return null;
   const exact = allowedBuckets.find((b) => b.name === input || b.id === input);
@@ -718,14 +718,15 @@ async function resolveFromAuthorizedScope(
   // still have a usable id and fall back to the supplied input for display.
   if (exact) return { name: exact.name ?? input, id: exact.id };
   // No exact hit: surface only in-scope names that partially match the input,
-  // never the full scope. A fully-unrelated input yields {} → "No bucket matches",
-  // matching the unrestricted path's 'no match' vs 'ambiguous match' distinction.
+  // never the full scope. A fully-unrelated input flags outOfScope so the error
+  // explains the bucket is outside the key's authorized scope, without leaking
+  // any in-scope names — while a genuine substring ambiguity still lists matches.
   const subs = allowedBuckets.filter((b) => b.name?.includes(input));
   if (subs.length === 1 && subs[0].name) return { name: subs[0].name, id: subs[0].id };
   if (subs.length > 1) {
     return { candidates: subs.map((b) => b.name).filter((n): n is string => Boolean(n)) };
   }
-  return {};
+  return { outOfScope: true };
 }
 
 /** Resolve a bucket name/id pair from a name-or-bucketId input. */
@@ -733,7 +734,7 @@ async function resolveBucketName(
   b2Client: B2Client,
   auth: B2AuthManager,
   input: string,
-): Promise<{ name?: string; id?: string; candidates?: string[] }> {
+): Promise<{ name?: string; id?: string; candidates?: string[]; outOfScope?: boolean }> {
   const scoped = await resolveFromAuthorizedScope(auth, input);
   if (scoped) return scoped;
   const result = await b2Client.listBuckets();
@@ -750,7 +751,7 @@ async function resolveBucketName(
 
 function bucketResolutionError(
   input: string,
-  resolved: { name?: string; id?: string; candidates?: string[] },
+  resolved: { name?: string; id?: string; candidates?: string[]; outOfScope?: boolean },
 ): Record<string, unknown> | null {
   if (!resolved.name) {
     return {
@@ -758,7 +759,9 @@ function bucketResolutionError(
       candidates: resolved.candidates ?? [],
       note: resolved.candidates?.length
         ? "Multiple buckets match; pass an exact name or bucketId."
-        : `No bucket matches '${input}'.`,
+        : resolved.outOfScope
+          ? `Bucket '${input}' is not in the key's authorized scope (or does not exist).`
+          : `No bucket matches '${input}'.`,
     };
   }
   if (!resolved.id) {

--- a/src/b2/insights.ts
+++ b/src/b2/insights.ts
@@ -685,11 +685,39 @@ export function computeSnapshotGrowth(
 
 // ── Phase 2 helpers ─────────────────────────────────────────────────────────
 
+/**
+ * Resolve the caller's authorized bucket scope directly from the authorize
+ * response. A bucket-scoped key cannot call the unfiltered `listBuckets()`
+ * (it lacks the `listBuckets` capability and B2 answers 401), yet the authorized
+ * bucket's id — and usually its name — is already present in `allowedBuckets`.
+ * Returns null when the key is unrestricted (no recorded scope), so the caller
+ * falls back to a live listing.
+ *
+ * @returns The resolved bucket, in-scope candidates, or null for unrestricted keys.
+ */
+async function resolveFromAuthorizedScope(
+  auth: B2AuthManager,
+  input: string,
+): Promise<{ name?: string; id?: string; candidates?: string[] } | null> {
+  const { allowedBuckets } = await auth.getAuth();
+  if (!allowedBuckets || allowedBuckets.length === 0) return null;
+  const exact = allowedBuckets.find((b) => b.name === input || b.id === input);
+  // A key restricted by name (not id) may report a null name; matched by id we
+  // still have a usable id and fall back to the supplied input for display.
+  if (exact) return { name: exact.name ?? input, id: exact.id };
+  // Restricted key whose scope excludes the requested bucket: surface the
+  // in-scope names as candidates rather than let an out-of-scope listing 401.
+  return { candidates: allowedBuckets.map((b) => b.name).filter((n): n is string => Boolean(n)) };
+}
+
 /** Resolve a bucket name/id pair from a name-or-bucketId input. */
 async function resolveBucketName(
   b2Client: B2Client,
+  auth: B2AuthManager,
   input: string,
 ): Promise<{ name?: string; id?: string; candidates?: string[] }> {
+  const scoped = await resolveFromAuthorizedScope(auth, input);
+  if (scoped) return scoped;
   const result = await b2Client.listBuckets();
   const buckets = result.buckets ?? [];
   const exact = buckets.find((b) => b.bucketName === input || b.bucketId === input);
@@ -990,7 +1018,7 @@ export function registerInsightTools(
     },
     async (args) => {
       try {
-        const resolved = await resolveBucketName(b2Client, args.bucket);
+        const resolved = await resolveBucketName(b2Client, auth, args.bucket);
         const resolutionError = bucketResolutionError(args.bucket, resolved);
         if (resolutionError) return toolJson(resolutionError);
         const resolvedBucketName = resolved.name!;
@@ -1114,7 +1142,7 @@ export function registerInsightTools(
     },
     async (args) => {
       try {
-        const resolved = await resolveBucketName(b2Client, args.bucket);
+        const resolved = await resolveBucketName(b2Client, auth, args.bucket);
         const resolutionError = bucketResolutionError(args.bucket, resolved);
         if (resolutionError) return toolJson(resolutionError);
         const resolvedBucketName = resolved.name!;

--- a/src/b2/insights.ts
+++ b/src/b2/insights.ts
@@ -693,6 +693,18 @@ export function computeSnapshotGrowth(
  * Returns null when the key is unrestricted (no recorded scope), so the caller
  * falls back to a live listing.
  *
+ * Resolution reads the authorize scope cached by `B2AuthManager` (~23h TTL), so
+ * after a bucket rename a lookup by the new name can briefly miss (falling to the
+ * "no match" path) and a lookup by id can display the stale cached name. This is
+ * self-healing within the token TTL and never targets the wrong bucket — object
+ * operations always use the resolved `id`, which a rename does not change.
+ *
+ * Matching mirrors the unrestricted `resolveBucketName()` path exactly: an exact
+ * name/id hit, else a substring match against in-scope names. It never echoes the
+ * whole scope on a miss — on the `server`/`principal` HTTP modes the remote caller
+ * does not hold the key, so dumping every in-scope bucket name for an arbitrary
+ * bogus input would let them enumerate the credential's full bucket namespace.
+ *
  * @returns The resolved bucket, in-scope candidates, or null for unrestricted keys.
  */
 async function resolveFromAuthorizedScope(
@@ -705,9 +717,15 @@ async function resolveFromAuthorizedScope(
   // A key restricted by name (not id) may report a null name; matched by id we
   // still have a usable id and fall back to the supplied input for display.
   if (exact) return { name: exact.name ?? input, id: exact.id };
-  // Restricted key whose scope excludes the requested bucket: surface the
-  // in-scope names as candidates rather than let an out-of-scope listing 401.
-  return { candidates: allowedBuckets.map((b) => b.name).filter((n): n is string => Boolean(n)) };
+  // No exact hit: surface only in-scope names that partially match the input,
+  // never the full scope. A fully-unrelated input yields {} → "No bucket matches",
+  // matching the unrestricted path's 'no match' vs 'ambiguous match' distinction.
+  const subs = allowedBuckets.filter((b) => b.name?.includes(input));
+  if (subs.length === 1 && subs[0].name) return { name: subs[0].name, id: subs[0].id };
+  if (subs.length > 1) {
+    return { candidates: subs.map((b) => b.name).filter((n): n is string => Boolean(n)) };
+  }
+  return {};
 }
 
 /** Resolve a bucket name/id pair from a name-or-bucketId input. */

--- a/tests/fixtures/tool-contract/full.legacy.json
+++ b/tests/fixtures/tool-contract/full.legacy.json
@@ -473,6 +473,7 @@
         "properties": {
           "bucket": {
             "description": "Bucket name or bucketId to inspect.",
+            "minLength": 1,
             "type": "string"
           },
           "limit": {
@@ -759,6 +760,7 @@
         "properties": {
           "bucket": {
             "description": "Bucket name or bucketId to inspect.",
+            "minLength": 1,
             "type": "string"
           },
           "max_uploads": {
@@ -2029,5 +2031,5 @@
     "toolsListCacheHint": null,
     "discover": null
   },
-  "hash": "023b2a4c819f53a8ecbf3a0daca9d65a3d361bb0b0c8a81cd8afa3945d9c09fe"
+  "hash": "d2303ac126434295689e1bc06d2adb7d07441e96f53e88f0813594bdfe5b4a71"
 }

--- a/tests/fixtures/tool-contract/full.modern.json
+++ b/tests/fixtures/tool-contract/full.modern.json
@@ -473,6 +473,7 @@
         "properties": {
           "bucket": {
             "description": "Bucket name or bucketId to inspect.",
+            "minLength": 1,
             "type": "string"
           },
           "limit": {
@@ -759,6 +760,7 @@
         "properties": {
           "bucket": {
             "description": "Bucket name or bucketId to inspect.",
+            "minLength": 1,
             "type": "string"
           },
           "max_uploads": {
@@ -2042,5 +2044,5 @@
       "resultType": "complete"
     }
   },
-  "hash": "023b2a4c819f53a8ecbf3a0daca9d65a3d361bb0b0c8a81cd8afa3945d9c09fe"
+  "hash": "d2303ac126434295689e1bc06d2adb7d07441e96f53e88f0813594bdfe5b4a71"
 }

--- a/tests/fixtures/tool-contract/live-b2-contract.legacy.json
+++ b/tests/fixtures/tool-contract/live-b2-contract.legacy.json
@@ -465,6 +465,7 @@
         "properties": {
           "bucket": {
             "description": "Bucket name or bucketId to inspect.",
+            "minLength": 1,
             "type": "string"
           },
           "limit": {
@@ -751,6 +752,7 @@
         "properties": {
           "bucket": {
             "description": "Bucket name or bucketId to inspect.",
+            "minLength": 1,
             "type": "string"
           },
           "max_uploads": {
@@ -2021,5 +2023,5 @@
     "toolsListCacheHint": null,
     "discover": null
   },
-  "hash": "4d5c97ef2a70f3c45c5084dd9054b59e685b178d9240c177bac2162c1d967136"
+  "hash": "069b5c0910b3262e56fb821b1a8e1945c805689b67b4ebcf200f7f0ff9cad18c"
 }

--- a/tests/fixtures/tool-contract/live-b2-contract.modern.json
+++ b/tests/fixtures/tool-contract/live-b2-contract.modern.json
@@ -465,6 +465,7 @@
         "properties": {
           "bucket": {
             "description": "Bucket name or bucketId to inspect.",
+            "minLength": 1,
             "type": "string"
           },
           "limit": {
@@ -751,6 +752,7 @@
         "properties": {
           "bucket": {
             "description": "Bucket name or bucketId to inspect.",
+            "minLength": 1,
             "type": "string"
           },
           "max_uploads": {
@@ -2034,5 +2036,5 @@
       "resultType": "complete"
     }
   },
-  "hash": "4d5c97ef2a70f3c45c5084dd9054b59e685b178d9240c177bac2162c1d967136"
+  "hash": "069b5c0910b3262e56fb821b1a8e1945c805689b67b4ebcf200f7f0ff9cad18c"
 }

--- a/tests/fixtures/tool-contract/phase1-default.legacy.json
+++ b/tests/fixtures/tool-contract/phase1-default.legacy.json
@@ -441,6 +441,7 @@
         "properties": {
           "bucket": {
             "description": "Bucket name or bucketId to inspect.",
+            "minLength": 1,
             "type": "string"
           },
           "limit": {
@@ -653,6 +654,7 @@
         "properties": {
           "bucket": {
             "description": "Bucket name or bucketId to inspect.",
+            "minLength": 1,
             "type": "string"
           },
           "max_uploads": {
@@ -1923,5 +1925,5 @@
     "toolsListCacheHint": null,
     "discover": null
   },
-  "hash": "11be52cf8f077a208b7f6ecaa7335323f03a01360a8ce377f6e8d531498d10f4"
+  "hash": "c5aeb288ab6e0377d7c2da3582caadd0b3312c7bd8a27cb4a06adbc7c6f539ca"
 }

--- a/tests/fixtures/tool-contract/phase1-default.modern.json
+++ b/tests/fixtures/tool-contract/phase1-default.modern.json
@@ -441,6 +441,7 @@
         "properties": {
           "bucket": {
             "description": "Bucket name or bucketId to inspect.",
+            "minLength": 1,
             "type": "string"
           },
           "limit": {
@@ -653,6 +654,7 @@
         "properties": {
           "bucket": {
             "description": "Bucket name or bucketId to inspect.",
+            "minLength": 1,
             "type": "string"
           },
           "max_uploads": {
@@ -1936,5 +1938,5 @@
       "resultType": "complete"
     }
   },
-  "hash": "11be52cf8f077a208b7f6ecaa7335323f03a01360a8ce377f6e8d531498d10f4"
+  "hash": "c5aeb288ab6e0377d7c2da3582caadd0b3312c7bd8a27cb4a06adbc7c6f539ca"
 }

--- a/tests/fixtures/tool-contract/read-only.legacy.json
+++ b/tests/fixtures/tool-contract/read-only.legacy.json
@@ -183,6 +183,7 @@
         "properties": {
           "bucket": {
             "description": "Bucket name or bucketId to inspect.",
+            "minLength": 1,
             "type": "string"
           },
           "limit": {
@@ -308,6 +309,7 @@
         "properties": {
           "bucket": {
             "description": "Bucket name or bucketId to inspect.",
+            "minLength": 1,
             "type": "string"
           },
           "max_uploads": {
@@ -697,5 +699,5 @@
     "toolsListCacheHint": null,
     "discover": null
   },
-  "hash": "23a707ac7b596db31e641e7b4b670d05b7a1314d2c0d4cbc24639721987f0228"
+  "hash": "9873510da79d6862df6aa9b9d0bb55d4646f09b6daf6d89646f197b3845411c0"
 }

--- a/tests/fixtures/tool-contract/read-only.modern.json
+++ b/tests/fixtures/tool-contract/read-only.modern.json
@@ -183,6 +183,7 @@
         "properties": {
           "bucket": {
             "description": "Bucket name or bucketId to inspect.",
+            "minLength": 1,
             "type": "string"
           },
           "limit": {
@@ -308,6 +309,7 @@
         "properties": {
           "bucket": {
             "description": "Bucket name or bucketId to inspect.",
+            "minLength": 1,
             "type": "string"
           },
           "max_uploads": {
@@ -710,5 +712,5 @@
       "resultType": "complete"
     }
   },
-  "hash": "23a707ac7b596db31e641e7b4b670d05b7a1314d2c0d4cbc24639721987f0228"
+  "hash": "9873510da79d6862df6aa9b9d0bb55d4646f09b6daf6d89646f197b3845411c0"
 }

--- a/tests/unit/insights-read-paths.unit.test.ts
+++ b/tests/unit/insights-read-paths.unit.test.ts
@@ -46,6 +46,7 @@ type NativeInsightClient = Pick<
 
 type NativeClientOptions = {
   buckets?: BucketInfoResult[];
+  listBucketsError?: Error;
   filePages?: Array<ListFileNamesResult | Error>;
   uploadPages?: Array<ListUnfinishedLargeFilesResult | Error>;
   partPagesByFileId?: Record<string, Array<ListPartsResult | Error>>;
@@ -122,11 +123,10 @@ function createNativeClient(options: NativeClientOptions) {
     partPagesByFileId[fileId] = [...pages];
   }
   return {
-    listBuckets: vi.fn(
-      async (_input: BucketFilters = {}): Promise<ListBucketsResult> => ({
-        buckets: options.buckets ?? [bucket],
-      }),
-    ),
+    listBuckets: vi.fn(async (_input: BucketFilters = {}): Promise<ListBucketsResult> => {
+      if (options.listBucketsError) throw options.listBucketsError;
+      return { buckets: options.buckets ?? [bucket] };
+    }),
     listFileNames: vi.fn(async (_input: ListFileNamesOptions): Promise<ListFileNamesResult> => {
       const reply = filePages.shift() ?? { files: [], nextFileName: null };
       if (reply instanceof Error) throw reply;
@@ -153,12 +153,13 @@ function createNativeClient(options: NativeClientOptions) {
 function registerTools(
   reportClient: ReportObjectClient,
   nativeClient: NativeInsightClient = createNativeClient({}),
+  allowedBuckets?: Array<{ id: string; name: string | null }> | null,
 ) {
   const harness = new ToolHarness();
   registerInsightTools(
     harness,
     nativeClient as B2Client,
-    { getAuth: async () => ({ accountId: "test-account" }) } as Parameters<
+    { getAuth: async () => ({ accountId: "test-account", allowedBuckets }) } as Parameters<
       typeof registerInsightTools
     >[2],
     reportClient,
@@ -414,6 +415,65 @@ describe("insight native bucket read paths", () => {
 
     expect(result.error).toBe("bucket_not_uniquely_resolved");
     expect(result.candidates).toEqual(["logs-alpha", "logs-beta"]);
+  });
+
+  it("resolves a bucket-scoped key from its authorized scope without listBuckets", async () => {
+    // A bucket-scoped key cannot call the unfiltered listBuckets() — B2 answers
+    // 401 — so the tool must resolve from the authorize response's allowedBuckets.
+    const nativeClient = createNativeClient({
+      listBucketsError: Object.assign(new Error("unauthorized"), { status: 401 }),
+      filePages: [{ files: [file("raw/a.bin", 10 * GB)], nextFileName: null }],
+    });
+    const tools = registerTools(createPagedReportClient({}).client, nativeClient, [
+      { id: "bucket-1", name: "photos" },
+    ]);
+
+    const result = parseResult(
+      await tools.call("b2_largest_files", { bucket: "photos", limit: 5, max_scan: 1000 }),
+    );
+
+    expect(result).toMatchObject({ bucket: "photos", returned: 1, truncated: false });
+    expect(nativeClient.listBuckets).not.toHaveBeenCalled();
+    expect(nativeClient.listFileNames).toHaveBeenCalledWith(
+      expect.objectContaining({ bucketId: "bucket-1" }),
+    );
+  });
+
+  it("resolves a scoped bucket by bucketId even when its name is unknown", async () => {
+    const nativeClient = createNativeClient({
+      listBucketsError: Object.assign(new Error("unauthorized"), { status: 401 }),
+      uploadPages: [{ files: [], nextFileId: null }],
+    });
+    const tools = registerTools(createPagedReportClient({}).client, nativeClient, [
+      { id: "bucket-1", name: null },
+    ]);
+
+    const result = parseResult(
+      await tools.call("b2_unfinished_uploads", { bucket: "bucket-1", max_uploads: 10 }),
+    );
+
+    expect(result).toMatchObject({ bucket: "bucket-1", unfinished_count: 0 });
+    expect(nativeClient.listBuckets).not.toHaveBeenCalled();
+    expect(nativeClient.listUnfinishedLargeFiles).toHaveBeenCalledWith(
+      expect.objectContaining({ bucketId: "bucket-1" }),
+    );
+  });
+
+  it("surfaces in-scope candidates when a scoped key requests an out-of-scope bucket", async () => {
+    const nativeClient = createNativeClient({
+      listBucketsError: Object.assign(new Error("unauthorized"), { status: 401 }),
+    });
+    const tools = registerTools(createPagedReportClient({}).client, nativeClient, [
+      { id: "bucket-1", name: "photos" },
+    ]);
+
+    const result = parseResult(
+      await tools.call("b2_largest_files", { bucket: "other-bucket", limit: 5, max_scan: 1000 }),
+    );
+
+    expect(result.error).toBe("bucket_not_uniquely_resolved");
+    expect(result.candidates).toEqual(["photos"]);
+    expect(nativeClient.listBuckets).not.toHaveBeenCalled();
   });
 
   it("returns an empty b2_largest_files result and passes the prefix filter", async () => {

--- a/tests/unit/insights-read-paths.unit.test.ts
+++ b/tests/unit/insights-read-paths.unit.test.ts
@@ -489,6 +489,28 @@ describe("insight native bucket read paths", () => {
     expect(nativeClient.listBuckets).not.toHaveBeenCalled();
   });
 
+  it("treats an empty scoped bucket input as a miss, not a full-scope enumeration", async () => {
+    // Every non-null name satisfies name.includes(""), so a blank input must be a
+    // miss rather than dump the whole authorized namespace back to the caller.
+    const nativeClient = createNativeClient({
+      listBucketsError: Object.assign(new Error("unauthorized"), { status: 401 }),
+    });
+    const tools = registerTools(createPagedReportClient({}).client, nativeClient, [
+      { id: "bucket-1", name: "photos" },
+      { id: "bucket-2", name: "invoices" },
+    ]);
+
+    const result = parseResult(
+      await tools.call("b2_unfinished_uploads", { bucket: "", max_uploads: 10 }),
+    );
+
+    expect(result.error).toBe("bucket_not_uniquely_resolved");
+    expect(result.candidates).toEqual([]);
+    expect(result.note).not.toContain("photos");
+    expect(result.note).not.toContain("invoices");
+    expect(nativeClient.listBuckets).not.toHaveBeenCalled();
+  });
+
   it("surfaces only partially-matching in-scope names for an ambiguous scoped input", async () => {
     const nativeClient = createNativeClient({
       listBucketsError: Object.assign(new Error("unauthorized"), { status: 401 }),

--- a/tests/unit/insights-read-paths.unit.test.ts
+++ b/tests/unit/insights-read-paths.unit.test.ts
@@ -459,20 +459,49 @@ describe("insight native bucket read paths", () => {
     );
   });
 
-  it("surfaces in-scope candidates when a scoped key requests an out-of-scope bucket", async () => {
+  it("does not enumerate the key's scope when a scoped key requests an unrelated bucket", async () => {
+    // A bogus, fully-unrelated name must NOT echo the credential's whole bucket
+    // scope back — that would let a server/principal HTTP caller enumerate every
+    // in-scope bucket with one request. Expect a plain "no match", no candidates.
     const nativeClient = createNativeClient({
       listBucketsError: Object.assign(new Error("unauthorized"), { status: 401 }),
     });
     const tools = registerTools(createPagedReportClient({}).client, nativeClient, [
       { id: "bucket-1", name: "photos" },
+      { id: "bucket-2", name: "invoices" },
     ]);
 
     const result = parseResult(
-      await tools.call("b2_largest_files", { bucket: "other-bucket", limit: 5, max_scan: 1000 }),
+      await tools.call("b2_largest_files", {
+        bucket: "zzz-does-not-exist",
+        limit: 5,
+        max_scan: 1000,
+      }),
     );
 
     expect(result.error).toBe("bucket_not_uniquely_resolved");
-    expect(result.candidates).toEqual(["photos"]);
+    expect(result.candidates).toEqual([]);
+    expect(result.note).toBe("No bucket matches 'zzz-does-not-exist'.");
+    expect(nativeClient.listBuckets).not.toHaveBeenCalled();
+  });
+
+  it("surfaces only partially-matching in-scope names for an ambiguous scoped input", async () => {
+    const nativeClient = createNativeClient({
+      listBucketsError: Object.assign(new Error("unauthorized"), { status: 401 }),
+    });
+    const tools = registerTools(createPagedReportClient({}).client, nativeClient, [
+      { id: "logs-a", name: "logs-alpha" },
+      { id: "logs-b", name: "logs-beta" },
+      { id: "photos-1", name: "photos" },
+    ]);
+
+    const result = parseResult(
+      await tools.call("b2_largest_files", { bucket: "logs", limit: 5, max_scan: 1000 }),
+    );
+
+    expect(result.error).toBe("bucket_not_uniquely_resolved");
+    expect(result.candidates).toEqual(["logs-alpha", "logs-beta"]);
+    expect(result.note).toBe("Multiple buckets match; pass an exact name or bucketId.");
     expect(nativeClient.listBuckets).not.toHaveBeenCalled();
   });
 

--- a/tests/unit/insights-read-paths.unit.test.ts
+++ b/tests/unit/insights-read-paths.unit.test.ts
@@ -459,10 +459,10 @@ describe("insight native bucket read paths", () => {
     );
   });
 
-  it("does not enumerate the key's scope when a scoped key requests an unrelated bucket", async () => {
+  it("reports out-of-scope without enumerating the key's scope for an unrelated bucket", async () => {
     // A bogus, fully-unrelated name must NOT echo the credential's whole bucket
     // scope back — that would let a server/principal HTTP caller enumerate every
-    // in-scope bucket with one request. Expect a plain "no match", no candidates.
+    // in-scope bucket with one request. Expect an out-of-scope note, no candidates.
     const nativeClient = createNativeClient({
       listBucketsError: Object.assign(new Error("unauthorized"), { status: 401 }),
     });
@@ -481,7 +481,11 @@ describe("insight native bucket read paths", () => {
 
     expect(result.error).toBe("bucket_not_uniquely_resolved");
     expect(result.candidates).toEqual([]);
-    expect(result.note).toBe("No bucket matches 'zzz-does-not-exist'.");
+    expect(result.note).toBe(
+      "Bucket 'zzz-does-not-exist' is not in the key's authorized scope (or does not exist).",
+    );
+    expect(result.note).not.toContain("photos");
+    expect(result.note).not.toContain("invoices");
     expect(nativeClient.listBuckets).not.toHaveBeenCalled();
   });
 


### PR DESCRIPTION
## Summary

`b2_largest_files` and `b2_unfinished_uploads` resolved the supplied bucket by
first calling `b2Client.listBuckets()` with **no filter**. A bucket-scoped
application key — the recommended credential — cannot perform an unfiltered
account-wide listing, so B2 answered `HTTP 401` and both tools were unusable
even when given the exact authorized bucket name/ID.

The authorized bucket's id (and usually its name) is already present in the
authorize response (`auth.allowedBuckets`). The fix resolves the bucket directly
from that scope and never touches `listBuckets()` for a scoped key.

## What changed

**Scope-based resolution (`src/b2/insights.ts`)**

- New `resolveFromAuthorizedScope()` matches the input against `allowedBuckets`
  by name or id and returns `{ name, id }` — no listing call.
- Matched by id when the name is unknown (B2 may report a `null` name), it falls
  back to the supplied input for display while still using the resolved id.
- Unrestricted keys (no recorded scope) fall through to the existing live
  `listBuckets()` path, preserving partner substring/candidate matching.

**Review hardening (applied during review of this PR)**

- A resolve miss no longer echoes the credential's entire authorized bucket
  scope. Matching now mirrors the unrestricted path: exact hit, else substring;
  a fully-unrelated input surfaces no names. This closes a bucket-namespace
  enumeration vector on the `server`/`principal` HTTP credential modes, where the
  remote caller does not hold the key.
- An out-of-scope request now returns an accurate note
  (`Bucket 'X' is not in the key's authorized scope (or does not exist).`)
  instead of a misleading "Multiple buckets match".
- Empty/blank `bucket` input is rejected: both tool schemas use
  `z.string().min(1)`, and the resolver treats blank input as a miss so
  `includes("")` cannot enumerate the scope (defense in depth).
- The cached-authorize-scope staleness window (~23h token TTL) is documented; it
  self-heals within the TTL and never targets the wrong bucket since object
  operations always use the resolved id.

**Contract and budget refresh (to keep CI green)**

- Regenerated the frozen tool profile (`docs/tool-profile-contract.json`,
  `docs/TOOL_PROFILES.md`, `tests/fixtures/tool-contract/*.json`) for the new
  `minLength: 1` on the `bucket` schemas.
- Adjusted the Cloudflare Worker source-graph byte budget
  (`scripts/lib/local-import-graph.cjs`) and refreshed `package-budget.json`
  baseline/limits with modest headroom for the added logic.

## Linked issue

Closes #212

## Tests run

- `pnpm run typecheck`, `pnpm run lint`, `pnpm run format:check`,
  `pnpm run lint:docs`, `pnpm run lint:links`, `pnpm run spell`,
  `pnpm run verify` — all pass.
- `pnpm test` (full unit suite) — 1304 passed, including new
  `insights-read-paths` cases:
  - resolves a bucket-scoped key from its authorized scope without calling
    `listBuckets` (which throws 401 in the fake);
  - resolves a scoped bucket by `bucketId` when its name is unknown;
  - reports out-of-scope without enumerating the scope for an unrelated bucket;
  - treats an empty bucket input as a miss, not a full-scope enumeration;
  - surfaces only partially-matching in-scope names for an ambiguous input.
- `pnpm run test:contract` (266) and `pnpm run test:protocol` (9) — pass.
- `pnpm run check:package-budget` — passes.
- Full PR CI run — **31 checks green, 0 failing**.

## Follow-up notes

None.
