### PR TITLE
fix: persist preflight target so live-B2 finalize can prove policy

### DIFF
--- a/scripts/live-b2-evidence.mjs
+++ b/scripts/live-b2-evidence.mjs
@@ -127,7 +127,10 @@ function writePreflight(out, state, status, reason, details = {}) {
       statusReason: reason,
       configuration: state.configuration,
       credentialPolicy: state.credentialPolicy,
-      target: details.target,
+      // The passing path carries the computed target on `state`; blocked/error
+      // paths pass it (or nothing) via `details`. Prefer state so a "passed"
+      // preflight persists the account/notification proof the finalizer reads.
+      target: state.target ?? details.target,
       error: details.error,
     }),
   );
@@ -402,11 +405,19 @@ function runFinalize(options) {
   writeFinalEvidence(options);
 }
 
-try {
-  const options = parseArgs(process.argv.slice(2));
-  if (options.command === "preflight") await runPreflight(options);
-  else runFinalize(options);
-} catch (err) {
-  usage(err instanceof Error ? err.message : String(err));
-  process.exit(2);
+export { writePreflight, safeTarget };
+
+const invokedAsScript = process.argv[1]
+  ? pathToFileURL(process.argv[1]).href === import.meta.url
+  : false;
+
+if (invokedAsScript) {
+  try {
+    const options = parseArgs(process.argv.slice(2));
+    if (options.command === "preflight") await runPreflight(options);
+    else runFinalize(options);
+  } catch (err) {
+    usage(err instanceof Error ? err.message : String(err));
+    process.exit(2);
+  }
 }

--- a/scripts/live-b2-evidence.mjs
+++ b/scripts/live-b2-evidence.mjs
@@ -127,10 +127,11 @@ function writePreflight(out, state, status, reason, details = {}) {
       statusReason: reason,
       configuration: state.configuration,
       credentialPolicy: state.credentialPolicy,
-      // The passing path carries the computed target on `state`; blocked/error
-      // paths pass it (or nothing) via `details`. Prefer state so a "passed"
-      // preflight persists the account/notification proof the finalizer reads.
-      target: state.target ?? details.target,
+      // Only a "passed" preflight persists the account/notification proof the
+      // finalizer reads; it carries the computed target on `state`. Blocked/
+      // error paths must omit it, so they only honor an explicit `details.target`
+      // even when `state` (e.g. post-authorization evidence) already holds one.
+      target: status === "passed" ? (state.target ?? details.target) : details.target,
       error: details.error,
     }),
   );

--- a/tests/unit/live-b2-evidence.unit.test.ts
+++ b/tests/unit/live-b2-evidence.unit.test.ts
@@ -790,4 +790,43 @@ describe("live B2 evidence", () => {
       rmSync(dir, { recursive: true, force: true });
     }
   });
