### PR TITLE
evals: add Anthropic Haiku 4.5 driver

### DIFF
--- a/evals/anthropic-driver.eval.test.ts
+++ b/evals/anthropic-driver.eval.test.ts
@@ -239,48 +239,75 @@ describe("Anthropic eval driver", () => {
     expect((caught as Error).message).not.toContain(largeBody);
   });
 
-  it("retries retryable Anthropic statuses before returning a successful turn", async () => {
-    const fetchImpl = vi
-      .fn<AnthropicFetch>()
-      .mockResolvedValueOnce(
-        new Response(JSON.stringify({ error: { message: "overloaded" } }), {
-          status: 529,
-          headers: { "retry-after": "0" },
-        }),
-      )
-      .mockResolvedValueOnce(
-        new Response(
-          JSON.stringify({
-            content: [{ type: "text", text: "Recovered." }],
+  it.each([408, 409, 529] as const)(
+    "retries retryable Anthropic status %i before returning a successful turn",
+    async (status) => {
+      const fetchImpl = vi
+        .fn<AnthropicFetch>()
+        .mockResolvedValueOnce(
+          new Response(JSON.stringify({ error: { message: "transient failure" } }), {
+            status,
+            headers: { "retry-after": "0" },
           }),
-          { status: 200 },
-        ),
+        )
+        .mockResolvedValueOnce(
+          new Response(
+            JSON.stringify({
+              content: [{ type: "text", text: "Recovered." }],
+            }),
+            { status: 200 },
+          ),
+        );
+      const driver = createAnthropicDriver({
+        apiKey: "test-anthropic-key",
+        fetch: fetchImpl,
+        retry: { baseDelayMs: 0, maxDelayMs: 0 },
+      });
+
+      await expect(driver.complete(driverInput({}))).resolves.toEqual({
+        text: "Recovered.",
+        toolCalls: [],
+      });
+      expect(fetchImpl).toHaveBeenCalledTimes(2);
+    },
+  );
+
+  it.each(["max_tokens", "model_context_window_exceeded"] as const)(
+    "rejects %s-truncated Anthropic responses instead of consuming them",
+    async (stopReason) => {
+      const { fetchImpl } = createFetchSequence([
+        {
+          stop_reason: stopReason,
+          content: [{ type: "text", text: "Partial" }],
+        },
+      ]);
+      const driver = createAnthropicDriver({ apiKey: "test-anthropic-key", fetch: fetchImpl });
+
+      await expect(driver.complete(driverInput({}))).rejects.toThrow(
+        new RegExp(`stopped with ${stopReason}`),
       );
+    },
+  );
+
+  it("does not retry non-retryable authentication failures", async () => {
+    const fetchImpl = vi.fn<AnthropicFetch>().mockResolvedValueOnce(
+      new Response(
+        JSON.stringify({
+          error: { type: "authentication_error", message: "invalid api key" },
+        }),
+        { status: 401 },
+      ),
+    );
     const driver = createAnthropicDriver({
-      apiKey: "test-anthropic-key",
+      apiKey: "bad-key",
       fetch: fetchImpl,
-      retry: { baseDelayMs: 0, maxDelayMs: 0 },
+      retry: { maxAttempts: 3, baseDelayMs: 0, maxDelayMs: 0 },
     });
-
-    await expect(driver.complete(driverInput({}))).resolves.toEqual({
-      text: "Recovered.",
-      toolCalls: [],
-    });
-    expect(fetchImpl).toHaveBeenCalledTimes(2);
-  });
-
-  it("rejects max_tokens-truncated Anthropic responses instead of consuming them", async () => {
-    const { fetchImpl } = createFetchSequence([
-      {
-        stop_reason: "max_tokens",
-        content: [{ type: "text", text: "Partial" }],
-      },
-    ]);
-    const driver = createAnthropicDriver({ apiKey: "test-anthropic-key", fetch: fetchImpl });
 
     await expect(driver.complete(driverInput({}))).rejects.toThrow(
-      /max_tokens was reached; increase maxTokens/,
+      /Anthropic Messages API request failed \(401\): invalid api key/,
     );
+    expect(fetchImpl).toHaveBeenCalledTimes(1);
   });
 
   it("uses the Haiku 4.5 model and gates on ANTHROPIC_API_KEY by default", () => {

--- a/evals/anthropic-driver.eval.test.ts
+++ b/evals/anthropic-driver.eval.test.ts
@@ -1,0 +1,239 @@
+import type { CallToolResult, Tool } from "@modelcontextprotocol/client";
+import { describe, expect, it, vi } from "vitest";
+import {
+  ANTHROPIC_API_KEY_ENV,
+  anthropicEvalGate,
+  createAnthropicDriver,
+  DEFAULT_ANTHROPIC_MODEL,
+  type AnthropicFetch,
+} from "./anthropic-driver";
+import { runEval, type EvalMessage, type EvalToolCall } from "./harness";
+
+interface CapturedRequest {
+  url: string | URL;
+  init: RequestInit | undefined;
+  body: Record<string, unknown>;
+}
+
+const deleteBucketTool = {
+  name: "b2_delete_bucket",
+  description: "Delete a B2 bucket.",
+  inputSchema: {
+    type: "object",
+    properties: {
+      bucketId: { type: "string" },
+      confirm: { type: "boolean" },
+    },
+    required: ["bucketId"],
+  },
+} satisfies Tool;
+
+function abortSignal(): AbortSignal {
+  return new AbortController().signal;
+}
+
+function createFetchSequence(responses: unknown[]): {
+  fetchImpl: AnthropicFetch;
+  requests: CapturedRequest[];
+} {
+  const requests: CapturedRequest[] = [];
+  const fetchImpl = vi.fn<AnthropicFetch>(async (url, init) => {
+    requests.push({
+      url,
+      init,
+      body: JSON.parse(String(init?.body ?? "{}")) as Record<string, unknown>,
+    });
+    const response = responses.shift();
+    return new Response(JSON.stringify(response), {
+      status: 200,
+      headers: { "content-type": "application/json" },
+    });
+  });
+  return { fetchImpl, requests };
+}
+
+function driverInput(args: {
+  prompt?: string;
+  tools?: Tool[];
+  messages?: EvalMessage[];
+  step?: number;
+}) {
+  const prompt = args.prompt ?? "Use the delete bucket tool.";
+  return {
+    prompt,
+    tools: args.tools ?? [deleteBucketTool],
+    messages: args.messages ?? [{ role: "user" as const, content: prompt }],
+    step: args.step ?? 0,
+    maxSteps: 2,
+    signal: abortSignal(),
+  };
+}
+
+describe("Anthropic eval driver", () => {
+  it("maps MCP tools into Anthropic tools and returns normalized tool calls", async () => {
+    const { fetchImpl, requests } = createFetchSequence([
+      {
+        content: [
+          { type: "text", text: "I will check deletion." },
+          {
+            type: "tool_use",
+            id: "toolu_1",
+            name: "b2_delete_bucket",
+            input: { bucketId: "bucket-id", confirm: true },
+          },
+        ],
+      },
+    ]);
+    const driver = createAnthropicDriver({
+      apiKey: "test-anthropic-key",
+      model: "test-model",
+      fetch: fetchImpl,
+    });
+
+    const output = await driver.complete(driverInput({}));
+
+    expect(output).toEqual({
+      text: "I will check deletion.",
+      toolCalls: [{ name: "b2_delete_bucket", args: { bucketId: "bucket-id", confirm: true } }],
+    });
+    expect(requests).toHaveLength(1);
+    expect(requests[0].url).toBe("https://api.anthropic.com/v1/messages");
+    expect(requests[0].init?.headers).toMatchObject({
+      "anthropic-version": "2023-06-01",
+      "content-type": "application/json",
+      "x-api-key": "test-anthropic-key",
+    });
+    expect(requests[0].body).toMatchObject({
+      model: "test-model",
+      max_tokens: 1024,
+      tools: [
+        {
+          name: "b2_delete_bucket",
+          description: "Delete a B2 bucket.",
+          input_schema: deleteBucketTool.inputSchema,
+        },
+      ],
+      messages: [{ role: "user", content: "Use the delete bucket tool." }],
+    });
+  });
+
+  it("sends structuredContent back as the preferred Anthropic tool_result content", async () => {
+    const { fetchImpl, requests } = createFetchSequence([
+      {
+        content: [
+          {
+            type: "tool_use",
+            id: "toolu_1",
+            name: "b2_delete_bucket",
+            input: { bucketId: "bucket-id", confirm: true },
+          },
+        ],
+      },
+      { content: [{ type: "text", text: "Deletion is blocked." }] },
+    ]);
+    const driver = createAnthropicDriver({
+      apiKey: "test-anthropic-key",
+      fetch: fetchImpl,
+    });
+    const toolCall: EvalToolCall = {
+      name: "b2_delete_bucket",
+      args: { bucketId: "bucket-id", confirm: true },
+    };
+    const toolResult = {
+      isError: true,
+      structuredContent: { code: "destructive_policy_blocked", status: 403 },
+      content: [{ type: "text", text: "fallback text" }],
+    } satisfies CallToolResult;
+
+    await driver.complete(driverInput({}));
+    const output = await driver.complete(
+      driverInput({
+        step: 1,
+        messages: [
+          { role: "user", content: "Use the delete bucket tool." },
+          { role: "assistant", content: "", toolCalls: [toolCall] },
+          { role: "tool", toolCall, result: toolResult },
+        ],
+      }),
+    );
+
+    expect(output).toEqual({ text: "Deletion is blocked.", toolCalls: [] });
+    expect(requests[1].body.messages).toEqual([
+      { role: "user", content: "Use the delete bucket tool." },
+      {
+        role: "assistant",
+        content: [
+          {
+            type: "tool_use",
+            id: "toolu_1",
+            name: "b2_delete_bucket",
+            input: { bucketId: "bucket-id", confirm: true },
+          },
+        ],
+      },
+      {
+        role: "user",
+        content: [
+          {
+            type: "tool_result",
+            tool_use_id: "toolu_1",
+            content: '{"code":"destructive_policy_blocked","status":403}',
+            is_error: true,
+          },
+        ],
+      },
+    ]);
+  });
+
+  it("surfaces Anthropic API errors with response status and message", async () => {
+    const fetchImpl = vi.fn<AnthropicFetch>(
+      async () =>
+        new Response(
+          JSON.stringify({
+            error: { type: "authentication_error", message: "invalid api key" },
+          }),
+          { status: 401 },
+        ),
+    );
+    const driver = createAnthropicDriver({ apiKey: "bad-key", fetch: fetchImpl });
+
+    await expect(driver.complete(driverInput({}))).rejects.toThrow(
+      /Anthropic Messages API request failed \(401\): invalid api key/,
+    );
+  });
+
+  it("uses the Haiku 4.5 model and gates on ANTHROPIC_API_KEY by default", () => {
+    expect(DEFAULT_ANTHROPIC_MODEL).toBe("claude-haiku-4-5-20251001");
+    expect(anthropicEvalGate({ RUN_LLM_EVALS: "1" })).toEqual({
+      enabled: false,
+      reason: `missing provider key (${ANTHROPIC_API_KEY_ENV})`,
+    });
+    expect(
+      anthropicEvalGate({ RUN_LLM_EVALS: "1", [ANTHROPIC_API_KEY_ENV]: "test-key" }).enabled,
+    ).toBe(true);
+  });
+});
+
+const liveGate = anthropicEvalGate();
+
+describe("Anthropic Haiku 4.5 live eval", () => {
+  it.skipIf(!liveGate.enabled)("runs a gated tool-use eval end to end", async () => {
+    const run = await runEval({
+      prompt:
+        "Call b2_delete_bucket exactly once with arguments " +
+        '{"bucketId":"eval-bucket-id","confirm":true}. Then summarize the result.',
+      toolNames: ["b2_delete_bucket"],
+      driver: createAnthropicDriver(),
+      maxSteps: 3,
+      timeouts: { driverStepMs: 60_000 },
+    });
+
+    expect(run.toolCalls[0]).toEqual({
+      name: "b2_delete_bucket",
+      args: { bucketId: "eval-bucket-id", confirm: true },
+    });
+    expect(run.toolResults[0].isError).toBe(true);
+    expect(JSON.stringify(run.toolResults[0])).toContain("destructive_policy_blocked");
+    expect(run.text).toMatch(/blocked|refused|destructive/i);
+  });
+});

--- a/evals/anthropic-driver.eval.test.ts
+++ b/evals/anthropic-driver.eval.test.ts
@@ -117,6 +117,19 @@ describe("Anthropic eval driver", () => {
     });
   });
 
+  it("rejects caller-supplied baseUrl values before attaching the API key", () => {
+    const fetchImpl = vi.fn<AnthropicFetch>();
+
+    expect(() =>
+      createAnthropicDriver({
+        apiKey: "test-anthropic-key",
+        fetch: fetchImpl,
+        ...({ baseUrl: "https://attacker.example/collect" } as Record<string, unknown>),
+      }),
+    ).toThrow(/does not support overriding baseUrl/);
+    expect(fetchImpl).not.toHaveBeenCalled();
+  });
+
   it("sends structuredContent back as the preferred Anthropic tool_result content", async () => {
     const { fetchImpl, requests } = createFetchSequence([
       {
@@ -192,13 +205,81 @@ describe("Anthropic eval driver", () => {
           JSON.stringify({
             error: { type: "authentication_error", message: "invalid api key" },
           }),
-          { status: 401 },
+          { status: 401, headers: { "request-id": "req_auth" } },
         ),
     );
     const driver = createAnthropicDriver({ apiKey: "bad-key", fetch: fetchImpl });
 
     await expect(driver.complete(driverInput({}))).rejects.toThrow(
-      /Anthropic Messages API request failed \(401\): invalid api key/,
+      /Anthropic Messages API request failed \(401\): invalid api key \(requestId: req_auth\)/,
+    );
+    expect(fetchImpl).toHaveBeenCalledTimes(1);
+  });
+
+  it("bounds non-JSON upstream error fallback bodies", async () => {
+    const largeBody = "gateway failure ".repeat(100);
+    const fetchImpl = vi.fn<AnthropicFetch>(
+      async () => new Response(largeBody, { status: 502, statusText: "Bad Gateway" }),
+    );
+    const driver = createAnthropicDriver({
+      apiKey: "test-anthropic-key",
+      fetch: fetchImpl,
+      retry: { maxAttempts: 1 },
+    });
+
+    let caught: unknown;
+    await driver.complete(driverInput({})).catch((err: unknown) => {
+      caught = err;
+    });
+
+    expect(caught).toBeInstanceOf(Error);
+    expect((caught as Error).message).toContain(
+      `Anthropic Messages API request failed (502): ${largeBody.slice(0, 500)}`,
+    );
+    expect((caught as Error).message).not.toContain(largeBody);
+  });
+
+  it("retries retryable Anthropic statuses before returning a successful turn", async () => {
+    const fetchImpl = vi
+      .fn<AnthropicFetch>()
+      .mockResolvedValueOnce(
+        new Response(JSON.stringify({ error: { message: "overloaded" } }), {
+          status: 529,
+          headers: { "retry-after": "0" },
+        }),
+      )
+      .mockResolvedValueOnce(
+        new Response(
+          JSON.stringify({
+            content: [{ type: "text", text: "Recovered." }],
+          }),
+          { status: 200 },
+        ),
+      );
+    const driver = createAnthropicDriver({
+      apiKey: "test-anthropic-key",
+      fetch: fetchImpl,
+      retry: { baseDelayMs: 0, maxDelayMs: 0 },
+    });
+
+    await expect(driver.complete(driverInput({}))).resolves.toEqual({
+      text: "Recovered.",
+      toolCalls: [],
+    });
+    expect(fetchImpl).toHaveBeenCalledTimes(2);
+  });
+
+  it("rejects max_tokens-truncated Anthropic responses instead of consuming them", async () => {
+    const { fetchImpl } = createFetchSequence([
+      {
+        stop_reason: "max_tokens",
+        content: [{ type: "text", text: "Partial" }],
+      },
+    ]);
+    const driver = createAnthropicDriver({ apiKey: "test-anthropic-key", fetch: fetchImpl });
+
+    await expect(driver.complete(driverInput({}))).rejects.toThrow(
+      /max_tokens was reached; increase maxTokens/,
     );
   });
 
@@ -228,10 +309,12 @@ describe("Anthropic Haiku 4.5 live eval", () => {
       timeouts: { driverStepMs: 60_000 },
     });
 
-    expect(run.toolCalls[0]).toEqual({
-      name: "b2_delete_bucket",
-      args: { bucketId: "eval-bucket-id", confirm: true },
-    });
+    expect(run.toolCalls).toEqual([
+      {
+        name: "b2_delete_bucket",
+        args: { bucketId: "eval-bucket-id", confirm: true },
+      },
+    ]);
     expect(run.toolResults[0].isError).toBe(true);
     expect(JSON.stringify(run.toolResults[0])).toContain("destructive_policy_blocked");
     expect(run.text).toMatch(/blocked|refused|destructive/i);

--- a/evals/anthropic-driver.ts
+++ b/evals/anthropic-driver.ts
@@ -1,0 +1,316 @@
+import type { CallToolResult, Tool } from "@modelcontextprotocol/client";
+import {
+  llmEvalGate,
+  type Driver,
+  type DriverInput,
+  type DriverOutput,
+  type EvalGate,
+  type EvalToolCall,
+} from "./harness";
+
+export const ANTHROPIC_API_KEY_ENV = "ANTHROPIC_API_KEY";
+export const DEFAULT_ANTHROPIC_MODEL = "claude-haiku-4-5-20251001";
+
+const ANTHROPIC_MESSAGES_URL = "https://api.anthropic.com/v1/messages";
+const ANTHROPIC_VERSION = "2023-06-01";
+const DEFAULT_MAX_TOKENS = 1024;
+const DEFAULT_SYSTEM_PROMPT =
+  "You are running deterministic MCP evals. Use the provided tools when the user asks for " +
+  "tool-backed evidence, then give a concise final answer based on the tool result.";
+
+export type AnthropicFetch = (input: string | URL, init?: RequestInit) => Promise<Response>;
+
+export interface AnthropicDriverOptions {
+  apiKey?: string;
+  model?: string;
+  maxTokens?: number;
+  system?: string;
+  baseUrl?: string;
+  fetch?: AnthropicFetch;
+}
+
+interface AnthropicTool {
+  name: string;
+  description: string;
+  input_schema: Record<string, unknown>;
+}
+
+interface AnthropicTextBlock {
+  type: "text";
+  text: string;
+}
+
+interface AnthropicToolUseBlock {
+  type: "tool_use";
+  id: string;
+  name: string;
+  input: Record<string, unknown>;
+}
+
+interface AnthropicToolResultBlock {
+  type: "tool_result";
+  tool_use_id: string;
+  content: string;
+  is_error?: true;
+}
+
+type AnthropicAssistantContentBlock = AnthropicTextBlock | AnthropicToolUseBlock;
+type AnthropicUserContentBlock = AnthropicTextBlock | AnthropicToolResultBlock;
+
+interface AnthropicMessage {
+  role: "user" | "assistant";
+  content: string | AnthropicAssistantContentBlock[] | AnthropicUserContentBlock[];
+}
+
+interface AnthropicRequestBody {
+  model: string;
+  max_tokens: number;
+  system?: string;
+  messages: AnthropicMessage[];
+  tools?: AnthropicTool[];
+}
+
+interface PendingToolUse {
+  id: string;
+  call: EvalToolCall;
+}
+
+export function anthropicEvalGate(env: NodeJS.ProcessEnv = process.env): EvalGate {
+  return llmEvalGate(env, { providerKeyEnvNames: [ANTHROPIC_API_KEY_ENV] });
+}
+
+export function createAnthropicDriver(options: AnthropicDriverOptions = {}): Driver {
+  return new AnthropicMessagesDriver(options);
+}
+
+function positiveInteger(value: number, name: string): number {
+  if (!Number.isInteger(value) || value <= 0) {
+    throw new Error(`${name} must be a positive integer.`);
+  }
+  return value;
+}
+
+function requireApiKey(value: string | undefined): string {
+  if (!value) {
+    throw new Error(`${ANTHROPIC_API_KEY_ENV} is required to run Anthropic evals.`);
+  }
+  return value;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function inputSchemaForTool(tool: Tool): Record<string, unknown> {
+  return isRecord(tool.inputSchema) ? tool.inputSchema : { type: "object", properties: {} };
+}
+
+function toAnthropicTool(tool: Tool): AnthropicTool {
+  return {
+    name: tool.name,
+    description: tool.description ?? "MCP tool exposed by b2-mcp.",
+    input_schema: inputSchemaForTool(tool),
+  };
+}
+
+function stringifyToolResultPayload(value: unknown): string {
+  if (typeof value === "string") return value;
+  try {
+    return JSON.stringify(value);
+  } catch {
+    return String(value);
+  }
+}
+
+function textFromContentBlocks(content: CallToolResult["content"]): string {
+  const parts = content.map((block) => {
+    if (block.type === "text") return block.text;
+    return stringifyToolResultPayload(block);
+  });
+  return parts.join("\n");
+}
+
+function toolResultContent(result: CallToolResult): string {
+  if (result.structuredContent !== undefined) {
+    return stringifyToolResultPayload(result.structuredContent);
+  }
+  return textFromContentBlocks(result.content);
+}
+
+function toToolResultBlock(
+  pending: PendingToolUse,
+  result: CallToolResult,
+): AnthropicToolResultBlock {
+  return {
+    type: "tool_result",
+    tool_use_id: pending.id,
+    content: toolResultContent(result),
+    ...(result.isError === true ? { is_error: true } : {}),
+  };
+}
+
+function parseToolInput(name: string, input: unknown): Record<string, unknown> {
+  if (!isRecord(input)) {
+    throw new Error(`Anthropic returned invalid input for tool call ${name}.`);
+  }
+  return input;
+}
+
+function parseContentBlocks(payload: unknown): AnthropicAssistantContentBlock[] {
+  if (!isRecord(payload) || !Array.isArray(payload.content)) {
+    throw new Error("Anthropic response did not include a content array.");
+  }
+
+  const blocks: AnthropicAssistantContentBlock[] = [];
+  for (const block of payload.content) {
+    if (!isRecord(block) || typeof block.type !== "string") continue;
+    if (block.type === "text" && typeof block.text === "string") {
+      blocks.push({ type: "text", text: block.text });
+    }
+    if (
+      block.type === "tool_use" &&
+      typeof block.id === "string" &&
+      typeof block.name === "string"
+    ) {
+      blocks.push({
+        type: "tool_use",
+        id: block.id,
+        name: block.name,
+        input: parseToolInput(block.name, block.input),
+      });
+    }
+  }
+  return blocks;
+}
+
+function extractErrorMessage(payload: unknown, fallback: string): string {
+  if (isRecord(payload) && isRecord(payload.error) && typeof payload.error.message === "string") {
+    return payload.error.message;
+  }
+  return fallback;
+}
+
+async function readAnthropicResponse(response: Response): Promise<unknown> {
+  const text = await response.text();
+  let payload: unknown;
+  try {
+    payload = text ? JSON.parse(text) : {};
+  } catch {
+    payload = undefined;
+  }
+
+  if (!response.ok) {
+    throw new Error(
+      `Anthropic Messages API request failed (${response.status}): ` +
+        extractErrorMessage(payload, text || response.statusText),
+    );
+  }
+  if (payload === undefined) {
+    throw new Error("Anthropic Messages API returned invalid JSON.");
+  }
+  return payload;
+}
+
+function textFromAssistantBlocks(blocks: AnthropicAssistantContentBlock[]): string {
+  return blocks
+    .filter((block): block is AnthropicTextBlock => block.type === "text")
+    .map((block) => block.text)
+    .join("\n");
+}
+
+function toolCallsFromAssistantBlocks(blocks: AnthropicAssistantContentBlock[]): PendingToolUse[] {
+  return blocks
+    .filter((block): block is AnthropicToolUseBlock => block.type === "tool_use")
+    .map((block) => ({
+      id: block.id,
+      call: {
+        name: block.name,
+        args: block.input,
+      },
+    }));
+}
+
+class AnthropicMessagesDriver implements Driver {
+  readonly name = "anthropic";
+  private readonly apiKey: string;
+  private readonly model: string;
+  private readonly maxTokens: number;
+  private readonly system: string | undefined;
+  private readonly baseUrl: string;
+  private readonly fetchImpl: AnthropicFetch;
+  private messages: AnthropicMessage[] = [];
+  private pendingToolUses: PendingToolUse[] = [];
+  private consumedToolResults = 0;
+
+  constructor(options: AnthropicDriverOptions) {
+    this.apiKey = requireApiKey(options.apiKey ?? process.env[ANTHROPIC_API_KEY_ENV]);
+    this.model = options.model ?? DEFAULT_ANTHROPIC_MODEL;
+    this.maxTokens = positiveInteger(options.maxTokens ?? DEFAULT_MAX_TOKENS, "maxTokens");
+    this.system = options.system ?? DEFAULT_SYSTEM_PROMPT;
+    this.baseUrl = options.baseUrl ?? ANTHROPIC_MESSAGES_URL;
+    this.fetchImpl = options.fetch ?? fetch;
+  }
+
+  async complete(input: DriverInput): Promise<DriverOutput> {
+    if (input.step === 0) this.reset(input.prompt);
+    this.appendToolResults(input);
+
+    const body: AnthropicRequestBody = {
+      model: this.model,
+      max_tokens: this.maxTokens,
+      system: this.system,
+      messages: this.messages,
+    };
+    const tools = input.tools.map(toAnthropicTool);
+    if (tools.length > 0) body.tools = tools;
+
+    const response = await this.fetchImpl(this.baseUrl, {
+      method: "POST",
+      signal: input.signal,
+      headers: {
+        "anthropic-version": ANTHROPIC_VERSION,
+        "content-type": "application/json",
+        "x-api-key": this.apiKey,
+      },
+      body: JSON.stringify(body),
+    });
+    const payload = await readAnthropicResponse(response);
+    const blocks = parseContentBlocks(payload);
+    const toolUses = toolCallsFromAssistantBlocks(blocks);
+
+    this.messages.push({ role: "assistant", content: blocks });
+    this.pendingToolUses = toolUses;
+
+    return {
+      text: textFromAssistantBlocks(blocks),
+      toolCalls: toolUses.map((toolUse) => toolUse.call),
+    };
+  }
+
+  private reset(prompt: string): void {
+    this.messages = [{ role: "user", content: prompt }];
+    this.pendingToolUses = [];
+    this.consumedToolResults = 0;
+  }
+
+  private appendToolResults(input: DriverInput): void {
+    const toolMessages = input.messages.filter((message) => message.role === "tool");
+    const newToolMessages = toolMessages.slice(this.consumedToolResults);
+    if (newToolMessages.length === 0) return;
+    if (newToolMessages.length !== this.pendingToolUses.length) {
+      throw new Error(
+        `Anthropic driver expected ${this.pendingToolUses.length} tool result(s) but ` +
+          `received ${newToolMessages.length}.`,
+      );
+    }
+
+    this.messages.push({
+      role: "user",
+      content: newToolMessages.map((message, index) =>
+        toToolResultBlock(this.pendingToolUses[index], message.result),
+      ),
+    });
+    this.consumedToolResults = toolMessages.length;
+    this.pendingToolUses = [];
+  }
+}

--- a/evals/anthropic-driver.ts
+++ b/evals/anthropic-driver.ts
@@ -14,6 +14,13 @@ export const DEFAULT_ANTHROPIC_MODEL = "claude-haiku-4-5-20251001";
 const ANTHROPIC_MESSAGES_URL = "https://api.anthropic.com/v1/messages";
 const ANTHROPIC_VERSION = "2023-06-01";
 const DEFAULT_MAX_TOKENS = 1024;
+const MAX_ERROR_FALLBACK_CHARS = 500;
+const RETRYABLE_HTTP_STATUSES = new Set([429, 500, 502, 503, 504, 529]);
+const DEFAULT_RETRY_POLICY = {
+  maxAttempts: 3,
+  baseDelayMs: 250,
+  maxDelayMs: 2_000,
+};
 const DEFAULT_SYSTEM_PROMPT =
   "You are running deterministic MCP evals. Use the provided tools when the user asks for " +
   "tool-backed evidence, then give a concise final answer based on the tool result.";
@@ -25,8 +32,14 @@ export interface AnthropicDriverOptions {
   model?: string;
   maxTokens?: number;
   system?: string;
-  baseUrl?: string;
+  retry?: Partial<AnthropicRetryOptions>;
   fetch?: AnthropicFetch;
+}
+
+export interface AnthropicRetryOptions {
+  maxAttempts: number;
+  baseDelayMs: number;
+  maxDelayMs: number;
 }
 
 interface AnthropicTool {
@@ -57,10 +70,9 @@ interface AnthropicToolResultBlock {
 type AnthropicAssistantContentBlock = AnthropicTextBlock | AnthropicToolUseBlock;
 type AnthropicUserContentBlock = AnthropicTextBlock | AnthropicToolResultBlock;
 
-interface AnthropicMessage {
-  role: "user" | "assistant";
-  content: string | AnthropicAssistantContentBlock[] | AnthropicUserContentBlock[];
-}
+type AnthropicMessage =
+  | { role: "user"; content: string | AnthropicUserContentBlock[] }
+  | { role: "assistant"; content: AnthropicAssistantContentBlock[] };
 
 interface AnthropicRequestBody {
   model: string;
@@ -75,6 +87,17 @@ interface PendingToolUse {
   call: EvalToolCall;
 }
 
+class AnthropicApiError extends Error {
+  constructor(
+    message: string,
+    readonly status: number,
+    readonly retryAfterMs: number | undefined,
+  ) {
+    super(message);
+    this.name = "AnthropicApiError";
+  }
+}
+
 export function anthropicEvalGate(env: NodeJS.ProcessEnv = process.env): EvalGate {
   return llmEvalGate(env, { providerKeyEnvNames: [ANTHROPIC_API_KEY_ENV] });
 }
@@ -83,9 +106,16 @@ export function createAnthropicDriver(options: AnthropicDriverOptions = {}): Dri
   return new AnthropicMessagesDriver(options);
 }
 
-function positiveInteger(value: number, name: string): number {
+function requirePositiveInteger(value: number, name: string): number {
   if (!Number.isInteger(value) || value <= 0) {
     throw new Error(`${name} must be a positive integer.`);
+  }
+  return value;
+}
+
+function requireNonNegativeInteger(value: number, name: string): number {
+  if (!Number.isInteger(value) || value < 0) {
+    throw new Error(`${name} must be a non-negative integer.`);
   }
   return value;
 }
@@ -95,6 +125,12 @@ function requireApiKey(value: string | undefined): string {
     throw new Error(`${ANTHROPIC_API_KEY_ENV} is required to run Anthropic evals.`);
   }
   return value;
+}
+
+function rejectBaseUrlOverride(options: AnthropicDriverOptions): void {
+  if ((options as AnthropicDriverOptions & { baseUrl?: unknown }).baseUrl !== undefined) {
+    throw new Error("Anthropic eval driver does not support overriding baseUrl.");
+  }
 }
 
 function isRecord(value: unknown): value is Record<string, unknown> {
@@ -111,6 +147,27 @@ function toAnthropicTool(tool: Tool): AnthropicTool {
     description: tool.description ?? "MCP tool exposed by b2-mcp.",
     input_schema: inputSchemaForTool(tool),
   };
+}
+
+function resolveRetryOptions(
+  options: Partial<AnthropicRetryOptions> | undefined,
+): AnthropicRetryOptions {
+  const maxAttempts = requirePositiveInteger(
+    options?.maxAttempts ?? DEFAULT_RETRY_POLICY.maxAttempts,
+    "retry.maxAttempts",
+  );
+  const baseDelayMs = requireNonNegativeInteger(
+    options?.baseDelayMs ?? DEFAULT_RETRY_POLICY.baseDelayMs,
+    "retry.baseDelayMs",
+  );
+  const maxDelayMs = requireNonNegativeInteger(
+    options?.maxDelayMs ?? DEFAULT_RETRY_POLICY.maxDelayMs,
+    "retry.maxDelayMs",
+  );
+  if (baseDelayMs > maxDelayMs) {
+    throw new Error("retry.baseDelayMs must be less than or equal to retry.maxDelayMs.");
+  }
+  return { maxAttempts, baseDelayMs, maxDelayMs };
 }
 
 function stringifyToolResultPayload(value: unknown): string {
@@ -183,11 +240,35 @@ function parseContentBlocks(payload: unknown): AnthropicAssistantContentBlock[] 
   return blocks;
 }
 
+function boundedFallback(value: string): string {
+  return value.slice(0, MAX_ERROR_FALLBACK_CHARS);
+}
+
 function extractErrorMessage(payload: unknown, fallback: string): string {
   if (isRecord(payload) && isRecord(payload.error) && typeof payload.error.message === "string") {
-    return payload.error.message;
+    return boundedFallback(payload.error.message);
   }
-  return fallback;
+  return boundedFallback(fallback);
+}
+
+function requestIdFromHeaders(headers: Headers): string | undefined {
+  return headers.get("request-id") ?? headers.get("anthropic-request-id") ?? undefined;
+}
+
+function messageWithRequestId(message: string, requestId: string | undefined): string {
+  return requestId ? `${message} (requestId: ${requestId})` : message;
+}
+
+function retryAfterMsFromHeaders(headers: Headers, now = Date.now()): number | undefined {
+  const value = headers.get("retry-after");
+  if (!value) return undefined;
+
+  const seconds = Number(value);
+  if (Number.isFinite(seconds) && seconds >= 0) return seconds * 1_000;
+
+  const retryDate = Date.parse(value);
+  if (Number.isFinite(retryDate)) return Math.max(0, retryDate - now);
+  return undefined;
 }
 
 async function readAnthropicResponse(response: Response): Promise<unknown> {
@@ -200,15 +281,67 @@ async function readAnthropicResponse(response: Response): Promise<unknown> {
   }
 
   if (!response.ok) {
-    throw new Error(
+    const message =
       `Anthropic Messages API request failed (${response.status}): ` +
-        extractErrorMessage(payload, text || response.statusText),
+      extractErrorMessage(payload, text || response.statusText);
+    throw new AnthropicApiError(
+      messageWithRequestId(message, requestIdFromHeaders(response.headers)),
+      response.status,
+      retryAfterMsFromHeaders(response.headers),
     );
   }
   if (payload === undefined) {
     throw new Error("Anthropic Messages API returned invalid JSON.");
   }
   return payload;
+}
+
+function rejectTruncatedResponse(payload: unknown): void {
+  if (isRecord(payload) && payload.stop_reason === "max_tokens") {
+    throw new Error(
+      "Anthropic response stopped because max_tokens was reached; increase maxTokens for this eval.",
+    );
+  }
+}
+
+function isAbortError(err: unknown): boolean {
+  return isRecord(err) && (err.name === "AbortError" || err.code === "ABORT_ERR");
+}
+
+function retryDelayMs(err: unknown, attempt: number, retry: AnthropicRetryOptions): number {
+  if (err instanceof AnthropicApiError && err.retryAfterMs !== undefined) {
+    return err.retryAfterMs;
+  }
+  const exponentialCap = Math.min(retry.maxDelayMs, retry.baseDelayMs * 2 ** (attempt - 1));
+  return Math.floor(Math.random() * (exponentialCap + 1));
+}
+
+function abortError(signal: AbortSignal): Error {
+  return signal.reason instanceof Error ? signal.reason : new Error("Anthropic request aborted.");
+}
+
+async function sleep(delayMs: number, signal: AbortSignal): Promise<void> {
+  if (signal.aborted) throw abortError(signal);
+  if (delayMs <= 0) return;
+
+  await new Promise<void>((resolve, reject) => {
+    let timer: NodeJS.Timeout;
+    function cleanup(): void {
+      clearTimeout(timer);
+      signal.removeEventListener("abort", onAbort);
+    }
+    function onDone(): void {
+      cleanup();
+      resolve();
+    }
+    function onAbort(): void {
+      cleanup();
+      reject(abortError(signal));
+    }
+    timer = setTimeout(onDone, delayMs);
+    timer.unref();
+    signal.addEventListener("abort", onAbort, { once: true });
+  });
 }
 
 function textFromAssistantBlocks(blocks: AnthropicAssistantContentBlock[]): string {
@@ -236,18 +369,22 @@ class AnthropicMessagesDriver implements Driver {
   private readonly model: string;
   private readonly maxTokens: number;
   private readonly system: string | undefined;
-  private readonly baseUrl: string;
+  private readonly retry: AnthropicRetryOptions;
   private readonly fetchImpl: AnthropicFetch;
+  // This driver is intentionally stateful because EvalToolCall does not carry
+  // Anthropic tool_use IDs. Use one driver instance for one run, called once
+  // per step in increasing step order with monotonically growing messages.
   private messages: AnthropicMessage[] = [];
   private pendingToolUses: PendingToolUse[] = [];
   private consumedToolResults = 0;
 
   constructor(options: AnthropicDriverOptions) {
+    rejectBaseUrlOverride(options);
     this.apiKey = requireApiKey(options.apiKey ?? process.env[ANTHROPIC_API_KEY_ENV]);
     this.model = options.model ?? DEFAULT_ANTHROPIC_MODEL;
-    this.maxTokens = positiveInteger(options.maxTokens ?? DEFAULT_MAX_TOKENS, "maxTokens");
+    this.maxTokens = requirePositiveInteger(options.maxTokens ?? DEFAULT_MAX_TOKENS, "maxTokens");
     this.system = options.system ?? DEFAULT_SYSTEM_PROMPT;
-    this.baseUrl = options.baseUrl ?? ANTHROPIC_MESSAGES_URL;
+    this.retry = resolveRetryOptions(options.retry);
     this.fetchImpl = options.fetch ?? fetch;
   }
 
@@ -264,17 +401,8 @@ class AnthropicMessagesDriver implements Driver {
     const tools = input.tools.map(toAnthropicTool);
     if (tools.length > 0) body.tools = tools;
 
-    const response = await this.fetchImpl(this.baseUrl, {
-      method: "POST",
-      signal: input.signal,
-      headers: {
-        "anthropic-version": ANTHROPIC_VERSION,
-        "content-type": "application/json",
-        "x-api-key": this.apiKey,
-      },
-      body: JSON.stringify(body),
-    });
-    const payload = await readAnthropicResponse(response);
+    const payload = await this.sendRequest(body, input.signal);
+    rejectTruncatedResponse(payload);
     const blocks = parseContentBlocks(payload);
     const toolUses = toolCallsFromAssistantBlocks(blocks);
 
@@ -291,6 +419,39 @@ class AnthropicMessagesDriver implements Driver {
     this.messages = [{ role: "user", content: prompt }];
     this.pendingToolUses = [];
     this.consumedToolResults = 0;
+  }
+
+  private async sendRequest(body: AnthropicRequestBody, signal: AbortSignal): Promise<unknown> {
+    const requestBody = JSON.stringify(body);
+    let lastError: unknown;
+
+    for (let attempt = 1; attempt <= this.retry.maxAttempts; attempt += 1) {
+      try {
+        const response = await this.fetchImpl(ANTHROPIC_MESSAGES_URL, {
+          method: "POST",
+          signal,
+          headers: {
+            "anthropic-version": ANTHROPIC_VERSION,
+            "content-type": "application/json",
+            "x-api-key": this.apiKey,
+          },
+          body: requestBody,
+        });
+        return await readAnthropicResponse(response);
+      } catch (err) {
+        lastError = err;
+        if (!this.shouldRetry(err, attempt)) throw err;
+        await sleep(retryDelayMs(err, attempt, this.retry), signal);
+      }
+    }
+
+    throw lastError;
+  }
+
+  private shouldRetry(err: unknown, attempt: number): boolean {
+    if (attempt >= this.retry.maxAttempts || isAbortError(err)) return false;
+    if (err instanceof AnthropicApiError) return RETRYABLE_HTTP_STATUSES.has(err.status);
+    return true;
   }
 
   private appendToolResults(input: DriverInput): void {

--- a/evals/anthropic-driver.ts
+++ b/evals/anthropic-driver.ts
@@ -15,7 +15,8 @@ const ANTHROPIC_MESSAGES_URL = "https://api.anthropic.com/v1/messages";
 const ANTHROPIC_VERSION = "2023-06-01";
 const DEFAULT_MAX_TOKENS = 1024;
 const MAX_ERROR_FALLBACK_CHARS = 500;
-const RETRYABLE_HTTP_STATUSES = new Set([429, 500, 502, 503, 504, 529]);
+const RETRYABLE_HTTP_STATUSES = new Set([408, 409, 429, 500, 502, 503, 504, 529]);
+const TRUNCATED_STOP_REASONS = new Set(["max_tokens", "model_context_window_exceeded"]);
 const DEFAULT_RETRY_POLICY = {
   maxAttempts: 3,
   baseDelayMs: 250,
@@ -297,9 +298,14 @@ async function readAnthropicResponse(response: Response): Promise<unknown> {
 }
 
 function rejectTruncatedResponse(payload: unknown): void {
-  if (isRecord(payload) && payload.stop_reason === "max_tokens") {
+  if (
+    isRecord(payload) &&
+    typeof payload.stop_reason === "string" &&
+    TRUNCATED_STOP_REASONS.has(payload.stop_reason)
+  ) {
     throw new Error(
-      "Anthropic response stopped because max_tokens was reached; increase maxTokens for this eval.",
+      `Anthropic response stopped with ${payload.stop_reason}; increase maxTokens or reduce ` +
+        "the eval context before treating this run as complete.",
     );
   }
 }


### PR DESCRIPTION
## Summary
- Add a dependency-free Anthropic Messages API eval driver with Claude Haiku 4.5 as the default model.
- Map MCP listTools schemas into Anthropic tools/input_schema, keep tool_use IDs across harness steps, and prefer structuredContent for tool_result content.
- Harden the driver to use only the official Anthropic Messages endpoint, bound upstream error text, include provider request IDs, and reject truncated stop reasons.
- Add bounded retry/backoff for transient Anthropic statuses, including 408, 409, 429, 5xx, and 529, while preserving non-retryable auth failures.
- Add deterministic mocked-provider coverage plus the gated live Haiku 4.5 eval.

## Linked issue
Closes #247

## Tests run
- pnpm run typecheck
- pnpm run evals
- pnpm run lint
- pnpm run format:check
- pnpm run spell
- pnpm test

## Follow-up notes
- The live Anthropic eval is skipped unless RUN_LLM_EVALS=1 and ANTHROPIC_API_KEY are set.