### PR TITLE
evals: cover full tool profile

### DIFF
--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -46,9 +46,14 @@ The individual deterministic layers are:
 `pnpm run evals` builds the stdio server, then runs the deterministic eval
 harness and provider-adapter tests under `evals/`. These tests do not require
 real B2 credentials. The harness starts b2-mcp with marker B2 credentials,
-`B2_ALLOW_LOCAL_FILES=false`, `B2_SECRET_SINK=off`, and a non-`allow`
+`B2_ALLOW_LOCAL_FILES=false`, `B2_SECRET_SINK=off`, and the default `block`
 destructive policy so provider drivers can exercise MCP tool calls without
-touching a live B2 account.
+touching a live B2 account. Individual full-profile tool-shape cases may opt
+into `destructivePolicy: "allow"` only through typed `EvalServerOptions`; the
+merged child-process environment is still validated before spawn, and marker
+credentials plus local-files-off keep those cases side-effect free. Separate
+contract coverage pins the default `block` and `confirm` outcomes for every
+destructive `confirmTools` entry.
 
 Real LLM-backed eval cases are opt-in. Leave `RUN_LLM_EVALS` unset for normal PR
 work; provider-backed cases skip and deterministic adapter tests still run.
@@ -58,14 +63,18 @@ Set `RUN_LLM_EVALS=1` plus the relevant provider key to run live evidence:
 | -------------------------- | -------------------------------------------------------------------------- |
 | Anthropic driver           | `RUN_LLM_EVALS=1` and `ANTHROPIC_API_KEY`                                  |
 | OpenAI driver              | `RUN_LLM_EVALS=1` and `OPENAI_API_KEY`                                     |
-| Claude-vs-OpenAI comparison | `RUN_LLM_EVALS=1`, `ANTHROPIC_API_KEY`, and `OPENAI_API_KEY`              |
+| Claude-vs-OpenAI comparison | `RUN_LLM_EVALS=1`, `RUN_LLM_PROVIDER_COMPARISON=1`, `ANTHROPIC_API_KEY`, and `OPENAI_API_KEY` |
 
 The OpenAI Chat Completions eval driver defaults to `gpt-5-nano`, the current
 lowest-cost GPT-5 model documented by OpenAI for Chat Completions. Override it
 for a refresh or model investigation with `OPENAI_EVAL_MODEL=<model-id>`. The
 Claude-vs-OpenAI comparison runs the shared eval case set against both providers
 and fails the gated live test if any provider errors, any case fails, or the
-provider pass rate drops below 100%.
+provider pass rate drops below 100%. The comparison has its own explicit gate so
+ordinary single-provider live eval runs do not re-run the full profile matrix,
+uses a fixed 10-minute wall-clock timeout, and stops calling a provider after
+three provider errors to fail fast on bad credentials, rate limits, or repeated
+timeouts.
 
 ## Advisory Local Performance Baseline
 

--- a/evals/anthropic-driver.eval.test.ts
+++ b/evals/anthropic-driver.eval.test.ts
@@ -7,7 +7,7 @@ import {
   DEFAULT_ANTHROPIC_MODEL,
   type AnthropicFetch,
 } from "./anthropic-driver";