+
+  it("omits the target on a blocked preflight even when state carries one", async () => {
+    // The post-authorization blocked path passes the same state object that
+    // already holds a computed target. Blocked evidence must still omit target,
+    // so the state fallback only applies to a "passed" status.
+    const evidenceCli = (await import("../../scripts/live-b2-evidence.mjs")) as unknown as {
+      writePreflight(
+        out: string,
+        state: unknown,
+        status: string,
+        reason: string,
+        details?: { target?: unknown; error?: unknown },
+      ): void;
+    };
+
+    const dir = mkdtempSync(join(tmpdir(), "b2-mcp-live-preflight-blocked-"));
+    try {
+      const out = join(dir, "validation.json");
+      const state = {
+        configuration: {},
+        credentialPolicy: {},
+        target: {
+          accountMatchedExpectedLiveTestAccount: false,
+          accountFingerprint: null,
+        },
+      };
+
+      evidenceCli.writePreflight(out, state, "configuration blocked", "some config failure");
+
+      const written = JSON.parse(readFileSync(out, "utf8")) as {
+        status?: string;
+        target?: unknown;
+      };
+      expect(written.status).toBe("configuration blocked");
+      expect(written.target).toBeUndefined();
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
 });

--- a/tests/unit/live-b2-evidence.unit.test.ts
+++ b/tests/unit/live-b2-evidence.unit.test.ts
@@ -8,6 +8,7 @@ import { join } from "path";
 const nodeRequire = createRequire(__filename);
 const liveB2Capabilities = nodeRequire("../../scripts/lib/live-b2-capabilities.cjs") as {
   LIVE_B2_CONTRACT_REQUIRED_CAPABILITIES: string[];
+  LIVE_B2_CONTRACT_FORBIDDEN_CAPABILITIES: string[];
 };
 const liveB2Contract = nodeRequire("../../scripts/lib/live-b2-contract.cjs") as {
   stableResourceFingerprint(value: string): string;
@@ -76,6 +77,22 @@ const evidence = nodeRequire("../../scripts/lib/live-b2-evidence.cjs") as {
     options?: { expectedPrefix?: string; env?: Record<string, string> },
   ): unknown;
   writeEvidenceJson(path: string, value: unknown, env?: Record<string, string>): void;
+  readValidationSummary(
+    path: string,
+    options?: { expectedPrefix?: string; env?: Record<string, string> },
+  ): { present: boolean; summary: unknown; validationError: string | null };
+  validationSummaryProvesLiveB2Policy(
+    validationSummary: { present: boolean; summary: unknown; validationError: string | null },
+    options?: {
+      expectedPrefix?: string;
+      expectedToolProfile?: string;
+      expectedToolCount?: number;
+      expectedNamesHash?: string;
+      requiredCapabilities?: string[];
+      forbiddenCapabilities?: string[];
+      env?: Record<string, string>;
+    },
+  ): boolean;
 };
 
 const LIVE_PREFIX = "mcp-contract-run1";
@@ -682,6 +699,93 @@ describe("live B2 evidence", () => {
       expect(written.status).toBe("configuration blocked");
       expect(written.configuration.missingEnv).toContain("B2_REGION");
       expect(JSON.stringify(written)).not.toContain("fake-application-key");
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("persists the passing-path preflight target so finalize can prove policy (regression)", async () => {
+    // The matrix leg's preflight validates in-memory and exits 0, but finalize
+    // re-derives trust solely from the written validation summary. A passing
+    // preflight that drops the `target` block makes finalize read all-false
+    // account/notification proof and stamp the run "configuration blocked",
+    // failing "Require live B2 run success" even though tests and cleanup passed.
+    const evidenceCli = (await import("../../scripts/live-b2-evidence.mjs")) as unknown as {
+      writePreflight(
+        out: string,
+        state: unknown,
+        status: string,
+        reason: string,
+        details?: { target?: unknown; error?: unknown },
+      ): void;
+    };
+
+    const dir = mkdtempSync(join(tmpdir(), "b2-mcp-live-preflight-"));
+    try {
+      const out = join(dir, "validation.json");
+      const requiredCapabilities = liveB2Capabilities.LIVE_B2_CONTRACT_REQUIRED_CAPABILITIES;
+      const forbiddenCapabilities = liveB2Capabilities.LIVE_B2_CONTRACT_FORBIDDEN_CAPABILITIES;
+
+      // Mirrors the object runPreflight() builds on the passing path: the computed
+      // target lives on `state`, and writePreflight() is invoked with no details arg.
+      const target = {
+        accountMatchedExpectedLiveTestAccount: true,
+        accountFingerprint: EXPECTED_ACCOUNT_FINGERPRINT,
+        expectedAccountFingerprint: EXPECTED_ACCOUNT_FINGERPRINT,
+        notificationBucketConfigured: true,
+        notificationBucketValidated: true,
+        notificationRuleToolRegistered: true,
+        notificationBucketFingerprint: EXPECTED_NOTIFICATION_BUCKET_FINGERPRINT,
+      };
+      const state = {
+        configuration: {
+          expectedToolProfile: EXPECTED_PROFILE,
+          expectedToolProfileApproved: true,
+          actualToolProfile: {
+            toolCount: EXPECTED_PROFILE_NAMES.length,
+            namesHash: EXPECTED_PROFILE_HASH,
+            matchesExpectedProfile: true,
+            missingExpectedTools: [],
+            unexpectedTools: [],
+          },
+        },
+        credentialPolicy: {
+          nonMasterApplicationKey: true,
+          overbroadCredentialRejected: false,
+          requiredCapabilitiesPresent: [...requiredCapabilities],
+          missingRequiredCapabilities: [],
+          forbiddenCapabilitiesGranted: [],
+        },
+        target,
+      };
+
+      evidenceCli.writePreflight(
+        out,
+        state,
+        "passed",
+        "live B2 validation passed for this Node matrix leg",
+      );
+
+      // Direct: the writer must persist the state target it was given.
+      const written = JSON.parse(readFileSync(out, "utf8")) as { target?: unknown };
+      expect(written.target).toEqual(target);
+
+      // End-to-end: the finalizer must accept the summary the writer produced.
+      const proven = evidence.validationSummaryProvesLiveB2Policy(
+        evidence.readValidationSummary(out, {}),
+        {
+          expectedToolProfile: EXPECTED_PROFILE,
+          expectedToolCount: EXPECTED_PROFILE_NAMES.length,
+          expectedNamesHash: EXPECTED_PROFILE_HASH,
+          requiredCapabilities,
+          forbiddenCapabilities,
+          env: {
+            B2_LIVE_TEST_ACCOUNT_ID: EXPECTED_ACCOUNT_ID,
+            B2_LIVE_NOTIFICATION_BUCKET: EXPECTED_NOTIFICATION_BUCKET,
+          },
+        },
+      );
+      expect(proven).toBe(true);
     } finally {
       rmSync(dir, { recursive: true, force: true });
     }


### PR DESCRIPTION
## Problem

The scheduled **Live B2 Contract** workflow fails every run at the **Require live B2 run success** step with `live B2 evidence status was configuration blocked` (exit 1) — even though matrix validation, the live suites, and cleanup all pass. Example: [run 32647933970](https://github.com/backblaze-labs/b2-mcp/actions/runs/32647933970).

The uploaded evidence artifact is the tell: `outcomes: { preflight, tests, cleanup } = success`, validation `status: "passed"`, `validationError: null` — yet `validation.target` shows `accountMatchedExpectedLiveTestAccount: false`, `accountFingerprint: null`, and every notification field `false`. That is exactly the all-`false`/`null` default `validateValidationSummary()` emits when the summary carries **no `target` block**.

## Root cause

On the passing path, `runPreflight()` computes the account/notification `target` onto `state` and calls:

```js
writePreflight(options.out, nextEvidence, "passed", preflightPassedReason());  // no details arg
```

But `writePreflight()` sourced the target from `details.target` (undefined), so `createPreflightEvidence()` omitted the `target` block entirely. `finalize` re-derives trust **solely** from the written summary via `validationSummaryProvesLiveB2Policy()`, reads the empty target, and downgrades the run to `configuration blocked`.

The `matrix_validation` step still passed because it validates the correct **in-memory** values and `exit(2)`s only on a real config failure — only the *serialized* evidence dropped `target`. The harness unit tests hand-build complete summaries, so the real writer was never exercised; and the whole flow was unreachable in CI until the missing `B2_MCP_EXPECTED_TOOL_PROFILE` repository/environment variable was configured, which is what first surfaced this latent bug.

## Fix

`writePreflight()` now persists the account/notification `target` **only on a `"passed"` preflight**, where it carries the computed target on `state`:

```js
target: status === "passed" ? (state.target ?? details.target) : details.target,
```

A `"passed"` preflight now persists the proof the finalizer requires. Blocked/error paths still correctly omit `target` — including the **post-authorization configuration-blocked path**, which passes the same `state` object that already holds a computed target; gating on `status === "passed"` ensures that state target is not serialized into blocked evidence, so those paths only honor an explicitly supplied `details.target`.

Also makes `scripts/live-b2-evidence.mjs` importable (main-module guard + `export { writePreflight, safeTarget }`) and adds regression tests that drive the **real** writer end-to-end through `validationSummaryProvesLiveB2Policy`, so a dropped target can't silently regress again, plus a test asserting the blocked path omits `target` even when `state` carries one.

## Verification

- New passing-path regression test is **RED before** the fix (`written.target` is `undefined`), **GREEN after**; the blocked-path test asserts `written.target` stays `undefined`.
- `pnpm run verify` passes end-to-end (typecheck, build, doc/deployment contracts, lint, docs, links, skills, format, spell, runtime-security, diagnostics).
- Full unit **1305 pass** · contract **266** · protocol pass · biome lint + format clean.
- CLI smoke: direct invocation still prints usage / writes `configuration blocked`; import no longer runs the CLI.

> Note: the live workflow runs only on `main`/`ci-green`, so this is exercised in CI once merged and a run is dispatched.

## Commits

- `fix: persist preflight target so live-B2 finalize can prove policy` — the core fix: passing preflight persists `target`; makes the script importable; adds the end-to-end regression test.
- `fix: omit preflight target on blocked path with state target` — gates the `state.target` fallback on `"passed"` so the post-authorization blocked path keeps omitting `target` (addresses review feedback); adds the blocked-path regression test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
