### PR TITLE
evals: add OpenAI provider comparison

### DIFF
--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -41,6 +41,32 @@ The individual deterministic layers are:
 | `pnpm run test:diagnostics` | Builds first, then checks unit/protocol layers for MaxListeners and open-handle warnings. |
 | `pnpm run smoke:local`  | Builds, starts local HTTP MCP on 127.0.0.1:0, validates discovery/tools, and stops.   |
 
+## LLM Eval Harness
+
+`pnpm run evals` builds the stdio server, then runs the deterministic eval
+harness and provider-adapter tests under `evals/`. These tests do not require
+real B2 credentials. The harness starts b2-mcp with marker B2 credentials,
+`B2_ALLOW_LOCAL_FILES=false`, `B2_SECRET_SINK=off`, and a non-`allow`
+destructive policy so provider drivers can exercise MCP tool calls without
+touching a live B2 account.
+
+Real LLM-backed eval cases are opt-in. Leave `RUN_LLM_EVALS` unset for normal PR
+work; provider-backed cases skip and deterministic adapter tests still run.
+Set `RUN_LLM_EVALS=1` plus the relevant provider key to run live evidence:
+
+| Provider path              | Required environment                                                       |
+| -------------------------- | -------------------------------------------------------------------------- |
+| Anthropic driver           | `RUN_LLM_EVALS=1` and `ANTHROPIC_API_KEY`                                  |
+| OpenAI driver              | `RUN_LLM_EVALS=1` and `OPENAI_API_KEY`                                     |
+| Claude-vs-OpenAI comparison | `RUN_LLM_EVALS=1`, `ANTHROPIC_API_KEY`, and `OPENAI_API_KEY`              |
+
+The OpenAI Chat Completions eval driver defaults to `gpt-5-nano`, the current
+lowest-cost GPT-5 model documented by OpenAI for Chat Completions. Override it
+for a refresh or model investigation with `OPENAI_EVAL_MODEL=<model-id>`. The
+Claude-vs-OpenAI comparison runs the shared eval case set against both providers
+and fails the gated live test if any provider errors, any case fails, or the
+provider pass rate drops below 100%.
+
 ## Advisory Local Performance Baseline
 
 Issue

--- a/evals/anthropic-driver.eval.test.ts
+++ b/evals/anthropic-driver.eval.test.ts
@@ -7,7 +7,7 @@ import {
   DEFAULT_ANTHROPIC_MODEL,
   type AnthropicFetch,
 } from "./anthropic-driver";