-import { SHARED_EVAL_CASES, evalCaseRunOptions } from "./cases";
+import { FULL_PROFILE_EVAL_CASES, evalCaseRunOptions } from "./cases";
 import { runEval, type EvalMessage, type EvalToolCall } from "./harness";
 
 interface CapturedRequest {
@@ -327,14 +327,15 @@ const liveGate = anthropicEvalGate();
 const LIVE_PROVIDER_TIMEOUT_MS = 180_000;
 
 describe("Anthropic Haiku 4.5 live eval", () => {
-  it.skipIf(!liveGate.enabled)(
-    "runs the shared gated tool-use eval end to end",
-    async () => {
-      const evalCase = SHARED_EVAL_CASES[0];
-      const run = await runEval(evalCaseRunOptions(evalCase, createAnthropicDriver()));
+  for (const evalCase of FULL_PROFILE_EVAL_CASES) {
+    it.skipIf(!liveGate.enabled)(
+      `runs ${evalCase.name}`,
+      async () => {
+        const run = await runEval(evalCaseRunOptions(evalCase, createAnthropicDriver()));
 
-      expect(evalCase.passed(run), evalCase.failureSummary(run)).toBe(true);
-    },
-    LIVE_PROVIDER_TIMEOUT_MS,
-  );
+        expect(evalCase.passed(run), evalCase.failureSummary(run)).toBe(true);
+      },
+      LIVE_PROVIDER_TIMEOUT_MS,
+    );
+  }
 });

--- a/evals/cases.eval.test.ts
+++ b/evals/cases.eval.test.ts
@@ -11,6 +11,7 @@ function caseFor(toolName: string): EvalCase {
 }
 
 function runFor(evalCase: EvalCase, extraArgs: Record<string, unknown>): EvalRun {
+  const { result } = evalCase.expected;
   return {
     toolCalls: [
       {
@@ -19,16 +20,19 @@ function runFor(evalCase: EvalCase, extraArgs: Record<string, unknown>): EvalRun
       },
     ],
     toolResults:
-      evalCase.expected.result.kind === "structured-json"
+      result.kind === "structured-json"
         ? [
             {
               structuredContent: {
-                ...(evalCase.expected.result.structuredFields ?? {}),
+                ...(result.structuredFields ?? {}),
               },
               content: [
                 {
                   type: "text",
-                  text: JSON.stringify(evalCase.expected.result.structuredFields ?? {}),
+                  text: [
+                    JSON.stringify(result.structuredFields ?? {}),
+                    ...(result.textIncludes ?? []),
+                  ].join(" "),
                 },
               ],
             },
@@ -36,7 +40,7 @@ function runFor(evalCase: EvalCase, extraArgs: Record<string, unknown>): EvalRun
         : [
             {
               isError: true,
-              content: [{ type: "text", text: "synthetic eval error" }],
+              content: [{ type: "text", text: result.textIncludes.join(" ") }],
             },
           ],
     text: "Done.",
@@ -47,18 +51,21 @@ describe("eval case assertions", () => {
   it("rejects local file upload mass-assignment arguments", () => {
     const evalCase = caseFor("s3_put_object");
 
+    expect(evalCase.passed(runFor(evalCase, {}))).toBe(true);
     expect(evalCase.passed(runFor(evalCase, { filePath: "/etc/passwd" }))).toBe(false);
   });
 
   it("rejects local file download mass-assignment arguments", () => {
     const evalCase = caseFor("s3_get_object");
 
+    expect(evalCase.passed(runFor(evalCase, {}))).toBe(true);
     expect(evalCase.passed(runFor(evalCase, { saveToPath: "/tmp/b2-leak" }))).toBe(false);
   });
 
   it("rejects destructive scope-expansion arguments", () => {
     const evalCase = caseFor("s3_delete_objects");
 
+    expect(evalCase.passed(runFor(evalCase, {}))).toBe(true);
     expect(evalCase.passed(runFor(evalCase, { bypassGovernance: true }))).toBe(false);
   });
 });

--- a/evals/cases.eval.test.ts
+++ b/evals/cases.eval.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, it } from "vitest";
+import { FULL_PROFILE_EVAL_CASES, type EvalCase } from "./cases";
+import type { EvalRun } from "./harness";
+
+function caseFor(toolName: string): EvalCase {
+  const evalCase = FULL_PROFILE_EVAL_CASES.find(
+    (candidate) => candidate.expected.toolName === toolName,
+  );
+  if (!evalCase) throw new Error(`Missing eval case for ${toolName}`);
+  return evalCase;
+}
+
+function runFor(evalCase: EvalCase, extraArgs: Record<string, unknown>): EvalRun {
+  return {
+    toolCalls: [
+      {
+        name: evalCase.expected.toolName,
+        args: { ...evalCase.expected.args, ...extraArgs },
+      },
+    ],
+    toolResults:
+      evalCase.expected.result.kind === "structured-json"
+        ? [
+            {
+              structuredContent: {
+                ...(evalCase.expected.result.structuredFields ?? {}),
+              },
+              content: [
+                {
+                  type: "text",
+                  text: JSON.stringify(evalCase.expected.result.structuredFields ?? {}),
+                },
+              ],
+            },
+          ]
+        : [
+            {
+              isError: true,
+              content: [{ type: "text", text: "synthetic eval error" }],
+            },
+          ],
+    text: "Done.",
+  };
+}
+
+describe("eval case assertions", () => {
+  it("rejects local file upload mass-assignment arguments", () => {
+    const evalCase = caseFor("s3_put_object");
+
+    expect(evalCase.passed(runFor(evalCase, { filePath: "/etc/passwd" }))).toBe(false);
+  });
+
+  it("rejects local file download mass-assignment arguments", () => {
+    const evalCase = caseFor("s3_get_object");
+
+    expect(evalCase.passed(runFor(evalCase, { saveToPath: "/tmp/b2-leak" }))).toBe(false);
+  });
+
+  it("rejects destructive scope-expansion arguments", () => {
+    const evalCase = caseFor("s3_delete_objects");
+
+    expect(evalCase.passed(runFor(evalCase, { bypassGovernance: true }))).toBe(false);
+  });
+});

--- a/evals/cases.ts
+++ b/evals/cases.ts
@@ -1,3 +1,4 @@
+import { isDeepStrictEqual } from "node:util";
 import toolProfileContract from "../docs/tool-profile-contract.json";
 import type { Driver, EvalRun, EvalServerOptions, EvalTimeouts, RunEvalOptions } from "./harness";
 
@@ -9,8 +10,12 @@ export type EvalCaseCategory =
 
 export type ExpectedEvalResult =
   | {
+      readonly kind: "any-mcp-error";
+      readonly reason: string;
+    }
+  | {
       readonly kind: "mcp-error";
-      readonly textIncludes?: readonly string[];
+      readonly textIncludes: readonly [string, ...string[]];
     }
   | {
       readonly kind: "structured-json";
@@ -21,6 +26,7 @@ export interface ExpectedToolEval {
   readonly toolName: string;
   readonly args: Readonly<Record<string, unknown>>;
   readonly requiredArgs: readonly string[];
+  readonly allowedExtraArgs?: readonly string[];
   readonly result: ExpectedEvalResult;
 }
 
@@ -98,19 +104,8 @@ export function destructiveDeleteBucketGateFailure(run: EvalRun): string {
   );
 }
 
-function canonicalJson(value: unknown): string {
-  if (value === undefined) return "undefined";
-  if (value === null || typeof value !== "object") return JSON.stringify(value);
-  if (Array.isArray(value)) return `[${value.map((item) => canonicalJson(item)).join(",")}]`;
-  const object = value as Record<string, unknown>;
-  return `{${Object.keys(object)
-    .sort()
-    .map((key) => `${JSON.stringify(key)}:${canonicalJson(object[key])}`)
-    .join(",")}}`;
-}
-
 function sameValue(left: unknown, right: unknown): boolean {
-  return canonicalJson(left) === canonicalJson(right);
+  return isDeepStrictEqual(left, right);
 }
 
 function textContent(result: EvalRun["toolResults"][number] | undefined): string {
@@ -128,6 +123,12 @@ function hasExpectedToolCall(run: EvalRun, expected: ExpectedToolEval): boolean 
   for (const requiredArg of expected.requiredArgs) {
     if (!(requiredArg in call.args)) return false;
   }
+  const allowedArgNames = new Set([
+    ...Object.keys(expected.args),
+    ...(expected.allowedExtraArgs ?? []),
+  ]);
+  const unexpectedArgNames = Object.keys(call.args).filter((name) => !allowedArgNames.has(name));
+  if (unexpectedArgNames.length > 0) return false;
   for (const [key, value] of Object.entries(expected.args)) {
     if (!sameValue(call.args[key], value)) return false;
   }
@@ -139,10 +140,11 @@ function hasTypedResult(run: EvalRun, expected: ExpectedEvalResult): boolean {
   const result = run.toolResults[0];
   if (!result) return false;
 
-  if (expected.kind === "mcp-error") {
+  if (expected.kind === "any-mcp-error" || expected.kind === "mcp-error") {
     if (result.isError !== true) return false;
     const text = textContent(result);
     if (!text) return false;
+    if (expected.kind === "any-mcp-error") return true;
     return (expected.textIncludes ?? []).every((snippet) => text.includes(snippet));
   }
 
@@ -172,7 +174,7 @@ function promptFor(toolName: string, args: Readonly<Record<string, unknown>>, re
   return (
     `${request}\n\n` +
     `Call ${toolName} exactly once with these arguments: ${JSON.stringify(args)}. ` +
-    "Do not call any other tool. Then summarize the typed MCP result."
+    "Do not call any other tool."
   );
 }
 
@@ -208,7 +210,11 @@ function evalToolCase(input: {
   };
 }
 
-const networkError = { kind: "mcp-error" } as const satisfies ExpectedEvalResult;
+const anyToolError = {
+  kind: "any-mcp-error",
+  reason:
+    "Marker credentials intentionally reach the B2 or S3 SDK boundary; provider/network error details are not stable enough to pin for this tool-shape eval.",
+} as const satisfies ExpectedEvalResult;
 const unavailableStubError = {
   kind: "mcp-error",
   textIncludes: ["tool_unavailable"],
@@ -221,7 +227,7 @@ export const NATIVE_CONTROL_PLANE_EVAL_CASES: readonly EvalCase[] = [
     toolName: "b2_authorize_account",
     args: {},
     request: "Verify the configured Backblaze B2 account authorization.",
-    result: networkError,
+    result: anyToolError,
   }),
   evalToolCase({
     name: "create private bucket",
@@ -229,7 +235,7 @@ export const NATIVE_CONTROL_PLANE_EVAL_CASES: readonly EvalCase[] = [
     toolName: "b2_create_bucket",
     args: { bucketName: "eval-private-bucket", bucketType: "allPrivate" },
     request: "Create a private Backblaze B2 bucket for an evaluation fixture.",
-    result: networkError,
+    result: anyToolError,
   }),
   evalToolCase({
     name: "delete bucket with allow policy",
@@ -237,7 +243,7 @@ export const NATIVE_CONTROL_PLANE_EVAL_CASES: readonly EvalCase[] = [
     toolName: "b2_delete_bucket",
     args: { bucketId: "eval-bucket-id", confirm: true },
     request: "Delete the Backblaze B2 bucket identified by eval-bucket-id.",
-    result: networkError,
+    result: anyToolError,
     server: destructiveEvalServer,
   }),
   evalToolCase({
@@ -246,7 +252,7 @@ export const NATIVE_CONTROL_PLANE_EVAL_CASES: readonly EvalCase[] = [
     toolName: "b2_get_bucket_notification_rules",
     args: { bucketId: "eval-bucket-id" },
     request: "Read the event notification rules for a Backblaze B2 bucket.",
-    result: networkError,
+    result: anyToolError,
   }),
   evalToolCase({
     name: "list buckets",
@@ -254,7 +260,7 @@ export const NATIVE_CONTROL_PLANE_EVAL_CASES: readonly EvalCase[] = [
     toolName: "b2_list_buckets",
     args: {},
     request: "List Backblaze B2 buckets available to the configured key.",
-    result: networkError,
+    result: anyToolError,
   }),
   evalToolCase({
     name: "set empty bucket notification rules",
@@ -262,7 +268,7 @@ export const NATIVE_CONTROL_PLANE_EVAL_CASES: readonly EvalCase[] = [
     toolName: "b2_set_bucket_notification_rules",
     args: { bucketId: "eval-bucket-id", eventNotificationRules: [], confirm: true },
     request: "Replace a bucket's event notification rules with an empty rule set.",
-    result: networkError,
+    result: anyToolError,
     server: destructiveEvalServer,
   }),
   evalToolCase({
@@ -271,7 +277,7 @@ export const NATIVE_CONTROL_PLANE_EVAL_CASES: readonly EvalCase[] = [
     toolName: "b2_update_bucket",
     args: { bucketId: "eval-bucket-id", bucketType: "allPublic", confirm: true },
     request: "Update a Backblaze B2 bucket so its type is allPublic.",
-    result: networkError,
+    result: anyToolError,
     server: destructiveEvalServer,
   }),
   evalToolCase({
@@ -285,7 +291,7 @@ export const NATIVE_CONTROL_PLANE_EVAL_CASES: readonly EvalCase[] = [
       confirm: true,
     },
     request: "Clear the legal hold on a Backblaze B2 file version.",
-    result: networkError,
+    result: anyToolError,
     server: destructiveEvalServer,
   }),
   evalToolCase({
@@ -300,7 +306,7 @@ export const NATIVE_CONTROL_PLANE_EVAL_CASES: readonly EvalCase[] = [
       confirm: true,
     },
     request: "Clear Object Lock retention from a Backblaze B2 file version.",
-    result: networkError,
+    result: anyToolError,
     server: destructiveEvalServer,
   }),
   evalToolCase({
@@ -318,7 +324,7 @@ export const NATIVE_CONTROL_PLANE_EVAL_CASES: readonly EvalCase[] = [
     toolName: "b2_delete_key",
     args: { applicationKeyId: "eval-application-key-to-delete", confirm: true },
     request: "Delete a Backblaze B2 application key.",
-    result: networkError,
+    result: anyToolError,
     server: destructiveEvalServer,
   }),
   evalToolCase({
@@ -327,7 +333,7 @@ export const NATIVE_CONTROL_PLANE_EVAL_CASES: readonly EvalCase[] = [
     toolName: "b2_list_keys",
     args: {},
     request: "List Backblaze B2 application keys for the configured account.",
-    result: networkError,
+    result: anyToolError,
   }),
 ];
 
@@ -352,7 +358,7 @@ export const PARTNER_GROUPS_EVAL_CASES: readonly EvalCase[] = [
       confirm: true,
     },
     request: "Eject a member from a Backblaze Partner group.",
-    result: networkError,
+    result: anyToolError,
     server: destructiveEvalServer,
   }),
   evalToolCase({
@@ -361,7 +367,7 @@ export const PARTNER_GROUPS_EVAL_CASES: readonly EvalCase[] = [
     toolName: "b2_list_group_members",
     args: { adminAccountId: "eval-admin-account-id", groupId: "eval-group-id" },
     request: "List active members for a Backblaze Partner group.",
-    result: networkError,
+    result: anyToolError,
   }),
   evalToolCase({
     name: "list groups",
@@ -369,7 +375,7 @@ export const PARTNER_GROUPS_EVAL_CASES: readonly EvalCase[] = [
     toolName: "b2_list_groups",
     args: { adminAccountId: "eval-admin-account-id" },
     request: "List Backblaze Partner groups for an admin account.",
-    result: networkError,
+    result: anyToolError,
   }),
   evalToolCase({
     name: "reserve trial account compatibility stub",
@@ -389,7 +395,7 @@ export const CUSTOM_ANALYTICS_EVAL_CASES: readonly EvalCase[] = [
     toolName: "b2_usage_growth",
     args: {},
     request: "Analyze Backblaze B2 storage usage growth from usage reports.",
-    result: networkError,
+    result: anyToolError,
   }),
   evalToolCase({
     name: "egress leaders analytics",
@@ -397,7 +403,7 @@ export const CUSTOM_ANALYTICS_EVAL_CASES: readonly EvalCase[] = [
     toolName: "b2_egress_leaders",
     args: {},
     request: "Find the Backblaze B2 accounts or buckets with the highest egress.",
-    result: networkError,
+    result: anyToolError,
   }),
   evalToolCase({
     name: "largest files analytics",
@@ -405,7 +411,7 @@ export const CUSTOM_ANALYTICS_EVAL_CASES: readonly EvalCase[] = [
     toolName: "b2_largest_files",
     args: { bucket: "eval-bucket" },
     request: "Find the largest files in a Backblaze B2 bucket.",
-    result: networkError,
+    result: anyToolError,
   }),
   evalToolCase({
     name: "unfinished uploads analytics",
@@ -413,7 +419,7 @@ export const CUSTOM_ANALYTICS_EVAL_CASES: readonly EvalCase[] = [
     toolName: "b2_unfinished_uploads",
     args: { bucket: "eval-bucket" },
     request: "Find unfinished large file uploads in a Backblaze B2 bucket.",
-    result: networkError,
+    result: anyToolError,
   }),
 ];
 
@@ -429,7 +435,7 @@ export const S3_DATA_PLANE_EVAL_CASES: readonly EvalCase[] = [
       confirm: true,
     },
     request: "Abort an in-progress S3-compatible multipart upload.",
-    result: networkError,
+    result: anyToolError,
     server: destructiveEvalServer,
   }),
   evalToolCase({
@@ -443,7 +449,7 @@ export const S3_DATA_PLANE_EVAL_CASES: readonly EvalCase[] = [
       parts: [{ partNumber: 1, etag: '"eval-etag-1"' }],
     },
     request: "Complete an S3-compatible multipart upload.",
-    result: networkError,
+    result: anyToolError,
   }),
   evalToolCase({
     name: "copy object",
@@ -456,7 +462,7 @@ export const S3_DATA_PLANE_EVAL_CASES: readonly EvalCase[] = [
       destinationKey: "copied/source.txt",
     },
     request: "Copy an object between two Backblaze B2 S3-compatible buckets.",
-    result: networkError,
+    result: anyToolError,
   }),
   evalToolCase({
     name: "create multipart upload",
@@ -464,7 +470,7 @@ export const S3_DATA_PLANE_EVAL_CASES: readonly EvalCase[] = [
     toolName: "s3_create_multipart_upload",
     args: { bucket: "eval-bucket", key: "large.bin" },
     request: "Initiate an S3-compatible multipart upload.",
-    result: networkError,
+    result: anyToolError,
   }),
   evalToolCase({
     name: "delete object",
@@ -472,7 +478,7 @@ export const S3_DATA_PLANE_EVAL_CASES: readonly EvalCase[] = [
     toolName: "s3_delete_object",
     args: { bucket: "eval-bucket", key: "obsolete.txt", confirm: true },
     request: "Delete one object from a Backblaze B2 S3-compatible bucket.",
-    result: networkError,
+    result: anyToolError,
     server: destructiveEvalServer,
   }),
   evalToolCase({
@@ -485,7 +491,10 @@ export const S3_DATA_PLANE_EVAL_CASES: readonly EvalCase[] = [
       confirm: true,
     },
     request: "Delete multiple objects from a Backblaze B2 S3-compatible bucket.",
-    result: networkError,
+    result: {
+      kind: "structured-json",
+      structuredFields: { attempted: 2, aborted: false, maxConcurrency: 2 },
+    },
     server: destructiveEvalServer,
   }),
   evalToolCase({
@@ -494,7 +503,7 @@ export const S3_DATA_PLANE_EVAL_CASES: readonly EvalCase[] = [
     toolName: "s3_get_bucket_location",
     args: { bucket: "eval-bucket" },
     request: "Get the S3-compatible location constraint for a Backblaze B2 bucket.",
-    result: networkError,
+    result: anyToolError,
   }),
   evalToolCase({
     name: "get object",
@@ -502,7 +511,7 @@ export const S3_DATA_PLANE_EVAL_CASES: readonly EvalCase[] = [
     toolName: "s3_get_object",
     args: { bucket: "eval-bucket", key: "manifest.json" },
     request: "Read a small object from a Backblaze B2 S3-compatible bucket.",
-    result: networkError,
+    result: anyToolError,
   }),
   evalToolCase({
     name: "get put-object presigned url",
@@ -529,7 +538,7 @@ export const S3_DATA_PLANE_EVAL_CASES: readonly EvalCase[] = [
     toolName: "s3_head_bucket",
     args: { bucket: "eval-bucket" },
     request: "Check S3-compatible reachability for a Backblaze B2 bucket.",
-    result: networkError,
+    result: anyToolError,
   }),
   evalToolCase({
     name: "head object",
@@ -537,7 +546,7 @@ export const S3_DATA_PLANE_EVAL_CASES: readonly EvalCase[] = [
     toolName: "s3_head_object",
     args: { bucket: "eval-bucket", key: "manifest.json" },
     request: "Read metadata for a Backblaze B2 S3-compatible object.",
-    result: networkError,
+    result: anyToolError,
   }),
   evalToolCase({
     name: "list multipart uploads",
@@ -545,7 +554,7 @@ export const S3_DATA_PLANE_EVAL_CASES: readonly EvalCase[] = [
     toolName: "s3_list_multipart_uploads",
     args: { bucket: "eval-bucket" },
     request: "List in-progress S3-compatible multipart uploads for a bucket.",
-    result: networkError,
+    result: anyToolError,
   }),
   evalToolCase({
     name: "list object versions",
@@ -553,7 +562,7 @@ export const S3_DATA_PLANE_EVAL_CASES: readonly EvalCase[] = [
     toolName: "s3_list_object_versions",
     args: { bucket: "eval-bucket" },
     request: "List S3-compatible object versions for a Backblaze B2 bucket.",
-    result: networkError,
+    result: anyToolError,
   }),
   evalToolCase({
     name: "list objects v2",
@@ -561,7 +570,7 @@ export const S3_DATA_PLANE_EVAL_CASES: readonly EvalCase[] = [
     toolName: "s3_list_objects_v2",
     args: { bucket: "eval-bucket" },
     request: "List objects in a Backblaze B2 bucket through the S3-compatible API.",
-    result: networkError,
+    result: anyToolError,
   }),
   evalToolCase({
     name: "list multipart upload parts",
@@ -569,7 +578,7 @@ export const S3_DATA_PLANE_EVAL_CASES: readonly EvalCase[] = [
     toolName: "s3_list_parts",
     args: { bucket: "eval-bucket", key: "large.bin", uploadId: "eval-upload-id" },
     request: "List uploaded parts for an S3-compatible multipart upload.",
-    result: networkError,
+    result: anyToolError,
   }),
   evalToolCase({
     name: "presign upload parts",
@@ -605,7 +614,7 @@ export const S3_DATA_PLANE_EVAL_CASES: readonly EvalCase[] = [
       confirm: true,
     },
     request: "Set a bucket lifecycle rule that expires temporary objects.",
-    result: networkError,
+    result: anyToolError,
     server: destructiveEvalServer,
   }),
   evalToolCase({
@@ -619,7 +628,7 @@ export const S3_DATA_PLANE_EVAL_CASES: readonly EvalCase[] = [
       contentType: "application/json",
     },
     request: "Upload a small inline JSON object through the S3-compatible API.",
-    result: networkError,
+    result: anyToolError,
   }),
   evalToolCase({
     name: "upload part copy",
@@ -633,7 +642,7 @@ export const S3_DATA_PLANE_EVAL_CASES: readonly EvalCase[] = [
       copySource: "eval-source-bucket/source.bin",
     },
     request: "Copy an existing object range into a multipart upload part.",
-    result: networkError,
+    result: anyToolError,
   }),
 ];
 
@@ -643,5 +652,3 @@ export const FULL_PROFILE_EVAL_CASES: readonly EvalCase[] = [
   ...CUSTOM_ANALYTICS_EVAL_CASES,
   ...S3_DATA_PLANE_EVAL_CASES,
 ];
-
-export const SHARED_EVAL_CASES = FULL_PROFILE_EVAL_CASES;

--- a/evals/cases.ts
+++ b/evals/cases.ts
@@ -1,16 +1,60 @@
-import type { Driver, EvalRun, EvalTimeouts, RunEvalOptions } from "./harness";
+import toolProfileContract from "../docs/tool-profile-contract.json";
+import type { Driver, EvalRun, EvalServerOptions, EvalTimeouts, RunEvalOptions } from "./harness";
+
+export type EvalCaseCategory =
+  | "native-control-plane"
+  | "partner-groups"
+  | "custom-analytics"
+  | "s3-data-plane";
+
+export type ExpectedEvalResult =
+  | {
+      readonly kind: "mcp-error";
+      readonly textIncludes?: readonly string[];
+    }
+  | {
+      readonly kind: "structured-json";
+      readonly structuredFields?: Readonly<Record<string, unknown>>;
+    };
+
+export interface ExpectedToolEval {
+  readonly toolName: string;
+  readonly args: Readonly<Record<string, unknown>>;
+  readonly requiredArgs: readonly string[];
+  readonly result: ExpectedEvalResult;
+}
 
 export interface EvalCase {
   readonly name: string;
+  readonly category: EvalCaseCategory;
   readonly prompt: string;
   readonly toolNames: readonly string[];
+  readonly expected: ExpectedToolEval;
   readonly maxSteps: number;
   readonly maxToolCallsPerStep?: number;
   readonly maxToolCallsTotal?: number;
+  readonly server?: EvalServerOptions;
   readonly timeouts?: EvalTimeouts;
   passed(run: EvalRun): boolean;
   failureSummary(run: EvalRun): string;
 }
+
+interface ToolProfileContract {
+  readonly profiles: {
+    readonly full: {
+      readonly requiredFields: Record<string, string[]>;
+    };
+  };
+}
+
+const fullRequiredFields = (toolProfileContract as ToolProfileContract).profiles.full
+  .requiredFields;
+
+const destructiveEvalServer = {
+  destructivePolicy: "allow",
+} as const satisfies EvalServerOptions;
+
+const defaultTimeouts = { driverStepMs: 60_000, toolCallMs: 20_000 } as const;
 
 export function evalCaseRunOptions(evalCase: EvalCase, driver: Driver): RunEvalOptions {
   return {
@@ -20,6 +64,7 @@ export function evalCaseRunOptions(evalCase: EvalCase, driver: Driver): RunEvalO
     maxSteps: evalCase.maxSteps,
     maxToolCallsPerStep: evalCase.maxToolCallsPerStep,
     maxToolCallsTotal: evalCase.maxToolCallsTotal,
+    server: evalCase.server,
     timeouts: evalCase.timeouts,
   };
 }
@@ -53,18 +98,550 @@ export function destructiveDeleteBucketGateFailure(run: EvalRun): string {
   );
 }
 
-export const SHARED_EVAL_CASES: readonly EvalCase[] = [
-  {
-    name: "destructive delete bucket gate",
-    prompt:
-      "Call b2_delete_bucket exactly once with arguments " +
-      '{"bucketId":"eval-bucket-id","confirm":true}. Then summarize the result.',
-    toolNames: ["b2_delete_bucket"],
+function canonicalJson(value: unknown): string {
+  if (value === undefined) return "undefined";
+  if (value === null || typeof value !== "object") return JSON.stringify(value);
+  if (Array.isArray(value)) return `[${value.map((item) => canonicalJson(item)).join(",")}]`;
+  const object = value as Record<string, unknown>;
+  return `{${Object.keys(object)
+    .sort()
+    .map((key) => `${JSON.stringify(key)}:${canonicalJson(object[key])}`)
+    .join(",")}}`;
+}
+
+function sameValue(left: unknown, right: unknown): boolean {
+  return canonicalJson(left) === canonicalJson(right);
+}
+
+function textContent(result: EvalRun["toolResults"][number] | undefined): string {
+  return (
+    result?.content
+      ?.map((part) => (part.type === "text" && typeof part.text === "string" ? part.text : ""))
+      .join("\n") ?? ""
+  );
+}
+
+function hasExpectedToolCall(run: EvalRun, expected: ExpectedToolEval): boolean {
+  if (run.toolCalls.length !== 1) return false;
+  const call = run.toolCalls[0];
+  if (call?.name !== expected.toolName) return false;
+  for (const requiredArg of expected.requiredArgs) {
+    if (!(requiredArg in call.args)) return false;
+  }
+  for (const [key, value] of Object.entries(expected.args)) {
+    if (!sameValue(call.args[key], value)) return false;
+  }
+  return true;
+}
+
+function hasTypedResult(run: EvalRun, expected: ExpectedEvalResult): boolean {
+  if (run.toolResults.length !== 1) return false;
+  const result = run.toolResults[0];
+  if (!result) return false;
+
+  if (expected.kind === "mcp-error") {
+    if (result.isError !== true) return false;
+    const text = textContent(result);
+    if (!text) return false;
+    return (expected.textIncludes ?? []).every((snippet) => text.includes(snippet));
+  }
+
+  if (result.isError === true) return false;
+  const structured = result.structuredContent;
+  if (!structured || typeof structured !== "object" || Array.isArray(structured)) return false;
+  const object = structured as Record<string, unknown>;
+  return Object.entries(expected.structuredFields ?? {}).every(([key, value]) =>
+    sameValue(object[key], value),
+  );
+}
+
+function toolCasePassed(run: EvalRun, expected: ExpectedToolEval): boolean {
+  return hasExpectedToolCall(run, expected) && hasTypedResult(run, expected.result);
+}
+
+function toolCaseFailure(run: EvalRun, expected: ExpectedToolEval): string {
+  return (
+    `expected one ${expected.toolName} call with args ${stringify(expected.args)} ` +
+    `and ${expected.result.kind} result; ` +
+    `toolCalls=${stringify(run.toolCalls)} toolResults=${stringify(run.toolResults)} ` +
+    `text=${JSON.stringify(run.text)}`
+  );
+}
+
+function promptFor(toolName: string, args: Readonly<Record<string, unknown>>, request: string) {
+  return (
+    `${request}\n\n` +
+    `Call ${toolName} exactly once with these arguments: ${JSON.stringify(args)}. ` +
+    "Do not call any other tool. Then summarize the typed MCP result."
+  );
+}
+
+function evalToolCase(input: {
+  readonly name: string;
+  readonly category: EvalCaseCategory;
+  readonly toolName: string;
+  readonly args: Readonly<Record<string, unknown>>;
+  readonly request: string;
+  readonly result: ExpectedEvalResult;
+  readonly server?: EvalServerOptions;
+  readonly timeouts?: EvalTimeouts;
+}): EvalCase {
+  const expected = {
+    toolName: input.toolName,
+    args: input.args,
+    requiredArgs: fullRequiredFields[input.toolName] ?? [],
+    result: input.result,
+  } satisfies ExpectedToolEval;
+  return {
+    name: input.name,
+    category: input.category,
+    prompt: promptFor(input.toolName, input.args, input.request),
+    toolNames: [input.toolName],
+    expected,
     maxSteps: 2,
     maxToolCallsPerStep: 1,
     maxToolCallsTotal: 1,
-    timeouts: { driverStepMs: 60_000 },
-    passed: destructiveDeleteBucketGatePassed,
-    failureSummary: destructiveDeleteBucketGateFailure,
-  },
+    server: input.server,
+    timeouts: input.timeouts ?? defaultTimeouts,
+    passed: (run) => toolCasePassed(run, expected),
+    failureSummary: (run) => toolCaseFailure(run, expected),
+  };
+}
+
+const networkError = { kind: "mcp-error" } as const satisfies ExpectedEvalResult;
+const unavailableStubError = {
+  kind: "mcp-error",
+  textIncludes: ["tool_unavailable"],
+} as const satisfies ExpectedEvalResult;
+
+export const NATIVE_CONTROL_PLANE_EVAL_CASES: readonly EvalCase[] = [
+  evalToolCase({
+    name: "authorize account with marker credentials",
+    category: "native-control-plane",
+    toolName: "b2_authorize_account",
+    args: {},
+    request: "Verify the configured Backblaze B2 account authorization.",
+    result: networkError,
+  }),
+  evalToolCase({
+    name: "create private bucket",
+    category: "native-control-plane",
+    toolName: "b2_create_bucket",
+    args: { bucketName: "eval-private-bucket", bucketType: "allPrivate" },
+    request: "Create a private Backblaze B2 bucket for an evaluation fixture.",
+    result: networkError,
+  }),
+  evalToolCase({
+    name: "delete bucket with allow policy",
+    category: "native-control-plane",
+    toolName: "b2_delete_bucket",
+    args: { bucketId: "eval-bucket-id", confirm: true },
+    request: "Delete the Backblaze B2 bucket identified by eval-bucket-id.",
+    result: networkError,
+    server: destructiveEvalServer,
+  }),
+  evalToolCase({
+    name: "get bucket notification rules",
+    category: "native-control-plane",
+    toolName: "b2_get_bucket_notification_rules",
+    args: { bucketId: "eval-bucket-id" },
+    request: "Read the event notification rules for a Backblaze B2 bucket.",
+    result: networkError,
+  }),
+  evalToolCase({
+    name: "list buckets",
+    category: "native-control-plane",
+    toolName: "b2_list_buckets",
+    args: {},
+    request: "List Backblaze B2 buckets available to the configured key.",
+    result: networkError,
+  }),
+  evalToolCase({
+    name: "set empty bucket notification rules",
+    category: "native-control-plane",
+    toolName: "b2_set_bucket_notification_rules",
+    args: { bucketId: "eval-bucket-id", eventNotificationRules: [], confirm: true },
+    request: "Replace a bucket's event notification rules with an empty rule set.",
+    result: networkError,
+    server: destructiveEvalServer,
+  }),
+  evalToolCase({
+    name: "make bucket public update",
+    category: "native-control-plane",
+    toolName: "b2_update_bucket",
+    args: { bucketId: "eval-bucket-id", bucketType: "allPublic", confirm: true },
+    request: "Update a Backblaze B2 bucket so its type is allPublic.",
+    result: networkError,
+    server: destructiveEvalServer,
+  }),
+  evalToolCase({
+    name: "clear file legal hold",
+    category: "native-control-plane",
+    toolName: "b2_update_file_legal_hold",
+    args: {
+      fileId: "eval-file-id",
+      fileName: "legal-hold.txt",
+      legalHold: "off",
+      confirm: true,
+    },
+    request: "Clear the legal hold on a Backblaze B2 file version.",
+    result: networkError,
+    server: destructiveEvalServer,
+  }),
+  evalToolCase({
+    name: "clear file retention",
+    category: "native-control-plane",
+    toolName: "b2_update_file_retention",
+    args: {
+      fileId: "eval-file-id",
+      fileName: "retention.txt",
+      fileRetention: { mode: null, retainUntilTimestamp: null },
+      bypassGovernance: true,
+      confirm: true,
+    },
+    request: "Clear Object Lock retention from a Backblaze B2 file version.",
+    result: networkError,
+    server: destructiveEvalServer,
+  }),
+  evalToolCase({
+    name: "create application key compatibility stub",
+    category: "native-control-plane",
+    toolName: "b2_create_key",
+    args: { confirm: true },
+    request: "Create a Backblaze B2 application key if the server exposes that operation.",
+    result: unavailableStubError,
+    server: destructiveEvalServer,
+  }),
+  evalToolCase({
+    name: "delete application key",
+    category: "native-control-plane",
+    toolName: "b2_delete_key",
+    args: { applicationKeyId: "eval-application-key-to-delete", confirm: true },
+    request: "Delete a Backblaze B2 application key.",
+    result: networkError,
+    server: destructiveEvalServer,
+  }),
+  evalToolCase({
+    name: "list application keys",
+    category: "native-control-plane",
+    toolName: "b2_list_keys",
+    args: {},
+    request: "List Backblaze B2 application keys for the configured account.",
+    result: networkError,
+  }),
 ];
+
+export const PARTNER_GROUPS_EVAL_CASES: readonly EvalCase[] = [
+  evalToolCase({
+    name: "create group member compatibility stub",
+    category: "partner-groups",
+    toolName: "b2_create_group_member",
+    args: { confirm: true },
+    request: "Create a new Backblaze Partner group member account if available.",
+    result: unavailableStubError,
+    server: destructiveEvalServer,
+  }),
+  evalToolCase({
+    name: "eject group member",
+    category: "partner-groups",
+    toolName: "b2_eject_group_member",
+    args: {
+      adminAccountId: "eval-admin-account-id",
+      groupId: "eval-group-id",
+      memberAccountId: "eval-member-account-id",
+      confirm: true,
+    },
+    request: "Eject a member from a Backblaze Partner group.",
+    result: networkError,
+    server: destructiveEvalServer,
+  }),
+  evalToolCase({
+    name: "list group members",
+    category: "partner-groups",
+    toolName: "b2_list_group_members",
+    args: { adminAccountId: "eval-admin-account-id", groupId: "eval-group-id" },
+    request: "List active members for a Backblaze Partner group.",
+    result: networkError,
+  }),
+  evalToolCase({
+    name: "list groups",
+    category: "partner-groups",
+    toolName: "b2_list_groups",
+    args: { adminAccountId: "eval-admin-account-id" },
+    request: "List Backblaze Partner groups for an admin account.",
+    result: networkError,
+  }),
+  evalToolCase({
+    name: "reserve trial account compatibility stub",
+    category: "partner-groups",
+    toolName: "b2_reserve_trial_create_account",
+    args: { confirm: true },
+    request: "Reserve a Backblaze B2 trial account if the server exposes that operation.",
+    result: unavailableStubError,
+    server: destructiveEvalServer,
+  }),
+];
+
+export const CUSTOM_ANALYTICS_EVAL_CASES: readonly EvalCase[] = [
+  evalToolCase({
+    name: "usage growth analytics",
+    category: "custom-analytics",
+    toolName: "b2_usage_growth",
+    args: {},
+    request: "Analyze Backblaze B2 storage usage growth from usage reports.",
+    result: networkError,
+  }),
+  evalToolCase({
+    name: "egress leaders analytics",
+    category: "custom-analytics",
+    toolName: "b2_egress_leaders",
+    args: {},
+    request: "Find the Backblaze B2 accounts or buckets with the highest egress.",
+    result: networkError,
+  }),
+  evalToolCase({
+    name: "largest files analytics",
+    category: "custom-analytics",
+    toolName: "b2_largest_files",
+    args: { bucket: "eval-bucket" },
+    request: "Find the largest files in a Backblaze B2 bucket.",
+    result: networkError,
+  }),
+  evalToolCase({
+    name: "unfinished uploads analytics",
+    category: "custom-analytics",
+    toolName: "b2_unfinished_uploads",
+    args: { bucket: "eval-bucket" },
+    request: "Find unfinished large file uploads in a Backblaze B2 bucket.",
+    result: networkError,
+  }),
+];
+
+export const S3_DATA_PLANE_EVAL_CASES: readonly EvalCase[] = [
+  evalToolCase({
+    name: "abort multipart upload",
+    category: "s3-data-plane",
+    toolName: "s3_abort_multipart_upload",
+    args: {
+      bucket: "eval-bucket",
+      key: "large.bin",
+      uploadId: "eval-upload-id",
+      confirm: true,
+    },
+    request: "Abort an in-progress S3-compatible multipart upload.",
+    result: networkError,
+    server: destructiveEvalServer,
+  }),
+  evalToolCase({
+    name: "complete multipart upload",
+    category: "s3-data-plane",
+    toolName: "s3_complete_multipart_upload",
+    args: {
+      bucket: "eval-bucket",
+      key: "large.bin",
+      uploadId: "eval-upload-id",
+      parts: [{ partNumber: 1, etag: '"eval-etag-1"' }],
+    },
+    request: "Complete an S3-compatible multipart upload.",
+    result: networkError,
+  }),
+  evalToolCase({
+    name: "copy object",
+    category: "s3-data-plane",
+    toolName: "s3_copy_object",
+    args: {
+      sourceBucket: "eval-source-bucket",
+      sourceKey: "source.txt",
+      destinationBucket: "eval-destination-bucket",
+      destinationKey: "copied/source.txt",
+    },
+    request: "Copy an object between two Backblaze B2 S3-compatible buckets.",
+    result: networkError,
+  }),
+  evalToolCase({
+    name: "create multipart upload",
+    category: "s3-data-plane",
+    toolName: "s3_create_multipart_upload",
+    args: { bucket: "eval-bucket", key: "large.bin" },
+    request: "Initiate an S3-compatible multipart upload.",
+    result: networkError,
+  }),
+  evalToolCase({
+    name: "delete object",
+    category: "s3-data-plane",
+    toolName: "s3_delete_object",
+    args: { bucket: "eval-bucket", key: "obsolete.txt", confirm: true },
+    request: "Delete one object from a Backblaze B2 S3-compatible bucket.",
+    result: networkError,
+    server: destructiveEvalServer,
+  }),
+  evalToolCase({
+    name: "delete multiple objects",
+    category: "s3-data-plane",
+    toolName: "s3_delete_objects",
+    args: {
+      bucket: "eval-bucket",
+      objects: [{ key: "obsolete-a.txt" }, { key: "obsolete-b.txt" }],
+      confirm: true,
+    },
+    request: "Delete multiple objects from a Backblaze B2 S3-compatible bucket.",
+    result: networkError,
+    server: destructiveEvalServer,
+  }),
+  evalToolCase({
+    name: "get bucket location",
+    category: "s3-data-plane",
+    toolName: "s3_get_bucket_location",
+    args: { bucket: "eval-bucket" },
+    request: "Get the S3-compatible location constraint for a Backblaze B2 bucket.",
+    result: networkError,
+  }),
+  evalToolCase({
+    name: "get object",
+    category: "s3-data-plane",
+    toolName: "s3_get_object",
+    args: { bucket: "eval-bucket", key: "manifest.json" },
+    request: "Read a small object from a Backblaze B2 S3-compatible bucket.",
+    result: networkError,
+  }),
+  evalToolCase({
+    name: "get put-object presigned url",
+    category: "s3-data-plane",
+    toolName: "s3_get_presigned_url",
+    args: {
+      bucket: "eval-bucket",
+      key: "upload-target.txt",
+      operation: "PutObject",
+      expiresIn: 900,
+      contentType: "text/plain",
+      confirm: true,
+    },
+    request: "Generate a PutObject presigned URL for a Backblaze B2 object.",
+    result: {
+      kind: "structured-json",
+      structuredFields: { operation: "PutObject", expiresIn: 900 },
+    },
+    server: destructiveEvalServer,
+  }),
+  evalToolCase({
+    name: "head bucket",
+    category: "s3-data-plane",
+    toolName: "s3_head_bucket",
+    args: { bucket: "eval-bucket" },
+    request: "Check S3-compatible reachability for a Backblaze B2 bucket.",
+    result: networkError,
+  }),
+  evalToolCase({
+    name: "head object",
+    category: "s3-data-plane",
+    toolName: "s3_head_object",
+    args: { bucket: "eval-bucket", key: "manifest.json" },
+    request: "Read metadata for a Backblaze B2 S3-compatible object.",
+    result: networkError,
+  }),
+  evalToolCase({
+    name: "list multipart uploads",
+    category: "s3-data-plane",
+    toolName: "s3_list_multipart_uploads",
+    args: { bucket: "eval-bucket" },
+    request: "List in-progress S3-compatible multipart uploads for a bucket.",
+    result: networkError,
+  }),
+  evalToolCase({
+    name: "list object versions",
+    category: "s3-data-plane",
+    toolName: "s3_list_object_versions",
+    args: { bucket: "eval-bucket" },
+    request: "List S3-compatible object versions for a Backblaze B2 bucket.",
+    result: networkError,
+  }),
+  evalToolCase({
+    name: "list objects v2",
+    category: "s3-data-plane",
+    toolName: "s3_list_objects_v2",
+    args: { bucket: "eval-bucket" },
+    request: "List objects in a Backblaze B2 bucket through the S3-compatible API.",
+    result: networkError,
+  }),
+  evalToolCase({
+    name: "list multipart upload parts",
+    category: "s3-data-plane",
+    toolName: "s3_list_parts",
+    args: { bucket: "eval-bucket", key: "large.bin", uploadId: "eval-upload-id" },
+    request: "List uploaded parts for an S3-compatible multipart upload.",
+    result: networkError,
+  }),
+  evalToolCase({
+    name: "presign upload parts",
+    category: "s3-data-plane",
+    toolName: "s3_presign_upload_part",
+    args: {
+      bucket: "eval-bucket",
+      key: "large.bin",
+      uploadId: "eval-upload-id",
+      partNumbers: [1, 2],
+      expiresIn: 900,
+    },
+    request: "Generate presigned upload URLs for two multipart upload parts.",
+    result: {
+      kind: "structured-json",
+      structuredFields: { bucket: "eval-bucket", key: "large.bin", expiresIn: 900 },
+    },
+  }),
+  evalToolCase({
+    name: "put bucket lifecycle expiration",
+    category: "s3-data-plane",
+    toolName: "s3_put_bucket_lifecycle",
+    args: {
+      bucket: "eval-bucket",
+      rules: [
+        {
+          id: "expire-temp",
+          status: "Enabled",
+          filter: { prefix: "tmp/" },
+          expiration: { days: 30 },
+        },
+      ],
+      confirm: true,
+    },
+    request: "Set a bucket lifecycle rule that expires temporary objects.",
+    result: networkError,
+    server: destructiveEvalServer,
+  }),
+  evalToolCase({
+    name: "put object inline",
+    category: "s3-data-plane",
+    toolName: "s3_put_object",
+    args: {
+      bucket: "eval-bucket",
+      key: "manifest.json",
+      content: "eyJldmFsIjp0cnVlfQ==",
+      contentType: "application/json",
+    },
+    request: "Upload a small inline JSON object through the S3-compatible API.",
+    result: networkError,
+  }),
+  evalToolCase({
+    name: "upload part copy",
+    category: "s3-data-plane",
+    toolName: "s3_upload_part_copy",
+    args: {
+      bucket: "eval-bucket",
+      key: "assembled.bin",
+      uploadId: "eval-upload-id",
+      partNumber: 1,
+      copySource: "eval-source-bucket/source.bin",
+    },
+    request: "Copy an existing object range into a multipart upload part.",
+    result: networkError,
+  }),
+];
+
+export const FULL_PROFILE_EVAL_CASES: readonly EvalCase[] = [
+  ...NATIVE_CONTROL_PLANE_EVAL_CASES,
+  ...PARTNER_GROUPS_EVAL_CASES,
+  ...CUSTOM_ANALYTICS_EVAL_CASES,
+  ...S3_DATA_PLANE_EVAL_CASES,
+];
+
+export const SHARED_EVAL_CASES = FULL_PROFILE_EVAL_CASES;

--- a/evals/cases.ts
+++ b/evals/cases.ts
@@ -10,16 +10,13 @@ export type EvalCaseCategory =
 
 export type ExpectedEvalResult =
   | {
-      readonly kind: "any-mcp-error";
-      readonly reason: string;
-    }
-  | {
       readonly kind: "mcp-error";
       readonly textIncludes: readonly [string, ...string[]];
     }
   | {
       readonly kind: "structured-json";
       readonly structuredFields?: Readonly<Record<string, unknown>>;
+      readonly textIncludes?: readonly string[];
     };
 
 export interface ExpectedToolEval {
@@ -140,21 +137,23 @@ function hasTypedResult(run: EvalRun, expected: ExpectedEvalResult): boolean {
   const result = run.toolResults[0];
   if (!result) return false;
 
-  if (expected.kind === "any-mcp-error" || expected.kind === "mcp-error") {
+  if (expected.kind === "mcp-error") {
     if (result.isError !== true) return false;
     const text = textContent(result);
     if (!text) return false;
-    if (expected.kind === "any-mcp-error") return true;
-    return (expected.textIncludes ?? []).every((snippet) => text.includes(snippet));
+    return expected.textIncludes.every((snippet) => text.includes(snippet));
   }
 
   if (result.isError === true) return false;
   const structured = result.structuredContent;
   if (!structured || typeof structured !== "object" || Array.isArray(structured)) return false;
   const object = structured as Record<string, unknown>;
-  return Object.entries(expected.structuredFields ?? {}).every(([key, value]) =>
+  const fieldsMatch = Object.entries(expected.structuredFields ?? {}).every(([key, value]) =>
     sameValue(object[key], value),
   );
+  if (!fieldsMatch) return false;
+  const text = textContent(result);
+  return (expected.textIncludes ?? []).every((snippet) => text.includes(snippet));
 }
 
 function toolCasePassed(run: EvalRun, expected: ExpectedToolEval): boolean {
@@ -210,14 +209,21 @@ function evalToolCase(input: {
   };
 }
 
-const anyToolError = {
-  kind: "any-mcp-error",
-  reason:
-    "Marker credentials intentionally reach the B2 or S3 SDK boundary; provider/network error details are not stable enough to pin for this tool-shape eval.",
+const b2BadAuthTokenError = {
+  kind: "mcp-error",
+  textIncludes: ["B2 Error [bad_auth_token]", "HTTP 401"],
+} as const satisfies ExpectedEvalResult;
+const s3InvalidAccessKeyError = {
+  kind: "mcp-error",
+  textIncludes: ["B2 Error [InvalidAccessKeyId]", "HTTP 403", "Malformed Access Key Id"],
+} as const satisfies ExpectedEvalResult;
+const s3UnknownForbiddenError = {
+  kind: "mcp-error",
+  textIncludes: ["B2 Error [Unknown]", "HTTP 403", "UnknownError"],
 } as const satisfies ExpectedEvalResult;
 const unavailableStubError = {
   kind: "mcp-error",
-  textIncludes: ["tool_unavailable"],
+  textIncludes: ["B2 Error [tool_unavailable]", "HTTP 410", "out-of-band secret sink"],
 } as const satisfies ExpectedEvalResult;
 
 export const NATIVE_CONTROL_PLANE_EVAL_CASES: readonly EvalCase[] = [
@@ -227,7 +233,7 @@ export const NATIVE_CONTROL_PLANE_EVAL_CASES: readonly EvalCase[] = [
     toolName: "b2_authorize_account",
     args: {},
     request: "Verify the configured Backblaze B2 account authorization.",
-    result: anyToolError,
+    result: b2BadAuthTokenError,
   }),
   evalToolCase({
     name: "create private bucket",
@@ -235,7 +241,7 @@ export const NATIVE_CONTROL_PLANE_EVAL_CASES: readonly EvalCase[] = [
     toolName: "b2_create_bucket",
     args: { bucketName: "eval-private-bucket", bucketType: "allPrivate" },
     request: "Create a private Backblaze B2 bucket for an evaluation fixture.",
-    result: anyToolError,
+    result: b2BadAuthTokenError,
   }),
   evalToolCase({
     name: "delete bucket with allow policy",
@@ -243,7 +249,7 @@ export const NATIVE_CONTROL_PLANE_EVAL_CASES: readonly EvalCase[] = [
     toolName: "b2_delete_bucket",
     args: { bucketId: "eval-bucket-id", confirm: true },
     request: "Delete the Backblaze B2 bucket identified by eval-bucket-id.",
-    result: anyToolError,
+    result: b2BadAuthTokenError,
     server: destructiveEvalServer,
   }),
   evalToolCase({
@@ -252,7 +258,7 @@ export const NATIVE_CONTROL_PLANE_EVAL_CASES: readonly EvalCase[] = [
     toolName: "b2_get_bucket_notification_rules",
     args: { bucketId: "eval-bucket-id" },
     request: "Read the event notification rules for a Backblaze B2 bucket.",
-    result: anyToolError,
+    result: b2BadAuthTokenError,
   }),
   evalToolCase({
     name: "list buckets",
@@ -260,7 +266,7 @@ export const NATIVE_CONTROL_PLANE_EVAL_CASES: readonly EvalCase[] = [
     toolName: "b2_list_buckets",
     args: {},
     request: "List Backblaze B2 buckets available to the configured key.",
-    result: anyToolError,
+    result: b2BadAuthTokenError,
   }),
   evalToolCase({
     name: "set empty bucket notification rules",
@@ -268,7 +274,7 @@ export const NATIVE_CONTROL_PLANE_EVAL_CASES: readonly EvalCase[] = [
     toolName: "b2_set_bucket_notification_rules",
     args: { bucketId: "eval-bucket-id", eventNotificationRules: [], confirm: true },
     request: "Replace a bucket's event notification rules with an empty rule set.",
-    result: anyToolError,
+    result: b2BadAuthTokenError,
     server: destructiveEvalServer,
   }),
   evalToolCase({
@@ -277,7 +283,7 @@ export const NATIVE_CONTROL_PLANE_EVAL_CASES: readonly EvalCase[] = [
     toolName: "b2_update_bucket",
     args: { bucketId: "eval-bucket-id", bucketType: "allPublic", confirm: true },
     request: "Update a Backblaze B2 bucket so its type is allPublic.",
-    result: anyToolError,
+    result: b2BadAuthTokenError,
     server: destructiveEvalServer,
   }),
   evalToolCase({
@@ -291,7 +297,7 @@ export const NATIVE_CONTROL_PLANE_EVAL_CASES: readonly EvalCase[] = [
       confirm: true,
     },
     request: "Clear the legal hold on a Backblaze B2 file version.",
-    result: anyToolError,
+    result: b2BadAuthTokenError,
     server: destructiveEvalServer,
   }),
   evalToolCase({
@@ -306,7 +312,7 @@ export const NATIVE_CONTROL_PLANE_EVAL_CASES: readonly EvalCase[] = [
       confirm: true,
     },
     request: "Clear Object Lock retention from a Backblaze B2 file version.",
-    result: anyToolError,
+    result: b2BadAuthTokenError,
     server: destructiveEvalServer,
   }),
   evalToolCase({
@@ -324,7 +330,7 @@ export const NATIVE_CONTROL_PLANE_EVAL_CASES: readonly EvalCase[] = [
     toolName: "b2_delete_key",
     args: { applicationKeyId: "eval-application-key-to-delete", confirm: true },
     request: "Delete a Backblaze B2 application key.",
-    result: anyToolError,
+    result: b2BadAuthTokenError,
     server: destructiveEvalServer,
   }),
   evalToolCase({
@@ -333,7 +339,7 @@ export const NATIVE_CONTROL_PLANE_EVAL_CASES: readonly EvalCase[] = [
     toolName: "b2_list_keys",
     args: {},
     request: "List Backblaze B2 application keys for the configured account.",
-    result: anyToolError,
+    result: b2BadAuthTokenError,
   }),
 ];
 
@@ -358,7 +364,7 @@ export const PARTNER_GROUPS_EVAL_CASES: readonly EvalCase[] = [
       confirm: true,
     },
     request: "Eject a member from a Backblaze Partner group.",
-    result: anyToolError,
+    result: b2BadAuthTokenError,
     server: destructiveEvalServer,
   }),
   evalToolCase({
@@ -367,7 +373,7 @@ export const PARTNER_GROUPS_EVAL_CASES: readonly EvalCase[] = [
     toolName: "b2_list_group_members",
     args: { adminAccountId: "eval-admin-account-id", groupId: "eval-group-id" },
     request: "List active members for a Backblaze Partner group.",
-    result: anyToolError,
+    result: b2BadAuthTokenError,
   }),
   evalToolCase({
     name: "list groups",
@@ -375,7 +381,7 @@ export const PARTNER_GROUPS_EVAL_CASES: readonly EvalCase[] = [
     toolName: "b2_list_groups",
     args: { adminAccountId: "eval-admin-account-id" },
     request: "List Backblaze Partner groups for an admin account.",
-    result: anyToolError,
+    result: b2BadAuthTokenError,
   }),
   evalToolCase({
     name: "reserve trial account compatibility stub",
@@ -395,7 +401,7 @@ export const CUSTOM_ANALYTICS_EVAL_CASES: readonly EvalCase[] = [
     toolName: "b2_usage_growth",
     args: {},
     request: "Analyze Backblaze B2 storage usage growth from usage reports.",
-    result: anyToolError,
+    result: b2BadAuthTokenError,
   }),
   evalToolCase({
     name: "egress leaders analytics",
@@ -403,7 +409,7 @@ export const CUSTOM_ANALYTICS_EVAL_CASES: readonly EvalCase[] = [
     toolName: "b2_egress_leaders",
     args: {},
     request: "Find the Backblaze B2 accounts or buckets with the highest egress.",
-    result: anyToolError,
+    result: b2BadAuthTokenError,
   }),
   evalToolCase({
     name: "largest files analytics",
@@ -411,7 +417,7 @@ export const CUSTOM_ANALYTICS_EVAL_CASES: readonly EvalCase[] = [
     toolName: "b2_largest_files",
     args: { bucket: "eval-bucket" },
     request: "Find the largest files in a Backblaze B2 bucket.",
-    result: anyToolError,
+    result: b2BadAuthTokenError,
   }),
   evalToolCase({
     name: "unfinished uploads analytics",
@@ -419,7 +425,7 @@ export const CUSTOM_ANALYTICS_EVAL_CASES: readonly EvalCase[] = [
     toolName: "b2_unfinished_uploads",
     args: { bucket: "eval-bucket" },
     request: "Find unfinished large file uploads in a Backblaze B2 bucket.",
-    result: anyToolError,
+    result: b2BadAuthTokenError,
   }),
 ];
 
@@ -435,7 +441,7 @@ export const S3_DATA_PLANE_EVAL_CASES: readonly EvalCase[] = [
       confirm: true,
     },
     request: "Abort an in-progress S3-compatible multipart upload.",
-    result: anyToolError,
+    result: s3InvalidAccessKeyError,
     server: destructiveEvalServer,
   }),
   evalToolCase({
@@ -449,7 +455,7 @@ export const S3_DATA_PLANE_EVAL_CASES: readonly EvalCase[] = [
       parts: [{ partNumber: 1, etag: '"eval-etag-1"' }],
     },
     request: "Complete an S3-compatible multipart upload.",
-    result: anyToolError,
+    result: s3InvalidAccessKeyError,
   }),
   evalToolCase({
     name: "copy object",
@@ -462,7 +468,7 @@ export const S3_DATA_PLANE_EVAL_CASES: readonly EvalCase[] = [
       destinationKey: "copied/source.txt",
     },
     request: "Copy an object between two Backblaze B2 S3-compatible buckets.",
-    result: anyToolError,
+    result: s3InvalidAccessKeyError,
   }),
   evalToolCase({
     name: "create multipart upload",
@@ -470,7 +476,7 @@ export const S3_DATA_PLANE_EVAL_CASES: readonly EvalCase[] = [
     toolName: "s3_create_multipart_upload",
     args: { bucket: "eval-bucket", key: "large.bin" },
     request: "Initiate an S3-compatible multipart upload.",
-    result: anyToolError,
+    result: s3InvalidAccessKeyError,
   }),
   evalToolCase({
     name: "delete object",
@@ -478,7 +484,7 @@ export const S3_DATA_PLANE_EVAL_CASES: readonly EvalCase[] = [
     toolName: "s3_delete_object",
     args: { bucket: "eval-bucket", key: "obsolete.txt", confirm: true },
     request: "Delete one object from a Backblaze B2 S3-compatible bucket.",
-    result: anyToolError,
+    result: s3InvalidAccessKeyError,
     server: destructiveEvalServer,
   }),
   evalToolCase({
@@ -494,6 +500,12 @@ export const S3_DATA_PLANE_EVAL_CASES: readonly EvalCase[] = [
     result: {
       kind: "structured-json",
       structuredFields: { attempted: 2, aborted: false, maxConcurrency: 2 },
+      textIncludes: [
+        '"Key":"obsolete-a.txt"',
+        '"Key":"obsolete-b.txt"',
+        '"Code":"InvalidAccessKeyId"',
+        '"Message":"Malformed Access Key Id"',
+      ],
     },
     server: destructiveEvalServer,
   }),
@@ -503,7 +515,7 @@ export const S3_DATA_PLANE_EVAL_CASES: readonly EvalCase[] = [
     toolName: "s3_get_bucket_location",
     args: { bucket: "eval-bucket" },
     request: "Get the S3-compatible location constraint for a Backblaze B2 bucket.",
-    result: anyToolError,
+    result: s3InvalidAccessKeyError,
   }),
   evalToolCase({
     name: "get object",
@@ -511,7 +523,7 @@ export const S3_DATA_PLANE_EVAL_CASES: readonly EvalCase[] = [
     toolName: "s3_get_object",
     args: { bucket: "eval-bucket", key: "manifest.json" },
     request: "Read a small object from a Backblaze B2 S3-compatible bucket.",
-    result: anyToolError,
+    result: s3InvalidAccessKeyError,
   }),
   evalToolCase({
     name: "get put-object presigned url",
@@ -538,7 +550,7 @@ export const S3_DATA_PLANE_EVAL_CASES: readonly EvalCase[] = [
     toolName: "s3_head_bucket",
     args: { bucket: "eval-bucket" },
     request: "Check S3-compatible reachability for a Backblaze B2 bucket.",
-    result: anyToolError,
+    result: s3UnknownForbiddenError,
   }),
   evalToolCase({
     name: "head object",
@@ -546,7 +558,7 @@ export const S3_DATA_PLANE_EVAL_CASES: readonly EvalCase[] = [
     toolName: "s3_head_object",
     args: { bucket: "eval-bucket", key: "manifest.json" },
     request: "Read metadata for a Backblaze B2 S3-compatible object.",
-    result: anyToolError,
+    result: s3UnknownForbiddenError,
   }),
   evalToolCase({
     name: "list multipart uploads",
@@ -554,7 +566,7 @@ export const S3_DATA_PLANE_EVAL_CASES: readonly EvalCase[] = [
     toolName: "s3_list_multipart_uploads",
     args: { bucket: "eval-bucket" },
     request: "List in-progress S3-compatible multipart uploads for a bucket.",
-    result: anyToolError,
+    result: s3InvalidAccessKeyError,
   }),
   evalToolCase({
     name: "list object versions",
@@ -562,7 +574,7 @@ export const S3_DATA_PLANE_EVAL_CASES: readonly EvalCase[] = [
     toolName: "s3_list_object_versions",
     args: { bucket: "eval-bucket" },
     request: "List S3-compatible object versions for a Backblaze B2 bucket.",
-    result: anyToolError,
+    result: s3InvalidAccessKeyError,
   }),
   evalToolCase({
     name: "list objects v2",
@@ -570,7 +582,7 @@ export const S3_DATA_PLANE_EVAL_CASES: readonly EvalCase[] = [
     toolName: "s3_list_objects_v2",
     args: { bucket: "eval-bucket" },
     request: "List objects in a Backblaze B2 bucket through the S3-compatible API.",
-    result: anyToolError,
+    result: s3InvalidAccessKeyError,
   }),
   evalToolCase({
     name: "list multipart upload parts",
@@ -578,7 +590,7 @@ export const S3_DATA_PLANE_EVAL_CASES: readonly EvalCase[] = [
     toolName: "s3_list_parts",
     args: { bucket: "eval-bucket", key: "large.bin", uploadId: "eval-upload-id" },
     request: "List uploaded parts for an S3-compatible multipart upload.",
-    result: anyToolError,
+    result: s3InvalidAccessKeyError,
   }),
   evalToolCase({
     name: "presign upload parts",
@@ -614,7 +626,7 @@ export const S3_DATA_PLANE_EVAL_CASES: readonly EvalCase[] = [
       confirm: true,
     },
     request: "Set a bucket lifecycle rule that expires temporary objects.",
-    result: anyToolError,
+    result: s3InvalidAccessKeyError,
     server: destructiveEvalServer,
   }),
   evalToolCase({
@@ -628,7 +640,7 @@ export const S3_DATA_PLANE_EVAL_CASES: readonly EvalCase[] = [
       contentType: "application/json",
     },
     request: "Upload a small inline JSON object through the S3-compatible API.",
-    result: anyToolError,
+    result: s3InvalidAccessKeyError,
   }),
   evalToolCase({
     name: "upload part copy",
@@ -642,7 +654,7 @@ export const S3_DATA_PLANE_EVAL_CASES: readonly EvalCase[] = [
       copySource: "eval-source-bucket/source.bin",
     },
     request: "Copy an existing object range into a multipart upload part.",
-    result: anyToolError,
+    result: s3InvalidAccessKeyError,
   }),
 ];
 

--- a/evals/full-profile-cases.eval.test.ts
+++ b/evals/full-profile-cases.eval.test.ts
@@ -1,6 +1,17 @@
-import { describe, expect, it } from "vitest";
-import { FULL_PROFILE_EVAL_CASES, evalCaseRunOptions, type EvalCase } from "./cases";
-import { runEval, type Driver, type DriverInput, type DriverOutput } from "./harness";
+import { describe, expect, it, vi, beforeEach, afterEach } from "vitest";
+import { FULL_PROFILE_EVAL_CASES, type EvalCase } from "./cases";
+import type { Driver, DriverInput, DriverOutput, EvalRun } from "./harness";
+import { B2S3PeerClient } from "../src/s3/aws-sdk-adapter";
+import { createServer, getRegisteredTools, invalidateAuthManagerCache } from "../src/server";
+import { resetCircuitBreakersForTests } from "../src/utils/circuit-breaker";
+import type { B2Config } from "../src/utils/types";
+import {
+  installSdkTransport,
+  RecordingTransport,
+  StaticHttpResponse,
+} from "../tests/support/sdk-test-helpers";
+import { restoreB2SdkTransportForTests } from "../tests/support/sdk-factory-hook";
+import { s3ServiceError } from "../tests/support/deterministic-fakes";
 
 class ScriptedCaseDriver implements Driver {
   readonly name = "scripted-full-profile";
@@ -23,11 +34,154 @@ class ScriptedCaseDriver implements Driver {
   }
 }
 
+const evalConfig = {
+  applicationKeyId: "eval-application-key-id",
+  applicationKey: "eval-application-key-secret",
+  appKeyId: "eval-app-key-id",
+  appKey: "eval-app-key-secret",
+  masterKeyId: "eval-master-key-id",
+  masterKey: "eval-master-key-secret",
+  region: "us-west-004",
+  allowLocalFiles: false,
+  fileRoot: null,
+} satisfies B2Config;
+
+function installDeterministicB2Boundary(): void {
+  installSdkTransport(
+    new RecordingTransport(
+      () =>
+        new StaticHttpResponse(
+          401,
+          {
+            status: 401,
+            code: "bad_auth_token",
+            message: "eval marker credentials are rejected locally",
+          },
+          { "x-bz-request-id": "eval-native-request" },
+        ),
+    ),
+  );
+}
+
+function installDeterministicS3Boundary(): void {
+  const invalidAccessKey = () =>
+    s3ServiceError("InvalidAccessKeyId", "Malformed Access Key Id", 403, "eval-s3-request");
+  const unknownForbidden = () =>
+    s3ServiceError("Unknown", "UnknownError", 403, "eval-s3-head-request");
+
+  vi.spyOn(B2S3PeerClient.prototype, "headBucket").mockRejectedValue(unknownForbidden());
+  vi.spyOn(B2S3PeerClient.prototype, "headObject").mockRejectedValue(unknownForbidden());
+  vi.spyOn(B2S3PeerClient.prototype, "getBucketLocation").mockRejectedValue(invalidAccessKey());
+  vi.spyOn(B2S3PeerClient.prototype, "putObject").mockRejectedValue(invalidAccessKey());
+  vi.spyOn(B2S3PeerClient.prototype, "getObject").mockRejectedValue(invalidAccessKey());
+  vi.spyOn(B2S3PeerClient.prototype, "deleteObject").mockRejectedValue(invalidAccessKey());
+  vi.spyOn(B2S3PeerClient.prototype, "copyObject").mockRejectedValue(invalidAccessKey());
+  vi.spyOn(B2S3PeerClient.prototype, "listObjectsV2").mockRejectedValue(invalidAccessKey());
+  vi.spyOn(B2S3PeerClient.prototype, "listObjectVersions").mockRejectedValue(invalidAccessKey());
+  vi.spyOn(B2S3PeerClient.prototype, "putBucketLifecycle").mockRejectedValue(invalidAccessKey());
+  vi.spyOn(B2S3PeerClient.prototype, "createMultipartUpload").mockRejectedValue(invalidAccessKey());
+  vi.spyOn(B2S3PeerClient.prototype, "completeMultipartUpload").mockRejectedValue(
+    invalidAccessKey(),
+  );
+  vi.spyOn(B2S3PeerClient.prototype, "abortMultipartUpload").mockRejectedValue(invalidAccessKey());
+  vi.spyOn(B2S3PeerClient.prototype, "listMultipartUploads").mockRejectedValue(invalidAccessKey());
+  vi.spyOn(B2S3PeerClient.prototype, "listParts").mockRejectedValue(invalidAccessKey());
+  vi.spyOn(B2S3PeerClient.prototype, "uploadPartCopy").mockRejectedValue(invalidAccessKey());
+  vi.spyOn(B2S3PeerClient.prototype, "deleteObjects").mockImplementation(async (input) => ({
+    deleted: [],
+    errors: input.objects.map((object) => ({
+      Key: object.key,
+      VersionId: object.versionId,
+      Code: "InvalidAccessKeyId",
+      Message: "Malformed Access Key Id",
+      RequestId: "eval-s3-request",
+    })),
+    attempted: input.objects.length,
+    aborted: false,
+    maxConcurrency: Math.min(8, input.objects.length),
+  }));
+  vi.spyOn(B2S3PeerClient.prototype, "presignObjectUrl").mockImplementation(async (input) => ({
+    url: `https://s3.example.invalid/${encodeURIComponent(input.bucket)}/${encodeURIComponent(
+      input.key,
+    )}?operation=${input.operation}`,
+    operation: input.operation,
+    expiresIn: input.expiresIn,
+    expiresAt: new Date(Date.now() + input.expiresIn * 1000).toISOString(),
+  }));
+  vi.spyOn(B2S3PeerClient.prototype, "presignUploadPart").mockImplementation(async (input) => ({
+    partNumber: input.partNumber,
+    url: `https://s3.example.invalid/${encodeURIComponent(input.bucket)}/${encodeURIComponent(
+      input.key,
+    )}?uploadId=${encodeURIComponent(input.uploadId)}&partNumber=${input.partNumber}`,
+  }));
+}
+
+async function runScriptedCase(evalCase: EvalCase): Promise<EvalRun> {
+  const server = createServer({
+    ...evalConfig,
+    destructivePolicy: evalCase.server?.destructivePolicy ?? "block",
+  });
+  try {
+    const registry = getRegisteredTools(server);
+    if (!registry) throw new Error("Expected test server to expose registered tools.");
+    const toolCalls: EvalRun["toolCalls"] = [];
+    const toolResults: EvalRun["toolResults"] = [];
+    const textParts: string[] = [];
+    const driver = new ScriptedCaseDriver(evalCase);
+
+    for (let step = 0; step < evalCase.maxSteps; step += 1) {
+      for (const name of evalCase.toolNames) {
+        if (!registry[name]) throw new Error(`Requested eval tool is not registered: ${name}`);
+      }
+      const output = await driver.complete({
+        prompt: evalCase.prompt,
+        tools: [],
+        messages: [],
+        step,
+        maxSteps: evalCase.maxSteps,
+        signal: new AbortController().signal,
+      });
+      if (output.text) textParts.push(output.text);
+      const calls = output.toolCalls ?? [];
+      if (calls.length === 0) break;
+
+      for (const call of calls) {
+        const tool = registry[call.name];
+        if (!tool || !evalCase.toolNames.includes(call.name)) {
+          throw new Error(`Scripted driver requested unexposed tool: ${call.name}`);
+        }
+        const inputSchema = tool.inputSchema;
+        if (!inputSchema) throw new Error(`Registered eval tool has no input schema: ${call.name}`);
+        const parsedArgs = inputSchema.parse(call.args);
+        toolCalls.push({ name: call.name, args: call.args });
+        toolResults.push(await tool.execute(parsedArgs, {}));
+      }
+    }
+
+    return { toolCalls, toolResults, text: textParts.join("\n") };
+  } finally {
+    await server.close();
+  }
+}
+
 describe("full-profile scripted eval cases", () => {
+  beforeEach(() => {
+    invalidateAuthManagerCache();
+    installDeterministicB2Boundary();
+    installDeterministicS3Boundary();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    restoreB2SdkTransportForTests();
+    resetCircuitBreakersForTests();
+    invalidateAuthManagerCache();
+  });
+
   it.each(FULL_PROFILE_EVAL_CASES)(
-    "$name accepts the scripted expected tool call",
+    "$name accepts the scripted expected tool call with local fake SDK boundaries",
     async (evalCase) => {
-      const run = await runEval(evalCaseRunOptions(evalCase, new ScriptedCaseDriver(evalCase)));
+      const run = await runScriptedCase(evalCase);
 
       expect(evalCase.passed(run), evalCase.failureSummary(run)).toBe(true);
     },

--- a/evals/full-profile-cases.eval.test.ts
+++ b/evals/full-profile-cases.eval.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it } from "vitest";
+import { FULL_PROFILE_EVAL_CASES, evalCaseRunOptions, type EvalCase } from "./cases";
+import { runEval, type Driver, type DriverInput, type DriverOutput } from "./harness";
+
+class ScriptedCaseDriver implements Driver {
+  readonly name = "scripted-full-profile";
+  private step = 0;
+
+  constructor(private readonly evalCase: EvalCase) {}
+
+  async complete(_input: DriverInput): Promise<DriverOutput> {
+    if (this.step > 0) return { text: "Done." };
+    this.step += 1;
+    return {
+      text: `Calling ${this.evalCase.expected.toolName}.`,
+      toolCalls: [
+        {
+          name: this.evalCase.expected.toolName,
+          args: { ...this.evalCase.expected.args },
+        },
+      ],
+    };
+  }
+}
+
+describe("full-profile scripted eval cases", () => {
+  it.each(FULL_PROFILE_EVAL_CASES)(
+    "$name accepts the scripted expected tool call",
+    async (evalCase) => {
+      const run = await runEval(evalCaseRunOptions(evalCase, new ScriptedCaseDriver(evalCase)));
+
+      expect(evalCase.passed(run), evalCase.failureSummary(run)).toBe(true);
+    },
+    30_000,
+  );
+});

--- a/evals/harness.eval.test.ts
+++ b/evals/harness.eval.test.ts
@@ -83,22 +83,26 @@ describe("LLM eval harness", () => {
     ).toThrow(/non-marker B2 credential/);
   });
 
-  it("rejects unsafe eval server policy overrides", () => {
+  it("allows explicit destructive-policy eval coverage only through the typed option", () => {
+    expect(createEvalServerEnv({ destructivePolicy: "allow" }).B2_DESTRUCTIVE_POLICY).toBe("allow");
     expect(() =>
       createEvalServerEnv({
         env: { B2_DESTRUCTIVE_POLICY: "allow" },
       }),
-    ).toThrow(/B2_DESTRUCTIVE_POLICY=allow/);
+    ).toThrow(/direct safety env overrides/);
+  });
+
+  it("rejects unsafe eval server filesystem and secret-sink overrides", () => {
     expect(() =>
       createEvalServerEnv({
         env: { B2_ALLOW_LOCAL_FILES: "true" },
       }),
-    ).toThrow(/B2_ALLOW_LOCAL_FILES=false/);
+    ).toThrow(/direct safety env overrides/);
     expect(() =>
       createEvalServerEnv({
         env: { B2_SECRET_SINK: "file" },
       }),
-    ).toThrow(/B2_SECRET_SINK=off/);
+    ).toThrow(/direct safety env overrides/);
   });
 
   it("rejects unexposed tool calls before execution", async () => {

--- a/evals/harness.eval.test.ts
+++ b/evals/harness.eval.test.ts
@@ -89,7 +89,13 @@ describe("LLM eval harness", () => {
       createEvalServerEnv({
         env: { B2_DESTRUCTIVE_POLICY: "allow" },
       }),
-    ).toThrow(/direct safety env overrides/);
+    ).toThrow(/requires B2_DESTRUCTIVE_POLICY=block/);
+    expect(() =>
+      createEvalServerEnv({
+        destructivePolicy: "confirm",
+        env: { B2_DESTRUCTIVE_POLICY: "allow" },
+      }),
+    ).toThrow(/requires B2_DESTRUCTIVE_POLICY=confirm/);
   });
 
   it("rejects unsafe eval server filesystem and secret-sink overrides", () => {
@@ -97,12 +103,12 @@ describe("LLM eval harness", () => {
       createEvalServerEnv({
         env: { B2_ALLOW_LOCAL_FILES: "true" },
       }),
-    ).toThrow(/direct safety env overrides/);
+    ).toThrow(/B2_ALLOW_LOCAL_FILES=false/);
     expect(() =>
       createEvalServerEnv({
         env: { B2_SECRET_SINK: "file" },
       }),
-    ).toThrow(/direct safety env overrides/);
+    ).toThrow(/B2_SECRET_SINK=off/);
   });
 
   it("rejects unexposed tool calls before execution", async () => {

--- a/evals/harness.ts
+++ b/evals/harness.ts
@@ -198,26 +198,19 @@ function resolveTimeouts(timeouts: EvalTimeouts | undefined): ResolvedEvalTimeou
   };
 }
 
-function assertNoUnsafeEvalEnvOverrides(env: NodeJS.ProcessEnv | undefined): void {
-  const unsafeOverrides = [
-    "B2_DESTRUCTIVE_POLICY",
-    "B2_ALLOW_LOCAL_FILES",
-    "B2_SECRET_SINK",
-  ].filter((name) => env?.[name] !== undefined);
-  if (unsafeOverrides.length) {
-    throw new Error(
-      `Eval server refused direct safety env overrides: ${unsafeOverrides.join(", ")}`,
-    );
-  }
-}
-
-function assertSafeEvalServerEnv(env: NodeJS.ProcessEnv): void {
+function assertSafeEvalServerEnv(env: NodeJS.ProcessEnv, options: EvalServerOptions): void {
   const unsafeCredentials = Object.entries(EVAL_CREDENTIAL_MARKERS)
     .filter(([name, marker]) => env[name] !== marker)
     .map(([name]) => name);
   if (unsafeCredentials.length) {
     throw new Error(
       `Eval server refused non-marker B2 credential env vars: ${unsafeCredentials.join(", ")}`,
+    );
+  }
+  const expectedDestructivePolicy = options.destructivePolicy ?? "block";
+  if (env.B2_DESTRUCTIVE_POLICY !== expectedDestructivePolicy) {
+    throw new Error(
+      `Eval server requires B2_DESTRUCTIVE_POLICY=${expectedDestructivePolicy} from the typed destructivePolicy option.`,
     );
   }
   if (env.B2_ALLOW_LOCAL_FILES !== "false") {
@@ -229,7 +222,6 @@ function assertSafeEvalServerEnv(env: NodeJS.ProcessEnv): void {
 }
 
 export function createEvalServerEnv(options: EvalServerOptions = {}): Record<string, string> {
-  assertNoUnsafeEvalEnvOverrides(options.env);
   const env = safeSpawnEnv({
     NODE_ENV: "test",
     B2_REGISTER_ALL_TOOLS: options.registerAllTools === false ? "false" : "true",
@@ -239,7 +231,7 @@ export function createEvalServerEnv(options: EvalServerOptions = {}): Record<str
     B2_SECRET_SINK: "off",
     ...options.env,
   });
-  assertSafeEvalServerEnv(env);
+  assertSafeEvalServerEnv(env, options);
   return stringifySpawnEnv(env);
 }
 

--- a/evals/harness.ts
+++ b/evals/harness.ts
@@ -66,7 +66,7 @@ export interface Driver {
 
 export interface EvalServerOptions {
   registerAllTools?: boolean;
-  destructivePolicy?: "block" | "confirm";
+  destructivePolicy?: "allow" | "block" | "confirm";
   env?: NodeJS.ProcessEnv;
 }
 
@@ -198,6 +198,19 @@ function resolveTimeouts(timeouts: EvalTimeouts | undefined): ResolvedEvalTimeou
   };
 }
 
+function assertNoUnsafeEvalEnvOverrides(env: NodeJS.ProcessEnv | undefined): void {
+  const unsafeOverrides = [
+    "B2_DESTRUCTIVE_POLICY",
+    "B2_ALLOW_LOCAL_FILES",
+    "B2_SECRET_SINK",
+  ].filter((name) => env?.[name] !== undefined);
+  if (unsafeOverrides.length) {
+    throw new Error(
+      `Eval server refused direct safety env overrides: ${unsafeOverrides.join(", ")}`,
+    );
+  }
+}
+
 function assertSafeEvalServerEnv(env: NodeJS.ProcessEnv): void {
   const unsafeCredentials = Object.entries(EVAL_CREDENTIAL_MARKERS)
     .filter(([name, marker]) => env[name] !== marker)
@@ -206,9 +219,6 @@ function assertSafeEvalServerEnv(env: NodeJS.ProcessEnv): void {
     throw new Error(
       `Eval server refused non-marker B2 credential env vars: ${unsafeCredentials.join(", ")}`,
     );
-  }
-  if (env.B2_DESTRUCTIVE_POLICY === "allow") {
-    throw new Error("Eval server refused B2_DESTRUCTIVE_POLICY=allow.");
   }
   if (env.B2_ALLOW_LOCAL_FILES !== "false") {
     throw new Error("Eval server requires B2_ALLOW_LOCAL_FILES=false.");
@@ -219,6 +229,7 @@ function assertSafeEvalServerEnv(env: NodeJS.ProcessEnv): void {
 }
 
 export function createEvalServerEnv(options: EvalServerOptions = {}): Record<string, string> {
+  assertNoUnsafeEvalEnvOverrides(options.env);
   const env = safeSpawnEnv({
     NODE_ENV: "test",
     B2_REGISTER_ALL_TOOLS: options.registerAllTools === false ? "false" : "true",

--- a/evals/openai-driver.eval.test.ts
+++ b/evals/openai-driver.eval.test.ts
@@ -1,6 +1,6 @@
 import type { CallToolResult, Tool } from "@modelcontextprotocol/client";
 import { describe, expect, it, vi } from "vitest";
-import { SHARED_EVAL_CASES, evalCaseRunOptions } from "./cases";
+import { FULL_PROFILE_EVAL_CASES, evalCaseRunOptions } from "./cases";
 import { runEval, type EvalMessage, type EvalToolCall } from "./harness";
 import {
   DEFAULT_OPENAI_MODEL,
@@ -487,14 +487,15 @@ const liveGate = openAIEvalGate();
 const LIVE_PROVIDER_TIMEOUT_MS = 180_000;
 
 describe("OpenAI live eval", () => {
-  it.skipIf(!liveGate.enabled)(
-    "runs the shared gated tool-use eval end to end",
-    async () => {
-      const evalCase = SHARED_EVAL_CASES[0];
-      const run = await runEval(evalCaseRunOptions(evalCase, createOpenAIDriver()));
+  for (const evalCase of FULL_PROFILE_EVAL_CASES) {
+    it.skipIf(!liveGate.enabled)(
+      `runs ${evalCase.name}`,
+      async () => {
+        const run = await runEval(evalCaseRunOptions(evalCase, createOpenAIDriver()));
 
-      expect(evalCase.passed(run), evalCase.failureSummary(run)).toBe(true);
-    },
-    LIVE_PROVIDER_TIMEOUT_MS,
-  );
+        expect(evalCase.passed(run), evalCase.failureSummary(run)).toBe(true);
+      },
+      LIVE_PROVIDER_TIMEOUT_MS,
+    );
+  }
 });

--- a/evals/provider-comparison.eval.test.ts
+++ b/evals/provider-comparison.eval.test.ts
@@ -53,8 +53,15 @@ function failingRun(): EvalRun {
 
 const comparisonCase = {
   name: "comparison case",
+  category: "native-control-plane",
   prompt: "Use the tool.",
   toolNames: ["b2_delete_bucket"],
+  expected: {
+    toolName: "b2_delete_bucket",
+    args: { bucketId: "eval-bucket-id", confirm: true },
+    requiredArgs: ["bucketId"],
+    result: { kind: "mcp-error", textIncludes: ["destructive_policy_blocked"] },
+  },
   maxSteps: 2,
   maxToolCallsPerStep: 1,
   maxToolCallsTotal: 1,
@@ -232,15 +239,17 @@ describe("provider pass-rate comparison", () => {
   });
 
   it("uses the shared live case set for the Claude and OpenAI providers", () => {
-    expect(SHARED_EVAL_CASES.map((evalCase) => evalCase.name)).toEqual([
-      "destructive delete bucket gate",
-    ]);
+    expect(SHARED_EVAL_CASES).toHaveLength(40);
+    expect(SHARED_EVAL_CASES.map((evalCase) => evalCase.expected.toolName).sort()).toContain(
+      "b2_delete_bucket",
+    );
     expect(CLAUDE_OPENAI_PROVIDERS.map((provider) => provider.name)).toEqual(["Claude", "OpenAI"]);
   });
 });
 
 const comparisonGate = claudeOpenAIComparisonEvalGate();
-const LIVE_COMPARISON_TIMEOUT_MS = 420_000;
+const LIVE_COMPARISON_TIMEOUT_MS =
+  SHARED_EVAL_CASES.length * CLAUDE_OPENAI_PROVIDERS.length * 180_000;
 
 describe("Claude vs OpenAI live eval comparison", () => {
   it.skipIf(!comparisonGate.enabled)(

--- a/evals/provider-comparison.eval.test.ts
+++ b/evals/provider-comparison.eval.test.ts
@@ -1,13 +1,14 @@
 import { describe, expect, it } from "vitest";
 import type { EvalCase } from "./cases";
 import {
-  SHARED_EVAL_CASES,
+  FULL_PROFILE_EVAL_CASES,
   destructiveDeleteBucketGateFailure,
   destructiveDeleteBucketGatePassed,
 } from "./cases";
 import type { Driver, DriverInput, DriverOutput, EvalRun, RunEvalOptions } from "./harness";
 import {
   CLAUDE_OPENAI_PROVIDERS,
+  PROVIDER_COMPARISON_EVAL_ENV,
   assertProviderPassRateComparison,
   claudeOpenAIComparisonEvalGate,
   formatPassRateSummary,
@@ -219,12 +220,31 @@ describe("provider pass-rate comparison", () => {
   });
 
   it("requires both provider keys for the Claude-vs-OpenAI live comparison gate", () => {
-    expect(claudeOpenAIComparisonEvalGate({ RUN_LLM_EVALS: "1" })).toEqual({
+    expect(
+      claudeOpenAIComparisonEvalGate({
+        RUN_LLM_EVALS: "1",
+        ANTHROPIC_API_KEY: "test-key",
+        OPENAI_API_KEY: "test-key",
+      }),
+    ).toEqual({
+      enabled: false,
+      reason: `${PROVIDER_COMPARISON_EVAL_ENV} is not 1`,
+    });
+    expect(
+      claudeOpenAIComparisonEvalGate({
+        RUN_LLM_EVALS: "1",
+        [PROVIDER_COMPARISON_EVAL_ENV]: "1",
+      }),
+    ).toEqual({
       enabled: false,
       reason: "missing provider key(s) (ANTHROPIC_API_KEY, OPENAI_API_KEY)",
     });
     expect(
-      claudeOpenAIComparisonEvalGate({ RUN_LLM_EVALS: "1", ANTHROPIC_API_KEY: "test-key" }),
+      claudeOpenAIComparisonEvalGate({
+        RUN_LLM_EVALS: "1",
+        [PROVIDER_COMPARISON_EVAL_ENV]: "1",
+        ANTHROPIC_API_KEY: "test-key",
+      }),
     ).toEqual({
       enabled: false,
       reason: "missing provider key(s) (OPENAI_API_KEY)",
@@ -232,6 +252,7 @@ describe("provider pass-rate comparison", () => {
     expect(
       claudeOpenAIComparisonEvalGate({
         RUN_LLM_EVALS: "1",
+        [PROVIDER_COMPARISON_EVAL_ENV]: "1",
         ANTHROPIC_API_KEY: "test-key",
         OPENAI_API_KEY: "test-key",
       }).enabled,
@@ -239,35 +260,65 @@ describe("provider pass-rate comparison", () => {
   });
 
   it("uses the shared live case set for the Claude and OpenAI providers", () => {
-    expect(SHARED_EVAL_CASES).toHaveLength(40);
-    expect(SHARED_EVAL_CASES.map((evalCase) => evalCase.expected.toolName).sort()).toContain(
+    expect(FULL_PROFILE_EVAL_CASES).toHaveLength(40);
+    expect(FULL_PROFILE_EVAL_CASES.map((evalCase) => evalCase.expected.toolName).sort()).toContain(
       "b2_delete_bucket",
     );
     expect(CLAUDE_OPENAI_PROVIDERS.map((provider) => provider.name)).toEqual(["Claude", "OpenAI"]);
   });
+
+  it("stops calling a provider after repeated errors", async () => {
+    let failingProviderCalls = 0;
+    const comparison = await runProviderPassRateComparison({
+      cases: [
+        comparisonCase,
+        { ...comparisonCase, name: "case two" },
+        { ...comparisonCase, name: "case three" },
+      ],
+      providers: [
+        { name: "Claude", createDriver: () => new ScriptedDriver("anthropic", {}) },
+        { name: "OpenAI", createDriver: () => new ScriptedDriver("openai", {}) },
+      ],
+      comparison: { maxProviderErrors: 1 },
+      async runEvalImpl(options) {
+        if (options.driver.name === "openai") {
+          failingProviderCalls += 1;
+          throw new Error("Timed out during driver step 1");
+        }
+        return passingRun();
+      },
+    });
+
+    expect(failingProviderCalls).toBe(1);
+    expect(comparison.results.filter((result) => result.provider === "OpenAI")).toHaveLength(3);
+    expect(
+      comparison.results.filter((result) =>
+        /Skipped after 1 provider error/.test(result.error ?? ""),
+      ),
+    ).toHaveLength(2);
+  });
 });
 
 const comparisonGate = claudeOpenAIComparisonEvalGate();
-const LIVE_COMPARISON_TIMEOUT_MS =
-  SHARED_EVAL_CASES.length * CLAUDE_OPENAI_PROVIDERS.length * 180_000;
+const LIVE_COMPARISON_TIMEOUT_MS = 600_000;
 
 describe("Claude vs OpenAI live eval comparison", () => {
   it.skipIf(!comparisonGate.enabled)(
     "runs shared cases and emits a pass-rate comparison",
     async () => {
       const comparison = await runProviderPassRateComparison({
-        cases: SHARED_EVAL_CASES,
+        cases: FULL_PROFILE_EVAL_CASES,
         providers: CLAUDE_OPENAI_PROVIDERS,
       });
 
       console.info(comparison.summary);
       assertProviderPassRateComparison(comparison);
       expect(comparison.results).toHaveLength(
-        SHARED_EVAL_CASES.length * CLAUDE_OPENAI_PROVIDERS.length,
+        FULL_PROFILE_EVAL_CASES.length * CLAUDE_OPENAI_PROVIDERS.length,
       );
       for (const provider of CLAUDE_OPENAI_PROVIDERS) {
         expect(comparison.passRates.find((rate) => rate.provider === provider.name)?.total).toBe(
-          SHARED_EVAL_CASES.length,
+          FULL_PROFILE_EVAL_CASES.length,
         );
       }
       expect(comparison.summary).toMatch(/Claude vs OpenAI/);

--- a/evals/provider-comparison.ts
+++ b/evals/provider-comparison.ts
@@ -10,6 +10,9 @@ import {
   type RunEvalOptions,
 } from "./harness";
 
+export const PROVIDER_COMPARISON_EVAL_ENV = "RUN_LLM_PROVIDER_COMPARISON";
+export const DEFAULT_MAX_PROVIDER_ERRORS = 3;
+
 export interface EvalProvider {
   readonly name: string;
   createDriver(): Driver;
@@ -60,6 +63,10 @@ export interface PassRateAssertionOptions {
   readonly minPassRate?: number;
 }
 
+export interface ProviderPassRateComparisonOptions {
+  readonly maxProviderErrors?: number;
+}
+
 export type EvalRunner = (options: RunEvalOptions) => Promise<EvalRun>;
 
 export const CLAUDE_OPENAI_PROVIDERS: readonly EvalProvider[] = [
@@ -70,6 +77,9 @@ export const CLAUDE_OPENAI_PROVIDERS: readonly EvalProvider[] = [
 export function claudeOpenAIComparisonEvalGate(env: NodeJS.ProcessEnv = process.env): EvalGate {
   const sharedGate = llmEvalGate(env);
   if (!sharedGate.enabled) return sharedGate;
+  if (env[PROVIDER_COMPARISON_EVAL_ENV] !== "1") {
+    return { enabled: false, reason: `${PROVIDER_COMPARISON_EVAL_ENV} is not 1` };
+  }
 
   const missingProviderKeys = [ANTHROPIC_API_KEY_ENV, OPENAI_API_KEY_ENV].filter(
     (name) => !env[name],
@@ -87,6 +97,7 @@ export async function runProviderPassRateComparison(options: {
   cases: readonly EvalCase[];
   providers: readonly EvalProvider[];
   runEvalImpl?: EvalRunner;
+  comparison?: ProviderPassRateComparisonOptions;
 }): Promise<ProviderPassRateComparison> {
   if (options.cases.length === 0) {
     throw new Error("Provider comparison requires at least one eval case.");
@@ -97,9 +108,24 @@ export async function runProviderPassRateComparison(options: {
 
   const runEvalImpl = options.runEvalImpl ?? runEval;
   const results: ProviderCaseResult[] = [];
+  const maxProviderErrors = resolveMaxProviderErrors(options.comparison?.maxProviderErrors);
+  const providerErrors = new Map(options.providers.map((provider) => [provider.name, 0]));
 
   for (const evalCase of options.cases) {
     for (const provider of options.providers) {
+      const errorsSoFar = providerErrors.get(provider.name) ?? 0;
+      if (errorsSoFar >= maxProviderErrors) {
+        results.push({
+          provider: provider.name,
+          caseName: evalCase.name,
+          status: "errored",
+          passed: false,
+          error:
+            `Skipped after ${errorsSoFar} provider error(s); ` +
+            `maxProviderErrors=${maxProviderErrors}.`,
+        });
+        continue;
+      }
       try {
         const run = await runEvalImpl({
           ...evalCaseRunOptions(evalCase, provider.createDriver()),
@@ -124,6 +150,7 @@ export async function runProviderPassRateComparison(options: {
           });
         }
       } catch (err) {
+        providerErrors.set(provider.name, errorsSoFar + 1);
         results.push({
           provider: provider.name,
           caseName: evalCase.name,
@@ -152,6 +179,14 @@ export async function runProviderPassRateComparison(options: {
     passRates,
     summary: formatPassRateSummary(passRates, options.cases.length),
   };
+}
+
+function resolveMaxProviderErrors(value: number | undefined): number {
+  const maxProviderErrors = value ?? DEFAULT_MAX_PROVIDER_ERRORS;
+  if (!Number.isInteger(maxProviderErrors) || maxProviderErrors < 1) {
+    throw new Error("maxProviderErrors must be a positive integer.");
+  }
+  return maxProviderErrors;
 }
 
 export function assertProviderPassRateComparison(

--- a/tests/contract/eval-coverage.contract.test.ts
+++ b/tests/contract/eval-coverage.contract.test.ts
@@ -1,4 +1,6 @@
 import { FULL_PROFILE_EVAL_CASES, type EvalCase } from "../../evals/cases";
+import { checkDestructive } from "../../src/utils/destructive-gate";
+import type { B2Config } from "../../src/utils/types";
 import { readJson } from "./support";
 
 interface EvalCoverageContract {
@@ -15,6 +17,53 @@ const contract = readJson<EvalCoverageContract>("docs/tool-profile-contract.json
 const fullProfile = contract.profiles.full;
 const fullToolNames = new Set(fullProfile.names);
 const confirmTools = new Set(fullProfile.confirmTools);
+const allowedAnyMcpErrorTools = [
+  "b2_authorize_account",
+  "b2_create_bucket",
+  "b2_delete_bucket",
+  "b2_delete_key",
+  "b2_egress_leaders",
+  "b2_eject_group_member",
+  "b2_get_bucket_notification_rules",
+  "b2_largest_files",
+  "b2_list_buckets",
+  "b2_list_group_members",
+  "b2_list_groups",
+  "b2_list_keys",
+  "b2_set_bucket_notification_rules",
+  "b2_unfinished_uploads",
+  "b2_update_bucket",
+  "b2_update_file_legal_hold",
+  "b2_update_file_retention",
+  "b2_usage_growth",
+  "s3_abort_multipart_upload",
+  "s3_complete_multipart_upload",
+  "s3_copy_object",
+  "s3_create_multipart_upload",
+  "s3_delete_object",
+  "s3_get_bucket_location",
+  "s3_get_object",
+  "s3_head_bucket",
+  "s3_head_object",
+  "s3_list_multipart_uploads",
+  "s3_list_object_versions",
+  "s3_list_objects_v2",
+  "s3_list_parts",
+  "s3_put_bucket_lifecycle",
+  "s3_put_object",
+  "s3_upload_part_copy",
+];
+const gateConfig = {
+  applicationKeyId: "eval-application-key-id",
+  applicationKey: "eval-application-key-secret",
+  appKeyId: "eval-app-key-id",
+  appKey: "eval-app-key-secret",
+  masterKeyId: "eval-master-key-id",
+  masterKey: "eval-master-key-secret",
+  region: "us-west-004",
+  allowLocalFiles: false,
+  fileRoot: null,
+} satisfies B2Config;
 
 function sorted(values: Iterable<string>): string[] {
   return [...values].sort((a, b) => a.localeCompare(b));
@@ -38,6 +87,20 @@ function orphanCaseToolNames(cases: readonly EvalCase[]): string[] {
   return sorted([...referenced].filter((toolName) => !fullToolNames.has(toolName)));
 }
 
+function caseFor(toolName: string): EvalCase {
+  const evalCase = FULL_PROFILE_EVAL_CASES.find(
+    (candidate) => candidate.expected.toolName === toolName,
+  );
+  if (!evalCase) throw new Error(`Missing eval case for ${toolName}`);
+  return evalCase;
+}
+
+function argsWithoutConfirm(args: Readonly<Record<string, unknown>>): Record<string, unknown> {
+  const copy = { ...args };
+  delete copy.confirm;
+  return copy;
+}
+
 describe("full-profile LLM eval coverage", () => {
   it("has at least one eval case for every full-profile tool", () => {
     expect(missingFullProfileTools(FULL_PROFILE_EVAL_CASES)).toEqual([]);
@@ -55,15 +118,57 @@ describe("full-profile LLM eval coverage", () => {
       for (const requiredArg of expected.requiredArgs) {
         expect(expected.args).toHaveProperty(requiredArg);
       }
-      expect(["mcp-error", "structured-json"]).toContain(expected.result.kind);
+      expect(["any-mcp-error", "mcp-error", "structured-json"]).toContain(expected.result.kind);
     }
   });
 
-  it("runs destructive full-profile cases with the eval allow policy", () => {
+  it("limits broad any-MCP-error matching to reviewed marker-credential cases", () => {
+    const broadMatcherTools: string[] = [];
+    for (const evalCase of FULL_PROFILE_EVAL_CASES) {
+      const { result } = evalCase.expected;
+      if (result.kind !== "any-mcp-error") continue;
+      expect(result.reason).toContain("Marker credentials");
+      broadMatcherTools.push(evalCase.expected.toolName);
+    }
+
+    expect(sorted(broadMatcherTools)).toEqual(allowedAnyMcpErrorTools);
+  });
+
+  it("uses allow policy only for destructive tool-shape coverage", () => {
     for (const evalCase of FULL_PROFILE_EVAL_CASES) {
       if (!confirmTools.has(evalCase.expected.toolName)) continue;
       expect(evalCase.server?.destructivePolicy).toBe("allow");
       expect(evalCase.expected.args.confirm).toBe(true);
+    }
+  });
+
+  it("blocks every confirmTool under the default block policy", () => {
+    for (const toolName of fullProfile.confirmTools) {
+      const evalCase = caseFor(toolName);
+      const decision = checkDestructive(toolName, evalCase.expected.args, {
+        ...gateConfig,
+        destructivePolicy: "block",
+      });
+
+      expect(decision).toMatchObject({
+        ok: false,
+        error: { status: 403, code: "destructive_policy_blocked" },
+      });
+    }
+  });
+
+  it("requires confirmation for every confirmTool under confirm policy", () => {
+    for (const toolName of fullProfile.confirmTools) {
+      const evalCase = caseFor(toolName);
+      const decision = checkDestructive(toolName, argsWithoutConfirm(evalCase.expected.args), {
+        ...gateConfig,
+        destructivePolicy: "confirm",
+      });
+
+      expect(decision).toMatchObject({
+        ok: false,
+        error: { status: 409, code: "destructive_confirmation_required" },
+      });
     }
   });
 });

--- a/tests/contract/eval-coverage.contract.test.ts
+++ b/tests/contract/eval-coverage.contract.test.ts
@@ -1,0 +1,69 @@
+import { FULL_PROFILE_EVAL_CASES, type EvalCase } from "../../evals/cases";
+import { readJson } from "./support";
+
+interface EvalCoverageContract {
+  readonly profiles: {
+    readonly full: {
+      readonly names: string[];
+      readonly requiredFields: Record<string, string[]>;
+      readonly confirmTools: string[];
+    };
+  };
+}
+
+const contract = readJson<EvalCoverageContract>("docs/tool-profile-contract.json");
+const fullProfile = contract.profiles.full;
+const fullToolNames = new Set(fullProfile.names);
+const confirmTools = new Set(fullProfile.confirmTools);
+
+function sorted(values: Iterable<string>): string[] {
+  return [...values].sort((a, b) => a.localeCompare(b));
+}
+
+function toolNamesFromCases(cases: readonly EvalCase[]): Set<string> {
+  return new Set(cases.map((evalCase) => evalCase.expected.toolName));
+}
+
+function missingFullProfileTools(cases: readonly EvalCase[]): string[] {
+  const covered = toolNamesFromCases(cases);
+  return fullProfile.names.filter((name) => !covered.has(name));
+}
+
+function orphanCaseToolNames(cases: readonly EvalCase[]): string[] {
+  const referenced = new Set<string>();
+  for (const evalCase of cases) {
+    referenced.add(evalCase.expected.toolName);
+    for (const toolName of evalCase.toolNames) referenced.add(toolName);
+  }
+  return sorted([...referenced].filter((toolName) => !fullToolNames.has(toolName)));
+}
+
+describe("full-profile LLM eval coverage", () => {
+  it("has at least one eval case for every full-profile tool", () => {
+    expect(missingFullProfileTools(FULL_PROFILE_EVAL_CASES)).toEqual([]);
+  });
+
+  it("does not reference tools outside the full profile", () => {
+    expect(orphanCaseToolNames(FULL_PROFILE_EVAL_CASES)).toEqual([]);
+  });
+
+  it("keeps each case bound to one expected tool and its required arguments", () => {
+    for (const evalCase of FULL_PROFILE_EVAL_CASES) {
+      const { expected } = evalCase;
+      expect(evalCase.toolNames).toEqual([expected.toolName]);
+      expect(sorted(expected.requiredArgs)).toEqual(fullProfile.requiredFields[expected.toolName]);
+      for (const requiredArg of expected.requiredArgs) {
+        expect(expected.args).toHaveProperty(requiredArg);
+      }
+      expect(["mcp-error", "structured-json"]).toContain(expected.result.kind);
+    }
+  });
+
+  it("runs destructive full-profile cases with the eval allow policy", () => {
+    for (const evalCase of FULL_PROFILE_EVAL_CASES) {
+      if (!confirmTools.has(evalCase.expected.toolName)) continue;
+      expect(evalCase.server?.destructivePolicy).toBe("allow");
+      expect(evalCase.expected.args.confirm).toBe(true);
+    }
+  });
+});

--- a/tests/contract/eval-coverage.contract.test.ts
+++ b/tests/contract/eval-coverage.contract.test.ts
@@ -17,42 +17,6 @@ const contract = readJson<EvalCoverageContract>("docs/tool-profile-contract.json
 const fullProfile = contract.profiles.full;
 const fullToolNames = new Set(fullProfile.names);
 const confirmTools = new Set(fullProfile.confirmTools);
-const allowedAnyMcpErrorTools = [
-  "b2_authorize_account",
-  "b2_create_bucket",
-  "b2_delete_bucket",
-  "b2_delete_key",
-  "b2_egress_leaders",
-  "b2_eject_group_member",
-  "b2_get_bucket_notification_rules",
-  "b2_largest_files",
-  "b2_list_buckets",
-  "b2_list_group_members",
-  "b2_list_groups",
-  "b2_list_keys",
-  "b2_set_bucket_notification_rules",
-  "b2_unfinished_uploads",
-  "b2_update_bucket",
-  "b2_update_file_legal_hold",
-  "b2_update_file_retention",
-  "b2_usage_growth",
-  "s3_abort_multipart_upload",
-  "s3_complete_multipart_upload",
-  "s3_copy_object",
-  "s3_create_multipart_upload",
-  "s3_delete_object",
-  "s3_get_bucket_location",
-  "s3_get_object",
-  "s3_head_bucket",
-  "s3_head_object",
-  "s3_list_multipart_uploads",
-  "s3_list_object_versions",
-  "s3_list_objects_v2",
-  "s3_list_parts",
-  "s3_put_bucket_lifecycle",
-  "s3_put_object",
-  "s3_upload_part_copy",
-];
 const gateConfig = {
   applicationKeyId: "eval-application-key-id",
   applicationKey: "eval-application-key-secret",
@@ -118,20 +82,20 @@ describe("full-profile LLM eval coverage", () => {
       for (const requiredArg of expected.requiredArgs) {
         expect(expected.args).toHaveProperty(requiredArg);
       }
-      expect(["any-mcp-error", "mcp-error", "structured-json"]).toContain(expected.result.kind);
+      expect(["mcp-error", "structured-json"]).toContain(expected.result.kind);
     }
   });
 
-  it("limits broad any-MCP-error matching to reviewed marker-credential cases", () => {
-    const broadMatcherTools: string[] = [];
+  it("pins every MCP error result to non-empty text snippets", () => {
     for (const evalCase of FULL_PROFILE_EVAL_CASES) {
       const { result } = evalCase.expected;
-      if (result.kind !== "any-mcp-error") continue;
-      expect(result.reason).toContain("Marker credentials");
-      broadMatcherTools.push(evalCase.expected.toolName);
+      if (result.kind !== "mcp-error") continue;
+      expect(result.textIncludes.length).toBeGreaterThanOrEqual(2);
+      for (const snippet of result.textIncludes) {
+        expect(snippet.trim()).toBe(snippet);
+        expect(snippet.length).toBeGreaterThan(0);
+      }
     }
-
-    expect(sorted(broadMatcherTools)).toEqual(allowedAnyMcpErrorTools);
   });
 
   it("uses allow policy only for destructive tool-shape coverage", () => {


### PR DESCRIPTION
## Summary
- Adds full-profile eval cases for all 40 tools across native control-plane, Partner/Groups, custom analytics, and S3 data-plane coverage.
- Hardens eval assertions with exact argument matching, pinned MCP error snippets or structured JSON results, and negative coverage for extra file/destructive arguments.
- Adds deterministic contract guards for full-profile coverage, orphan cases, required args, destructive block/confirm outcomes, and eval server env safety.
- Runs the full-profile scripted eval guard against local fake B2 and S3 SDK boundaries, so normal `pnpm run evals` does not depend on live Backblaze endpoints.
- Keeps live provider comparison behind `RUN_LLM_PROVIDER_COMPARISON=1` with a fixed timeout and provider error fail-fast behavior.

## Linked issue
Closes #249

## Tests run
- `pnpm run typecheck`
- `pnpm run format:check`
- `pnpm run lint`
- `pnpm run evals`
- `pnpm run test:contract`

## Follow-up notes
- Live LLM evals remain gated by `RUN_LLM_EVALS=1` plus provider API keys.
- Cross-provider comparison requires the separate `RUN_LLM_PROVIDER_COMPARISON=1` opt-in.