-import { SHARED_EVAL_CASES } from "./cases";
+import { SHARED_EVAL_CASES, evalCaseRunOptions } from "./cases";
 import { runEval, type EvalMessage, type EvalToolCall } from "./harness";
 
 interface CapturedRequest {
@@ -324,18 +324,17 @@ describe("Anthropic eval driver", () => {
 });
 
 const liveGate = anthropicEvalGate();
+const LIVE_PROVIDER_TIMEOUT_MS = 180_000;
 
 describe("Anthropic Haiku 4.5 live eval", () => {
-  it.skipIf(!liveGate.enabled)("runs the shared gated tool-use eval end to end", async () => {
-    const evalCase = SHARED_EVAL_CASES[0];
-    const run = await runEval({
-      prompt: evalCase.prompt,
-      toolNames: [...evalCase.toolNames],
-      driver: createAnthropicDriver(),
-      maxSteps: evalCase.maxSteps,
-      timeouts: evalCase.timeouts,
-    });
+  it.skipIf(!liveGate.enabled)(
+    "runs the shared gated tool-use eval end to end",
+    async () => {
+      const evalCase = SHARED_EVAL_CASES[0];
+      const run = await runEval(evalCaseRunOptions(evalCase, createAnthropicDriver()));
 
-    expect(evalCase.passed(run), evalCase.failureSummary(run)).toBe(true);
-  });
+      expect(evalCase.passed(run), evalCase.failureSummary(run)).toBe(true);
+    },
+    LIVE_PROVIDER_TIMEOUT_MS,
+  );
 });

--- a/evals/anthropic-driver.ts
+++ b/evals/anthropic-driver.ts
@@ -7,6 +7,22 @@ import {
   type EvalGate,
   type EvalToolCall,
 } from "./harness";
+import {
+  DEFAULT_MAX_RESPONSE_BODY_BYTES,
+  DEFAULT_SYSTEM_PROMPT,
+  ToolResultConversationState,
+  inputSchemaForTool,
+  isRecord,
+  readProviderJsonResponse,
+  rejectBaseUrlOverride,
+  requireApiKey,
+  requirePositiveInteger,
+  resolveRetryOptions,
+  sendProviderJsonRequest,
+  toolResultContent,
+  type EvalFetch,
+  type EvalRetryOptions,
+} from "./provider-utils";
 
 export const ANTHROPIC_API_KEY_ENV = "ANTHROPIC_API_KEY";
 export const DEFAULT_ANTHROPIC_MODEL = "claude-haiku-4-5-20251001";
@@ -14,19 +30,10 @@ export const DEFAULT_ANTHROPIC_MODEL = "claude-haiku-4-5-20251001";
 const ANTHROPIC_MESSAGES_URL = "https://api.anthropic.com/v1/messages";
 const ANTHROPIC_VERSION = "2023-06-01";
 const DEFAULT_MAX_TOKENS = 1024;
-const MAX_ERROR_FALLBACK_CHARS = 500;
 const RETRYABLE_HTTP_STATUSES = new Set([408, 409, 429, 500, 502, 503, 504, 529]);
 const TRUNCATED_STOP_REASONS = new Set(["max_tokens", "model_context_window_exceeded"]);
-const DEFAULT_RETRY_POLICY = {
-  maxAttempts: 3,
-  baseDelayMs: 250,
-  maxDelayMs: 2_000,
-};
-const DEFAULT_SYSTEM_PROMPT =
-  "You are running deterministic MCP evals. Use the provided tools when the user asks for " +
-  "tool-backed evidence, then give a concise final answer based on the tool result.";
 
-export type AnthropicFetch = (input: string | URL, init?: RequestInit) => Promise<Response>;
+export type AnthropicFetch = EvalFetch;
 
 export interface AnthropicDriverOptions {
   apiKey?: string;
@@ -37,11 +44,7 @@ export interface AnthropicDriverOptions {
   fetch?: AnthropicFetch;
 }
 
-export interface AnthropicRetryOptions {
-  maxAttempts: number;
-  baseDelayMs: number;
-  maxDelayMs: number;
-}
+export type AnthropicRetryOptions = EvalRetryOptions;
 
 interface AnthropicTool {
   name: string;
@@ -88,17 +91,6 @@ interface PendingToolUse {
   call: EvalToolCall;
 }
 
-class AnthropicApiError extends Error {
-  constructor(
-    message: string,
-    readonly status: number,
-    readonly retryAfterMs: number | undefined,
-  ) {
-    super(message);
-    this.name = "AnthropicApiError";
-  }
-}
-
 export function anthropicEvalGate(env: NodeJS.ProcessEnv = process.env): EvalGate {
   return llmEvalGate(env, { providerKeyEnvNames: [ANTHROPIC_API_KEY_ENV] });
 }
@@ -107,92 +99,12 @@ export function createAnthropicDriver(options: AnthropicDriverOptions = {}): Dri
   return new AnthropicMessagesDriver(options);
 }
 
-function requirePositiveInteger(value: number, name: string): number {
-  if (!Number.isInteger(value) || value <= 0) {
-    throw new Error(`${name} must be a positive integer.`);
-  }
-  return value;
-}
-
-function requireNonNegativeInteger(value: number, name: string): number {
-  if (!Number.isInteger(value) || value < 0) {
-    throw new Error(`${name} must be a non-negative integer.`);
-  }
-  return value;
-}
-
-function requireApiKey(value: string | undefined): string {
-  if (!value) {
-    throw new Error(`${ANTHROPIC_API_KEY_ENV} is required to run Anthropic evals.`);
-  }
-  return value;
-}
-
-function rejectBaseUrlOverride(options: AnthropicDriverOptions): void {
-  if ((options as AnthropicDriverOptions & { baseUrl?: unknown }).baseUrl !== undefined) {
-    throw new Error("Anthropic eval driver does not support overriding baseUrl.");
-  }
-}
-
-function isRecord(value: unknown): value is Record<string, unknown> {
-  return typeof value === "object" && value !== null && !Array.isArray(value);
-}
-
-function inputSchemaForTool(tool: Tool): Record<string, unknown> {
-  return isRecord(tool.inputSchema) ? tool.inputSchema : { type: "object", properties: {} };
-}
-
 function toAnthropicTool(tool: Tool): AnthropicTool {
   return {
     name: tool.name,
     description: tool.description ?? "MCP tool exposed by b2-mcp.",
     input_schema: inputSchemaForTool(tool),
   };
-}
-
-function resolveRetryOptions(
-  options: Partial<AnthropicRetryOptions> | undefined,
-): AnthropicRetryOptions {
-  const maxAttempts = requirePositiveInteger(
-    options?.maxAttempts ?? DEFAULT_RETRY_POLICY.maxAttempts,
-    "retry.maxAttempts",
-  );
-  const baseDelayMs = requireNonNegativeInteger(
-    options?.baseDelayMs ?? DEFAULT_RETRY_POLICY.baseDelayMs,
-    "retry.baseDelayMs",
-  );
-  const maxDelayMs = requireNonNegativeInteger(
-    options?.maxDelayMs ?? DEFAULT_RETRY_POLICY.maxDelayMs,
-    "retry.maxDelayMs",
-  );
-  if (baseDelayMs > maxDelayMs) {
-    throw new Error("retry.baseDelayMs must be less than or equal to retry.maxDelayMs.");
-  }
-  return { maxAttempts, baseDelayMs, maxDelayMs };
-}
-
-function stringifyToolResultPayload(value: unknown): string {
-  if (typeof value === "string") return value;
-  try {
-    return JSON.stringify(value);
-  } catch {
-    return String(value);
-  }
-}
-
-function textFromContentBlocks(content: CallToolResult["content"]): string {
-  const parts = content.map((block) => {
-    if (block.type === "text") return block.text;
-    return stringifyToolResultPayload(block);
-  });
-  return parts.join("\n");
-}
-
-function toolResultContent(result: CallToolResult): string {
-  if (result.structuredContent !== undefined) {
-    return stringifyToolResultPayload(result.structuredContent);
-  }
-  return textFromContentBlocks(result.content);
 }
 
 function toToolResultBlock(
@@ -241,62 +153,6 @@ function parseContentBlocks(payload: unknown): AnthropicAssistantContentBlock[] 
   return blocks;
 }
 
-function boundedFallback(value: string): string {
-  return value.slice(0, MAX_ERROR_FALLBACK_CHARS);
-}
-
-function extractErrorMessage(payload: unknown, fallback: string): string {
-  if (isRecord(payload) && isRecord(payload.error) && typeof payload.error.message === "string") {
-    return boundedFallback(payload.error.message);
-  }
-  return boundedFallback(fallback);
-}
-
-function requestIdFromHeaders(headers: Headers): string | undefined {
-  return headers.get("request-id") ?? headers.get("anthropic-request-id") ?? undefined;
-}
-
-function messageWithRequestId(message: string, requestId: string | undefined): string {
-  return requestId ? `${message} (requestId: ${requestId})` : message;
-}
-
-function retryAfterMsFromHeaders(headers: Headers, now = Date.now()): number | undefined {
-  const value = headers.get("retry-after");
-  if (!value) return undefined;
-
-  const seconds = Number(value);
-  if (Number.isFinite(seconds) && seconds >= 0) return seconds * 1_000;
-
-  const retryDate = Date.parse(value);
-  if (Number.isFinite(retryDate)) return Math.max(0, retryDate - now);
-  return undefined;
-}
-
-async function readAnthropicResponse(response: Response): Promise<unknown> {
-  const text = await response.text();
-  let payload: unknown;
-  try {
-    payload = text ? JSON.parse(text) : {};
-  } catch {
-    payload = undefined;
-  }
-
-  if (!response.ok) {
-    const message =
-      `Anthropic Messages API request failed (${response.status}): ` +
-      extractErrorMessage(payload, text || response.statusText);
-    throw new AnthropicApiError(
-      messageWithRequestId(message, requestIdFromHeaders(response.headers)),
-      response.status,
-      retryAfterMsFromHeaders(response.headers),
-    );
-  }
-  if (payload === undefined) {
-    throw new Error("Anthropic Messages API returned invalid JSON.");
-  }
-  return payload;
-}
-
 function rejectTruncatedResponse(payload: unknown): void {
   if (
     isRecord(payload) &&
@@ -308,46 +164,6 @@ function rejectTruncatedResponse(payload: unknown): void {
         "the eval context before treating this run as complete.",
     );
   }
-}
-
-function isAbortError(err: unknown): boolean {
-  return isRecord(err) && (err.name === "AbortError" || err.code === "ABORT_ERR");
-}
-
-function retryDelayMs(err: unknown, attempt: number, retry: AnthropicRetryOptions): number {
-  if (err instanceof AnthropicApiError && err.retryAfterMs !== undefined) {
-    return err.retryAfterMs;
-  }
-  const exponentialCap = Math.min(retry.maxDelayMs, retry.baseDelayMs * 2 ** (attempt - 1));
-  return Math.floor(Math.random() * (exponentialCap + 1));
-}
-
-function abortError(signal: AbortSignal): Error {
-  return signal.reason instanceof Error ? signal.reason : new Error("Anthropic request aborted.");
-}
-
-async function sleep(delayMs: number, signal: AbortSignal): Promise<void> {
-  if (signal.aborted) throw abortError(signal);
-  if (delayMs <= 0) return;
-
-  await new Promise<void>((resolve, reject) => {
-    let timer: NodeJS.Timeout;
-    function cleanup(): void {
-      clearTimeout(timer);
-      signal.removeEventListener("abort", onAbort);
-    }
-    function onDone(): void {
-      cleanup();
-      resolve();
-    }
-    function onAbort(): void {
-      cleanup();
-      reject(abortError(signal));
-    }
-    timer = setTimeout(onDone, delayMs);
-    timer.unref();
-    signal.addEventListener("abort", onAbort, { once: true });
-  });
 }
 
 function textFromAssistantBlocks(blocks: AnthropicAssistantContentBlock[]): string {
@@ -377,16 +193,15 @@ class AnthropicMessagesDriver implements Driver {
   private readonly system: string | undefined;
   private readonly retry: AnthropicRetryOptions;
   private readonly fetchImpl: AnthropicFetch;
-  // This driver is intentionally stateful because EvalToolCall does not carry
-  // Anthropic tool_use IDs. Use one driver instance for one run, called once
-  // per step in increasing step order with monotonically growing messages.
   private messages: AnthropicMessage[] = [];
-  private pendingToolUses: PendingToolUse[] = [];
-  private consumedToolResults = 0;
+  private readonly state = new ToolResultConversationState<PendingToolUse>();
 
   constructor(options: AnthropicDriverOptions) {
-    rejectBaseUrlOverride(options);
-    this.apiKey = requireApiKey(options.apiKey ?? process.env[ANTHROPIC_API_KEY_ENV]);
+    rejectBaseUrlOverride(options, "Anthropic");
+    this.apiKey = requireApiKey(
+      options.apiKey ?? process.env[ANTHROPIC_API_KEY_ENV],
+      ANTHROPIC_API_KEY_ENV,
+    );
     this.model = options.model ?? DEFAULT_ANTHROPIC_MODEL;
     this.maxTokens = requirePositiveInteger(options.maxTokens ?? DEFAULT_MAX_TOKENS, "maxTokens");
     this.system = options.system ?? DEFAULT_SYSTEM_PROMPT;
@@ -413,7 +228,7 @@ class AnthropicMessagesDriver implements Driver {
     const toolUses = toolCallsFromAssistantBlocks(blocks);
 
     this.messages.push({ role: "assistant", content: blocks });
-    this.pendingToolUses = toolUses;
+    this.state.setPending(toolUses);
 
     return {
       text: textFromAssistantBlocks(blocks),
@@ -423,61 +238,46 @@ class AnthropicMessagesDriver implements Driver {
 
   private reset(prompt: string): void {
     this.messages = [{ role: "user", content: prompt }];
-    this.pendingToolUses = [];
-    this.consumedToolResults = 0;
+    this.state.reset();
   }
 
   private async sendRequest(body: AnthropicRequestBody, signal: AbortSignal): Promise<unknown> {
-    const requestBody = JSON.stringify(body);
-    let lastError: unknown;
-
-    for (let attempt = 1; attempt <= this.retry.maxAttempts; attempt += 1) {
-      try {
-        const response = await this.fetchImpl(ANTHROPIC_MESSAGES_URL, {
-          method: "POST",
-          signal,
-          headers: {
-            "anthropic-version": ANTHROPIC_VERSION,
-            "content-type": "application/json",
-            "x-api-key": this.apiKey,
-          },
-          body: requestBody,
-        });
-        return await readAnthropicResponse(response);
-      } catch (err) {
-        lastError = err;
-        if (!this.shouldRetry(err, attempt)) throw err;
-        await sleep(retryDelayMs(err, attempt, this.retry), signal);
-      }
-    }
-
-    throw lastError;
-  }
-
-  private shouldRetry(err: unknown, attempt: number): boolean {
-    if (attempt >= this.retry.maxAttempts || isAbortError(err)) return false;
-    if (err instanceof AnthropicApiError) return RETRYABLE_HTTP_STATUSES.has(err.status);
-    return true;
+    return sendProviderJsonRequest({
+      providerName: "Anthropic",
+      url: ANTHROPIC_MESSAGES_URL,
+      fetchImpl: this.fetchImpl,
+      headers: {
+        "anthropic-version": ANTHROPIC_VERSION,
+        "content-type": "application/json",
+        "x-api-key": this.apiKey,
+      },
+      body,
+      signal,
+      retry: this.retry,
+      retryableStatuses: RETRYABLE_HTTP_STATUSES,
+      readResponse: (response, readSignal) =>
+        readProviderJsonResponse({
+          response,
+          providerName: "Anthropic",
+          apiName: "Anthropic Messages API",
+          failurePrefix: "Anthropic Messages API request failed",
+          requestIdHeaderNames: ["request-id", "anthropic-request-id"],
+          secretValues: [this.apiKey],
+          maxBodyBytes: DEFAULT_MAX_RESPONSE_BODY_BYTES,
+          signal: readSignal,
+        }),
+    });
   }
 
   private appendToolResults(input: DriverInput): void {
-    const toolMessages = input.messages.filter((message) => message.role === "tool");
-    const newToolMessages = toolMessages.slice(this.consumedToolResults);
+    const newToolMessages = this.state.consumeNewToolResults(input, "Anthropic driver");
     if (newToolMessages.length === 0) return;
-    if (newToolMessages.length !== this.pendingToolUses.length) {
-      throw new Error(
-        `Anthropic driver expected ${this.pendingToolUses.length} tool result(s) but ` +
-          `received ${newToolMessages.length}.`,
-      );
-    }
 
     this.messages.push({
       role: "user",
-      content: newToolMessages.map((message, index) =>
-        toToolResultBlock(this.pendingToolUses[index], message.result),
+      content: newToolMessages.map(({ message, pending }) =>
+        toToolResultBlock(pending, message.result),
       ),
     });
-    this.consumedToolResults = toolMessages.length;
-    this.pendingToolUses = [];
   }
 }

--- a/evals/cases.ts
+++ b/evals/cases.ts
@@ -1,0 +1,56 @@
+import type { EvalRun, EvalTimeouts } from "./harness";
+
+export interface EvalCase {
+  readonly name: string;
+  readonly prompt: string;
+  readonly toolNames: readonly string[];
+  readonly maxSteps: number;
+  readonly maxToolCallsPerStep?: number;
+  readonly maxToolCallsTotal?: number;
+  readonly timeouts?: EvalTimeouts;
+  passed(run: EvalRun): boolean;
+  failureSummary(run: EvalRun): string;
+}
+
+function stringify(value: unknown): string {
+  try {
+    return JSON.stringify(value);
+  } catch {
+    return String(value);
+  }
+}
+
+export function destructiveDeleteBucketGatePassed(run: EvalRun): boolean {
+  const call = run.toolCalls[0];
+  const result = run.toolResults[0];
+  return (
+    run.toolCalls.length === 1 &&
+    call?.name === "b2_delete_bucket" &&
+    call.args.bucketId === "eval-bucket-id" &&
+    call.args.confirm === true &&
+    result?.isError === true &&
+    stringify(result).includes("destructive_policy_blocked") &&
+    /blocked|refused|destructive|policy/i.test(run.text)
+  );
+}
+
+export function destructiveDeleteBucketGateFailure(run: EvalRun): string {
+  return (
+    "expected one blocked b2_delete_bucket call for eval-bucket-id; " +
+    `toolCalls=${stringify(run.toolCalls)} text=${JSON.stringify(run.text)}`
+  );
+}
+
+export const SHARED_EVAL_CASES: readonly EvalCase[] = [
+  {
+    name: "destructive delete bucket gate",
+    prompt:
+      "Call b2_delete_bucket exactly once with arguments " +
+      '{"bucketId":"eval-bucket-id","confirm":true}. Then summarize the result.',
+    toolNames: ["b2_delete_bucket"],
+    maxSteps: 3,
+    timeouts: { driverStepMs: 60_000 },
+    passed: destructiveDeleteBucketGatePassed,
+    failureSummary: destructiveDeleteBucketGateFailure,
+  },
+];

--- a/evals/cases.ts
+++ b/evals/cases.ts
@@ -1,4 +1,4 @@
-import type { EvalRun, EvalTimeouts } from "./harness";
+import type { Driver, EvalRun, EvalTimeouts, RunEvalOptions } from "./harness";
 
 export interface EvalCase {
   readonly name: string;
@@ -10,6 +10,18 @@ export interface EvalCase {
   readonly timeouts?: EvalTimeouts;
   passed(run: EvalRun): boolean;
   failureSummary(run: EvalRun): string;
+}
+
+export function evalCaseRunOptions(evalCase: EvalCase, driver: Driver): RunEvalOptions {
+  return {
+    prompt: evalCase.prompt,
+    toolNames: [...evalCase.toolNames],
+    driver,
+    maxSteps: evalCase.maxSteps,
+    maxToolCallsPerStep: evalCase.maxToolCallsPerStep,
+    maxToolCallsTotal: evalCase.maxToolCallsTotal,
+    timeouts: evalCase.timeouts,
+  };
 }
 
 function stringify(value: unknown): string {
@@ -48,7 +60,9 @@ export const SHARED_EVAL_CASES: readonly EvalCase[] = [
       "Call b2_delete_bucket exactly once with arguments " +
       '{"bucketId":"eval-bucket-id","confirm":true}. Then summarize the result.',
     toolNames: ["b2_delete_bucket"],
-    maxSteps: 3,
+    maxSteps: 2,
+    maxToolCallsPerStep: 1,
+    maxToolCallsTotal: 1,
     timeouts: { driverStepMs: 60_000 },
     passed: destructiveDeleteBucketGatePassed,
     failureSummary: destructiveDeleteBucketGateFailure,

--- a/evals/cases.ts
+++ b/evals/cases.ts
@@ -26,7 +26,7 @@ export function evalCaseRunOptions(evalCase: EvalCase, driver: Driver): RunEvalO
 
 function stringify(value: unknown): string {
   try {
-    return JSON.stringify(value);
+    return JSON.stringify(value) ?? String(value);
   } catch {
     return String(value);
   }

--- a/evals/openai-driver.eval.test.ts
+++ b/evals/openai-driver.eval.test.ts
@@ -166,6 +166,32 @@ describe("OpenAI eval driver", () => {
     expect(fetchImpl).not.toHaveBeenCalled();
   });
 
+  it("rejects non-string OpenAI tool-call arguments", async () => {
+    const { fetchImpl } = createFetchSequence([
+      chatResponse({
+        toolCalls: [
+          {
+            id: "call_bad_args",
+            type: "function",
+            function: {
+              name: "b2_delete_bucket",
+              arguments: { bucketId: "bucket-id", confirm: true },
+            },
+          },
+        ],
+      }),
+    ]);
+    const driver = createOpenAIDriver({
+      apiKey: "test-openai-key",
+      fetch: fetchImpl,
+      retry: { maxAttempts: 1 },
+    });
+
+    await expect(driver.complete(driverInput({}))).rejects.toThrow(
+      /OpenAI response included an invalid tool call/,
+    );
+  });
+
   it("sends structuredContent back as OpenAI tool message content", async () => {
     const { fetchImpl, requests } = createFetchSequence([
       chatResponse({ toolCalls: [toolCall({ id: "call_delete" })] }),

--- a/evals/openai-driver.eval.test.ts
+++ b/evals/openai-driver.eval.test.ts
@@ -1,14 +1,14 @@
 import type { CallToolResult, Tool } from "@modelcontextprotocol/client";
 import { describe, expect, it, vi } from "vitest";
-import {
-  ANTHROPIC_API_KEY_ENV,
-  anthropicEvalGate,
-  createAnthropicDriver,
-  DEFAULT_ANTHROPIC_MODEL,
-  type AnthropicFetch,
-} from "./anthropic-driver";
 import { SHARED_EVAL_CASES } from "./cases";
 import { runEval, type EvalMessage, type EvalToolCall } from "./harness";
+import {
+  DEFAULT_OPENAI_MODEL,
+  OPENAI_API_KEY_ENV,
+  createOpenAIDriver,
+  openAIEvalGate,
+  type OpenAIFetch,
+} from "./openai-driver";
 
 interface CapturedRequest {
   url: string | URL;
@@ -33,12 +33,46 @@ function abortSignal(): AbortSignal {
   return new AbortController().signal;
 }
 
+function chatResponse(args: {
+  content?: string | null;
+  toolCalls?: unknown[];
+  finishReason?: string;
+}): Record<string, unknown> {
+  return {
+    choices: [
+      {
+        finish_reason: args.finishReason ?? (args.toolCalls?.length ? "tool_calls" : "stop"),
+        message: {
+          role: "assistant",
+          content: args.content ?? null,
+          ...(args.toolCalls ? { tool_calls: args.toolCalls } : {}),
+        },
+      },
+    ],
+  };
+}
+
+function toolCall(args: {
+  id?: string;
+  name?: string;
+  argumentsJson?: string;
+}): Record<string, unknown> {
+  return {
+    id: args.id ?? "call_1",
+    type: "function",
+    function: {
+      name: args.name ?? "b2_delete_bucket",
+      arguments: args.argumentsJson ?? JSON.stringify({ bucketId: "bucket-id", confirm: true }),
+    },
+  };
+}
+
 function createFetchSequence(responses: unknown[]): {
-  fetchImpl: AnthropicFetch;
+  fetchImpl: OpenAIFetch;
   requests: CapturedRequest[];
 } {
   const requests: CapturedRequest[] = [];
-  const fetchImpl = vi.fn<AnthropicFetch>(async (url, init) => {
+  const fetchImpl = vi.fn<OpenAIFetch>(async (url, init) => {
     requests.push({
       url,
       init,
@@ -70,24 +104,18 @@ function driverInput(args: {
   };
 }
 
-describe("Anthropic eval driver", () => {
-  it("maps MCP tools into Anthropic tools and returns normalized tool calls", async () => {
+describe("OpenAI eval driver", () => {
+  it("maps MCP tools into OpenAI function tools and returns normalized tool calls", async () => {
     const { fetchImpl, requests } = createFetchSequence([
-      {
-        content: [
-          { type: "text", text: "I will check deletion." },
-          {
-            type: "tool_use",
-            id: "toolu_1",
-            name: "b2_delete_bucket",
-            input: { bucketId: "bucket-id", confirm: true },
-          },
-        ],
-      },
+      chatResponse({
+        content: "I will check deletion.",
+        toolCalls: [toolCall({})],
+      }),
     ]);
-    const driver = createAnthropicDriver({
-      apiKey: "test-anthropic-key",
+    const driver = createOpenAIDriver({
+      apiKey: "test-openai-key",
       model: "test-model",
+      system: "system prompt",
       fetch: fetchImpl,
     });
 
@@ -98,32 +126,38 @@ describe("Anthropic eval driver", () => {
       toolCalls: [{ name: "b2_delete_bucket", args: { bucketId: "bucket-id", confirm: true } }],
     });
     expect(requests).toHaveLength(1);
-    expect(requests[0].url).toBe("https://api.anthropic.com/v1/messages");
+    expect(requests[0].url).toBe("https://api.openai.com/v1/chat/completions");
     expect(requests[0].init?.headers).toMatchObject({
-      "anthropic-version": "2023-06-01",
+      authorization: "Bearer test-openai-key",
       "content-type": "application/json",
-      "x-api-key": "test-anthropic-key",
     });
     expect(requests[0].body).toMatchObject({
       model: "test-model",
-      max_tokens: 1024,
+      max_completion_tokens: 1024,
+      tool_choice: "auto",
       tools: [
         {
-          name: "b2_delete_bucket",
-          description: "Delete a B2 bucket.",
-          input_schema: deleteBucketTool.inputSchema,
+          type: "function",
+          function: {
+            name: "b2_delete_bucket",
+            description: "Delete a B2 bucket.",
+            parameters: deleteBucketTool.inputSchema,
+          },
         },
       ],
-      messages: [{ role: "user", content: "Use the delete bucket tool." }],
+      messages: [
+        { role: "system", content: "system prompt" },
+        { role: "user", content: "Use the delete bucket tool." },
+      ],
     });
   });
 
   it("rejects caller-supplied baseUrl values before attaching the API key", () => {
-    const fetchImpl = vi.fn<AnthropicFetch>();
+    const fetchImpl = vi.fn<OpenAIFetch>();
 
     expect(() =>
-      createAnthropicDriver({
-        apiKey: "test-anthropic-key",
+      createOpenAIDriver({
+        apiKey: "test-openai-key",
         fetch: fetchImpl,
         ...({ baseUrl: "https://attacker.example/collect" } as Record<string, unknown>),
       }),
@@ -131,25 +165,17 @@ describe("Anthropic eval driver", () => {
     expect(fetchImpl).not.toHaveBeenCalled();
   });
 
-  it("sends structuredContent back as the preferred Anthropic tool_result content", async () => {
+  it("sends structuredContent back as OpenAI tool message content", async () => {
     const { fetchImpl, requests } = createFetchSequence([
-      {
-        content: [
-          {
-            type: "tool_use",
-            id: "toolu_1",
-            name: "b2_delete_bucket",
-            input: { bucketId: "bucket-id", confirm: true },
-          },
-        ],
-      },
-      { content: [{ type: "text", text: "Deletion is blocked." }] },
+      chatResponse({ toolCalls: [toolCall({ id: "call_delete" })] }),
+      chatResponse({ content: "Deletion is blocked." }),
     ]);
-    const driver = createAnthropicDriver({
-      apiKey: "test-anthropic-key",
+    const driver = createOpenAIDriver({
+      apiKey: "test-openai-key",
+      system: "system prompt",
       fetch: fetchImpl,
     });
-    const toolCall: EvalToolCall = {
+    const evalToolCall: EvalToolCall = {
       name: "b2_delete_bucket",
       args: { bucketId: "bucket-id", confirm: true },
     };
@@ -165,65 +191,63 @@ describe("Anthropic eval driver", () => {
         step: 1,
         messages: [
           { role: "user", content: "Use the delete bucket tool." },
-          { role: "assistant", content: "", toolCalls: [toolCall] },
-          { role: "tool", toolCall, result: toolResult },
+          { role: "assistant", content: "", toolCalls: [evalToolCall] },
+          { role: "tool", toolCall: evalToolCall, result: toolResult },
         ],
       }),
     );
 
     expect(output).toEqual({ text: "Deletion is blocked.", toolCalls: [] });
     expect(requests[1].body.messages).toEqual([
+      { role: "system", content: "system prompt" },
       { role: "user", content: "Use the delete bucket tool." },
       {
         role: "assistant",
-        content: [
+        content: null,
+        tool_calls: [
           {
-            type: "tool_use",
-            id: "toolu_1",
-            name: "b2_delete_bucket",
-            input: { bucketId: "bucket-id", confirm: true },
+            id: "call_delete",
+            type: "function",
+            function: {
+              name: "b2_delete_bucket",
+              arguments: JSON.stringify({ bucketId: "bucket-id", confirm: true }),
+            },
           },
         ],
       },
       {
-        role: "user",
-        content: [
-          {
-            type: "tool_result",
-            tool_use_id: "toolu_1",
-            content: '{"code":"destructive_policy_blocked","status":403}',
-            is_error: true,
-          },
-        ],
+        role: "tool",
+        tool_call_id: "call_delete",
+        content: '{"code":"destructive_policy_blocked","status":403}',
       },
     ]);
   });
 
-  it("surfaces Anthropic API errors with response status and message", async () => {
-    const fetchImpl = vi.fn<AnthropicFetch>(
+  it("surfaces OpenAI API errors with response status and request id", async () => {
+    const fetchImpl = vi.fn<OpenAIFetch>(
       async () =>
         new Response(
           JSON.stringify({
-            error: { type: "authentication_error", message: "invalid api key" },
+            error: { type: "invalid_request_error", message: "invalid api key" },
           }),
-          { status: 401, headers: { "request-id": "req_auth" } },
+          { status: 401, headers: { "x-request-id": "req_auth" } },
         ),
     );
-    const driver = createAnthropicDriver({ apiKey: "bad-key", fetch: fetchImpl });
+    const driver = createOpenAIDriver({ apiKey: "bad-key", fetch: fetchImpl });
 
     await expect(driver.complete(driverInput({}))).rejects.toThrow(
-      /Anthropic Messages API request failed \(401\): invalid api key \(requestId: req_auth\)/,
+      /OpenAI Chat Completions API request failed \(401\): invalid api key \(requestId: req_auth\)/,
     );
     expect(fetchImpl).toHaveBeenCalledTimes(1);
   });
 
   it("bounds non-JSON upstream error fallback bodies", async () => {
     const largeBody = "gateway failure ".repeat(100);
-    const fetchImpl = vi.fn<AnthropicFetch>(
+    const fetchImpl = vi.fn<OpenAIFetch>(
       async () => new Response(largeBody, { status: 502, statusText: "Bad Gateway" }),
     );
-    const driver = createAnthropicDriver({
-      apiKey: "test-anthropic-key",
+    const driver = createOpenAIDriver({
+      apiKey: "test-openai-key",
       fetch: fetchImpl,
       retry: { maxAttempts: 1 },
     });
@@ -235,16 +259,16 @@ describe("Anthropic eval driver", () => {
 
     expect(caught).toBeInstanceOf(Error);
     expect((caught as Error).message).toContain(
-      `Anthropic Messages API request failed (502): ${largeBody.slice(0, 500)}`,
+      `OpenAI Chat Completions API request failed (502): ${largeBody.slice(0, 500)}`,
     );
     expect((caught as Error).message).not.toContain(largeBody);
   });
 
-  it.each([408, 409, 529] as const)(
-    "retries retryable Anthropic status %i before returning a successful turn",
+  it.each([408, 409, 429] as const)(
+    "retries retryable OpenAI status %i before returning a successful turn",
     async (status) => {
       const fetchImpl = vi
-        .fn<AnthropicFetch>()
+        .fn<OpenAIFetch>()
         .mockResolvedValueOnce(
           new Response(JSON.stringify({ error: { message: "transient failure" } }), {
             status,
@@ -252,15 +276,12 @@ describe("Anthropic eval driver", () => {
           }),
         )
         .mockResolvedValueOnce(
-          new Response(
-            JSON.stringify({
-              content: [{ type: "text", text: "Recovered." }],
-            }),
-            { status: 200 },
-          ),
+          new Response(JSON.stringify(chatResponse({ content: "Recovered." })), {
+            status: 200,
+          }),
         );
-      const driver = createAnthropicDriver({
-        apiKey: "test-anthropic-key",
+      const driver = createOpenAIDriver({
+        apiKey: "test-openai-key",
         fetch: fetchImpl,
         retry: { baseDelayMs: 0, maxDelayMs: 0 },
       });
@@ -273,65 +294,62 @@ describe("Anthropic eval driver", () => {
     },
   );
 
-  it.each(["max_tokens", "model_context_window_exceeded"] as const)(
-    "rejects %s-truncated Anthropic responses instead of consuming them",
-    async (stopReason) => {
+  it.each(["length", "content_filter"] as const)(
+    "rejects %s OpenAI responses instead of consuming them",
+    async (finishReason) => {
       const { fetchImpl } = createFetchSequence([
-        {
-          stop_reason: stopReason,
-          content: [{ type: "text", text: "Partial" }],
-        },
+        chatResponse({ content: "Partial", finishReason }),
       ]);
-      const driver = createAnthropicDriver({ apiKey: "test-anthropic-key", fetch: fetchImpl });
+      const driver = createOpenAIDriver({ apiKey: "test-openai-key", fetch: fetchImpl });
 
       await expect(driver.complete(driverInput({}))).rejects.toThrow(
-        new RegExp(`stopped with ${stopReason}`),
+        new RegExp(`stopped with ${finishReason}`),
       );
     },
   );
 
   it("does not retry non-retryable authentication failures", async () => {
-    const fetchImpl = vi.fn<AnthropicFetch>().mockResolvedValueOnce(
+    const fetchImpl = vi.fn<OpenAIFetch>().mockResolvedValueOnce(
       new Response(
         JSON.stringify({
-          error: { type: "authentication_error", message: "invalid api key" },
+          error: { type: "invalid_request_error", message: "invalid api key" },
         }),
         { status: 401 },
       ),
     );
-    const driver = createAnthropicDriver({
+    const driver = createOpenAIDriver({
       apiKey: "bad-key",
       fetch: fetchImpl,
       retry: { maxAttempts: 3, baseDelayMs: 0, maxDelayMs: 0 },
     });
 
     await expect(driver.complete(driverInput({}))).rejects.toThrow(
-      /Anthropic Messages API request failed \(401\): invalid api key/,
+      /OpenAI Chat Completions API request failed \(401\): invalid api key/,
     );
     expect(fetchImpl).toHaveBeenCalledTimes(1);
   });
 
-  it("uses the Haiku 4.5 model and gates on ANTHROPIC_API_KEY by default", () => {
-    expect(DEFAULT_ANTHROPIC_MODEL).toBe("claude-haiku-4-5-20251001");
-    expect(anthropicEvalGate({ RUN_LLM_EVALS: "1" })).toEqual({
+  it("uses the current low-cost OpenAI model and gates on OPENAI_API_KEY by default", () => {
+    expect(DEFAULT_OPENAI_MODEL).toBe("gpt-5.6-luna");
+    expect(openAIEvalGate({ RUN_LLM_EVALS: "1" })).toEqual({
       enabled: false,
-      reason: `missing provider key (${ANTHROPIC_API_KEY_ENV})`,
+      reason: `missing provider key (${OPENAI_API_KEY_ENV})`,
     });
-    expect(
-      anthropicEvalGate({ RUN_LLM_EVALS: "1", [ANTHROPIC_API_KEY_ENV]: "test-key" }).enabled,
-    ).toBe(true);
+    expect(openAIEvalGate({ RUN_LLM_EVALS: "1", [OPENAI_API_KEY_ENV]: "test-key" }).enabled).toBe(
+      true,
+    );
   });
 });
 
-const liveGate = anthropicEvalGate();
+const liveGate = openAIEvalGate();
 
-describe("Anthropic Haiku 4.5 live eval", () => {
+describe("OpenAI live eval", () => {
   it.skipIf(!liveGate.enabled)("runs the shared gated tool-use eval end to end", async () => {
     const evalCase = SHARED_EVAL_CASES[0];
     const run = await runEval({
       prompt: evalCase.prompt,
       toolNames: [...evalCase.toolNames],
-      driver: createAnthropicDriver(),
+      driver: createOpenAIDriver(),
       maxSteps: evalCase.maxSteps,
       timeouts: evalCase.timeouts,
     });

--- a/evals/openai-driver.eval.test.ts
+++ b/evals/openai-driver.eval.test.ts
@@ -166,7 +166,10 @@ describe("OpenAI eval driver", () => {
     expect(fetchImpl).not.toHaveBeenCalled();
   });
 
-  it("rejects non-string OpenAI tool-call arguments", async () => {
+  it.each([
+    ["non-string", { bucketId: "bucket-id", confirm: true }],
+    ["missing", undefined],
+  ] as const)("rejects %s OpenAI tool-call arguments", async (_caseName, argumentsValue) => {
     const { fetchImpl } = createFetchSequence([
       chatResponse({
         toolCalls: [
@@ -175,7 +178,7 @@ describe("OpenAI eval driver", () => {
             type: "function",
             function: {
               name: "b2_delete_bucket",
-              arguments: { bucketId: "bucket-id", confirm: true },
+              ...(argumentsValue === undefined ? {} : { arguments: argumentsValue }),
             },
           },
         ],

--- a/evals/openai-driver.eval.test.ts
+++ b/evals/openai-driver.eval.test.ts
@@ -1,6 +1,6 @@
 import type { CallToolResult, Tool } from "@modelcontextprotocol/client";
 import { describe, expect, it, vi } from "vitest";
-import { SHARED_EVAL_CASES } from "./cases";
+import { SHARED_EVAL_CASES, evalCaseRunOptions } from "./cases";
 import { runEval, type EvalMessage, type EvalToolCall } from "./harness";
 import {
   DEFAULT_OPENAI_MODEL,
@@ -9,6 +9,7 @@ import {
   openAIEvalGate,
   type OpenAIFetch,
 } from "./openai-driver";
+import { DEFAULT_MAX_RESPONSE_BODY_BYTES } from "./provider-utils";
 
 interface CapturedRequest {
   url: string | URL;
@@ -241,6 +242,36 @@ describe("OpenAI eval driver", () => {
     expect(fetchImpl).toHaveBeenCalledTimes(1);
   });
 
+  it("redacts echoed OpenAI credentials from upstream error messages", async () => {
+    const apiKey = "sk-proj-real-secret-1234567890";
+    const fetchImpl = vi.fn<OpenAIFetch>(
+      async () =>
+        new Response(
+          JSON.stringify({
+            error: {
+              message:
+                `invalid Authorization: Bearer ${apiKey}; key ${apiKey}; ` +
+                "alternate sk-proj-other-secret-1234567890",
+            },
+          }),
+          { status: 401 },
+        ),
+    );
+    const driver = createOpenAIDriver({ apiKey, fetch: fetchImpl });
+
+    let caught: unknown;
+    await driver.complete(driverInput({})).catch((err: unknown) => {
+      caught = err;
+    });
+
+    expect(caught).toBeInstanceOf(Error);
+    const message = (caught as Error).message;
+    expect(message).toContain("Bearer [REDACTED]");
+    expect(message).toContain("[REDACTED_SECRET]");
+    expect(message).not.toContain(apiKey);
+    expect(message).not.toContain("sk-proj-other-secret-1234567890");
+  });
+
   it("bounds non-JSON upstream error fallback bodies", async () => {
     const largeBody = "gateway failure ".repeat(100);
     const fetchImpl = vi.fn<OpenAIFetch>(
@@ -294,6 +325,36 @@ describe("OpenAI eval driver", () => {
     },
   );
 
+  it.each([
+    ["seconds", "3600"],
+    ["HTTP date", new Date(Date.now() + 3_600_000).toUTCString()],
+  ] as const)("clamps Retry-After %s values before retrying", async (_kind, retryAfter) => {
+    const fetchImpl = vi
+      .fn<OpenAIFetch>()
+      .mockResolvedValueOnce(
+        new Response(JSON.stringify({ error: { message: "rate limited" } }), {
+          status: 429,
+          headers: { "retry-after": retryAfter },
+        }),
+      )
+      .mockResolvedValueOnce(
+        new Response(JSON.stringify(chatResponse({ content: "Recovered." })), {
+          status: 200,
+        }),
+      );
+    const driver = createOpenAIDriver({
+      apiKey: "test-openai-key",
+      fetch: fetchImpl,
+      retry: { baseDelayMs: 0, maxDelayMs: 0 },
+    });
+
+    await expect(driver.complete(driverInput({}))).resolves.toEqual({
+      text: "Recovered.",
+      toolCalls: [],
+    });
+    expect(fetchImpl).toHaveBeenCalledTimes(2);
+  });
+
   it.each(["length", "content_filter"] as const)(
     "rejects %s OpenAI responses instead of consuming them",
     async (finishReason) => {
@@ -329,8 +390,60 @@ describe("OpenAI eval driver", () => {
     expect(fetchImpl).toHaveBeenCalledTimes(1);
   });
 
-  it("uses the current low-cost OpenAI model and gates on OPENAI_API_KEY by default", () => {
-    expect(DEFAULT_OPENAI_MODEL).toBe("gpt-5.6-luna");
+  it("does not retry malformed successful provider JSON", async () => {
+    const fetchImpl = vi.fn<OpenAIFetch>().mockResolvedValue(
+      new Response("{not-json", {
+        status: 200,
+        headers: { "content-type": "application/json" },
+      }),
+    );
+    const driver = createOpenAIDriver({
+      apiKey: "test-openai-key",
+      fetch: fetchImpl,
+      retry: { maxAttempts: 3, baseDelayMs: 0, maxDelayMs: 0 },
+    });
+
+    await expect(driver.complete(driverInput({}))).rejects.toThrow(
+      /OpenAI Chat Completions API returned invalid JSON/,
+    );
+    expect(fetchImpl).toHaveBeenCalledTimes(1);
+  });
+
+  it("rejects oversized non-JSON and JSON OpenAI responses before parsing", async () => {
+    const oversizedText = "x".repeat(DEFAULT_MAX_RESPONSE_BODY_BYTES + 1);
+    const oversizedJson = JSON.stringify({
+      choices: [{ message: { role: "assistant", content: "ok" } }],
+      padding: oversizedText,
+    });
+
+    for (const response of [
+      new Response(oversizedText, { status: 502 }),
+      new Response(oversizedJson, { status: 200 }),
+    ]) {
+      const fetchImpl = vi.fn<OpenAIFetch>().mockResolvedValueOnce(response);
+      const driver = createOpenAIDriver({
+        apiKey: "test-openai-key",
+        fetch: fetchImpl,
+        retry: { maxAttempts: 1 },
+      });
+
+      await expect(driver.complete(driverInput({}))).rejects.toThrow(/response body exceeded/);
+      expect(fetchImpl).toHaveBeenCalledTimes(1);
+    }
+  });
+
+  it("uses the current low-cost OpenAI default model and gates on OPENAI_API_KEY", async () => {
+    const { fetchImpl, requests } = createFetchSequence([
+      chatResponse({ content: "Default model." }),
+    ]);
+    const driver = createOpenAIDriver({ apiKey: "test-openai-key", fetch: fetchImpl });
+
+    await expect(driver.complete(driverInput({}))).resolves.toEqual({
+      text: "Default model.",
+      toolCalls: [],
+    });
+    expect(requests[0].body.model).toBe(DEFAULT_OPENAI_MODEL);
+    expect(DEFAULT_OPENAI_MODEL).toMatch(/^gpt-/);
     expect(openAIEvalGate({ RUN_LLM_EVALS: "1" })).toEqual({
       enabled: false,
       reason: `missing provider key (${OPENAI_API_KEY_ENV})`,
@@ -342,18 +455,17 @@ describe("OpenAI eval driver", () => {
 });
 
 const liveGate = openAIEvalGate();
+const LIVE_PROVIDER_TIMEOUT_MS = 180_000;
 
 describe("OpenAI live eval", () => {
-  it.skipIf(!liveGate.enabled)("runs the shared gated tool-use eval end to end", async () => {
-    const evalCase = SHARED_EVAL_CASES[0];
-    const run = await runEval({
-      prompt: evalCase.prompt,
-      toolNames: [...evalCase.toolNames],
-      driver: createOpenAIDriver(),
-      maxSteps: evalCase.maxSteps,
-      timeouts: evalCase.timeouts,
-    });
+  it.skipIf(!liveGate.enabled)(
+    "runs the shared gated tool-use eval end to end",
+    async () => {
+      const evalCase = SHARED_EVAL_CASES[0];
+      const run = await runEval(evalCaseRunOptions(evalCase, createOpenAIDriver()));
 
-    expect(evalCase.passed(run), evalCase.failureSummary(run)).toBe(true);
-  });
+      expect(evalCase.passed(run), evalCase.failureSummary(run)).toBe(true);
+    },
+    LIVE_PROVIDER_TIMEOUT_MS,
+  );
 });

--- a/evals/openai-driver.ts
+++ b/evals/openai-driver.ts
@@ -1,0 +1,500 @@
+import type { CallToolResult, Tool } from "@modelcontextprotocol/client";
+import {
+  llmEvalGate,
+  type Driver,
+  type DriverInput,
+  type DriverOutput,
+  type EvalGate,
+  type EvalToolCall,
+} from "./harness";
+
+export const OPENAI_API_KEY_ENV = "OPENAI_API_KEY";
+export const OPENAI_EVAL_MODEL_ENV = "OPENAI_EVAL_MODEL";
+export const DEFAULT_OPENAI_MODEL = "gpt-5.6-luna";
+
+const OPENAI_CHAT_COMPLETIONS_URL = "https://api.openai.com/v1/chat/completions";
+const DEFAULT_MAX_COMPLETION_TOKENS = 1024;
+const MAX_ERROR_FALLBACK_CHARS = 500;
+const RETRYABLE_HTTP_STATUSES = new Set([408, 409, 429, 500, 502, 503, 504, 529]);
+const INCOMPLETE_FINISH_REASONS = new Set(["length", "content_filter"]);
+const DEFAULT_RETRY_POLICY = {
+  maxAttempts: 3,
+  baseDelayMs: 250,
+  maxDelayMs: 2_000,
+};
+const DEFAULT_SYSTEM_PROMPT =
+  "You are running deterministic MCP evals. Use the provided tools when the user asks for " +
+  "tool-backed evidence, then give a concise final answer based on the tool result.";
+
+export type OpenAIFetch = (input: string | URL, init?: RequestInit) => Promise<Response>;
+
+export interface OpenAIDriverOptions {
+  apiKey?: string;
+  model?: string;
+  maxCompletionTokens?: number;
+  system?: string;
+  retry?: Partial<OpenAIRetryOptions>;
+  fetch?: OpenAIFetch;
+}
+
+export interface OpenAIRetryOptions {
+  maxAttempts: number;
+  baseDelayMs: number;
+  maxDelayMs: number;
+}
+
+interface OpenAITool {
+  type: "function";
+  function: {
+    name: string;
+    description: string;
+    parameters: Record<string, unknown>;
+  };
+}
+
+interface OpenAIToolCall {
+  id: string;
+  type: "function";
+  function: {
+    name: string;
+    arguments: string;
+  };
+}
+
+type OpenAIMessage =
+  | { role: "system"; content: string }
+  | { role: "user"; content: string }
+  | { role: "assistant"; content: string | null; tool_calls?: OpenAIToolCall[] }
+  | { role: "tool"; tool_call_id: string; content: string };
+
+interface OpenAIRequestBody {
+  model: string;
+  max_completion_tokens: number;
+  messages: OpenAIMessage[];
+  tools?: OpenAITool[];
+  tool_choice?: "auto";
+}
+
+interface ParsedAssistantMessage {
+  content: string;
+  toolCalls: PendingToolCall[];
+  finishReason?: string;
+}
+
+interface PendingToolCall {
+  id: string;
+  call: EvalToolCall;
+  providerCall: OpenAIToolCall;
+}
+
+class OpenAIApiError extends Error {
+  constructor(
+    message: string,
+    readonly status: number,
+    readonly retryAfterMs: number | undefined,
+  ) {
+    super(message);
+    this.name = "OpenAIApiError";
+  }
+}
+
+export function openAIEvalGate(env: NodeJS.ProcessEnv = process.env): EvalGate {
+  return llmEvalGate(env, { providerKeyEnvNames: [OPENAI_API_KEY_ENV] });
+}
+
+export function createOpenAIDriver(options: OpenAIDriverOptions = {}): Driver {
+  return new OpenAIChatCompletionsDriver(options);
+}
+
+function requirePositiveInteger(value: number, name: string): number {
+  if (!Number.isInteger(value) || value <= 0) {
+    throw new Error(`${name} must be a positive integer.`);
+  }
+  return value;
+}
+
+function requireNonNegativeInteger(value: number, name: string): number {
+  if (!Number.isInteger(value) || value < 0) {
+    throw new Error(`${name} must be a non-negative integer.`);
+  }
+  return value;
+}
+
+function requireApiKey(value: string | undefined): string {
+  if (!value) {
+    throw new Error(`${OPENAI_API_KEY_ENV} is required to run OpenAI evals.`);
+  }
+  return value;
+}
+
+function rejectBaseUrlOverride(options: OpenAIDriverOptions): void {
+  if ((options as OpenAIDriverOptions & { baseUrl?: unknown }).baseUrl !== undefined) {
+    throw new Error("OpenAI eval driver does not support overriding baseUrl.");
+  }
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function inputSchemaForTool(tool: Tool): Record<string, unknown> {
+  return isRecord(tool.inputSchema) ? tool.inputSchema : { type: "object", properties: {} };
+}
+
+function toOpenAITool(tool: Tool): OpenAITool {
+  return {
+    type: "function",
+    function: {
+      name: tool.name,
+      description: tool.description ?? "MCP tool exposed by b2-mcp.",
+      parameters: inputSchemaForTool(tool),
+    },
+  };
+}
+
+function resolveRetryOptions(options: Partial<OpenAIRetryOptions> | undefined): OpenAIRetryOptions {
+  const maxAttempts = requirePositiveInteger(
+    options?.maxAttempts ?? DEFAULT_RETRY_POLICY.maxAttempts,
+    "retry.maxAttempts",
+  );
+  const baseDelayMs = requireNonNegativeInteger(
+    options?.baseDelayMs ?? DEFAULT_RETRY_POLICY.baseDelayMs,
+    "retry.baseDelayMs",
+  );
+  const maxDelayMs = requireNonNegativeInteger(
+    options?.maxDelayMs ?? DEFAULT_RETRY_POLICY.maxDelayMs,
+    "retry.maxDelayMs",
+  );
+  if (baseDelayMs > maxDelayMs) {
+    throw new Error("retry.baseDelayMs must be less than or equal to retry.maxDelayMs.");
+  }
+  return { maxAttempts, baseDelayMs, maxDelayMs };
+}
+
+function stringifyToolResultPayload(value: unknown): string {
+  if (typeof value === "string") return value;
+  try {
+    return JSON.stringify(value);
+  } catch {
+    return String(value);
+  }
+}
+
+function textFromContentBlocks(content: CallToolResult["content"]): string {
+  const parts = content.map((block) => {
+    if (block.type === "text") return block.text;
+    return stringifyToolResultPayload(block);
+  });
+  return parts.join("\n");
+}
+
+function toolResultContent(result: CallToolResult): string {
+  if (result.structuredContent !== undefined) {
+    return stringifyToolResultPayload(result.structuredContent);
+  }
+  return textFromContentBlocks(result.content);
+}
+
+function parseArguments(name: string, value: unknown): Record<string, unknown> {
+  if (value === undefined || value === "") return {};
+  if (typeof value !== "string") {
+    throw new Error(`OpenAI returned non-string arguments for tool call ${name}.`);
+  }
+
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(value);
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    throw new Error(`OpenAI returned invalid JSON arguments for tool call ${name}: ${message}`);
+  }
+  if (!isRecord(parsed)) {
+    throw new Error(`OpenAI returned non-object arguments for tool call ${name}.`);
+  }
+  return parsed;
+}
+
+function parseToolCalls(value: unknown): PendingToolCall[] {
+  if (!Array.isArray(value)) return [];
+
+  const calls: PendingToolCall[] = [];
+  for (const item of value) {
+    if (
+      !isRecord(item) ||
+      typeof item.id !== "string" ||
+      item.type !== "function" ||
+      !isRecord(item.function) ||
+      typeof item.function.name !== "string"
+    ) {
+      throw new Error("OpenAI response included an invalid tool call.");
+    }
+    const argumentsJson =
+      typeof item.function.arguments === "string" ? item.function.arguments : "";
+    const providerCall: OpenAIToolCall = {
+      id: item.id,
+      type: "function",
+      function: {
+        name: item.function.name,
+        arguments: argumentsJson,
+      },
+    };
+    calls.push({
+      id: item.id,
+      providerCall,
+      call: {
+        name: item.function.name,
+        args: parseArguments(item.function.name, argumentsJson),
+      },
+    });
+  }
+  return calls;
+}
+
+function parseAssistantMessage(payload: unknown): ParsedAssistantMessage {
+  if (!isRecord(payload) || !Array.isArray(payload.choices) || payload.choices.length === 0) {
+    throw new Error("OpenAI response did not include any choices.");
+  }
+  const choice = payload.choices[0];
+  if (!isRecord(choice) || !isRecord(choice.message)) {
+    throw new Error("OpenAI response did not include an assistant message.");
+  }
+  const message = choice.message;
+  return {
+    content: typeof message.content === "string" ? message.content : "",
+    toolCalls: parseToolCalls(message.tool_calls),
+    finishReason: typeof choice.finish_reason === "string" ? choice.finish_reason : undefined,
+  };
+}
+
+function boundedFallback(value: string): string {
+  return value.slice(0, MAX_ERROR_FALLBACK_CHARS);
+}
+
+function extractErrorMessage(payload: unknown, fallback: string): string {
+  if (isRecord(payload) && isRecord(payload.error) && typeof payload.error.message === "string") {
+    return boundedFallback(payload.error.message);
+  }
+  return boundedFallback(fallback);
+}
+
+function requestIdFromHeaders(headers: Headers): string | undefined {
+  return (
+    headers.get("x-request-id") ??
+    headers.get("openai-request-id") ??
+    headers.get("request-id") ??
+    undefined
+  );
+}
+
+function messageWithRequestId(message: string, requestId: string | undefined): string {
+  return requestId ? `${message} (requestId: ${requestId})` : message;
+}
+
+function retryAfterMsFromHeaders(headers: Headers, now = Date.now()): number | undefined {
+  const value = headers.get("retry-after");
+  if (!value) return undefined;
+
+  const seconds = Number(value);
+  if (Number.isFinite(seconds) && seconds >= 0) return seconds * 1_000;
+
+  const retryDate = Date.parse(value);
+  if (Number.isFinite(retryDate)) return Math.max(0, retryDate - now);
+  return undefined;
+}
+
+async function readOpenAIResponse(response: Response): Promise<unknown> {
+  const text = await response.text();
+  let payload: unknown;
+  try {
+    payload = text ? JSON.parse(text) : {};
+  } catch {
+    payload = undefined;
+  }
+
+  if (!response.ok) {
+    const message =
+      `OpenAI Chat Completions API request failed (${response.status}): ` +
+      extractErrorMessage(payload, text || response.statusText);
+    throw new OpenAIApiError(
+      messageWithRequestId(message, requestIdFromHeaders(response.headers)),
+      response.status,
+      retryAfterMsFromHeaders(response.headers),
+    );
+  }
+  if (payload === undefined) {
+    throw new Error("OpenAI Chat Completions API returned invalid JSON.");
+  }
+  return payload;
+}
+
+function rejectIncompleteResponse(message: ParsedAssistantMessage): void {
+  if (message.finishReason && INCOMPLETE_FINISH_REASONS.has(message.finishReason)) {
+    throw new Error(
+      `OpenAI response stopped with ${message.finishReason}; increase maxCompletionTokens or ` +
+        "reduce the eval context before treating this run as complete.",
+    );
+  }
+}
+
+function isAbortError(err: unknown): boolean {
+  return isRecord(err) && (err.name === "AbortError" || err.code === "ABORT_ERR");
+}
+
+function retryDelayMs(err: unknown, attempt: number, retry: OpenAIRetryOptions): number {
+  if (err instanceof OpenAIApiError && err.retryAfterMs !== undefined) {
+    return err.retryAfterMs;
+  }
+  const exponentialCap = Math.min(retry.maxDelayMs, retry.baseDelayMs * 2 ** (attempt - 1));
+  return Math.floor(Math.random() * (exponentialCap + 1));
+}
+
+function abortError(signal: AbortSignal): Error {
+  return signal.reason instanceof Error ? signal.reason : new Error("OpenAI request aborted.");
+}
+
+async function sleep(delayMs: number, signal: AbortSignal): Promise<void> {
+  if (signal.aborted) throw abortError(signal);
+  if (delayMs <= 0) return;
+
+  await new Promise<void>((resolve, reject) => {
+    let timer: NodeJS.Timeout;
+    function cleanup(): void {
+      clearTimeout(timer);
+      signal.removeEventListener("abort", onAbort);
+    }
+    function onDone(): void {
+      cleanup();
+      resolve();
+    }
+    function onAbort(): void {
+      cleanup();
+      reject(abortError(signal));
+    }
+    timer = setTimeout(onDone, delayMs);
+    timer.unref();
+    signal.addEventListener("abort", onAbort, { once: true });
+  });
+}
+
+class OpenAIChatCompletionsDriver implements Driver {
+  readonly name = "openai";
+  private readonly apiKey: string;
+  private readonly model: string;
+  private readonly maxCompletionTokens: number;
+  private readonly system: string | undefined;
+  private readonly retry: OpenAIRetryOptions;
+  private readonly fetchImpl: OpenAIFetch;
+  private messages: OpenAIMessage[] = [];
+  private pendingToolCalls: PendingToolCall[] = [];
+  private consumedToolResults = 0;
+
+  constructor(options: OpenAIDriverOptions) {
+    rejectBaseUrlOverride(options);
+    this.apiKey = requireApiKey(options.apiKey ?? process.env[OPENAI_API_KEY_ENV]);
+    this.model = options.model ?? process.env[OPENAI_EVAL_MODEL_ENV] ?? DEFAULT_OPENAI_MODEL;
+    this.maxCompletionTokens = requirePositiveInteger(
+      options.maxCompletionTokens ?? DEFAULT_MAX_COMPLETION_TOKENS,
+      "maxCompletionTokens",
+    );
+    this.system = options.system ?? DEFAULT_SYSTEM_PROMPT;
+    this.retry = resolveRetryOptions(options.retry);
+    this.fetchImpl = options.fetch ?? fetch;
+  }
+
+  async complete(input: DriverInput): Promise<DriverOutput> {
+    if (input.step === 0) this.reset(input.prompt);
+    this.appendToolResults(input);
+
+    const body: OpenAIRequestBody = {
+      model: this.model,
+      max_completion_tokens: this.maxCompletionTokens,
+      messages: this.messages,
+    };
+    const tools = input.tools.map(toOpenAITool);
+    if (tools.length > 0) {
+      body.tools = tools;
+      body.tool_choice = "auto";
+    }
+
+    const payload = await this.sendRequest(body, input.signal);
+    const message = parseAssistantMessage(payload);
+    rejectIncompleteResponse(message);
+
+    this.messages.push({
+      role: "assistant",
+      content: message.content || null,
+      ...(message.toolCalls.length > 0
+        ? { tool_calls: message.toolCalls.map((toolCall) => toolCall.providerCall) }
+        : {}),
+    });
+    this.pendingToolCalls = message.toolCalls;
+
+    return {
+      text: message.content,
+      toolCalls: message.toolCalls.map((toolCall) => toolCall.call),
+    };
+  }
+
+  private reset(prompt: string): void {
+    this.messages = [
+      ...(this.system ? [{ role: "system" as const, content: this.system }] : []),
+      { role: "user", content: prompt },
+    ];
+    this.pendingToolCalls = [];
+    this.consumedToolResults = 0;
+  }
+
+  private async sendRequest(body: OpenAIRequestBody, signal: AbortSignal): Promise<unknown> {
+    const requestBody = JSON.stringify(body);
+    let lastError: unknown;
+
+    for (let attempt = 1; attempt <= this.retry.maxAttempts; attempt += 1) {
+      try {
+        const response = await this.fetchImpl(OPENAI_CHAT_COMPLETIONS_URL, {
+          method: "POST",
+          signal,
+          headers: {
+            authorization: `Bearer ${this.apiKey}`,
+            "content-type": "application/json",
+          },
+          body: requestBody,
+        });
+        return await readOpenAIResponse(response);
+      } catch (err) {
+        lastError = err;
+        if (!this.shouldRetry(err, attempt)) throw err;
+        await sleep(retryDelayMs(err, attempt, this.retry), signal);
+      }
+    }
+
+    throw lastError;
+  }
+
+  private shouldRetry(err: unknown, attempt: number): boolean {
+    if (attempt >= this.retry.maxAttempts || isAbortError(err)) return false;
+    if (err instanceof OpenAIApiError) return RETRYABLE_HTTP_STATUSES.has(err.status);
+    return true;
+  }
+
+  private appendToolResults(input: DriverInput): void {
+    const toolMessages = input.messages.filter((message) => message.role === "tool");
+    const newToolMessages = toolMessages.slice(this.consumedToolResults);
+    if (newToolMessages.length === 0) return;
+    if (newToolMessages.length !== this.pendingToolCalls.length) {
+      throw new Error(
+        `OpenAI driver expected ${this.pendingToolCalls.length} tool result(s) but ` +
+          `received ${newToolMessages.length}.`,
+      );
+    }
+
+    this.messages.push(
+      ...newToolMessages.map((message, index) => ({
+        role: "tool" as const,
+        tool_call_id: this.pendingToolCalls[index].id,
+        content: toolResultContent(message.result),
+      })),
+    );
+    this.consumedToolResults = toolMessages.length;
+    this.pendingToolCalls = [];
+  }
+}

--- a/evals/openai-driver.ts
+++ b/evals/openai-driver.ts
@@ -1,4 +1,4 @@
-import type { CallToolResult, Tool } from "@modelcontextprotocol/client";
+import type { Tool } from "@modelcontextprotocol/client";
 import {
   llmEvalGate,
   type Driver,
@@ -7,26 +7,33 @@ import {
   type EvalGate,
   type EvalToolCall,
 } from "./harness";
+import {
+  DEFAULT_MAX_RESPONSE_BODY_BYTES,
+  DEFAULT_SYSTEM_PROMPT,
+  ToolResultConversationState,
+  inputSchemaForTool,
+  isRecord,
+  readProviderJsonResponse,
+  rejectBaseUrlOverride,
+  requireApiKey,
+  requirePositiveInteger,
+  resolveRetryOptions,
+  sendProviderJsonRequest,
+  toolResultContent,
+  type EvalFetch,
+  type EvalRetryOptions,
+} from "./provider-utils";
 
 export const OPENAI_API_KEY_ENV = "OPENAI_API_KEY";
 export const OPENAI_EVAL_MODEL_ENV = "OPENAI_EVAL_MODEL";
-export const DEFAULT_OPENAI_MODEL = "gpt-5.6-luna";
+export const DEFAULT_OPENAI_MODEL = "gpt-5-nano";
 
 const OPENAI_CHAT_COMPLETIONS_URL = "https://api.openai.com/v1/chat/completions";
 const DEFAULT_MAX_COMPLETION_TOKENS = 1024;
-const MAX_ERROR_FALLBACK_CHARS = 500;
 const RETRYABLE_HTTP_STATUSES = new Set([408, 409, 429, 500, 502, 503, 504, 529]);
 const INCOMPLETE_FINISH_REASONS = new Set(["length", "content_filter"]);
-const DEFAULT_RETRY_POLICY = {
-  maxAttempts: 3,
-  baseDelayMs: 250,
-  maxDelayMs: 2_000,
-};
-const DEFAULT_SYSTEM_PROMPT =
-  "You are running deterministic MCP evals. Use the provided tools when the user asks for " +
-  "tool-backed evidence, then give a concise final answer based on the tool result.";
 
-export type OpenAIFetch = (input: string | URL, init?: RequestInit) => Promise<Response>;
+export type OpenAIFetch = EvalFetch;
 
 export interface OpenAIDriverOptions {
   apiKey?: string;
@@ -37,11 +44,7 @@ export interface OpenAIDriverOptions {
   fetch?: OpenAIFetch;
 }
 
-export interface OpenAIRetryOptions {
-  maxAttempts: number;
-  baseDelayMs: number;
-  maxDelayMs: number;
-}
+export type OpenAIRetryOptions = EvalRetryOptions;
 
 interface OpenAITool {
   type: "function";
@@ -87,58 +90,12 @@ interface PendingToolCall {
   providerCall: OpenAIToolCall;
 }
 
-class OpenAIApiError extends Error {
-  constructor(
-    message: string,
-    readonly status: number,
-    readonly retryAfterMs: number | undefined,
-  ) {
-    super(message);
-    this.name = "OpenAIApiError";
-  }
-}
-
 export function openAIEvalGate(env: NodeJS.ProcessEnv = process.env): EvalGate {
   return llmEvalGate(env, { providerKeyEnvNames: [OPENAI_API_KEY_ENV] });
 }
 
 export function createOpenAIDriver(options: OpenAIDriverOptions = {}): Driver {
   return new OpenAIChatCompletionsDriver(options);
-}
-
-function requirePositiveInteger(value: number, name: string): number {
-  if (!Number.isInteger(value) || value <= 0) {
-    throw new Error(`${name} must be a positive integer.`);
-  }
-  return value;
-}
-
-function requireNonNegativeInteger(value: number, name: string): number {
-  if (!Number.isInteger(value) || value < 0) {
-    throw new Error(`${name} must be a non-negative integer.`);
-  }
-  return value;
-}
-
-function requireApiKey(value: string | undefined): string {
-  if (!value) {
-    throw new Error(`${OPENAI_API_KEY_ENV} is required to run OpenAI evals.`);
-  }
-  return value;
-}
-
-function rejectBaseUrlOverride(options: OpenAIDriverOptions): void {
-  if ((options as OpenAIDriverOptions & { baseUrl?: unknown }).baseUrl !== undefined) {
-    throw new Error("OpenAI eval driver does not support overriding baseUrl.");
-  }
-}
-
-function isRecord(value: unknown): value is Record<string, unknown> {
-  return typeof value === "object" && value !== null && !Array.isArray(value);
-}
-
-function inputSchemaForTool(tool: Tool): Record<string, unknown> {
-  return isRecord(tool.inputSchema) ? tool.inputSchema : { type: "object", properties: {} };
 }
 
 function toOpenAITool(tool: Tool): OpenAITool {
@@ -150,49 +107,6 @@ function toOpenAITool(tool: Tool): OpenAITool {
       parameters: inputSchemaForTool(tool),
     },
   };
-}
-
-function resolveRetryOptions(options: Partial<OpenAIRetryOptions> | undefined): OpenAIRetryOptions {
-  const maxAttempts = requirePositiveInteger(
-    options?.maxAttempts ?? DEFAULT_RETRY_POLICY.maxAttempts,
-    "retry.maxAttempts",
-  );
-  const baseDelayMs = requireNonNegativeInteger(
-    options?.baseDelayMs ?? DEFAULT_RETRY_POLICY.baseDelayMs,
-    "retry.baseDelayMs",
-  );
-  const maxDelayMs = requireNonNegativeInteger(
-    options?.maxDelayMs ?? DEFAULT_RETRY_POLICY.maxDelayMs,
-    "retry.maxDelayMs",
-  );
-  if (baseDelayMs > maxDelayMs) {
-    throw new Error("retry.baseDelayMs must be less than or equal to retry.maxDelayMs.");
-  }
-  return { maxAttempts, baseDelayMs, maxDelayMs };
-}
-
-function stringifyToolResultPayload(value: unknown): string {
-  if (typeof value === "string") return value;
-  try {
-    return JSON.stringify(value);
-  } catch {
-    return String(value);
-  }
-}
-
-function textFromContentBlocks(content: CallToolResult["content"]): string {
-  const parts = content.map((block) => {
-    if (block.type === "text") return block.text;
-    return stringifyToolResultPayload(block);
-  });
-  return parts.join("\n");
-}
-
-function toolResultContent(result: CallToolResult): string {
-  if (result.structuredContent !== undefined) {
-    return stringifyToolResultPayload(result.structuredContent);
-  }
-  return textFromContentBlocks(result.content);
 }
 
 function parseArguments(name: string, value: unknown): Record<string, unknown> {
@@ -266,67 +180,6 @@ function parseAssistantMessage(payload: unknown): ParsedAssistantMessage {
   };
 }
 
-function boundedFallback(value: string): string {
-  return value.slice(0, MAX_ERROR_FALLBACK_CHARS);
-}
-
-function extractErrorMessage(payload: unknown, fallback: string): string {
-  if (isRecord(payload) && isRecord(payload.error) && typeof payload.error.message === "string") {
-    return boundedFallback(payload.error.message);
-  }
-  return boundedFallback(fallback);
-}
-
-function requestIdFromHeaders(headers: Headers): string | undefined {
-  return (
-    headers.get("x-request-id") ??
-    headers.get("openai-request-id") ??
-    headers.get("request-id") ??
-    undefined
-  );
-}
-
-function messageWithRequestId(message: string, requestId: string | undefined): string {
-  return requestId ? `${message} (requestId: ${requestId})` : message;
-}
-
-function retryAfterMsFromHeaders(headers: Headers, now = Date.now()): number | undefined {
-  const value = headers.get("retry-after");
-  if (!value) return undefined;
-
-  const seconds = Number(value);
-  if (Number.isFinite(seconds) && seconds >= 0) return seconds * 1_000;
-
-  const retryDate = Date.parse(value);
-  if (Number.isFinite(retryDate)) return Math.max(0, retryDate - now);
-  return undefined;
-}
-
-async function readOpenAIResponse(response: Response): Promise<unknown> {
-  const text = await response.text();
-  let payload: unknown;
-  try {
-    payload = text ? JSON.parse(text) : {};
-  } catch {
-    payload = undefined;
-  }
-
-  if (!response.ok) {
-    const message =
-      `OpenAI Chat Completions API request failed (${response.status}): ` +
-      extractErrorMessage(payload, text || response.statusText);
-    throw new OpenAIApiError(
-      messageWithRequestId(message, requestIdFromHeaders(response.headers)),
-      response.status,
-      retryAfterMsFromHeaders(response.headers),
-    );
-  }
-  if (payload === undefined) {
-    throw new Error("OpenAI Chat Completions API returned invalid JSON.");
-  }
-  return payload;
-}
-
 function rejectIncompleteResponse(message: ParsedAssistantMessage): void {
   if (message.finishReason && INCOMPLETE_FINISH_REASONS.has(message.finishReason)) {
     throw new Error(
@@ -334,46 +187,6 @@ function rejectIncompleteResponse(message: ParsedAssistantMessage): void {
         "reduce the eval context before treating this run as complete.",
     );
   }
-}
-
-function isAbortError(err: unknown): boolean {
-  return isRecord(err) && (err.name === "AbortError" || err.code === "ABORT_ERR");
-}
-
-function retryDelayMs(err: unknown, attempt: number, retry: OpenAIRetryOptions): number {
-  if (err instanceof OpenAIApiError && err.retryAfterMs !== undefined) {
-    return err.retryAfterMs;
-  }
-  const exponentialCap = Math.min(retry.maxDelayMs, retry.baseDelayMs * 2 ** (attempt - 1));
-  return Math.floor(Math.random() * (exponentialCap + 1));
-}
-
-function abortError(signal: AbortSignal): Error {
-  return signal.reason instanceof Error ? signal.reason : new Error("OpenAI request aborted.");
-}
-
-async function sleep(delayMs: number, signal: AbortSignal): Promise<void> {
-  if (signal.aborted) throw abortError(signal);
-  if (delayMs <= 0) return;
-
-  await new Promise<void>((resolve, reject) => {
-    let timer: NodeJS.Timeout;
-    function cleanup(): void {
-      clearTimeout(timer);
-      signal.removeEventListener("abort", onAbort);
-    }
-    function onDone(): void {
-      cleanup();
-      resolve();
-    }
-    function onAbort(): void {
-      cleanup();
-      reject(abortError(signal));
-    }
-    timer = setTimeout(onDone, delayMs);
-    timer.unref();
-    signal.addEventListener("abort", onAbort, { once: true });
-  });
 }
 
 class OpenAIChatCompletionsDriver implements Driver {
@@ -385,12 +198,14 @@ class OpenAIChatCompletionsDriver implements Driver {
   private readonly retry: OpenAIRetryOptions;
   private readonly fetchImpl: OpenAIFetch;
   private messages: OpenAIMessage[] = [];
-  private pendingToolCalls: PendingToolCall[] = [];
-  private consumedToolResults = 0;
+  private readonly state = new ToolResultConversationState<PendingToolCall>();
 
   constructor(options: OpenAIDriverOptions) {
-    rejectBaseUrlOverride(options);
-    this.apiKey = requireApiKey(options.apiKey ?? process.env[OPENAI_API_KEY_ENV]);
+    rejectBaseUrlOverride(options, "OpenAI");
+    this.apiKey = requireApiKey(
+      options.apiKey ?? process.env[OPENAI_API_KEY_ENV],
+      OPENAI_API_KEY_ENV,
+    );
     this.model = options.model ?? process.env[OPENAI_EVAL_MODEL_ENV] ?? DEFAULT_OPENAI_MODEL;
     this.maxCompletionTokens = requirePositiveInteger(
       options.maxCompletionTokens ?? DEFAULT_MAX_COMPLETION_TOKENS,
@@ -427,7 +242,7 @@ class OpenAIChatCompletionsDriver implements Driver {
         ? { tool_calls: message.toolCalls.map((toolCall) => toolCall.providerCall) }
         : {}),
     });
-    this.pendingToolCalls = message.toolCalls;
+    this.state.setPending(message.toolCalls);
 
     return {
       text: message.content,
@@ -440,61 +255,46 @@ class OpenAIChatCompletionsDriver implements Driver {
       ...(this.system ? [{ role: "system" as const, content: this.system }] : []),
       { role: "user", content: prompt },
     ];
-    this.pendingToolCalls = [];
-    this.consumedToolResults = 0;
+    this.state.reset();
   }
 
   private async sendRequest(body: OpenAIRequestBody, signal: AbortSignal): Promise<unknown> {
-    const requestBody = JSON.stringify(body);
-    let lastError: unknown;
-
-    for (let attempt = 1; attempt <= this.retry.maxAttempts; attempt += 1) {
-      try {
-        const response = await this.fetchImpl(OPENAI_CHAT_COMPLETIONS_URL, {
-          method: "POST",
-          signal,
-          headers: {
-            authorization: `Bearer ${this.apiKey}`,
-            "content-type": "application/json",
-          },
-          body: requestBody,
-        });
-        return await readOpenAIResponse(response);
-      } catch (err) {
-        lastError = err;
-        if (!this.shouldRetry(err, attempt)) throw err;
-        await sleep(retryDelayMs(err, attempt, this.retry), signal);
-      }
-    }
-
-    throw lastError;
-  }
-
-  private shouldRetry(err: unknown, attempt: number): boolean {
-    if (attempt >= this.retry.maxAttempts || isAbortError(err)) return false;
-    if (err instanceof OpenAIApiError) return RETRYABLE_HTTP_STATUSES.has(err.status);
-    return true;
+    return sendProviderJsonRequest({
+      providerName: "OpenAI",
+      url: OPENAI_CHAT_COMPLETIONS_URL,
+      fetchImpl: this.fetchImpl,
+      headers: {
+        authorization: `Bearer ${this.apiKey}`,
+        "content-type": "application/json",
+      },
+      body,
+      signal,
+      retry: this.retry,
+      retryableStatuses: RETRYABLE_HTTP_STATUSES,
+      readResponse: (response, readSignal) =>
+        readProviderJsonResponse({
+          response,
+          providerName: "OpenAI",
+          apiName: "OpenAI Chat Completions API",
+          failurePrefix: "OpenAI Chat Completions API request failed",
+          requestIdHeaderNames: ["x-request-id", "openai-request-id", "request-id"],
+          secretValues: [this.apiKey],
+          maxBodyBytes: DEFAULT_MAX_RESPONSE_BODY_BYTES,
+          signal: readSignal,
+        }),
+    });
   }
 
   private appendToolResults(input: DriverInput): void {
-    const toolMessages = input.messages.filter((message) => message.role === "tool");
-    const newToolMessages = toolMessages.slice(this.consumedToolResults);
+    const newToolMessages = this.state.consumeNewToolResults(input, "OpenAI driver");
     if (newToolMessages.length === 0) return;
-    if (newToolMessages.length !== this.pendingToolCalls.length) {
-      throw new Error(
-        `OpenAI driver expected ${this.pendingToolCalls.length} tool result(s) but ` +
-          `received ${newToolMessages.length}.`,
-      );
-    }
 
     this.messages.push(
-      ...newToolMessages.map((message, index) => ({
+      ...newToolMessages.map(({ message, pending }) => ({
         role: "tool" as const,
-        tool_call_id: this.pendingToolCalls[index].id,
+        tool_call_id: pending.id,
         content: toolResultContent(message.result),
       })),
     );
-    this.consumedToolResults = toolMessages.length;
-    this.pendingToolCalls = [];
   }
 }

--- a/evals/openai-driver.ts
+++ b/evals/openai-driver.ts
@@ -138,12 +138,12 @@ function parseToolCalls(value: unknown): PendingToolCall[] {
       typeof item.id !== "string" ||
       item.type !== "function" ||
       !isRecord(item.function) ||
-      typeof item.function.name !== "string"
+      typeof item.function.name !== "string" ||
+      typeof item.function.arguments !== "string"
     ) {
       throw new Error("OpenAI response included an invalid tool call.");
     }
-    const argumentsJson =
-      typeof item.function.arguments === "string" ? item.function.arguments : "";
+    const argumentsJson = item.function.arguments;
     const providerCall: OpenAIToolCall = {
       id: item.id,
       type: "function",

--- a/evals/provider-comparison.eval.test.ts
+++ b/evals/provider-comparison.eval.test.ts
@@ -1,0 +1,167 @@
+import { describe, expect, it } from "vitest";
+import type { EvalCase } from "./cases";
+import {
+  SHARED_EVAL_CASES,
+  destructiveDeleteBucketGateFailure,
+  destructiveDeleteBucketGatePassed,
+} from "./cases";
+import type { Driver, DriverInput, DriverOutput, EvalRun, RunEvalOptions } from "./harness";
+import {
+  CLAUDE_OPENAI_PROVIDERS,
+  claudeOpenAIComparisonEvalGate,
+  formatPassRateSummary,
+  runProviderPassRateComparison,
+} from "./provider-comparison";
+
+class ScriptedDriver implements Driver {
+  readonly name: string;
+
+  constructor(
+    name: string,
+    private readonly output: DriverOutput,
+  ) {
+    this.name = name;
+  }
+
+  async complete(_input: DriverInput): Promise<DriverOutput> {
+    return this.output;
+  }
+}
+
+function passingRun(): EvalRun {
+  return {
+    toolCalls: [{ name: "b2_delete_bucket", args: { bucketId: "eval-bucket-id", confirm: true } }],
+    toolResults: [
+      {
+        isError: true,
+        structuredContent: { code: "destructive_policy_blocked", status: 403 },
+        content: [{ type: "text", text: "Deletion blocked by destructive policy." }],
+      },
+    ],
+    text: "Deletion is blocked by destructive policy.",
+  };
+}
+
+function failingRun(): EvalRun {
+  return {
+    toolCalls: [],
+    toolResults: [],
+    text: "Done.",
+  };
+}
+
+const comparisonCase = {
+  name: "comparison case",
+  prompt: "Use the tool.",
+  toolNames: ["b2_delete_bucket"],
+  maxSteps: 2,
+  passed: destructiveDeleteBucketGatePassed,
+  failureSummary: destructiveDeleteBucketGateFailure,
+} satisfies EvalCase;
+
+describe("provider pass-rate comparison", () => {
+  it("runs the same cases for each provider and summarizes pass rates", async () => {
+    const observed: Array<{ provider: string; prompt: string; tools: string[] }> = [];
+    const runEvalImpl = async (options: RunEvalOptions): Promise<EvalRun> => {
+      observed.push({
+        provider: options.driver.name,
+        prompt: options.prompt,
+        tools: options.toolNames,
+      });
+      return options.driver.name === "openai" ? failingRun() : passingRun();
+    };
+
+    const comparison = await runProviderPassRateComparison({
+      cases: [comparisonCase],
+      providers: [
+        { name: "Claude", createDriver: () => new ScriptedDriver("anthropic", {}) },
+        { name: "OpenAI", createDriver: () => new ScriptedDriver("openai", {}) },
+      ],
+      runEvalImpl,
+    });
+
+    expect(observed).toEqual([
+      { provider: "anthropic", prompt: "Use the tool.", tools: ["b2_delete_bucket"] },
+      { provider: "openai", prompt: "Use the tool.", tools: ["b2_delete_bucket"] },
+    ]);
+    expect(comparison.passRates).toEqual([
+      { provider: "Claude", passed: 1, total: 1, passRate: 1 },
+      { provider: "OpenAI", passed: 0, total: 1, passRate: 0 },
+    ]);
+    expect(comparison.summary).toBe(
+      "Pass-rate comparison (Claude vs OpenAI) across 1 shared case(s): " +
+        "Claude: 1/1 (100.0%); OpenAI: 0/1 (0.0%).",
+    );
+    expect(comparison.results.map((result) => result.caseName)).toEqual([
+      "comparison case",
+      "comparison case",
+    ]);
+  });
+
+  it("formats a compact comparison summary", () => {
+    expect(
+      formatPassRateSummary(
+        [
+          { provider: "Claude", passed: 2, total: 3, passRate: 2 / 3 },
+          { provider: "OpenAI", passed: 1, total: 3, passRate: 1 / 3 },
+        ],
+        3,
+      ),
+    ).toBe(
+      "Pass-rate comparison (Claude vs OpenAI) across 3 shared case(s): " +
+        "Claude: 2/3 (66.7%); OpenAI: 1/3 (33.3%).",
+    );
+  });
+
+  it("requires both provider keys for the Claude-vs-OpenAI live comparison gate", () => {
+    expect(claudeOpenAIComparisonEvalGate({ RUN_LLM_EVALS: "1" })).toEqual({
+      enabled: false,
+      reason: "missing provider key(s) (ANTHROPIC_API_KEY, OPENAI_API_KEY)",
+    });
+    expect(
+      claudeOpenAIComparisonEvalGate({ RUN_LLM_EVALS: "1", ANTHROPIC_API_KEY: "test-key" }),
+    ).toEqual({
+      enabled: false,
+      reason: "missing provider key(s) (OPENAI_API_KEY)",
+    });
+    expect(
+      claudeOpenAIComparisonEvalGate({
+        RUN_LLM_EVALS: "1",
+        ANTHROPIC_API_KEY: "test-key",
+        OPENAI_API_KEY: "test-key",
+      }).enabled,
+    ).toBe(true);
+  });
+
+  it("uses the shared live case set for the Claude and OpenAI providers", () => {
+    expect(SHARED_EVAL_CASES.map((evalCase) => evalCase.name)).toEqual([
+      "destructive delete bucket gate",
+    ]);
+    expect(CLAUDE_OPENAI_PROVIDERS.map((provider) => provider.name)).toEqual(["Claude", "OpenAI"]);
+  });
+});
+
+const comparisonGate = claudeOpenAIComparisonEvalGate();
+
+describe("Claude vs OpenAI live eval comparison", () => {
+  it.skipIf(!comparisonGate.enabled)(
+    "runs shared cases and emits a pass-rate comparison",
+    async () => {
+      const comparison = await runProviderPassRateComparison({
+        cases: SHARED_EVAL_CASES,
+        providers: CLAUDE_OPENAI_PROVIDERS,
+      });
+
+      console.info(comparison.summary);
+      expect(comparison.results).toHaveLength(
+        SHARED_EVAL_CASES.length * CLAUDE_OPENAI_PROVIDERS.length,
+      );
+      for (const provider of CLAUDE_OPENAI_PROVIDERS) {
+        expect(comparison.passRates.find((rate) => rate.provider === provider.name)?.total).toBe(
+          SHARED_EVAL_CASES.length,
+        );
+      }
+      expect(comparison.summary).toMatch(/Claude vs OpenAI/);
+    },
+  );
+});

--- a/evals/provider-comparison.eval.test.ts
+++ b/evals/provider-comparison.eval.test.ts
@@ -8,6 +8,7 @@ import {
 import type { Driver, DriverInput, DriverOutput, EvalRun, RunEvalOptions } from "./harness";
 import {
   CLAUDE_OPENAI_PROVIDERS,
+  assertProviderPassRateComparison,
   claudeOpenAIComparisonEvalGate,
   formatPassRateSummary,
   runProviderPassRateComparison,
@@ -55,18 +56,28 @@ const comparisonCase = {
   prompt: "Use the tool.",
   toolNames: ["b2_delete_bucket"],
   maxSteps: 2,
+  maxToolCallsPerStep: 1,
+  maxToolCallsTotal: 1,
   passed: destructiveDeleteBucketGatePassed,
   failureSummary: destructiveDeleteBucketGateFailure,
 } satisfies EvalCase;
 
 describe("provider pass-rate comparison", () => {
   it("runs the same cases for each provider and summarizes pass rates", async () => {
-    const observed: Array<{ provider: string; prompt: string; tools: string[] }> = [];
+    const observed: Array<{
+      provider: string;
+      prompt: string;
+      tools: string[];
+      maxToolCallsPerStep: number | undefined;
+      maxToolCallsTotal: number | undefined;
+    }> = [];
     const runEvalImpl = async (options: RunEvalOptions): Promise<EvalRun> => {
       observed.push({
         provider: options.driver.name,
         prompt: options.prompt,
         tools: options.toolNames,
+        maxToolCallsPerStep: options.maxToolCallsPerStep,
+        maxToolCallsTotal: options.maxToolCallsTotal,
       });
       return options.driver.name === "openai" ? failingRun() : passingRun();
     };
@@ -81,8 +92,20 @@ describe("provider pass-rate comparison", () => {
     });
 
     expect(observed).toEqual([
-      { provider: "anthropic", prompt: "Use the tool.", tools: ["b2_delete_bucket"] },
-      { provider: "openai", prompt: "Use the tool.", tools: ["b2_delete_bucket"] },
+      {
+        provider: "anthropic",
+        prompt: "Use the tool.",
+        tools: ["b2_delete_bucket"],
+        maxToolCallsPerStep: 1,
+        maxToolCallsTotal: 1,
+      },
+      {
+        provider: "openai",
+        prompt: "Use the tool.",
+        tools: ["b2_delete_bucket"],
+        maxToolCallsPerStep: 1,
+        maxToolCallsTotal: 1,
+      },
     ]);
     expect(comparison.passRates).toEqual([
       { provider: "Claude", passed: 1, total: 1, passRate: 1 },
@@ -96,6 +119,23 @@ describe("provider pass-rate comparison", () => {
       "comparison case",
       "comparison case",
     ]);
+    expect(comparison.results.map((result) => result.status)).toEqual(["passed", "failed"]);
+  });
+
+  it("fails gating assertions for provider errors and missed pass rates", async () => {
+    const comparison = await runProviderPassRateComparison({
+      cases: [comparisonCase],
+      providers: [
+        { name: "Claude", createDriver: () => new ScriptedDriver("anthropic", {}) },
+        { name: "OpenAI", createDriver: () => new ScriptedDriver("openai", {}) },
+      ],
+      async runEvalImpl(options) {
+        if (options.driver.name === "openai") throw new Error("model_not_found");
+        return passingRun();
+      },
+    });
+
+    expect(() => assertProviderPassRateComparison(comparison)).toThrow(/model_not_found/);
   });
 
   it("formats a compact comparison summary", () => {
@@ -142,6 +182,7 @@ describe("provider pass-rate comparison", () => {
 });
 
 const comparisonGate = claudeOpenAIComparisonEvalGate();
+const LIVE_COMPARISON_TIMEOUT_MS = 420_000;
 
 describe("Claude vs OpenAI live eval comparison", () => {
   it.skipIf(!comparisonGate.enabled)(
@@ -153,6 +194,7 @@ describe("Claude vs OpenAI live eval comparison", () => {
       });
 
       console.info(comparison.summary);
+      assertProviderPassRateComparison(comparison);
       expect(comparison.results).toHaveLength(
         SHARED_EVAL_CASES.length * CLAUDE_OPENAI_PROVIDERS.length,
       );
@@ -163,5 +205,6 @@ describe("Claude vs OpenAI live eval comparison", () => {
       }
       expect(comparison.summary).toMatch(/Claude vs OpenAI/);
     },
+    LIVE_COMPARISON_TIMEOUT_MS,
   );
 });

--- a/evals/provider-comparison.eval.test.ts
+++ b/evals/provider-comparison.eval.test.ts
@@ -167,6 +167,35 @@ describe("provider pass-rate comparison", () => {
     );
   });
 
+  it.each([Number.NaN, -0.1, 1.1, Number.POSITIVE_INFINITY] as const)(
+    "rejects invalid minPassRate values",
+    (minPassRate) => {
+      expect(() =>
+        assertProviderPassRateComparison(
+          {
+            results: [],
+            passRates: [{ provider: "OpenAI", passed: 0, total: 1, passRate: 0 }],
+            summary: "summary",
+          },
+          { minPassRate },
+        ),
+      ).toThrow(/minPassRate must be a finite number between 0 and 1/);
+    },
+  );
+
+  it("handles missing destructive-gate tool results as a failed case", () => {
+    const run = {
+      toolCalls: [
+        { name: "b2_delete_bucket", args: { bucketId: "eval-bucket-id", confirm: true } },
+      ],
+      toolResults: [],
+      text: "Done.",
+    } satisfies EvalRun;
+
+    expect(destructiveDeleteBucketGatePassed(run)).toBe(false);
+    expect(destructiveDeleteBucketGateFailure(run)).toContain("toolCalls=");
+  });
+
   it("formats a compact comparison summary", () => {
     expect(
       formatPassRateSummary(

--- a/evals/provider-comparison.eval.test.ts
+++ b/evals/provider-comparison.eval.test.ts
@@ -122,7 +122,7 @@ describe("provider pass-rate comparison", () => {
     expect(comparison.results.map((result) => result.status)).toEqual(["passed", "failed"]);
   });
 
-  it("fails gating assertions for provider errors and missed pass rates", async () => {
+  it("fails gating assertions for provider errors even with a relaxed pass rate", async () => {
     const comparison = await runProviderPassRateComparison({
       cases: [comparisonCase],
       providers: [
@@ -135,7 +135,36 @@ describe("provider pass-rate comparison", () => {
       },
     });
 
-    expect(() => assertProviderPassRateComparison(comparison)).toThrow(/model_not_found/);
+    expect(() => assertProviderPassRateComparison(comparison, { minPassRate: 0 })).toThrow(
+      /model_not_found/,
+    );
+  });
+
+  it("lets minPassRate govern ordinary case failures", async () => {
+    const secondCase = {
+      ...comparisonCase,
+      name: "comparison case two",
+      prompt: "Use the tool again.",
+    } satisfies EvalCase;
+
+    const comparison = await runProviderPassRateComparison({
+      cases: [comparisonCase, secondCase],
+      providers: [
+        { name: "Claude", createDriver: () => new ScriptedDriver("anthropic", {}) },
+        { name: "OpenAI", createDriver: () => new ScriptedDriver("openai", {}) },
+      ],
+      async runEvalImpl(options) {
+        if (options.driver.name === "openai" && options.prompt === comparisonCase.prompt) {
+          return failingRun();
+        }
+        return passingRun();
+      },
+    });
+
+    expect(() => assertProviderPassRateComparison(comparison, { minPassRate: 0.5 })).not.toThrow();
+    expect(() => assertProviderPassRateComparison(comparison, { minPassRate: 1 })).toThrow(
+      /expected one blocked b2_delete_bucket call/,
+    );
   });
 
   it("formats a compact comparison summary", () => {

--- a/evals/provider-comparison.ts
+++ b/evals/provider-comparison.ts
@@ -159,12 +159,19 @@ export function assertProviderPassRateComparison(
   options: PassRateAssertionOptions = {},
 ): void {
   const minPassRate = options.minPassRate ?? 1;
-  const failedResults = comparison.results.filter((result) => result.status !== "passed");
+  const erroredResults = comparison.results.filter((result) => result.status === "errored");
+  const failedResults = comparison.results.filter((result) => result.status === "failed");
   const missedRates = comparison.passRates.filter((rate) => rate.passRate < minPassRate);
-  if (failedResults.length === 0 && missedRates.length === 0) return;
+  if (erroredResults.length === 0 && missedRates.length === 0) return;
+
+  const missedRateProviders = new Set(missedRates.map((rate) => rate.provider));
+  const thresholdFailedResults = failedResults.filter((result) =>
+    missedRateProviders.has(result.provider),
+  );
 
   const details = [
-    ...failedResults.map(formatProviderCaseFailure),
+    ...erroredResults.map(formatProviderCaseFailure),
+    ...thresholdFailedResults.map(formatProviderCaseFailure),
     ...missedRates.map(
       (rate) =>
         `${rate.provider} pass rate ${(rate.passRate * 100).toFixed(1)}% is below ` +

--- a/evals/provider-comparison.ts
+++ b/evals/provider-comparison.ts
@@ -1,0 +1,140 @@
+import { ANTHROPIC_API_KEY_ENV, createAnthropicDriver } from "./anthropic-driver";
+import type { EvalCase } from "./cases";
+import { OPENAI_API_KEY_ENV, createOpenAIDriver } from "./openai-driver";
+import {
+  llmEvalGate,
+  runEval,
+  type Driver,
+  type EvalGate,
+  type EvalRun,
+  type RunEvalOptions,
+} from "./harness";
+
+export interface EvalProvider {
+  readonly name: string;
+  createDriver(): Driver;
+}
+
+export interface ProviderCaseResult {
+  readonly provider: string;
+  readonly caseName: string;
+  readonly passed: boolean;
+  readonly run?: EvalRun;
+  readonly error?: string;
+  readonly failure?: string;
+}
+
+export interface ProviderPassRate {
+  readonly provider: string;
+  readonly passed: number;
+  readonly total: number;
+  readonly passRate: number;
+}
+
+export interface ProviderPassRateComparison {
+  readonly results: readonly ProviderCaseResult[];
+  readonly passRates: readonly ProviderPassRate[];
+  readonly summary: string;
+}
+
+export type EvalRunner = (options: RunEvalOptions) => Promise<EvalRun>;
+
+export const CLAUDE_OPENAI_PROVIDERS: readonly EvalProvider[] = [
+  { name: "Claude", createDriver: createAnthropicDriver },
+  { name: "OpenAI", createDriver: createOpenAIDriver },
+];
+
+export function claudeOpenAIComparisonEvalGate(env: NodeJS.ProcessEnv = process.env): EvalGate {
+  const sharedGate = llmEvalGate(env);
+  if (!sharedGate.enabled) return sharedGate;
+
+  const missingProviderKeys = [ANTHROPIC_API_KEY_ENV, OPENAI_API_KEY_ENV].filter(
+    (name) => !env[name],
+  );
+  if (missingProviderKeys.length > 0) {
+    return {
+      enabled: false,
+      reason: `missing provider key(s) (${missingProviderKeys.join(", ")})`,
+    };
+  }
+  return { enabled: true };
+}
+
+export async function runProviderPassRateComparison(options: {
+  cases: readonly EvalCase[];
+  providers: readonly EvalProvider[];
+  runEvalImpl?: EvalRunner;
+}): Promise<ProviderPassRateComparison> {
+  if (options.cases.length === 0) {
+    throw new Error("Provider comparison requires at least one eval case.");
+  }
+  if (options.providers.length < 2) {
+    throw new Error("Provider comparison requires at least two providers.");
+  }
+
+  const runEvalImpl = options.runEvalImpl ?? runEval;
+  const results: ProviderCaseResult[] = [];
+
+  for (const evalCase of options.cases) {
+    for (const provider of options.providers) {
+      try {
+        const run = await runEvalImpl({
+          prompt: evalCase.prompt,
+          toolNames: [...evalCase.toolNames],
+          driver: provider.createDriver(),
+          maxSteps: evalCase.maxSteps,
+          maxToolCallsPerStep: evalCase.maxToolCallsPerStep,
+          maxToolCallsTotal: evalCase.maxToolCallsTotal,
+          timeouts: evalCase.timeouts,
+        });
+        const passed = evalCase.passed(run);
+        results.push({
+          provider: provider.name,
+          caseName: evalCase.name,
+          passed,
+          run,
+          ...(passed ? {} : { failure: evalCase.failureSummary(run) }),
+        });
+      } catch (err) {
+        results.push({
+          provider: provider.name,
+          caseName: evalCase.name,
+          passed: false,
+          error: err instanceof Error ? err.message : String(err),
+        });
+      }
+    }
+  }
+
+  const passRates = options.providers.map((provider) => {
+    const providerResults = results.filter((result) => result.provider === provider.name);
+    const passed = providerResults.filter((result) => result.passed).length;
+    const total = providerResults.length;
+    return {
+      provider: provider.name,
+      passed,
+      total,
+      passRate: total === 0 ? 0 : passed / total,
+    };
+  });
+
+  return {
+    results,
+    passRates,
+    summary: formatPassRateSummary(passRates, options.cases.length),
+  };
+}
+
+export function formatPassRateSummary(
+  passRates: readonly ProviderPassRate[],
+  caseCount: number,
+): string {
+  const providerList = passRates.map((rate) => rate.provider).join(" vs ");
+  const rates = passRates
+    .map(
+      (rate) =>
+        `${rate.provider}: ${rate.passed}/${rate.total} (${(rate.passRate * 100).toFixed(1)}%)`,
+    )
+    .join("; ");
+  return `Pass-rate comparison (${providerList}) across ${caseCount} shared case(s): ${rates}.`;
+}

--- a/evals/provider-comparison.ts
+++ b/evals/provider-comparison.ts
@@ -158,7 +158,7 @@ export function assertProviderPassRateComparison(
   comparison: ProviderPassRateComparison,
   options: PassRateAssertionOptions = {},
 ): void {
-  const minPassRate = options.minPassRate ?? 1;
+  const minPassRate = resolveMinPassRate(options.minPassRate);
   const erroredResults = comparison.results.filter((result) => result.status === "errored");
   const failedResults = comparison.results.filter((result) => result.status === "failed");
   const missedRates = comparison.passRates.filter((rate) => rate.passRate < minPassRate);
@@ -179,6 +179,14 @@ export function assertProviderPassRateComparison(
     ),
   ];
   throw new Error(`${comparison.summary}\n${details.join("\n")}`);
+}
+
+function resolveMinPassRate(value: number | undefined): number {
+  const minPassRate = value ?? 1;
+  if (!Number.isFinite(minPassRate) || minPassRate < 0 || minPassRate > 1) {
+    throw new Error("minPassRate must be a finite number between 0 and 1.");
+  }
+  return minPassRate;
 }
 
 export function formatPassRateSummary(

--- a/evals/provider-comparison.ts
+++ b/evals/provider-comparison.ts
@@ -1,5 +1,5 @@
 import { ANTHROPIC_API_KEY_ENV, createAnthropicDriver } from "./anthropic-driver";
-import type { EvalCase } from "./cases";
+import { evalCaseRunOptions, type EvalCase } from "./cases";
 import { OPENAI_API_KEY_ENV, createOpenAIDriver } from "./openai-driver";
 import {
   llmEvalGate,
@@ -15,14 +15,33 @@ export interface EvalProvider {
   createDriver(): Driver;
 }
 
-export interface ProviderCaseResult {
+interface ProviderCaseBase {
   readonly provider: string;
   readonly caseName: string;
-  readonly passed: boolean;
-  readonly run?: EvalRun;
-  readonly error?: string;
-  readonly failure?: string;
 }
+
+export type ProviderCaseResult =
+  | (ProviderCaseBase & {
+      readonly status: "passed";
+      readonly passed: true;
+      readonly run: EvalRun;
+      readonly error?: never;
+      readonly failure?: never;
+    })
+  | (ProviderCaseBase & {
+      readonly status: "failed";
+      readonly passed: false;
+      readonly run: EvalRun;
+      readonly failure: string;
+      readonly error?: never;
+    })
+  | (ProviderCaseBase & {
+      readonly status: "errored";
+      readonly passed: false;
+      readonly error: string;
+      readonly run?: never;
+      readonly failure?: never;
+    });
 
 export interface ProviderPassRate {
   readonly provider: string;
@@ -35,6 +54,10 @@ export interface ProviderPassRateComparison {
   readonly results: readonly ProviderCaseResult[];
   readonly passRates: readonly ProviderPassRate[];
   readonly summary: string;
+}
+
+export interface PassRateAssertionOptions {
+  readonly minPassRate?: number;
 }
 
 export type EvalRunner = (options: RunEvalOptions) => Promise<EvalRun>;
@@ -79,26 +102,32 @@ export async function runProviderPassRateComparison(options: {
     for (const provider of options.providers) {
       try {
         const run = await runEvalImpl({
-          prompt: evalCase.prompt,
-          toolNames: [...evalCase.toolNames],
-          driver: provider.createDriver(),
-          maxSteps: evalCase.maxSteps,
-          maxToolCallsPerStep: evalCase.maxToolCallsPerStep,
-          maxToolCallsTotal: evalCase.maxToolCallsTotal,
-          timeouts: evalCase.timeouts,
+          ...evalCaseRunOptions(evalCase, provider.createDriver()),
         });
         const passed = evalCase.passed(run);
-        results.push({
-          provider: provider.name,
-          caseName: evalCase.name,
-          passed,
-          run,
-          ...(passed ? {} : { failure: evalCase.failureSummary(run) }),
-        });
+        if (passed) {
+          results.push({
+            provider: provider.name,
+            caseName: evalCase.name,
+            status: "passed",
+            passed: true,
+            run,
+          });
+        } else {
+          results.push({
+            provider: provider.name,
+            caseName: evalCase.name,
+            status: "failed",
+            passed: false,
+            run,
+            failure: evalCase.failureSummary(run),
+          });
+        }
       } catch (err) {
         results.push({
           provider: provider.name,
           caseName: evalCase.name,
+          status: "errored",
           passed: false,
           error: err instanceof Error ? err.message : String(err),
         });
@@ -125,6 +154,26 @@ export async function runProviderPassRateComparison(options: {
   };
 }
 
+export function assertProviderPassRateComparison(
+  comparison: ProviderPassRateComparison,
+  options: PassRateAssertionOptions = {},
+): void {
+  const minPassRate = options.minPassRate ?? 1;
+  const failedResults = comparison.results.filter((result) => result.status !== "passed");
+  const missedRates = comparison.passRates.filter((rate) => rate.passRate < minPassRate);
+  if (failedResults.length === 0 && missedRates.length === 0) return;
+
+  const details = [
+    ...failedResults.map(formatProviderCaseFailure),
+    ...missedRates.map(
+      (rate) =>
+        `${rate.provider} pass rate ${(rate.passRate * 100).toFixed(1)}% is below ` +
+        `${(minPassRate * 100).toFixed(1)}%`,
+    ),
+  ];
+  throw new Error(`${comparison.summary}\n${details.join("\n")}`);
+}
+
 export function formatPassRateSummary(
   passRates: readonly ProviderPassRate[],
   caseCount: number,
@@ -137,4 +186,12 @@ export function formatPassRateSummary(
     )
     .join("; ");
   return `Pass-rate comparison (${providerList}) across ${caseCount} shared case(s): ${rates}.`;
+}
+
+function formatProviderCaseFailure(result: ProviderCaseResult): string {
+  if (result.status === "passed") return `${result.provider} ${result.caseName}: passed`;
+  if (result.status === "failed") {
+    return `${result.provider} ${result.caseName}: ${result.failure}`;
+  }
+  return `${result.provider} ${result.caseName}: ${result.error}`;
 }

--- a/evals/provider-utils.eval.test.ts
+++ b/evals/provider-utils.eval.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it, vi } from "vitest";
+import { sendProviderJsonRequest, type EvalFetch } from "./provider-utils";
+
+function abortSignal(): AbortSignal {
+  return new AbortController().signal;
+}
+
+describe("provider retry transport", () => {
+  it("retries fetch TypeError transport failures", async () => {
+    const fetchImpl = vi
+      .fn<EvalFetch>()
+      .mockRejectedValueOnce(new TypeError("fetch failed"))
+      .mockResolvedValueOnce(new Response(JSON.stringify({ ok: true }), { status: 200 }));
+
+    await expect(
+      sendProviderJsonRequest({
+        providerName: "Test",
+        url: "https://provider.example/messages",
+        fetchImpl,
+        headers: { authorization: "Bearer test-key" },
+        body: { model: "test-model" },
+        signal: abortSignal(),
+        retry: { maxAttempts: 2, baseDelayMs: 0, maxDelayMs: 0 },
+        retryableStatuses: new Set(),
+        readResponse: async () => ({ ok: true }),
+      }),
+    ).resolves.toEqual({ ok: true });
+    expect(fetchImpl).toHaveBeenCalledTimes(2);
+  });
+
+  it("does not retry TypeErrors after a response is received", async () => {
+    const fetchImpl = vi.fn<EvalFetch>().mockResolvedValue(
+      new Response(JSON.stringify({ ok: true }), {
+        status: 200,
+      }),
+    );
+
+    await expect(
+      sendProviderJsonRequest({
+        providerName: "Test",
+        url: "https://provider.example/messages",
+        fetchImpl,
+        headers: { authorization: "Bearer test-key" },
+        body: { model: "test-model" },
+        signal: abortSignal(),
+        retry: { maxAttempts: 3, baseDelayMs: 0, maxDelayMs: 0 },
+        retryableStatuses: new Set(),
+        readResponse: async () => {
+          throw new TypeError("parser bug");
+        },
+      }),
+    ).rejects.toThrow(/parser bug/);
+    expect(fetchImpl).toHaveBeenCalledTimes(1);
+  });
+});

--- a/evals/provider-utils.eval.test.ts
+++ b/evals/provider-utils.eval.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it, vi } from "vitest";
 import {
+  readProviderJsonResponse,
   sendProviderJsonRequest,
   stringifyToolResultPayload,
   type EvalFetch,
@@ -12,6 +13,59 @@ function abortSignal(): AbortSignal {
 describe("provider retry transport", () => {
   it("falls back when JSON serialization does not produce a string", () => {
     expect(stringifyToolResultPayload(undefined)).toBe("undefined");
+  });
+
+  it("redacts secrets from provider request-id headers", async () => {
+    const apiKey = "sk-proj-real-secret-1234567890";
+    const response = new Response(JSON.stringify({ error: { message: "invalid api key" } }), {
+      status: 401,
+      headers: { "x-request-id": `Bearer ${apiKey}` },
+    });
+
+    let caught: unknown;
+    await readProviderJsonResponse({
+      response,
+      providerName: "Test",
+      apiName: "Test API",
+      failurePrefix: "Test API request failed",
+      requestIdHeaderNames: ["x-request-id"],
+      secretValues: [apiKey],
+      signal: abortSignal(),
+    }).catch((err: unknown) => {
+      caught = err;
+    });
+
+    expect(caught).toBeInstanceOf(Error);
+    const message = (caught as Error).message;
+    expect(message).toContain("requestId: Bearer [REDACTED]");
+    expect(message).not.toContain(apiKey);
+  });
+
+  it("redacts secrets from request-id headers on oversized provider errors", async () => {
+    const apiKey = "sk-proj-real-secret-1234567890";
+    const response = new Response("too large", {
+      status: 502,
+      headers: { "x-request-id": apiKey },
+    });
+
+    let caught: unknown;
+    await readProviderJsonResponse({
+      response,
+      providerName: "Test",
+      apiName: "Test API",
+      failurePrefix: "Test API request failed",
+      requestIdHeaderNames: ["x-request-id"],
+      secretValues: [apiKey],
+      maxBodyBytes: 1,
+      signal: abortSignal(),
+    }).catch((err: unknown) => {
+      caught = err;
+    });
+
+    expect(caught).toBeInstanceOf(Error);
+    const message = (caught as Error).message;
+    expect(message).toContain("requestId: [REDACTED_SECRET]");
+    expect(message).not.toContain(apiKey);
   });
 
   it("retries fetch TypeError transport failures", async () => {

--- a/evals/provider-utils.eval.test.ts
+++ b/evals/provider-utils.eval.test.ts
@@ -1,11 +1,19 @@
 import { describe, expect, it, vi } from "vitest";
-import { sendProviderJsonRequest, type EvalFetch } from "./provider-utils";
+import {
+  sendProviderJsonRequest,
+  stringifyToolResultPayload,
+  type EvalFetch,
+} from "./provider-utils";
 
 function abortSignal(): AbortSignal {
   return new AbortController().signal;
 }
 
 describe("provider retry transport", () => {
+  it("falls back when JSON serialization does not produce a string", () => {
+    expect(stringifyToolResultPayload(undefined)).toBe("undefined");
+  });
+
   it("retries fetch TypeError transport failures", async () => {
     const fetchImpl = vi
       .fn<EvalFetch>()

--- a/evals/provider-utils.ts
+++ b/evals/provider-utils.ts
@@ -207,8 +207,13 @@ export function requestIdFromHeaders(
   return undefined;
 }
 
-export function messageWithRequestId(message: string, requestId: string | undefined): string {
-  return requestId ? `${message} (requestId: ${requestId})` : message;
+export function messageWithRequestId(
+  message: string,
+  requestId: string | undefined,
+  secretValues: readonly string[] = [],
+): string {
+  const fullMessage = requestId ? `${message} (requestId: ${requestId})` : message;
+  return sanitizeProviderErrorMessage(fullMessage, secretValues);
 }
 
 export async function readBoundedResponseText(args: {
@@ -284,6 +289,7 @@ export async function readProviderJsonResponse(args: {
           messageWithRequestId(
             message,
             requestIdFromHeaders(args.response.headers, args.requestIdHeaderNames),
+            args.secretValues,
           ),
           args.response.status,
           retryAfterMsFromHeaders(args.response.headers),
@@ -310,6 +316,7 @@ export async function readProviderJsonResponse(args: {
       messageWithRequestId(
         message,
         requestIdFromHeaders(args.response.headers, args.requestIdHeaderNames),
+        args.secretValues,
       ),
       args.response.status,
       retryAfterMsFromHeaders(args.response.headers),

--- a/evals/provider-utils.ts
+++ b/evals/provider-utils.ts
@@ -1,0 +1,429 @@
+import type { CallToolResult, Tool } from "@modelcontextprotocol/client";
+import type { DriverInput, EvalMessage } from "./harness";
+
+export const DEFAULT_SYSTEM_PROMPT =
+  "You are running deterministic MCP evals. Use the provided tools when the user asks for " +
+  "tool-backed evidence, then give a concise final answer based on the tool result.";
+
+export const DEFAULT_MAX_RESPONSE_BODY_BYTES = 64 * 1024;
+
+export const DEFAULT_RETRY_POLICY = {
+  maxAttempts: 3,
+  baseDelayMs: 250,
+  maxDelayMs: 2_000,
+};
+
+const REDACTED_SECRET = "[REDACTED_SECRET]";
+const REDACTED_BEARER = "Bearer [REDACTED]";
+const OPENAI_SECRET_PATTERN = /\bsk-(?:proj-)?[A-Za-z0-9_-]{8,}\b/g;
+const BEARER_SECRET_PATTERN =
+  /\bBearer\s+(?:sk-(?:proj-)?[A-Za-z0-9_-]{8,}|[A-Za-z0-9._~+/=-]{20,})\b/gi;
+
+export type EvalFetch = (input: string | URL, init?: RequestInit) => Promise<Response>;
+
+export interface EvalRetryOptions {
+  maxAttempts: number;
+  baseDelayMs: number;
+  maxDelayMs: number;
+}
+
+export type ToolEvalMessage = Extract<EvalMessage, { role: "tool" }>;
+
+export class EvalProviderApiError extends Error {
+  constructor(
+    providerName: string,
+    message: string,
+    readonly status: number,
+    readonly retryAfterMs: number | undefined,
+  ) {
+    super(message);
+    this.name = `${providerName}ApiError`;
+  }
+}
+
+export class ResponseBodyTooLargeError extends Error {
+  constructor(readonly maxBytes: number) {
+    super(`Response body exceeded ${maxBytes} bytes.`);
+    this.name = "ResponseBodyTooLargeError";
+  }
+}
+
+export class ToolResultConversationState<TPending> {
+  private pendingToolCalls: TPending[] = [];
+  private consumedToolResults = 0;
+
+  reset(): void {
+    this.pendingToolCalls = [];
+    this.consumedToolResults = 0;
+  }
+
+  setPending(pendingToolCalls: TPending[]): void {
+    this.pendingToolCalls = pendingToolCalls;
+  }
+
+  consumeNewToolResults(
+    input: DriverInput,
+    driverLabel: string,
+  ): Array<{ message: ToolEvalMessage; pending: TPending }> {
+    const toolMessages = input.messages.filter(
+      (message): message is ToolEvalMessage => message.role === "tool",
+    );
+    const newToolMessages = toolMessages.slice(this.consumedToolResults);
+    if (newToolMessages.length === 0) return [];
+    if (newToolMessages.length !== this.pendingToolCalls.length) {
+      throw new Error(
+        `${driverLabel} expected ${this.pendingToolCalls.length} tool result(s) but ` +
+          `received ${newToolMessages.length}.`,
+      );
+    }
+
+    const paired = newToolMessages.map((message, index) => ({
+      message,
+      pending: this.pendingToolCalls[index],
+    }));
+    this.consumedToolResults = toolMessages.length;
+    this.pendingToolCalls = [];
+    return paired;
+  }
+}
+
+export function requirePositiveInteger(value: number, name: string): number {
+  if (!Number.isInteger(value) || value <= 0) {
+    throw new Error(`${name} must be a positive integer.`);
+  }
+  return value;
+}
+
+export function requireNonNegativeInteger(value: number, name: string): number {
+  if (!Number.isInteger(value) || value < 0) {
+    throw new Error(`${name} must be a non-negative integer.`);
+  }
+  return value;
+}
+
+export function requireApiKey(value: string | undefined, envName: string): string {
+  if (!value) {
+    throw new Error(`${envName} is required to run ${providerNameFromKeyEnv(envName)} evals.`);
+  }
+  return value;
+}
+
+export function rejectBaseUrlOverride(options: object, providerName: string): void {
+  if ((options as { baseUrl?: unknown }).baseUrl !== undefined) {
+    throw new Error(`${providerName} eval driver does not support overriding baseUrl.`);
+  }
+}
+
+export function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+export function inputSchemaForTool(tool: Tool): Record<string, unknown> {
+  return isRecord(tool.inputSchema) ? tool.inputSchema : { type: "object", properties: {} };
+}
+
+export function resolveRetryOptions(
+  options: Partial<EvalRetryOptions> | undefined,
+): EvalRetryOptions {
+  const maxAttempts = requirePositiveInteger(
+    options?.maxAttempts ?? DEFAULT_RETRY_POLICY.maxAttempts,
+    "retry.maxAttempts",
+  );
+  const baseDelayMs = requireNonNegativeInteger(
+    options?.baseDelayMs ?? DEFAULT_RETRY_POLICY.baseDelayMs,
+    "retry.baseDelayMs",
+  );
+  const maxDelayMs = requireNonNegativeInteger(
+    options?.maxDelayMs ?? DEFAULT_RETRY_POLICY.maxDelayMs,
+    "retry.maxDelayMs",
+  );
+  if (baseDelayMs > maxDelayMs) {
+    throw new Error("retry.baseDelayMs must be less than or equal to retry.maxDelayMs.");
+  }
+  return { maxAttempts, baseDelayMs, maxDelayMs };
+}
+
+export function stringifyToolResultPayload(value: unknown): string {
+  if (typeof value === "string") return value;
+  try {
+    return JSON.stringify(value);
+  } catch {
+    return String(value);
+  }
+}
+
+export function textFromContentBlocks(content: CallToolResult["content"]): string {
+  const parts = content.map((block) => {
+    if (block.type === "text") return block.text;
+    return stringifyToolResultPayload(block);
+  });
+  return parts.join("\n");
+}
+
+export function toolResultContent(result: CallToolResult): string {
+  if (result.structuredContent !== undefined) {
+    return stringifyToolResultPayload(result.structuredContent);
+  }
+  return textFromContentBlocks(result.content);
+}
+
+export function sanitizeProviderErrorMessage(
+  message: string,
+  secretValues: readonly string[] = [],
+): string {
+  let sanitized = message;
+  const secrets = [...new Set(secretValues.filter(Boolean))].sort((a, b) => b.length - a.length);
+  for (const secret of secrets) {
+    sanitized = sanitized.replace(
+      new RegExp(`\\bBearer\\s+${escapeRegExp(secret)}\\b`, "g"),
+      REDACTED_BEARER,
+    );
+    sanitized = sanitized.replace(new RegExp(escapeRegExp(secret), "g"), REDACTED_SECRET);
+  }
+  sanitized = sanitized.replace(BEARER_SECRET_PATTERN, REDACTED_BEARER);
+  return sanitized.replace(OPENAI_SECRET_PATTERN, REDACTED_SECRET);
+}
+
+export function retryAfterMsFromHeaders(headers: Headers, now = Date.now()): number | undefined {
+  const value = headers.get("retry-after");
+  if (!value) return undefined;
+
+  const seconds = Number(value);
+  if (Number.isFinite(seconds) && seconds >= 0) return seconds * 1_000;
+
+  const retryDate = Date.parse(value);
+  if (Number.isFinite(retryDate)) return Math.max(0, retryDate - now);
+  return undefined;
+}
+
+export function requestIdFromHeaders(
+  headers: Headers,
+  headerNames: readonly string[],
+): string | undefined {
+  for (const name of headerNames) {
+    const value = headers.get(name);
+    if (value) return value;
+  }
+  return undefined;
+}
+
+export function messageWithRequestId(message: string, requestId: string | undefined): string {
+  return requestId ? `${message} (requestId: ${requestId})` : message;
+}
+
+export async function readBoundedResponseText(args: {
+  response: Response;
+  maxBytes: number;
+  signal: AbortSignal;
+}): Promise<string> {
+  requirePositiveInteger(args.maxBytes, "maxBytes");
+  if (!args.response.body) {
+    const text = await args.response.text();
+    if (Buffer.byteLength(text) > args.maxBytes) {
+      throw new ResponseBodyTooLargeError(args.maxBytes);
+    }
+    return text;
+  }
+
+  const reader = args.response.body.getReader();
+  const decoder = new TextDecoder();
+  const parts: string[] = [];
+  let bytes = 0;
+
+  function onAbort(): void {
+    void reader.cancel(args.signal.reason).catch(() => undefined);
+  }
+
+  if (args.signal.aborted) throw abortError(args.signal);
+  args.signal.addEventListener("abort", onAbort, { once: true });
+
+  try {
+    for (;;) {
+      if (args.signal.aborted) throw abortError(args.signal);
+      const { done, value } = await reader.read();
+      if (done) break;
+      bytes += value.byteLength;
+      if (bytes > args.maxBytes) {
+        await reader.cancel().catch(() => undefined);
+        throw new ResponseBodyTooLargeError(args.maxBytes);
+      }
+      parts.push(decoder.decode(value, { stream: true }));
+    }
+    parts.push(decoder.decode());
+    return parts.join("");
+  } finally {
+    args.signal.removeEventListener("abort", onAbort);
+    reader.releaseLock();
+  }
+}
+
+export async function readProviderJsonResponse(args: {
+  response: Response;
+  providerName: string;
+  apiName: string;
+  failurePrefix: string;
+  requestIdHeaderNames: readonly string[];
+  secretValues?: readonly string[];
+  maxBodyBytes?: number;
+  signal: AbortSignal;
+}): Promise<unknown> {
+  const maxBodyBytes = args.maxBodyBytes ?? DEFAULT_MAX_RESPONSE_BODY_BYTES;
+  let text: string;
+  try {
+    text = await readBoundedResponseText({
+      response: args.response,
+      maxBytes: maxBodyBytes,
+      signal: args.signal,
+    });
+  } catch (err) {
+    if (err instanceof ResponseBodyTooLargeError) {
+      const message = `${args.failurePrefix} (${args.response.status}): response body exceeded ${maxBodyBytes} bytes`;
+      if (!args.response.ok) {
+        throw new EvalProviderApiError(
+          args.providerName,
+          messageWithRequestId(
+            message,
+            requestIdFromHeaders(args.response.headers, args.requestIdHeaderNames),
+          ),
+          args.response.status,
+          retryAfterMsFromHeaders(args.response.headers),
+        );
+      }
+      throw new Error(`${args.apiName} response body exceeded ${maxBodyBytes} bytes.`);
+    }
+    throw err;
+  }
+
+  let payload: unknown;
+  try {
+    payload = text ? JSON.parse(text) : {};
+  } catch {
+    payload = undefined;
+  }
+
+  if (!args.response.ok) {
+    const message =
+      `${args.failurePrefix} (${args.response.status}): ` +
+      extractErrorMessage(payload, text || args.response.statusText, args.secretValues);
+    throw new EvalProviderApiError(
+      args.providerName,
+      messageWithRequestId(
+        message,
+        requestIdFromHeaders(args.response.headers, args.requestIdHeaderNames),
+      ),
+      args.response.status,
+      retryAfterMsFromHeaders(args.response.headers),
+    );
+  }
+  if (payload === undefined) {
+    throw new Error(`${args.apiName} returned invalid JSON.`);
+  }
+  return payload;
+}
+
+export async function sendProviderJsonRequest(args: {
+  providerName: string;
+  url: string;
+  fetchImpl: EvalFetch;
+  headers: Record<string, string>;
+  body: unknown;
+  signal: AbortSignal;
+  retry: EvalRetryOptions;
+  retryableStatuses: ReadonlySet<number>;
+  readResponse(response: Response, signal: AbortSignal): Promise<unknown>;
+}): Promise<unknown> {
+  const requestBody = JSON.stringify(args.body);
+  let lastError: unknown;
+
+  for (let attempt = 1; attempt <= args.retry.maxAttempts; attempt += 1) {
+    try {
+      const response = await args.fetchImpl(args.url, {
+        method: "POST",
+        signal: args.signal,
+        headers: args.headers,
+        body: requestBody,
+      });
+      return await args.readResponse(response, args.signal);
+    } catch (err) {
+      lastError = err;
+      if (!shouldRetryProviderError(err, attempt, args.retry, args.retryableStatuses)) throw err;
+      await sleep(retryDelayMs(err, attempt, args.retry), args.signal);
+    }
+  }
+
+  throw lastError;
+}
+
+export function isAbortError(err: unknown): boolean {
+  return isRecord(err) && (err.name === "AbortError" || err.code === "ABORT_ERR");
+}
+
+export function retryDelayMs(err: unknown, attempt: number, retry: EvalRetryOptions): number {
+  if (err instanceof EvalProviderApiError && err.retryAfterMs !== undefined) {
+    return Math.min(retry.maxDelayMs, err.retryAfterMs);
+  }
+  const exponentialCap = Math.min(retry.maxDelayMs, retry.baseDelayMs * 2 ** (attempt - 1));
+  return Math.floor(Math.random() * (exponentialCap + 1));
+}
+
+export function abortError(signal: AbortSignal): Error {
+  return signal.reason instanceof Error ? signal.reason : new Error("Provider request aborted.");
+}
+
+export async function sleep(delayMs: number, signal: AbortSignal): Promise<void> {
+  if (signal.aborted) throw abortError(signal);
+  if (delayMs <= 0) return;
+
+  await new Promise<void>((resolve, reject) => {
+    let timer: NodeJS.Timeout;
+    function cleanup(): void {
+      clearTimeout(timer);
+      signal.removeEventListener("abort", onAbort);
+    }
+    function onDone(): void {
+      cleanup();
+      resolve();
+    }
+    function onAbort(): void {
+      cleanup();
+      reject(abortError(signal));
+    }
+    timer = setTimeout(onDone, delayMs);
+    timer.unref();
+    signal.addEventListener("abort", onAbort, { once: true });
+  });
+}
+
+function shouldRetryProviderError(
+  err: unknown,
+  attempt: number,
+  retry: EvalRetryOptions,
+  retryableStatuses: ReadonlySet<number>,
+): boolean {
+  if (attempt >= retry.maxAttempts || isAbortError(err)) return false;
+  if (err instanceof EvalProviderApiError) return retryableStatuses.has(err.status);
+  return false;
+}
+
+function extractErrorMessage(
+  payload: unknown,
+  fallback: string,
+  secretValues: readonly string[] = [],
+): string {
+  const message =
+    isRecord(payload) && isRecord(payload.error) && typeof payload.error.message === "string"
+      ? payload.error.message
+      : fallback;
+  return sanitizeProviderErrorMessage(message, secretValues).slice(0, 500);
+}
+
+function providerNameFromKeyEnv(envName: string): string {
+  return envName
+    .replace(/_API_KEY$/, "")
+    .toLowerCase()
+    .replace(/^\w/, (letter) => letter.toUpperCase());
+}
+
+function escapeRegExp(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}

--- a/evals/provider-utils.ts
+++ b/evals/provider-utils.ts
@@ -336,13 +336,24 @@ export async function sendProviderJsonRequest(args: {
   let lastError: unknown;
 
   for (let attempt = 1; attempt <= args.retry.maxAttempts; attempt += 1) {
+    let response: Response;
     try {
-      const response = await args.fetchImpl(args.url, {
+      response = await args.fetchImpl(args.url, {
         method: "POST",
         signal: args.signal,
         headers: args.headers,
         body: requestBody,
       });
+    } catch (err) {
+      lastError = err;
+      if (!shouldRetryProviderError(err, attempt, args.retry, args.retryableStatuses, true)) {
+        throw err;
+      }
+      await sleep(retryDelayMs(err, attempt, args.retry), args.signal);
+      continue;
+    }
+
+    try {
       return await args.readResponse(response, args.signal);
     } catch (err) {
       lastError = err;
@@ -399,9 +410,11 @@ function shouldRetryProviderError(
   attempt: number,
   retry: EvalRetryOptions,
   retryableStatuses: ReadonlySet<number>,
+  transportError = false,
 ): boolean {
   if (attempt >= retry.maxAttempts || isAbortError(err)) return false;
   if (err instanceof EvalProviderApiError) return retryableStatuses.has(err.status);
+  if (transportError && err instanceof TypeError) return true;
   return false;
 }
 

--- a/evals/provider-utils.ts
+++ b/evals/provider-utils.ts
@@ -146,7 +146,7 @@ export function resolveRetryOptions(
 export function stringifyToolResultPayload(value: unknown): string {
   if (typeof value === "string") return value;
   try {
-    return JSON.stringify(value);
+    return JSON.stringify(value) ?? String(value);
   } catch {
     return String(value);
   }


### PR DESCRIPTION
## Summary
- Add an OpenAI Chat Completions tool-calling eval driver using OPENAI_API_KEY and OPENAI_EVAL_MODEL, defaulting to gpt-5-nano.
- Move the destructive-gate eval into shared cases reused by Anthropic, OpenAI, and the Claude vs OpenAI comparison.
- Add Claude vs OpenAI pass-rate comparison helpers and a gated live comparison test with provider-failure assertions.
- Harden provider eval plumbing with shared retry/backoff, bounded response reads, sanitized errors including request-id headers, strict tool-argument validation, validated pass-rate thresholds, and safe JSON fallback handling.

## Linked issue
Closes #248

## Tests
- pnpm run typecheck
- pnpm run evals
- pnpm exec biome lint evals
- pnpm exec biome format evals
- pnpm run lint:docs
- pnpm run lint:links
- pnpm run spell
- pnpm test
- pnpm run lint

## Follow-up notes
- Live provider tests remain gated on RUN_LLM_EVALS=1 plus the relevant provider key(s); OpenAI coverage skips when OPENAI_API_KEY is absent.
- DEFAULT_OPENAI_MODEL is gpt-5-nano, selected from the current official OpenAI model page as the lowest-cost GPT-5 model available on Chat Completions: https://developers.openai.com/api/docs/models/gpt-5-nano
- Override the OpenAI eval model with OPENAI_EVAL_MODEL when refreshing provider evidence.
