### PR TITLE
evals: gated CI workflow and pass-rate artifact

### DIFF
--- a/.github/workflows/evals.yml
+++ b/.github/workflows/evals.yml
@@ -1,0 +1,155 @@
+name: LLM Evals
+
+# Cost-controlled provider eval evidence. This workflow intentionally avoids
+# pull_request events so provider secrets never run against unreviewed fork code.
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: "37 10 * * 2"
+
+permissions:
+  contents: read
+
+concurrency:
+  group: llm-evals-${{ github.repository }}-${{ github.ref_name || github.run_id }}
+  cancel-in-progress: false
+
+jobs:
+  guard:
+    if: github.repository == 'backblaze-labs/b2-mcp'
+    runs-on: ubuntu-latest
+    outputs:
+      should-run: ${{ steps.ref.outputs.should_run }}
+      checkout-sha: ${{ steps.ref.outputs.checkout_sha }}
+      skip-reason: ${{ steps.ref.outputs.skip_reason }}
+    steps:
+      - name: Resolve trusted eval ref and provider secrets
+        id: ref
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+          OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+        run: |
+          set -euo pipefail
+          should_run=true
+          checkout_sha="${GITHUB_SHA}"
+          skip_reason=""
+
+          case "${EVENT_NAME}" in
+            workflow_dispatch|schedule)
+              if [[ "$GITHUB_REF" != "refs/heads/main" ]]; then
+                echo "::error::${EVENT_NAME} eval runs must target main; got ${GITHUB_REF}"
+                exit 1
+              fi
+              ;;
+            *)
+              echo "::error::unsupported eval event: ${EVENT_NAME}"
+              exit 1
+              ;;
+          esac
+
+          for value in "${ANTHROPIC_API_KEY:-}" "${OPENAI_API_KEY:-}"; do
+            if [[ -n "$value" ]]; then echo "::add-mask::$value"; fi
+          done
+
+          missing=()
+          if [[ -z "${ANTHROPIC_API_KEY:-}" ]]; then missing+=("ANTHROPIC_API_KEY"); fi
+          if [[ -z "${OPENAI_API_KEY:-}" ]]; then missing+=("OPENAI_API_KEY"); fi
+          if [[ "${#missing[@]}" -gt 0 ]]; then
+            should_run=false
+            checkout_sha=""
+            skip_reason="missing provider secret(s): ${missing[*]}"
+          fi
+
+          echo "should_run=${should_run}" >> "$GITHUB_OUTPUT"
+          echo "checkout_sha=${checkout_sha}" >> "$GITHUB_OUTPUT"
+          echo "skip_reason=${skip_reason}" >> "$GITHUB_OUTPUT"
+
+  skipped:
+    name: LLM evals skipped
+    needs: guard
+    if: ${{ always() && needs.guard.result == 'success' && needs.guard.outputs.should-run != 'true' }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 2
+    steps:
+      - name: Report skipped evals
+        run: |
+          echo "LLM evals skipped: ${{ needs.guard.outputs.skip-reason }}" >> "$GITHUB_STEP_SUMMARY"
+
+  evals:
+    name: Claude vs OpenAI pass rates
+    needs: guard
+    if: needs.guard.outputs.should-run == 'true'
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      # actions/checkout v6, reviewed 2026-08-06.
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803
+        with:
+          ref: ${{ needs.guard.outputs.checkout-sha }}
+          persist-credentials: false
+      # pnpm/action-setup v6.0.10, reviewed 2026-08-06.
+      - uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86
+        with:
+          run_install: false
+      # actions/setup-node v7, reviewed 2026-08-06.
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020
+        with:
+          node-version: 22.23.1
+          cache: pnpm
+      - run: pnpm install --frozen-lockfile
+      - run: pnpm run build
+      - name: Run Claude vs OpenAI eval comparison
+        env:
+          RUN_LLM_EVALS: "1"
+          RUN_LLM_PROVIDER_COMPARISON: "1"
+          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+          OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+          ANTHROPIC_EVAL_MODEL: claude-haiku-4-5-20251001
+          OPENAI_EVAL_MODEL: gpt-5-nano
+          LLM_EVAL_CASE_SET: ci-no-b2
+          LLM_EVAL_CASE_LIMIT: "5"
+          LLM_EVAL_BLOCK_SERVER_NETWORK: "1"
+          LLM_EVAL_PASS_RATE_REPORT: reports/evals/provider-pass-rates.json
+        run: |
+          set -euo pipefail
+          mkdir -p reports/evals
+          pnpm exec vitest run --config evals/vitest.config.mts \
+            evals/provider-comparison.eval.test.ts \
+            --testNamePattern "runs shared cases and emits a pass-rate comparison"
+      - name: Publish pass-rate summary
+        if: always()
+        run: |
+          set -euo pipefail
+          if [[ ! -s reports/evals/provider-pass-rates.json ]]; then
+            echo "Provider pass-rate report was not produced." >> "$GITHUB_STEP_SUMMARY"
+            exit 0
+          fi
+          node - <<'NODE'
+          const fs = require("node:fs");
+          const report = JSON.parse(fs.readFileSync("reports/evals/provider-pass-rates.json", "utf8"));
+          const lines = [
+            "## Claude vs OpenAI pass rates",
+            "",
+            report.summary,
+            "",
+            "| Provider | Model | Passed | Total | Pass rate |",
+            "| --- | --- | ---: | ---: | ---: |",
+            ...report.providers.map((provider) => {
+              const pct = `${(provider.passRate * 100).toFixed(1)}%`;
+              return `| ${provider.provider} | ${provider.model} | ${provider.passed} | ${provider.total} | ${pct} |`;
+            }),
+            "",
+          ];
+          fs.appendFileSync(process.env.GITHUB_STEP_SUMMARY, lines.join("\n"));
+          NODE
+      # actions/upload-artifact v6, reviewed 2026-08-06.
+      - name: Upload Claude vs OpenAI pass-rate report
+        if: always()
+        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f
+        with:
+          name: claude-openai-pass-rate-report
+          path: reports/evals/provider-pass-rates.json
+          if-no-files-found: warn
+          retention-days: 14

--- a/.github/workflows/evals.yml
+++ b/.github/workflows/evals.yml
@@ -19,6 +19,7 @@ jobs:
   guard:
     if: github.repository == 'backblaze-labs/b2-mcp'
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     outputs:
       should-run: ${{ steps.ref.outputs.should_run }}
       checkout-sha: ${{ steps.ref.outputs.checkout_sha }}
@@ -74,8 +75,10 @@ jobs:
     timeout-minutes: 2
     steps:
       - name: Report skipped evals
+        env:
+          SKIP_REASON: ${{ needs.guard.outputs.skip-reason }}
         run: |
-          echo "LLM evals skipped: ${{ needs.guard.outputs.skip-reason }}" >> "$GITHUB_STEP_SUMMARY"
+          echo "LLM evals skipped: ${SKIP_REASON}" >> "$GITHUB_STEP_SUMMARY"
 
   evals:
     name: Claude vs OpenAI pass rates
@@ -101,6 +104,8 @@ jobs:
       - run: pnpm install --frozen-lockfile
       - run: pnpm run build
       - name: Run Claude vs OpenAI eval comparison
+        id: run_evals
+        continue-on-error: true
         env:
           RUN_LLM_EVALS: "1"
           RUN_LLM_PROVIDER_COMPARISON: "1"
@@ -115,41 +120,32 @@ jobs:
         run: |
           set -euo pipefail
           mkdir -p reports/evals
-          pnpm exec vitest run --config evals/vitest.config.mts \
-            evals/provider-comparison.eval.test.ts \
-            --testNamePattern "runs shared cases and emits a pass-rate comparison"
-      - name: Publish pass-rate summary
+          pnpm run evals:provider-comparison
+      - name: Validate pass-rate report
+        id: validate_report
         if: always()
+        env:
+          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+          OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
         run: |
           set -euo pipefail
-          if [[ ! -s reports/evals/provider-pass-rates.json ]]; then
-            echo "Provider pass-rate report was not produced." >> "$GITHUB_STEP_SUMMARY"
-            exit 0
-          fi
-          node - <<'NODE'
-          const fs = require("node:fs");
-          const report = JSON.parse(fs.readFileSync("reports/evals/provider-pass-rates.json", "utf8"));
-          const lines = [
-            "## Claude vs OpenAI pass rates",
-            "",
-            report.summary,
-            "",
-            "| Provider | Model | Passed | Total | Pass rate |",
-            "| --- | --- | ---: | ---: | ---: |",
-            ...report.providers.map((provider) => {
-              const pct = `${(provider.passRate * 100).toFixed(1)}%`;
-              return `| ${provider.provider} | ${provider.model} | ${provider.passed} | ${provider.total} | ${pct} |`;
-            }),
-            "",
-          ];
-          fs.appendFileSync(process.env.GITHUB_STEP_SUMMARY, lines.join("\n"));
-          NODE
+          node scripts/eval-pass-rate-report.mjs validate reports/evals/provider-pass-rates.json
+      - name: Publish pass-rate summary
+        if: ${{ always() && steps.validate_report.outcome == 'success' }}
+        run: |
+          set -euo pipefail
+          node scripts/eval-pass-rate-report.mjs summary reports/evals/provider-pass-rates.json >> "$GITHUB_STEP_SUMMARY"
       # actions/upload-artifact v6, reviewed 2026-08-06.
       - name: Upload Claude vs OpenAI pass-rate report
-        if: always()
+        if: ${{ always() && steps.validate_report.outcome == 'success' }}
         uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f
         with:
           name: claude-openai-pass-rate-report
           path: reports/evals/provider-pass-rates.json
-          if-no-files-found: warn
+          if-no-files-found: error
           retention-days: 14
+      - name: Require eval comparison success
+        if: ${{ always() && steps.run_evals.outcome != 'success' }}
+        run: |
+          echo "::error::Claude vs OpenAI eval comparison failed"
+          exit 1

--- a/evals/anthropic-driver.eval.test.ts
+++ b/evals/anthropic-driver.eval.test.ts
@@ -2,6 +2,7 @@ import type { CallToolResult, Tool } from "@modelcontextprotocol/client";
 import { describe, expect, it, vi } from "vitest";
 import {
   ANTHROPIC_API_KEY_ENV,
+  ANTHROPIC_EVAL_MODEL_ENV,
   anthropicEvalGate,
   createAnthropicDriver,
   DEFAULT_ANTHROPIC_MODEL,
@@ -320,6 +321,32 @@ describe("Anthropic eval driver", () => {
     expect(
       anthropicEvalGate({ RUN_LLM_EVALS: "1", [ANTHROPIC_API_KEY_ENV]: "test-key" }).enabled,
     ).toBe(true);
+  });
+
+  it("lets CI pin the Anthropic eval model through the environment", async () => {
+    const previous = process.env[ANTHROPIC_EVAL_MODEL_ENV];
+    process.env[ANTHROPIC_EVAL_MODEL_ENV] = "claude-env-model";
+    try {
+      const { fetchImpl, requests } = createFetchSequence([
+        { content: [{ type: "text", text: "Env model." }] },
+      ]);
+      const driver = createAnthropicDriver({
+        apiKey: "test-anthropic-key",
+        fetch: fetchImpl,
+      });
+
+      await expect(driver.complete(driverInput({}))).resolves.toEqual({
+        text: "Env model.",
+        toolCalls: [],
+      });
+      expect(requests[0].body.model).toBe("claude-env-model");
+    } finally {
+      if (previous === undefined) {
+        delete process.env[ANTHROPIC_EVAL_MODEL_ENV];
+      } else {
+        process.env[ANTHROPIC_EVAL_MODEL_ENV] = previous;
+      }
+    }
   });
 });
 

--- a/evals/anthropic-driver.ts
+++ b/evals/anthropic-driver.ts
@@ -25,6 +25,7 @@ import {
 } from "./provider-utils";
 
 export const ANTHROPIC_API_KEY_ENV = "ANTHROPIC_API_KEY";
+export const ANTHROPIC_EVAL_MODEL_ENV = "ANTHROPIC_EVAL_MODEL";
 export const DEFAULT_ANTHROPIC_MODEL = "claude-haiku-4-5-20251001";
 
 const ANTHROPIC_MESSAGES_URL = "https://api.anthropic.com/v1/messages";
@@ -202,7 +203,7 @@ class AnthropicMessagesDriver implements Driver {
       options.apiKey ?? process.env[ANTHROPIC_API_KEY_ENV],
       ANTHROPIC_API_KEY_ENV,
     );
-    this.model = options.model ?? DEFAULT_ANTHROPIC_MODEL;
+    this.model = options.model ?? process.env[ANTHROPIC_EVAL_MODEL_ENV] ?? DEFAULT_ANTHROPIC_MODEL;
     this.maxTokens = requirePositiveInteger(options.maxTokens ?? DEFAULT_MAX_TOKENS, "maxTokens");
     this.system = options.system ?? DEFAULT_SYSTEM_PROMPT;
     this.retry = resolveRetryOptions(options.retry);

--- a/evals/anthropic-driver.ts
+++ b/evals/anthropic-driver.ts
@@ -96,6 +96,10 @@ export function anthropicEvalGate(env: NodeJS.ProcessEnv = process.env): EvalGat
   return llmEvalGate(env, { providerKeyEnvNames: [ANTHROPIC_API_KEY_ENV] });
 }
 
+export function anthropicEvalModel(env: NodeJS.ProcessEnv = process.env): string {
+  return env[ANTHROPIC_EVAL_MODEL_ENV] ?? DEFAULT_ANTHROPIC_MODEL;
+}
+
 export function createAnthropicDriver(options: AnthropicDriverOptions = {}): Driver {
   return new AnthropicMessagesDriver(options);
 }
@@ -203,7 +207,7 @@ class AnthropicMessagesDriver implements Driver {
       options.apiKey ?? process.env[ANTHROPIC_API_KEY_ENV],
       ANTHROPIC_API_KEY_ENV,
     );
-    this.model = options.model ?? process.env[ANTHROPIC_EVAL_MODEL_ENV] ?? DEFAULT_ANTHROPIC_MODEL;
+    this.model = options.model ?? anthropicEvalModel();
     this.maxTokens = requirePositiveInteger(options.maxTokens ?? DEFAULT_MAX_TOKENS, "maxTokens");
     this.system = options.system ?? DEFAULT_SYSTEM_PROMPT;
     this.retry = resolveRetryOptions(options.retry);

--- a/evals/cases.ts
+++ b/evals/cases.ts
@@ -225,6 +225,10 @@ const unavailableStubError = {
   kind: "mcp-error",
   textIncludes: ["B2 Error [tool_unavailable]", "HTTP 410", "out-of-band secret sink"],
 } as const satisfies ExpectedEvalResult;
+const destructivePolicyBlockedError = {
+  kind: "mcp-error",
+  textIncludes: ["destructive_policy_blocked"],
+} as const satisfies ExpectedEvalResult;
 
 export const NATIVE_CONTROL_PLANE_EVAL_CASES: readonly EvalCase[] = [
   evalToolCase({
@@ -655,6 +659,56 @@ export const S3_DATA_PLANE_EVAL_CASES: readonly EvalCase[] = [
     },
     request: "Copy an existing object range into a multipart upload part.",
     result: s3InvalidAccessKeyError,
+  }),
+];
+
+export const CI_PROVIDER_COMPARISON_EVAL_CASES: readonly EvalCase[] = [
+  evalToolCase({
+    name: "blocked delete bucket",
+    category: "native-control-plane",
+    toolName: "b2_delete_bucket",
+    args: { bucketId: "eval-bucket-id", confirm: true },
+    request: "Delete the Backblaze B2 bucket identified by eval-bucket-id.",
+    result: destructivePolicyBlockedError,
+  }),
+  evalToolCase({
+    name: "blocked empty bucket notification rules",
+    category: "native-control-plane",
+    toolName: "b2_set_bucket_notification_rules",
+    args: { bucketId: "eval-bucket-id", eventNotificationRules: [], confirm: true },
+    request: "Replace a bucket's event notification rules with an empty rule set.",
+    result: destructivePolicyBlockedError,
+  }),
+  evalToolCase({
+    name: "application key compatibility stub without secret sink",
+    category: "native-control-plane",
+    toolName: "b2_create_key",
+    args: { confirm: true },
+    request: "Create a Backblaze B2 application key.",
+    result: unavailableStubError,
+  }),
+  evalToolCase({
+    name: "blocked delete object",
+    category: "s3-data-plane",
+    toolName: "s3_delete_object",
+    args: { bucket: "eval-bucket", key: "obsolete.txt", confirm: true },
+    request: "Delete one object from a Backblaze B2 S3-compatible bucket.",
+    result: destructivePolicyBlockedError,
+  }),
+  evalToolCase({
+    name: "blocked put-object presigned url",
+    category: "s3-data-plane",
+    toolName: "s3_get_presigned_url",
+    args: {
+      bucket: "eval-bucket",
+      key: "upload-target.txt",
+      operation: "PutObject",
+      expiresIn: 900,
+      contentType: "text/plain",
+      confirm: true,
+    },
+    request: "Generate a PutObject presigned URL for a Backblaze B2 object.",
+    result: destructivePolicyBlockedError,
   }),
 ];
 

--- a/evals/full-profile-cases.eval.test.ts
+++ b/evals/full-profile-cases.eval.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it, vi, beforeEach, afterEach } from "vitest";
-import { FULL_PROFILE_EVAL_CASES, type EvalCase } from "./cases";
+import { CI_PROVIDER_COMPARISON_EVAL_CASES, FULL_PROFILE_EVAL_CASES, type EvalCase } from "./cases";
 import type { Driver, DriverInput, DriverOutput, EvalRun } from "./harness";
 import { B2S3PeerClient } from "../src/s3/aws-sdk-adapter";
 import { createServer, getRegisteredTools, invalidateAuthManagerCache } from "../src/server";
@@ -183,6 +183,17 @@ describe("full-profile scripted eval cases", () => {
     async (evalCase) => {
       const run = await runScriptedCase(evalCase);
 
+      expect(evalCase.passed(run), evalCase.failureSummary(run)).toBe(true);
+    },
+    30_000,
+  );
+
+  it.each(CI_PROVIDER_COMPARISON_EVAL_CASES)(
+    "$name accepts the scripted no-B2 CI tool call",
+    async (evalCase) => {
+      const run = await runScriptedCase(evalCase);
+
+      expect(evalCase.server?.destructivePolicy).not.toBe("allow");
       expect(evalCase.passed(run), evalCase.failureSummary(run)).toBe(true);
     },
     30_000,

--- a/evals/harness.eval.test.ts
+++ b/evals/harness.eval.test.ts
@@ -1,6 +1,7 @@
 import { existsSync } from "fs";
 import { join } from "path";
 import { tmpdir } from "os";
+import { spawnSync } from "child_process";
 import { describe, expect, it } from "vitest";
 import {
   EVAL_SERVER_NETWORK_GUARD_ENV,
@@ -120,6 +121,27 @@ describe("LLM eval harness", () => {
 
       expect(env.NODE_OPTIONS).toContain("--import");
       expect(env.NODE_OPTIONS).toContain("scripts/no-network-guard.mjs");
+
+      const blocked = spawnSync(
+        process.execPath,
+        ["--input-type=module", "-e", 'await fetch("https://example.com")'],
+        { env, encoding: "utf8" },
+      );
+      expect(blocked.status).not.toBe(0);
+      expect(blocked.stderr).toContain("MCP_CLIENT_SMOKE_NETWORK_BLOCKED:fetch");
+
+      const missingGuard = spawnSync(process.execPath, ["-e", 'console.log("unguarded")'], {
+        env: {
+          ...env,
+          NODE_OPTIONS: env.NODE_OPTIONS.replace(
+            "scripts/no-network-guard.mjs",
+            "scripts/missing-no-network-guard.mjs",
+          ),
+        },
+        encoding: "utf8",
+      });
+      expect(missingGuard.status).not.toBe(0);
+      expect(missingGuard.stdout).not.toContain("unguarded");
     } finally {
       if (previous === undefined) {
         delete process.env[EVAL_SERVER_NETWORK_GUARD_ENV];

--- a/evals/harness.eval.test.ts
+++ b/evals/harness.eval.test.ts
@@ -3,6 +3,7 @@ import { join } from "path";
 import { tmpdir } from "os";
 import { describe, expect, it } from "vitest";
 import {
+  EVAL_SERVER_NETWORK_GUARD_ENV,
   createEvalServerEnv,
   llmEvalGate,
   runEval,
@@ -109,6 +110,23 @@ describe("LLM eval harness", () => {
         env: { B2_SECRET_SINK: "file" },
       }),
     ).toThrow(/B2_SECRET_SINK=off/);
+  });
+
+  it("can block outbound network in the eval server child process", () => {
+    const previous = process.env[EVAL_SERVER_NETWORK_GUARD_ENV];
+    process.env[EVAL_SERVER_NETWORK_GUARD_ENV] = "1";
+    try {
+      const env = createEvalServerEnv();
+
+      expect(env.NODE_OPTIONS).toContain("--import");
+      expect(env.NODE_OPTIONS).toContain("scripts/no-network-guard.mjs");
+    } finally {
+      if (previous === undefined) {
+        delete process.env[EVAL_SERVER_NETWORK_GUARD_ENV];
+      } else {
+        process.env[EVAL_SERVER_NETWORK_GUARD_ENV] = previous;
+      }
+    }
   });
 
   it("rejects unexposed tool calls before execution", async () => {

--- a/evals/harness.ts
+++ b/evals/harness.ts
@@ -1,5 +1,7 @@
 import { Client, type CallToolResult, type Tool } from "@modelcontextprotocol/client";
 import { StdioClientTransport } from "@modelcontextprotocol/client/stdio";
+import { join } from "path";
+import { pathToFileURL } from "url";
 import {
   DIST_INDEX,
   ROOT,
@@ -15,6 +17,8 @@ const DEFAULT_TOOL_CALL_TIMEOUT_MS = 30_000;
 const DEFAULT_STDERR_TAIL_BYTES = 8_192;
 const DEFAULT_MAX_TOOL_CALLS_PER_STEP = 8;
 const DEFAULT_MAX_TOOL_CALLS_TOTAL = 32;
+
+export const EVAL_SERVER_NETWORK_GUARD_ENV = "LLM_EVAL_BLOCK_SERVER_NETWORK";
 
 const EVAL_CREDENTIAL_MARKERS: Record<string, string> = {
   B2_APPLICATION_KEY_ID: "eval-application-key-id",
@@ -222,6 +226,17 @@ function assertSafeEvalServerEnv(env: NodeJS.ProcessEnv, options: EvalServerOpti
 }
 
 export function createEvalServerEnv(options: EvalServerOptions = {}): Record<string, string> {
+  const networkGuardEnabled =
+    process.env[EVAL_SERVER_NETWORK_GUARD_ENV] === "1" ||
+    options.env?.[EVAL_SERVER_NETWORK_GUARD_ENV] === "1";
+  const nodeOptions = networkGuardEnabled
+    ? [
+        options.env?.NODE_OPTIONS,
+        `--import ${pathToFileURL(join(ROOT, "scripts/no-network-guard.mjs")).href}`,
+      ]
+        .filter(Boolean)
+        .join(" ")
+    : options.env?.NODE_OPTIONS;
   const env = safeSpawnEnv({
     NODE_ENV: "test",
     B2_REGISTER_ALL_TOOLS: options.registerAllTools === false ? "false" : "true",
@@ -230,6 +245,7 @@ export function createEvalServerEnv(options: EvalServerOptions = {}): Record<str
     B2_ALLOW_LOCAL_FILES: "false",
     B2_SECRET_SINK: "off",
     ...options.env,
+    ...(nodeOptions ? { NODE_OPTIONS: nodeOptions } : {}),
   });
   assertSafeEvalServerEnv(env, options);
   return stringifySpawnEnv(env);

--- a/evals/openai-driver.ts
+++ b/evals/openai-driver.ts
@@ -94,6 +94,10 @@ export function openAIEvalGate(env: NodeJS.ProcessEnv = process.env): EvalGate {
   return llmEvalGate(env, { providerKeyEnvNames: [OPENAI_API_KEY_ENV] });
 }
 
+export function openAIEvalModel(env: NodeJS.ProcessEnv = process.env): string {
+  return env[OPENAI_EVAL_MODEL_ENV] ?? DEFAULT_OPENAI_MODEL;
+}
+
 export function createOpenAIDriver(options: OpenAIDriverOptions = {}): Driver {
   return new OpenAIChatCompletionsDriver(options);
 }
@@ -206,7 +210,7 @@ class OpenAIChatCompletionsDriver implements Driver {
       options.apiKey ?? process.env[OPENAI_API_KEY_ENV],
       OPENAI_API_KEY_ENV,
     );
-    this.model = options.model ?? process.env[OPENAI_EVAL_MODEL_ENV] ?? DEFAULT_OPENAI_MODEL;
+    this.model = options.model ?? openAIEvalModel();
     this.maxCompletionTokens = requirePositiveInteger(
       options.maxCompletionTokens ?? DEFAULT_MAX_COMPLETION_TOKENS,
       "maxCompletionTokens",

--- a/evals/provider-comparison-cli.ts
+++ b/evals/provider-comparison-cli.ts
@@ -1,0 +1,17 @@
+import {
+  type ProviderPassRateComparison,
+  assertProviderPassRateComparison,
+} from "./provider-comparison";
+
+export const PROVIDER_COMPARISON_ASSERTION_FAILURE_MESSAGE =
+  "Claude vs OpenAI eval comparison failed policy checks; see the sanitized pass-rate report artifact.";
+
+export function assertProviderPassRateComparisonForCli(
+  comparison: ProviderPassRateComparison,
+): void {
+  try {
+    assertProviderPassRateComparison(comparison);
+  } catch {
+    throw new Error(PROVIDER_COMPARISON_ASSERTION_FAILURE_MESSAGE);
+  }
+}

--- a/evals/provider-comparison.eval.test.ts
+++ b/evals/provider-comparison.eval.test.ts
@@ -429,7 +429,9 @@ describe("provider pass-rate comparison", () => {
           caseName: "comparison case",
           status: "errored" as const,
           passed: false as const,
-          error: "request failed for sk-proj-secret123456789",
+          error:
+            "request failed with toolCalls=[raw] text=raw model text " +
+            "eval-application-key-secret sk-proj-secret123456789",
         },
       ],
     };
@@ -483,7 +485,7 @@ describe("provider pass-rate comparison", () => {
     expect(report.results[2]).toMatchObject({
       provider: "OpenAI",
       status: "errored",
-      error: "request failed for [REDACTED_SECRET]",
+      error: "Case errored during evaluation; raw model and tool payloads omitted.",
     });
   });
 

--- a/evals/provider-comparison.eval.test.ts
+++ b/evals/provider-comparison.eval.test.ts
@@ -18,6 +18,7 @@ import {
 } from "./provider-pass-rate-report";
 import {
   CLAUDE_OPENAI_PROVIDERS,
+  type EvalProvider,
   PROVIDER_COMPARISON_EVAL_ENV,
   assertProviderPassRateComparison,
   claudeOpenAIComparisonEvalGate,
@@ -80,6 +81,14 @@ const comparisonCase = {
   failureSummary: destructiveDeleteBucketGateFailure,
 } satisfies EvalCase;
 
+function scriptedProvider(name: string, driverName: string): EvalProvider {
+  return {
+    name,
+    model: () => `${driverName}-model`,
+    createDriver: () => new ScriptedDriver(driverName, {}),
+  };
+}
+
 describe("provider pass-rate comparison", () => {
   it("runs the same cases for each provider and summarizes pass rates", async () => {
     const observed: Array<{
@@ -102,10 +111,7 @@ describe("provider pass-rate comparison", () => {
 
     const comparison = await runProviderPassRateComparison({
       cases: [comparisonCase],
-      providers: [
-        { name: "Claude", createDriver: () => new ScriptedDriver("anthropic", {}) },
-        { name: "OpenAI", createDriver: () => new ScriptedDriver("openai", {}) },
-      ],
+      providers: [scriptedProvider("Claude", "anthropic"), scriptedProvider("OpenAI", "openai")],
       runEvalImpl,
     });
 
@@ -143,10 +149,7 @@ describe("provider pass-rate comparison", () => {
   it("fails gating assertions for provider errors even with a relaxed pass rate", async () => {
     const comparison = await runProviderPassRateComparison({
       cases: [comparisonCase],
-      providers: [
-        { name: "Claude", createDriver: () => new ScriptedDriver("anthropic", {}) },
-        { name: "OpenAI", createDriver: () => new ScriptedDriver("openai", {}) },
-      ],
+      providers: [scriptedProvider("Claude", "anthropic"), scriptedProvider("OpenAI", "openai")],
       async runEvalImpl(options) {
         if (options.driver.name === "openai") throw new Error("model_not_found");
         return passingRun();
@@ -161,10 +164,7 @@ describe("provider pass-rate comparison", () => {
   it("sanitizes provider errors before assertions can print them", async () => {
     const comparison = await runProviderPassRateComparison({
       cases: [comparisonCase],
-      providers: [
-        { name: "Claude", createDriver: () => new ScriptedDriver("anthropic", {}) },
-        { name: "OpenAI", createDriver: () => new ScriptedDriver("openai", {}) },
-      ],
+      providers: [scriptedProvider("Claude", "anthropic"), scriptedProvider("OpenAI", "openai")],
       async runEvalImpl(options) {
         if (options.driver.name === "openai") {
           throw new Error("provider echoed sk-proj-secret123456789");
@@ -188,10 +188,7 @@ describe("provider pass-rate comparison", () => {
 
     const comparison = await runProviderPassRateComparison({
       cases: [comparisonCase, secondCase],
-      providers: [
-        { name: "Claude", createDriver: () => new ScriptedDriver("anthropic", {}) },
-        { name: "OpenAI", createDriver: () => new ScriptedDriver("openai", {}) },
-      ],
+      providers: [scriptedProvider("Claude", "anthropic"), scriptedProvider("OpenAI", "openai")],
       async runEvalImpl(options) {
         if (options.driver.name === "openai" && options.prompt === comparisonCase.prompt) {
           return failingRun();
@@ -306,10 +303,7 @@ describe("provider pass-rate comparison", () => {
         { ...comparisonCase, name: "case two" },
         { ...comparisonCase, name: "case three" },
       ],
-      providers: [
-        { name: "Claude", createDriver: () => new ScriptedDriver("anthropic", {}) },
-        { name: "OpenAI", createDriver: () => new ScriptedDriver("openai", {}) },
-      ],
+      providers: [scriptedProvider("Claude", "anthropic"), scriptedProvider("OpenAI", "openai")],
       comparison: { maxProviderErrors: 1 },
       async runEvalImpl(options) {
         if (options.driver.name === "openai") {
@@ -380,6 +374,27 @@ describe("provider pass-rate comparison", () => {
         },
         {
           provider: "OpenAI",
+          caseName: "failed comparison case",
+          status: "failed" as const,
+          passed: false as const,
+          run: {
+            toolCalls: [
+              { name: "b2_list_buckets", args: { marker: "eval-application-key-secret" } },
+            ],
+            toolResults: [
+              {
+                isError: true,
+                content: [{ type: "text", text: "raw tool result sk-proj-secret123456789" }],
+              },
+            ],
+            text: "raw model text sk-proj-secret123456789",
+          } satisfies EvalRun,
+          failure:
+            'expected one call; toolCalls=[{"marker":"eval-application-key-secret"}] ' +
+            "toolResults=[secret] text=raw model text sk-proj-secret123456789",
+        },
+        {
+          provider: "OpenAI",
           caseName: "comparison case",
           status: "errored" as const,
           passed: false as const,
@@ -401,8 +416,9 @@ describe("provider pass-rate comparison", () => {
       now: new Date("2026-08-24T00:00:00.000Z"),
     });
 
-    expect(report.issue.number).toBe(250);
     expect(report.caseCount).toBe(1);
+    expect("caseLimit" in report).toBe(false);
+    expect("issue" in report).toBe(false);
     expect(report.providers).toEqual([
       {
         provider: "Claude",
@@ -420,12 +436,38 @@ describe("provider pass-rate comparison", () => {
       },
     ]);
     expect(JSON.stringify(report)).not.toContain("sk-proj-secret123456789");
+    expect(JSON.stringify(report)).not.toContain("eval-application-key-secret");
+    expect(JSON.stringify(report)).not.toContain("raw model text");
+    expect(JSON.stringify(report)).not.toContain("toolCalls");
     expect(JSON.stringify(report)).not.toContain("toolResults");
     expect(report.results[1]).toMatchObject({
+      provider: "OpenAI",
+      status: "failed",
+      failure: "Case failed validation; raw model and tool payloads omitted.",
+    });
+    expect(report.results[1]).toMatchObject({
+      provider: "OpenAI",
+      status: "failed",
+    });
+    expect(report.results[2]).toMatchObject({
       provider: "OpenAI",
       status: "errored",
       error: "request failed for [REDACTED_SECRET]",
     });
+  });
+
+  it("fails report generation when provider model metadata is missing", () => {
+    expect(() =>
+      createProviderPassRateReport({
+        comparison: {
+          summary: "summary",
+          passRates: [{ provider: "Missing", passed: 0, total: 1, passRate: 0 }],
+          results: [],
+        },
+        cases: [comparisonCase],
+        providers: [scriptedProvider("Claude", "anthropic")],
+      }),
+    ).toThrow(/Missing provider model metadata for Missing/);
   });
 });
 

--- a/evals/provider-comparison.eval.test.ts
+++ b/evals/provider-comparison.eval.test.ts
@@ -1,11 +1,21 @@
 import { describe, expect, it } from "vitest";
 import type { EvalCase } from "./cases";
 import {
+  CI_PROVIDER_COMPARISON_EVAL_CASES,
   FULL_PROFILE_EVAL_CASES,
   destructiveDeleteBucketGateFailure,
   destructiveDeleteBucketGatePassed,
 } from "./cases";
 import type { Driver, DriverInput, DriverOutput, EvalRun, RunEvalOptions } from "./harness";
+import {
+  PROVIDER_COMPARISON_CASE_LIMIT_ENV,
+  PROVIDER_COMPARISON_CASE_SET_ENV,
+  PROVIDER_PASS_RATE_REPORT_ENV,
+  createProviderPassRateReport,
+  selectBoundedProviderComparisonCases,
+  selectProviderComparisonCases,
+  writeProviderPassRateReport,
+} from "./provider-pass-rate-report";
 import {
   CLAUDE_OPENAI_PROVIDERS,
   PROVIDER_COMPARISON_EVAL_ENV,
@@ -145,6 +155,27 @@ describe("provider pass-rate comparison", () => {
 
     expect(() => assertProviderPassRateComparison(comparison, { minPassRate: 0 })).toThrow(
       /model_not_found/,
+    );
+  });
+
+  it("sanitizes provider errors before assertions can print them", async () => {
+    const comparison = await runProviderPassRateComparison({
+      cases: [comparisonCase],
+      providers: [
+        { name: "Claude", createDriver: () => new ScriptedDriver("anthropic", {}) },
+        { name: "OpenAI", createDriver: () => new ScriptedDriver("openai", {}) },
+      ],
+      async runEvalImpl(options) {
+        if (options.driver.name === "openai") {
+          throw new Error("provider echoed sk-proj-secret123456789");
+        }
+        return passingRun();
+      },
+    });
+
+    expect(JSON.stringify(comparison)).not.toContain("sk-proj-secret123456789");
+    expect(() => assertProviderPassRateComparison(comparison, { minPassRate: 0 })).toThrow(
+      /provider echoed \[REDACTED_SECRET\]/,
     );
   });
 
@@ -297,6 +328,105 @@ describe("provider pass-rate comparison", () => {
       ),
     ).toHaveLength(2);
   });
+
+  it("selects a bounded CI case set from the full provider comparison suite", () => {
+    expect(selectBoundedProviderComparisonCases([comparisonCase], {})).toEqual([comparisonCase]);
+    expect(
+      selectBoundedProviderComparisonCases(
+        [comparisonCase, { ...comparisonCase, name: "case two" }],
+        { [PROVIDER_COMPARISON_CASE_LIMIT_ENV]: "1" },
+      ),
+    ).toEqual([comparisonCase]);
+    expect(() =>
+      selectBoundedProviderComparisonCases([comparisonCase], {
+        [PROVIDER_COMPARISON_CASE_LIMIT_ENV]: "0",
+      }),
+    ).toThrow(/LLM_EVAL_CASE_LIMIT must be a positive integer/);
+    expect(
+      selectProviderComparisonCases(
+        { full: [comparisonCase], "ci-no-b2": CI_PROVIDER_COMPARISON_EVAL_CASES },
+        {
+          [PROVIDER_COMPARISON_CASE_SET_ENV]: "ci-no-b2",
+          [PROVIDER_COMPARISON_CASE_LIMIT_ENV]: "2",
+        },
+      ).map((evalCase) => evalCase.name),
+    ).toEqual(["blocked delete bucket", "blocked empty bucket notification rules"]);
+    expect(() =>
+      selectProviderComparisonCases(
+        { full: [comparisonCase] },
+        {
+          [PROVIDER_COMPARISON_CASE_SET_ENV]: "missing",
+        },
+      ),
+    ).toThrow(/LLM_EVAL_CASE_SET must be one of: full/);
+  });
+
+  it("builds a secret-safe pass-rate report without raw runs", () => {
+    const comparison = {
+      summary:
+        "Pass-rate comparison (Claude vs OpenAI) across 1 shared case(s): " +
+        "Claude: 1/1 (100.0%); OpenAI: 0/1 (0.0%).",
+      passRates: [
+        { provider: "Claude", passed: 1, total: 1, passRate: 1 },
+        { provider: "OpenAI", passed: 0, total: 1, passRate: 0 },
+      ],
+      results: [
+        {
+          provider: "Claude",
+          caseName: "comparison case",
+          status: "passed" as const,
+          passed: true as const,
+          run: passingRun(),
+        },
+        {
+          provider: "OpenAI",
+          caseName: "comparison case",
+          status: "errored" as const,
+          passed: false as const,
+          error: "request failed for sk-proj-secret123456789",
+        },
+      ],
+    };
+
+    const report = createProviderPassRateReport({
+      comparison,
+      cases: [comparisonCase],
+      providers: CLAUDE_OPENAI_PROVIDERS,
+      env: {
+        ANTHROPIC_API_KEY: "anthropic-secret",
+        OPENAI_API_KEY: "sk-proj-secret123456789",
+        OPENAI_EVAL_MODEL: "gpt-5-nano",
+        ANTHROPIC_EVAL_MODEL: "claude-haiku-4-5-20251001",
+      },
+      now: new Date("2026-08-24T00:00:00.000Z"),
+    });
+
+    expect(report.issue.number).toBe(250);
+    expect(report.caseCount).toBe(1);
+    expect(report.providers).toEqual([
+      {
+        provider: "Claude",
+        model: "claude-haiku-4-5-20251001",
+        passed: 1,
+        total: 1,
+        passRate: 1,
+      },
+      {
+        provider: "OpenAI",
+        model: "gpt-5-nano",
+        passed: 0,
+        total: 1,
+        passRate: 0,
+      },
+    ]);
+    expect(JSON.stringify(report)).not.toContain("sk-proj-secret123456789");
+    expect(JSON.stringify(report)).not.toContain("toolResults");
+    expect(report.results[1]).toMatchObject({
+      provider: "OpenAI",
+      status: "errored",
+      error: "request failed for [REDACTED_SECRET]",
+    });
+  });
 });
 
 const comparisonGate = claudeOpenAIComparisonEvalGate();
@@ -306,19 +436,34 @@ describe("Claude vs OpenAI live eval comparison", () => {
   it.skipIf(!comparisonGate.enabled)(
     "runs shared cases and emits a pass-rate comparison",
     async () => {
+      const liveComparisonCases = selectProviderComparisonCases({
+        full: FULL_PROFILE_EVAL_CASES,
+        "ci-no-b2": CI_PROVIDER_COMPARISON_EVAL_CASES,
+      });
       const comparison = await runProviderPassRateComparison({
-        cases: FULL_PROFILE_EVAL_CASES,
+        cases: liveComparisonCases,
         providers: CLAUDE_OPENAI_PROVIDERS,
       });
 
       console.info(comparison.summary);
+      const reportPath = process.env[PROVIDER_PASS_RATE_REPORT_ENV];
+      if (reportPath) {
+        writeProviderPassRateReport(
+          reportPath,
+          createProviderPassRateReport({
+            comparison,
+            cases: liveComparisonCases,
+            providers: CLAUDE_OPENAI_PROVIDERS,
+          }),
+        );
+      }
       assertProviderPassRateComparison(comparison);
       expect(comparison.results).toHaveLength(
-        FULL_PROFILE_EVAL_CASES.length * CLAUDE_OPENAI_PROVIDERS.length,
+        liveComparisonCases.length * CLAUDE_OPENAI_PROVIDERS.length,
       );
       for (const provider of CLAUDE_OPENAI_PROVIDERS) {
         expect(comparison.passRates.find((rate) => rate.provider === provider.name)?.total).toBe(
-          FULL_PROFILE_EVAL_CASES.length,
+          liveComparisonCases.length,
         );
       }
       expect(comparison.summary).toMatch(/Claude vs OpenAI/);

--- a/evals/provider-comparison.eval.test.ts
+++ b/evals/provider-comparison.eval.test.ts
@@ -25,6 +25,10 @@ import {
   formatPassRateSummary,
   runProviderPassRateComparison,
 } from "./provider-comparison";
+import {
+  PROVIDER_COMPARISON_ASSERTION_FAILURE_MESSAGE,
+  assertProviderPassRateComparisonForCli,
+} from "./provider-comparison-cli";
 
 class ScriptedDriver implements Driver {
   readonly name: string;
@@ -201,6 +205,33 @@ describe("provider pass-rate comparison", () => {
     expect(() => assertProviderPassRateComparison(comparison, { minPassRate: 1 })).toThrow(
       /expected one blocked b2_delete_bucket call/,
     );
+  });
+
+  it("prints a fixed CLI failure instead of raw failed-case payloads", () => {
+    expect(() =>
+      assertProviderPassRateComparisonForCli({
+        summary: "summary",
+        passRates: [{ provider: "OpenAI", passed: 0, total: 1, passRate: 0 }],
+        results: [
+          {
+            provider: "OpenAI",
+            caseName: "raw failure",
+            status: "failed",
+            passed: false,
+            run: {
+              toolCalls: [
+                { name: "b2_list_buckets", args: { marker: "eval-application-key-secret" } },
+              ],
+              toolResults: [{ content: [{ type: "text", text: "secret tool result" }] }],
+              text: "raw model text",
+            },
+            failure:
+              'toolCalls=[{"args":{"marker":"eval-application-key-secret"}}] ' +
+              "toolResults=[secret] text=raw model text",
+          },
+        ],
+      }),
+    ).toThrow(PROVIDER_COMPARISON_ASSERTION_FAILURE_MESSAGE);
   });
 
   it.each([Number.NaN, -0.1, 1.1, Number.POSITIVE_INFINITY] as const)(

--- a/evals/provider-comparison.ts
+++ b/evals/provider-comparison.ts
@@ -1,6 +1,11 @@
-import { ANTHROPIC_API_KEY_ENV, createAnthropicDriver } from "./anthropic-driver";
+import {
+  ANTHROPIC_API_KEY_ENV,
+  anthropicEvalModel,
+  createAnthropicDriver,
+} from "./anthropic-driver";
 import { evalCaseRunOptions, type EvalCase } from "./cases";
-import { OPENAI_API_KEY_ENV, createOpenAIDriver } from "./openai-driver";
+import { OPENAI_API_KEY_ENV, createOpenAIDriver, openAIEvalModel } from "./openai-driver";
+import { providerSecretValues } from "./provider-secrets";
 import { sanitizeProviderErrorMessage } from "./provider-utils";
 import {
   llmEvalGate,
@@ -16,6 +21,7 @@ export const DEFAULT_MAX_PROVIDER_ERRORS = 3;
 
 export interface EvalProvider {
   readonly name: string;
+  model(env?: NodeJS.ProcessEnv): string;
   createDriver(): Driver;
 }
 
@@ -71,8 +77,8 @@ export interface ProviderPassRateComparisonOptions {
 export type EvalRunner = (options: RunEvalOptions) => Promise<EvalRun>;
 
 export const CLAUDE_OPENAI_PROVIDERS: readonly EvalProvider[] = [
-  { name: "Claude", createDriver: createAnthropicDriver },
-  { name: "OpenAI", createDriver: createOpenAIDriver },
+  { name: "Claude", model: anthropicEvalModel, createDriver: createAnthropicDriver },
+  { name: "OpenAI", model: openAIEvalModel, createDriver: createOpenAIDriver },
 ];
 
 export function claudeOpenAIComparisonEvalGate(env: NodeJS.ProcessEnv = process.env): EvalGate {
@@ -189,12 +195,6 @@ function resolveMaxProviderErrors(value: number | undefined): number {
     throw new Error("maxProviderErrors must be a positive integer.");
   }
   return maxProviderErrors;
-}
-
-function providerSecretValues(env: NodeJS.ProcessEnv = process.env): string[] {
-  return [env[ANTHROPIC_API_KEY_ENV], env[OPENAI_API_KEY_ENV]].filter((value): value is string =>
-    Boolean(value),
-  );
 }
 
 export function assertProviderPassRateComparison(

--- a/evals/provider-comparison.ts
+++ b/evals/provider-comparison.ts
@@ -1,6 +1,7 @@
 import { ANTHROPIC_API_KEY_ENV, createAnthropicDriver } from "./anthropic-driver";
 import { evalCaseRunOptions, type EvalCase } from "./cases";
 import { OPENAI_API_KEY_ENV, createOpenAIDriver } from "./openai-driver";
+import { sanitizeProviderErrorMessage } from "./provider-utils";
 import {
   llmEvalGate,
   runEval,
@@ -151,12 +152,13 @@ export async function runProviderPassRateComparison(options: {
         }
       } catch (err) {
         providerErrors.set(provider.name, errorsSoFar + 1);
+        const message = err instanceof Error ? err.message : String(err);
         results.push({
           provider: provider.name,
           caseName: evalCase.name,
           status: "errored",
           passed: false,
-          error: err instanceof Error ? err.message : String(err),
+          error: sanitizeProviderErrorMessage(message, providerSecretValues()),
         });
       }
     }
@@ -187,6 +189,12 @@ function resolveMaxProviderErrors(value: number | undefined): number {
     throw new Error("maxProviderErrors must be a positive integer.");
   }
   return maxProviderErrors;
+}
+
+function providerSecretValues(env: NodeJS.ProcessEnv = process.env): string[] {
+  return [env[ANTHROPIC_API_KEY_ENV], env[OPENAI_API_KEY_ENV]].filter((value): value is string =>
+    Boolean(value),
+  );
 }
 
 export function assertProviderPassRateComparison(

--- a/evals/provider-pass-rate-report.ts
+++ b/evals/provider-pass-rate-report.ts
@@ -1,17 +1,12 @@
 import { mkdirSync, writeFileSync } from "fs";
 import { dirname } from "path";
-import {
-  ANTHROPIC_API_KEY_ENV,
-  ANTHROPIC_EVAL_MODEL_ENV,
-  DEFAULT_ANTHROPIC_MODEL,
-} from "./anthropic-driver";
 import type { EvalCase } from "./cases";
-import { DEFAULT_OPENAI_MODEL, OPENAI_API_KEY_ENV, OPENAI_EVAL_MODEL_ENV } from "./openai-driver";
 import type {
   EvalProvider,
   ProviderCaseResult,
   ProviderPassRateComparison,
 } from "./provider-comparison";
+import { providerSecretValues } from "./provider-secrets";
 import { sanitizeProviderErrorMessage } from "./provider-utils";
 
 export const PROVIDER_COMPARISON_CASE_LIMIT_ENV = "LLM_EVAL_CASE_LIMIT";
@@ -20,13 +15,7 @@ export const PROVIDER_PASS_RATE_REPORT_ENV = "LLM_EVAL_PASS_RATE_REPORT";
 
 export interface ProviderPassRateReport {
   readonly schemaVersion: 1;
-  readonly issue: {
-    readonly number: 250;
-    readonly url: "https://github.com/backblaze-labs/b2-mcp/issues/250";
-    readonly title: "evals: gated CI workflow + provider secrets + pass-rate artifact";
-  };
   readonly generatedAt: string;
-  readonly caseLimit: number;
   readonly caseCount: number;
   readonly providers: readonly {
     readonly provider: string;
@@ -87,28 +76,22 @@ export function createProviderPassRateReport(args: {
   now?: Date;
 }): ProviderPassRateReport {
   const env = args.env ?? process.env;
-  const secretValues = [env[ANTHROPIC_API_KEY_ENV], env[OPENAI_API_KEY_ENV]].filter(
-    (value): value is string => Boolean(value),
+  const secretValues = providerSecretValues(env);
+  const modelByProvider = new Map(
+    args.providers.map((provider) => [provider.name, provider.model(env)]),
   );
-  const modelByProvider = new Map([
-    ["Claude", env[ANTHROPIC_EVAL_MODEL_ENV] ?? DEFAULT_ANTHROPIC_MODEL],
-    ["OpenAI", env[OPENAI_EVAL_MODEL_ENV] ?? DEFAULT_OPENAI_MODEL],
-  ]);
 
   return {
     schemaVersion: 1,
-    issue: {
-      number: 250,
-      url: "https://github.com/backblaze-labs/b2-mcp/issues/250",
-      title: "evals: gated CI workflow + provider secrets + pass-rate artifact",
-    },
     generatedAt: (args.now ?? new Date()).toISOString(),
-    caseLimit: args.cases.length,
     caseCount: args.cases.length,
-    providers: args.comparison.passRates.map((rate) => ({
-      ...rate,
-      model: modelByProvider.get(rate.provider) ?? "unknown",
-    })),
+    providers: args.comparison.passRates.map((rate) => {
+      const model = modelByProvider.get(rate.provider);
+      if (!model) {
+        throw new Error(`Missing provider model metadata for ${rate.provider}.`);
+      }
+      return { ...rate, model };
+    }),
     summary: args.comparison.summary,
     results: args.comparison.results.map((result) =>
       sanitizeProviderCaseResult(result, secretValues),
@@ -143,7 +126,7 @@ function sanitizeProviderCaseResult(
   if (result.status === "failed") {
     return {
       ...base,
-      failure: sanitizeProviderErrorMessage(result.failure, secretValues),
+      failure: "Case failed validation; raw model and tool payloads omitted.",
     };
   }
   if (result.status === "errored") {

--- a/evals/provider-pass-rate-report.ts
+++ b/evals/provider-pass-rate-report.ts
@@ -1,0 +1,156 @@
+import { mkdirSync, writeFileSync } from "fs";
+import { dirname } from "path";
+import {
+  ANTHROPIC_API_KEY_ENV,
+  ANTHROPIC_EVAL_MODEL_ENV,
+  DEFAULT_ANTHROPIC_MODEL,
+} from "./anthropic-driver";
+import type { EvalCase } from "./cases";
+import { DEFAULT_OPENAI_MODEL, OPENAI_API_KEY_ENV, OPENAI_EVAL_MODEL_ENV } from "./openai-driver";
+import type {
+  EvalProvider,
+  ProviderCaseResult,
+  ProviderPassRateComparison,
+} from "./provider-comparison";
+import { sanitizeProviderErrorMessage } from "./provider-utils";
+
+export const PROVIDER_COMPARISON_CASE_LIMIT_ENV = "LLM_EVAL_CASE_LIMIT";
+export const PROVIDER_COMPARISON_CASE_SET_ENV = "LLM_EVAL_CASE_SET";
+export const PROVIDER_PASS_RATE_REPORT_ENV = "LLM_EVAL_PASS_RATE_REPORT";
+
+export interface ProviderPassRateReport {
+  readonly schemaVersion: 1;
+  readonly issue: {
+    readonly number: 250;
+    readonly url: "https://github.com/backblaze-labs/b2-mcp/issues/250";
+    readonly title: "evals: gated CI workflow + provider secrets + pass-rate artifact";
+  };
+  readonly generatedAt: string;
+  readonly caseLimit: number;
+  readonly caseCount: number;
+  readonly providers: readonly {
+    readonly provider: string;
+    readonly model: string;
+    readonly passed: number;
+    readonly total: number;
+    readonly passRate: number;
+  }[];
+  readonly summary: string;
+  readonly results: readonly SanitizedProviderCaseResult[];
+  readonly sensitivity: {
+    readonly secretSafe: true;
+    readonly omitted: readonly string[];
+  };
+}
+
+type SanitizedProviderCaseResult = Pick<
+  ProviderCaseResult,
+  "provider" | "caseName" | "status" | "passed"
+> & {
+  readonly failure?: string;
+  readonly error?: string;
+};
+
+export function selectBoundedProviderComparisonCases(
+  cases: readonly EvalCase[],
+  env: NodeJS.ProcessEnv = process.env,
+): readonly EvalCase[] {
+  const rawLimit = env[PROVIDER_COMPARISON_CASE_LIMIT_ENV];
+  if (!rawLimit) return cases;
+
+  const limit = Number(rawLimit);
+  if (!Number.isInteger(limit) || limit < 1) {
+    throw new Error(`${PROVIDER_COMPARISON_CASE_LIMIT_ENV} must be a positive integer.`);
+  }
+  return cases.slice(0, Math.min(limit, cases.length));
+}
+
+export function selectProviderComparisonCases(
+  caseSets: Readonly<Record<string, readonly EvalCase[]>>,
+  env: NodeJS.ProcessEnv = process.env,
+): readonly EvalCase[] {
+  const caseSet = env[PROVIDER_COMPARISON_CASE_SET_ENV] ?? "full";
+  const cases = caseSets[caseSet];
+  if (!cases) {
+    throw new Error(
+      `${PROVIDER_COMPARISON_CASE_SET_ENV} must be one of: ${Object.keys(caseSets).join(", ")}.`,
+    );
+  }
+  return selectBoundedProviderComparisonCases(cases, env);
+}
+
+export function createProviderPassRateReport(args: {
+  comparison: ProviderPassRateComparison;
+  cases: readonly EvalCase[];
+  providers: readonly EvalProvider[];
+  env?: NodeJS.ProcessEnv;
+  now?: Date;
+}): ProviderPassRateReport {
+  const env = args.env ?? process.env;
+  const secretValues = [env[ANTHROPIC_API_KEY_ENV], env[OPENAI_API_KEY_ENV]].filter(
+    (value): value is string => Boolean(value),
+  );
+  const modelByProvider = new Map([
+    ["Claude", env[ANTHROPIC_EVAL_MODEL_ENV] ?? DEFAULT_ANTHROPIC_MODEL],
+    ["OpenAI", env[OPENAI_EVAL_MODEL_ENV] ?? DEFAULT_OPENAI_MODEL],
+  ]);
+
+  return {
+    schemaVersion: 1,
+    issue: {
+      number: 250,
+      url: "https://github.com/backblaze-labs/b2-mcp/issues/250",
+      title: "evals: gated CI workflow + provider secrets + pass-rate artifact",
+    },
+    generatedAt: (args.now ?? new Date()).toISOString(),
+    caseLimit: args.cases.length,
+    caseCount: args.cases.length,
+    providers: args.comparison.passRates.map((rate) => ({
+      ...rate,
+      model: modelByProvider.get(rate.provider) ?? "unknown",
+    })),
+    summary: args.comparison.summary,
+    results: args.comparison.results.map((result) =>
+      sanitizeProviderCaseResult(result, secretValues),
+    ),
+    sensitivity: {
+      secretSafe: true,
+      omitted: [
+        "provider API keys",
+        "raw model responses",
+        "tool result payloads",
+        "B2 marker credential values",
+      ],
+    },
+  };
+}
+
+export function writeProviderPassRateReport(path: string, report: ProviderPassRateReport): void {
+  mkdirSync(dirname(path), { recursive: true });
+  writeFileSync(path, `${JSON.stringify(report, null, 2)}\n`, "utf8");
+}
+
+function sanitizeProviderCaseResult(
+  result: ProviderCaseResult,
+  secretValues: readonly string[],
+): SanitizedProviderCaseResult {
+  const base = {
+    provider: result.provider,
+    caseName: result.caseName,
+    status: result.status,
+    passed: result.passed,
+  };
+  if (result.status === "failed") {
+    return {
+      ...base,
+      failure: sanitizeProviderErrorMessage(result.failure, secretValues),
+    };
+  }
+  if (result.status === "errored") {
+    return {
+      ...base,
+      error: sanitizeProviderErrorMessage(result.error, secretValues),
+    };
+  }
+  return base;
+}

--- a/evals/provider-pass-rate-report.ts
+++ b/evals/provider-pass-rate-report.ts
@@ -6,8 +6,6 @@ import type {
   ProviderCaseResult,
   ProviderPassRateComparison,
 } from "./provider-comparison";
-import { providerSecretValues } from "./provider-secrets";
-import { sanitizeProviderErrorMessage } from "./provider-utils";
 
 export const PROVIDER_COMPARISON_CASE_LIMIT_ENV = "LLM_EVAL_CASE_LIMIT";
 export const PROVIDER_COMPARISON_CASE_SET_ENV = "LLM_EVAL_CASE_SET";
@@ -76,7 +74,6 @@ export function createProviderPassRateReport(args: {
   now?: Date;
 }): ProviderPassRateReport {
   const env = args.env ?? process.env;
-  const secretValues = providerSecretValues(env);
   const modelByProvider = new Map(
     args.providers.map((provider) => [provider.name, provider.model(env)]),
   );
@@ -93,9 +90,7 @@ export function createProviderPassRateReport(args: {
       return { ...rate, model };
     }),
     summary: args.comparison.summary,
-    results: args.comparison.results.map((result) =>
-      sanitizeProviderCaseResult(result, secretValues),
-    ),
+    results: args.comparison.results.map((result) => sanitizeProviderCaseResult(result)),
     sensitivity: {
       secretSafe: true,
       omitted: [
@@ -113,10 +108,7 @@ export function writeProviderPassRateReport(path: string, report: ProviderPassRa
   writeFileSync(path, `${JSON.stringify(report, null, 2)}\n`, "utf8");
 }
 
-function sanitizeProviderCaseResult(
-  result: ProviderCaseResult,
-  secretValues: readonly string[],
-): SanitizedProviderCaseResult {
+function sanitizeProviderCaseResult(result: ProviderCaseResult): SanitizedProviderCaseResult {
   const base = {
     provider: result.provider,
     caseName: result.caseName,
@@ -132,7 +124,7 @@ function sanitizeProviderCaseResult(
   if (result.status === "errored") {
     return {
       ...base,
-      error: sanitizeProviderErrorMessage(result.error, secretValues),
+      error: "Case errored during evaluation; raw model and tool payloads omitted.",
     };
   }
   return base;

--- a/evals/provider-secrets.ts
+++ b/evals/provider-secrets.ts
@@ -1,0 +1,10 @@
+import { ANTHROPIC_API_KEY_ENV } from "./anthropic-driver";
+import { OPENAI_API_KEY_ENV } from "./openai-driver";
+
+export const PROVIDER_SECRET_ENV_NAMES = [ANTHROPIC_API_KEY_ENV, OPENAI_API_KEY_ENV] as const;
+
+export function providerSecretValues(env: NodeJS.ProcessEnv = process.env): string[] {
+  return PROVIDER_SECRET_ENV_NAMES.map((name) => env[name]).filter((value): value is string =>
+    Boolean(value),
+  );
+}

--- a/evals/run-provider-comparison.ts
+++ b/evals/run-provider-comparison.ts
@@ -1,10 +1,10 @@
 import { CI_PROVIDER_COMPARISON_EVAL_CASES, FULL_PROFILE_EVAL_CASES } from "./cases";
 import {
   CLAUDE_OPENAI_PROVIDERS,
-  assertProviderPassRateComparison,
   claudeOpenAIComparisonEvalGate,
   runProviderPassRateComparison,
 } from "./provider-comparison";
+import { assertProviderPassRateComparisonForCli } from "./provider-comparison-cli";
 import {
   PROVIDER_PASS_RATE_REPORT_ENV,
   createProviderPassRateReport,
@@ -37,7 +37,7 @@ async function main(): Promise<void> {
   );
 
   console.info(comparison.summary);
-  assertProviderPassRateComparison(comparison);
+  assertProviderPassRateComparisonForCli(comparison);
 }
 
 main().catch((err) => {

--- a/evals/run-provider-comparison.ts
+++ b/evals/run-provider-comparison.ts
@@ -1,0 +1,46 @@
+import { CI_PROVIDER_COMPARISON_EVAL_CASES, FULL_PROFILE_EVAL_CASES } from "./cases";
+import {
+  CLAUDE_OPENAI_PROVIDERS,
+  assertProviderPassRateComparison,
+  claudeOpenAIComparisonEvalGate,
+  runProviderPassRateComparison,
+} from "./provider-comparison";
+import {
+  PROVIDER_PASS_RATE_REPORT_ENV,
+  createProviderPassRateReport,
+  selectProviderComparisonCases,
+  writeProviderPassRateReport,
+} from "./provider-pass-rate-report";
+
+async function main(): Promise<void> {
+  const comparisonGate = claudeOpenAIComparisonEvalGate();
+  if (!comparisonGate.enabled) {
+    throw new Error(`Claude vs OpenAI comparison gate disabled: ${comparisonGate.reason}`);
+  }
+
+  const cases = selectProviderComparisonCases({
+    full: FULL_PROFILE_EVAL_CASES,
+    "ci-no-b2": CI_PROVIDER_COMPARISON_EVAL_CASES,
+  });
+  const comparison = await runProviderPassRateComparison({
+    cases,
+    providers: CLAUDE_OPENAI_PROVIDERS,
+  });
+  const report = createProviderPassRateReport({
+    comparison,
+    cases,
+    providers: CLAUDE_OPENAI_PROVIDERS,
+  });
+  writeProviderPassRateReport(
+    process.env[PROVIDER_PASS_RATE_REPORT_ENV] ?? "reports/evals/provider-pass-rates.json",
+    report,
+  );
+
+  console.info(comparison.summary);
+  assertProviderPassRateComparison(comparison);
+}
+
+main().catch((err) => {
+  console.error(err instanceof Error ? err.message : String(err));
+  process.exitCode = 1;
+});

--- a/package.json
+++ b/package.json
@@ -54,6 +54,7 @@
     "test:live:b2": "pnpm run test:live:b2-contract && pnpm run test:live:b2-integration",
     "test:package": "pnpm run build && node scripts/run-vitest-layer.mjs package",
     "evals": "pnpm run build && vitest run --config evals/vitest.config.mts",
+    "evals:provider-comparison": "tsx evals/run-provider-comparison.ts",
     "verify": "pnpm run typecheck && pnpm run build && pnpm run check:doc-examples && pnpm run check:deployment-contracts && pnpm run lint && pnpm run lint:docs && pnpm run lint:links && pnpm run validate:skills && pnpm run format:check && pnpm run spell && pnpm run test:runtime-security && pnpm run test:diagnostics",
     "test:cross-platform": "node scripts/run-cross-platform-tests.mjs",
     "smoke": "node scripts/smoke-test.mjs",

--- a/scripts/eval-pass-rate-report.mjs
+++ b/scripts/eval-pass-rate-report.mjs
@@ -1,0 +1,167 @@
+import { readFileSync } from "node:fs";
+import { pathToFileURL } from "node:url";
+
+const PROVIDER_SECRET_ENV_NAMES = ["ANTHROPIC_API_KEY", "OPENAI_API_KEY"];
+const RAW_PAYLOAD_KEYS = new Set(["run", "toolCalls", "toolResults", "text"]);
+const RESULT_STATUSES = new Set(["passed", "failed", "errored"]);
+
+function fail(message) {
+  throw new Error(message);
+}
+
+function isRecord(value) {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function assertString(value, path) {
+  if (typeof value !== "string" || value.length === 0) fail(`${path} must be a non-empty string`);
+}
+
+function assertNonNegativeInteger(value, path) {
+  if (!Number.isInteger(value) || value < 0) fail(`${path} must be a non-negative integer`);
+}
+
+function assertPassRate(value, path) {
+  if (!Number.isFinite(value) || value < 0 || value > 1) {
+    fail(`${path} must be a finite number between 0 and 1`);
+  }
+}
+
+function findRawPayloadField(value, path = "$") {
+  if (Array.isArray(value)) {
+    for (let index = 0; index < value.length; index += 1) {
+      const found = findRawPayloadField(value[index], `${path}[${index}]`);
+      if (found) return found;
+    }
+    return null;
+  }
+  if (!isRecord(value)) return null;
+
+  for (const [key, child] of Object.entries(value)) {
+    const childPath = `${path}.${key}`;
+    if (RAW_PAYLOAD_KEYS.has(key)) return childPath;
+    const found = findRawPayloadField(child, childPath);
+    if (found) return found;
+  }
+  return null;
+}
+
+export function readReportFile(path) {
+  const raw = readFileSync(path, "utf8");
+  return { raw, report: JSON.parse(raw) };
+}
+
+export function providerSecretValuesFromEnv(env = process.env) {
+  return PROVIDER_SECRET_ENV_NAMES.map((name) => env[name]).filter(Boolean);
+}
+
+export function assertNoProviderSecrets(raw, secretValues) {
+  for (const secret of [...new Set(secretValues.filter(Boolean))]) {
+    if (raw.includes(secret)) fail("pass-rate report contains a provider secret value");
+  }
+}
+
+export function validateProviderPassRateReport(report) {
+  if (!isRecord(report)) fail("report must be an object");
+  if (report.schemaVersion !== 1) fail("report.schemaVersion must be 1");
+  assertString(report.generatedAt, "report.generatedAt");
+  assertNonNegativeInteger(report.caseCount, "report.caseCount");
+  assertString(report.summary, "report.summary");
+
+  if (!Array.isArray(report.providers) || report.providers.length === 0) {
+    fail("report.providers must be a non-empty array");
+  }
+  for (const [index, provider] of report.providers.entries()) {
+    const path = `report.providers[${index}]`;
+    if (!isRecord(provider)) fail(`${path} must be an object`);
+    assertString(provider.provider, `${path}.provider`);
+    assertString(provider.model, `${path}.model`);
+    assertNonNegativeInteger(provider.passed, `${path}.passed`);
+    assertNonNegativeInteger(provider.total, `${path}.total`);
+    if (provider.passed > provider.total) fail(`${path}.passed must not exceed total`);
+    assertPassRate(provider.passRate, `${path}.passRate`);
+  }
+
+  if (!Array.isArray(report.results)) fail("report.results must be an array");
+  for (const [index, result] of report.results.entries()) {
+    const path = `report.results[${index}]`;
+    if (!isRecord(result)) fail(`${path} must be an object`);
+    assertString(result.provider, `${path}.provider`);
+    assertString(result.caseName, `${path}.caseName`);
+    if (!RESULT_STATUSES.has(result.status)) fail(`${path}.status is invalid`);
+    if (typeof result.passed !== "boolean") fail(`${path}.passed must be boolean`);
+    if (result.status === "failed" && typeof result.failure !== "string") {
+      fail(`${path}.failure must be present for failed results`);
+    }
+    if (result.status === "errored" && typeof result.error !== "string") {
+      fail(`${path}.error must be present for errored results`);
+    }
+  }
+
+  if (!isRecord(report.sensitivity)) fail("report.sensitivity must be an object");
+  if (report.sensitivity.secretSafe !== true) fail("report.sensitivity.secretSafe must be true");
+  if (
+    !Array.isArray(report.sensitivity.omitted) ||
+    report.sensitivity.omitted.length === 0 ||
+    !report.sensitivity.omitted.every((value) => typeof value === "string" && value.length > 0)
+  ) {
+    fail("report.sensitivity.omitted must be a non-empty string array");
+  }
+
+  const rawField = findRawPayloadField(report);
+  if (rawField) fail(`pass-rate report includes raw payload field ${rawField}`);
+  return report;
+}
+
+export function validateReportFile(path, options = {}) {
+  const { raw, report } = readReportFile(path);
+  assertNoProviderSecrets(raw, options.secretValues ?? []);
+  return validateProviderPassRateReport(report);
+}
+
+export function renderPassRateSummaryMarkdown(report) {
+  validateProviderPassRateReport(report);
+  const lines = [
+    "## Claude vs OpenAI pass rates",
+    "",
+    report.summary,
+    "",
+    "| Provider | Model | Passed | Total | Pass rate |",
+    "| --- | --- | ---: | ---: | ---: |",
+    ...report.providers.map((provider) => {
+      const pct = `${(provider.passRate * 100).toFixed(1)}%`;
+      return `| ${provider.provider} | ${provider.model} | ${provider.passed} | ${provider.total} | ${pct} |`;
+    }),
+    "",
+  ];
+  return lines.join("\n");
+}
+
+function usage() {
+  return "Usage: node scripts/eval-pass-rate-report.mjs <validate|summary> <report.json>";
+}
+
+function main(argv = process.argv.slice(2)) {
+  const [command, path] = argv;
+  if (!command || !path) fail(usage());
+
+  if (command === "validate") {
+    validateReportFile(path, { secretValues: providerSecretValuesFromEnv() });
+    return;
+  }
+  if (command === "summary") {
+    const { report } = readReportFile(path);
+    process.stdout.write(renderPassRateSummaryMarkdown(report));
+    return;
+  }
+  fail(usage());
+}
+
+if (import.meta.url === pathToFileURL(process.argv[1]).href) {
+  try {
+    main();
+  } catch (err) {
+    console.error(err instanceof Error ? err.message : String(err));
+    process.exitCode = 1;
+  }
+}

--- a/scripts/eval-pass-rate-report.mjs
+++ b/scripts/eval-pass-rate-report.mjs
@@ -2,8 +2,10 @@ import { readFileSync } from "node:fs";
 import { pathToFileURL } from "node:url";
 
 const PROVIDER_SECRET_ENV_NAMES = ["ANTHROPIC_API_KEY", "OPENAI_API_KEY"];
+const EXPECTED_PROVIDER_NAMES = ["Claude", "OpenAI"];
 const RAW_PAYLOAD_KEYS = new Set(["run", "toolCalls", "toolResults", "text"]);
 const RESULT_STATUSES = new Set(["passed", "failed", "errored"]);
+const PASS_RATE_TOLERANCE = 1e-12;
 
 function fail(message) {
   throw new Error(message);
@@ -68,33 +70,65 @@ export function validateProviderPassRateReport(report) {
   assertNonNegativeInteger(report.caseCount, "report.caseCount");
   assertString(report.summary, "report.summary");
 
-  if (!Array.isArray(report.providers) || report.providers.length === 0) {
-    fail("report.providers must be a non-empty array");
+  if (!Array.isArray(report.providers)) {
+    fail("report.providers must be an array");
   }
+  if (report.providers.length !== EXPECTED_PROVIDER_NAMES.length) {
+    fail("report.providers must contain exactly one Claude and one OpenAI entry");
+  }
+  const providerCounts = new Map(EXPECTED_PROVIDER_NAMES.map((provider) => [provider, 0]));
   for (const [index, provider] of report.providers.entries()) {
     const path = `report.providers[${index}]`;
     if (!isRecord(provider)) fail(`${path} must be an object`);
     assertString(provider.provider, `${path}.provider`);
+    if (!providerCounts.has(provider.provider)) {
+      fail(`${path}.provider must be Claude or OpenAI`);
+    }
+    providerCounts.set(provider.provider, providerCounts.get(provider.provider) + 1);
     assertString(provider.model, `${path}.model`);
     assertNonNegativeInteger(provider.passed, `${path}.passed`);
     assertNonNegativeInteger(provider.total, `${path}.total`);
     if (provider.passed > provider.total) fail(`${path}.passed must not exceed total`);
+    if (provider.total !== report.caseCount) fail(`${path}.total must equal report.caseCount`);
     assertPassRate(provider.passRate, `${path}.passRate`);
+    const expectedPassRate = provider.total === 0 ? 0 : provider.passed / provider.total;
+    if (Math.abs(provider.passRate - expectedPassRate) > PASS_RATE_TOLERANCE) {
+      fail(`${path}.passRate must equal passed / total`);
+    }
+  }
+  for (const [provider, count] of providerCounts) {
+    if (count !== 1) fail(`report.providers must contain exactly one ${provider} entry`);
   }
 
   if (!Array.isArray(report.results)) fail("report.results must be an array");
+  const resultCountsByProvider = new Map(
+    EXPECTED_PROVIDER_NAMES.map((provider) => [provider, { passed: 0, total: 0 }]),
+  );
   for (const [index, result] of report.results.entries()) {
     const path = `report.results[${index}]`;
     if (!isRecord(result)) fail(`${path} must be an object`);
     assertString(result.provider, `${path}.provider`);
+    const providerResultCounts = resultCountsByProvider.get(result.provider);
+    if (!providerResultCounts) fail(`${path}.provider must be Claude or OpenAI`);
     assertString(result.caseName, `${path}.caseName`);
     if (!RESULT_STATUSES.has(result.status)) fail(`${path}.status is invalid`);
     if (typeof result.passed !== "boolean") fail(`${path}.passed must be boolean`);
+    providerResultCounts.total += 1;
+    if (result.passed) providerResultCounts.passed += 1;
     if (result.status === "failed" && typeof result.failure !== "string") {
       fail(`${path}.failure must be present for failed results`);
     }
     if (result.status === "errored" && typeof result.error !== "string") {
       fail(`${path}.error must be present for errored results`);
+    }
+  }
+  for (const provider of report.providers) {
+    const resultCounts = resultCountsByProvider.get(provider.provider);
+    if (resultCounts.total !== provider.total) {
+      fail(`report.results total for ${provider.provider} must equal provider.total`);
+    }
+    if (resultCounts.passed !== provider.passed) {
+      fail(`report.results passed count for ${provider.provider} must equal provider.passed`);
     }
   }
 

--- a/scripts/eval-pass-rate-report.mjs
+++ b/scripts/eval-pass-rate-report.mjs
@@ -3,9 +3,26 @@ import { pathToFileURL } from "node:url";
 
 const PROVIDER_SECRET_ENV_NAMES = ["ANTHROPIC_API_KEY", "OPENAI_API_KEY"];
 const EXPECTED_PROVIDER_NAMES = ["Claude", "OpenAI"];
-const RAW_PAYLOAD_KEYS = new Set(["run", "toolCalls", "toolResults", "text"]);
 const RESULT_STATUSES = new Set(["passed", "failed", "errored"]);
 const PASS_RATE_TOLERANCE = 1e-12;
+const REPORT_KEYS = new Set([
+  "schemaVersion",
+  "generatedAt",
+  "caseCount",
+  "providers",
+  "summary",
+  "results",
+  "sensitivity",
+]);
+const PROVIDER_KEYS = new Set(["provider", "model", "passed", "total", "passRate"]);
+const FAILED_RESULT_FAILURE = "Case failed validation; raw model and tool payloads omitted.";
+const ERRORED_RESULT_ERROR = "Case errored during evaluation; raw model and tool payloads omitted.";
+const RESULT_KEYS_BY_STATUS = {
+  passed: new Set(["provider", "caseName", "status", "passed"]),
+  failed: new Set(["provider", "caseName", "status", "passed", "failure"]),
+  errored: new Set(["provider", "caseName", "status", "passed", "error"]),
+};
+const SENSITIVITY_KEYS = new Set(["secretSafe", "omitted"]);
 
 function fail(message) {
   throw new Error(message);
@@ -29,23 +46,10 @@ function assertPassRate(value, path) {
   }
 }
 
-function findRawPayloadField(value, path = "$") {
-  if (Array.isArray(value)) {
-    for (let index = 0; index < value.length; index += 1) {
-      const found = findRawPayloadField(value[index], `${path}[${index}]`);
-      if (found) return found;
-    }
-    return null;
+function assertAllowedKeys(value, allowedKeys, path) {
+  for (const key of Object.keys(value)) {
+    if (!allowedKeys.has(key)) fail(`${path}.${key} is not allowed`);
   }
-  if (!isRecord(value)) return null;
-
-  for (const [key, child] of Object.entries(value)) {
-    const childPath = `${path}.${key}`;
-    if (RAW_PAYLOAD_KEYS.has(key)) return childPath;
-    const found = findRawPayloadField(child, childPath);
-    if (found) return found;
-  }
-  return null;
 }
 
 export function readReportFile(path) {
@@ -65,6 +69,7 @@ export function assertNoProviderSecrets(raw, secretValues) {
 
 export function validateProviderPassRateReport(report) {
   if (!isRecord(report)) fail("report must be an object");
+  assertAllowedKeys(report, REPORT_KEYS, "report");
   if (report.schemaVersion !== 1) fail("report.schemaVersion must be 1");
   assertString(report.generatedAt, "report.generatedAt");
   assertNonNegativeInteger(report.caseCount, "report.caseCount");
@@ -80,6 +85,7 @@ export function validateProviderPassRateReport(report) {
   for (const [index, provider] of report.providers.entries()) {
     const path = `report.providers[${index}]`;
     if (!isRecord(provider)) fail(`${path} must be an object`);
+    assertAllowedKeys(provider, PROVIDER_KEYS, path);
     assertString(provider.provider, `${path}.provider`);
     if (!providerCounts.has(provider.provider)) {
       fail(`${path}.provider must be Claude or OpenAI`);
@@ -112,14 +118,24 @@ export function validateProviderPassRateReport(report) {
     if (!providerResultCounts) fail(`${path}.provider must be Claude or OpenAI`);
     assertString(result.caseName, `${path}.caseName`);
     if (!RESULT_STATUSES.has(result.status)) fail(`${path}.status is invalid`);
+    assertAllowedKeys(result, RESULT_KEYS_BY_STATUS[result.status], path);
     if (typeof result.passed !== "boolean") fail(`${path}.passed must be boolean`);
+    if (result.passed !== (result.status === "passed")) {
+      fail(`${path}.passed must equal whether status is passed`);
+    }
     providerResultCounts.total += 1;
     if (result.passed) providerResultCounts.passed += 1;
     if (result.status === "failed" && typeof result.failure !== "string") {
       fail(`${path}.failure must be present for failed results`);
     }
+    if (result.status === "failed" && result.failure !== FAILED_RESULT_FAILURE) {
+      fail(`${path}.failure must be the bounded failed diagnostic`);
+    }
     if (result.status === "errored" && typeof result.error !== "string") {
       fail(`${path}.error must be present for errored results`);
+    }
+    if (result.status === "errored" && result.error !== ERRORED_RESULT_ERROR) {
+      fail(`${path}.error must be the bounded errored diagnostic`);
     }
   }
   for (const provider of report.providers) {
@@ -133,6 +149,7 @@ export function validateProviderPassRateReport(report) {
   }
 
   if (!isRecord(report.sensitivity)) fail("report.sensitivity must be an object");
+  assertAllowedKeys(report.sensitivity, SENSITIVITY_KEYS, "report.sensitivity");
   if (report.sensitivity.secretSafe !== true) fail("report.sensitivity.secretSafe must be true");
   if (
     !Array.isArray(report.sensitivity.omitted) ||
@@ -141,9 +158,6 @@ export function validateProviderPassRateReport(report) {
   ) {
     fail("report.sensitivity.omitted must be a non-empty string array");
   }
-
-  const rawField = findRawPayloadField(report);
-  if (rawField) fail(`pass-rate report includes raw payload field ${rawField}`);
   return report;
 }
 

--- a/tests/contract/ci-workflow-policy.contract.test.ts
+++ b/tests/contract/ci-workflow-policy.contract.test.ts
@@ -66,6 +66,14 @@ const topLevelMappingEntry = (key: string, childKey: string, value: string) =>
     "m",
   );
 
+function workflowStepBlock(text: string, stepName: string): string {
+  const marker = `- name: ${stepName}`;
+  const start = text.indexOf(marker);
+  if (start === -1) return "";
+  const next = text.indexOf("\n      - name:", start + marker.length);
+  return text.slice(start, next === -1 ? undefined : next);
+}
+
 describe("CI workflow policy", () => {
   const ci = readFileSync(join(root, ".github/workflows/test.yml"), "utf8");
   const evals = readFileSync(join(root, ".github/workflows/evals.yml"), "utf8");
@@ -399,6 +407,7 @@ describe("CI workflow policy", () => {
     expect(guard).toContain("if: github.repository == 'backblaze-labs/b2-mcp'");
     expect(guard).toContain("checkout-sha: ${{ steps.ref.outputs.checkout_sha }}");
     expect(guard).toContain("skip-reason: ${{ steps.ref.outputs.skip_reason }}");
+    expect(guard).toContain("timeout-minutes: 5");
     expect(guard).toContain("workflow_dispatch|schedule");
     expect(guard).toContain('[[ "$GITHUB_REF" != "refs/heads/main" ]]');
     expect(guard).toContain("ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}");
@@ -410,6 +419,9 @@ describe("CI workflow policy", () => {
 
     expect(skipped).toContain("needs.guard.outputs.should-run != 'true'");
     expect(skipped).toContain("LLM evals skipped");
+    expect(skipped).toContain("SKIP_REASON: ${{ needs.guard.outputs.skip-reason }}");
+    expect(skipped).toContain('echo "LLM evals skipped: ${SKIP_REASON}"');
+    expect(skipped).not.toContain("LLM evals skipped: ${{");
     expect(evalJob).toContain("needs.guard.outputs.should-run == 'true'");
     expect(evalJob).toContain("ref: ${{ needs.guard.outputs.checkout-sha }}");
     expect(evalJob).toContain("persist-credentials: false");
@@ -417,29 +429,54 @@ describe("CI workflow policy", () => {
 
   it("uploads bounded Claude-vs-OpenAI pass-rate artifacts without B2 secrets", () => {
     const evalJob = workflowJobBlock(evals, "evals") ?? "";
+    const run = workflowStepBlock(evals, "Run Claude vs OpenAI eval comparison");
+    const validate = workflowStepBlock(evals, "Validate pass-rate report");
+    const summary = workflowStepBlock(evals, "Publish pass-rate summary");
+    const upload = workflowStepBlock(evals, "Upload Claude vs OpenAI pass-rate report");
+    const requireSuccess = workflowStepBlock(evals, "Require eval comparison success");
     const secretRefs = [...evals.matchAll(/secrets\.([A-Z0-9_]+)/g)].map((match) => match[1]);
 
     expect([...new Set(secretRefs)].sort()).toEqual(["ANTHROPIC_API_KEY", "OPENAI_API_KEY"]);
+    expect(packageJson.scripts?.["evals:provider-comparison"]).toBe(
+      "tsx evals/run-provider-comparison.ts",
+    );
     expect(evalJob).not.toContain("LIVE_B2_");
     expect(evalJob).not.toContain("B2_APPLICATION_KEY");
     expect(evalJob).not.toContain("B2_MASTER_KEY");
-    expect(evalJob).toContain('RUN_LLM_EVALS: "1"');
-    expect(evalJob).toContain('RUN_LLM_PROVIDER_COMPARISON: "1"');
-    expect(evalJob).toContain("ANTHROPIC_EVAL_MODEL: claude-haiku-4-5-20251001");
-    expect(evalJob).toContain("OPENAI_EVAL_MODEL: gpt-5-nano");
-    expect(evalJob).toContain("LLM_EVAL_CASE_SET: ci-no-b2");
-    expect(evalJob).toContain('LLM_EVAL_CASE_LIMIT: "5"');
-    expect(evalJob).toContain('LLM_EVAL_BLOCK_SERVER_NETWORK: "1"');
-    expect(evalJob).toContain("LLM_EVAL_PASS_RATE_REPORT: reports/evals/provider-pass-rates.json");
-    expect(evalJob).toContain("evals/provider-comparison.eval.test.ts");
-    expect(evalJob).toContain(
-      '--testNamePattern "runs shared cases and emits a pass-rate comparison"',
+    expect(run).toContain("id: run_evals");
+    expect(run).toContain("continue-on-error: true");
+    expect(run).toContain('RUN_LLM_EVALS: "1"');
+    expect(run).toContain('RUN_LLM_PROVIDER_COMPARISON: "1"');
+    expect(run).toContain("ANTHROPIC_EVAL_MODEL: claude-haiku-4-5-20251001");
+    expect(run).toContain("OPENAI_EVAL_MODEL: gpt-5-nano");
+    expect(run).toContain("LLM_EVAL_CASE_SET: ci-no-b2");
+    expect(run).toContain('LLM_EVAL_CASE_LIMIT: "5"');
+    expect(run).toContain('LLM_EVAL_BLOCK_SERVER_NETWORK: "1"');
+    expect(run).toContain("LLM_EVAL_PASS_RATE_REPORT: reports/evals/provider-pass-rates.json");
+    expect(run).toContain("pnpm run evals:provider-comparison");
+    expect(evalJob).not.toContain("evals/provider-comparison.eval.test.ts");
+    expect(evalJob).not.toContain("--testNamePattern");
+    expect(evalJob).not.toMatch(/^\s+pnpm run evals\s*$/m);
+    expect(evalJob).not.toContain("node - <<");
+
+    expect(validate).toContain("id: validate_report");
+    expect(validate).toContain("if: always()");
+    expect(validate).toContain("ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}");
+    expect(validate).toContain("OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}");
+    expect(validate).toContain(
+      "node scripts/eval-pass-rate-report.mjs validate reports/evals/provider-pass-rates.json",
     );
-    expect(evalJob).not.toContain("pnpm run evals");
+    expect(summary).toContain("steps.validate_report.outcome == 'success'");
+    expect(summary).toContain(
+      'node scripts/eval-pass-rate-report.mjs summary reports/evals/provider-pass-rates.json >> "$GITHUB_STEP_SUMMARY"',
+    );
     expect(evalJob).toContain("Claude vs OpenAI pass rates");
-    expect(evalJob).toContain("claude-openai-pass-rate-report");
-    expect(evalJob).toContain("path: reports/evals/provider-pass-rates.json");
-    expect(evalJob).toContain("if-no-files-found: warn");
+    expect(upload).toContain("steps.validate_report.outcome == 'success'");
+    expect(upload).toContain("claude-openai-pass-rate-report");
+    expect(upload).toContain("path: reports/evals/provider-pass-rates.json");
+    expect(upload).toContain("if-no-files-found: error");
+    expect(requireSuccess).toContain("steps.run_evals.outcome != 'success'");
+    expect(requireSuccess).toContain("exit 1");
     expect(evalJob).not.toContain("path: reports/evals/**");
   });
 

--- a/tests/contract/ci-workflow-policy.contract.test.ts
+++ b/tests/contract/ci-workflow-policy.contract.test.ts
@@ -34,6 +34,7 @@ const workflowPaths = [
   ".github/workflows/test.yml",
   ".github/workflows/contract.yml",
   ".github/workflows/smoke.yml",
+  ".github/workflows/evals.yml",
   ".github/workflows/publish.yml",
 ];
 const requiredJobNames = [
@@ -56,8 +57,18 @@ const requiredJobNames = [
   "cross-platform minimum",
 ];
 
+const topLevelMappingEntry = (key: string, childKey: string, value: string) =>
+  new RegExp(
+    `^${key}:\\s*\\n(?:\\s*#.*\\n)*\\s+${childKey}:\\s*${value.replace(
+      /[.*+?^${}()|[\]\\]/g,
+      "\\$&",
+    )}\\s*$`,
+    "m",
+  );
+
 describe("CI workflow policy", () => {
   const ci = readFileSync(join(root, ".github/workflows/test.yml"), "utf8");
+  const evals = readFileSync(join(root, ".github/workflows/evals.yml"), "utf8");
   const publish = readFileSync(join(root, ".github/workflows/publish.yml"), "utf8");
   const qualityKeeper = readFileSync(join(root, ".github/workflows/quality-keeper.yml"), "utf8");
 
@@ -367,6 +378,69 @@ describe("CI workflow policy", () => {
     expect(crossPlatformJob).toContain("os: [ubuntu-latest, windows-latest, macos-latest]");
     expect(crossPlatformJob).toContain("node-version: 22.23.1");
     expect(crossPlatformJob).toContain("pnpm run test:cross-platform");
+  });
+
+  it("runs provider evals only from trusted scheduled or manual main refs", () => {
+    const guard = workflowJobBlock(evals, "guard") ?? "";
+    const skipped = workflowJobBlock(evals, "skipped") ?? "";
+    const evalJob = workflowJobBlock(evals, "evals") ?? "";
+
+    expect(evals).toMatch(topLevelMappingEntry("permissions", "contents", "read"));
+    expect(evals).toMatch(/^\s{2}workflow_dispatch:\s*$/m);
+    expect(evals).toMatch(/^\s{2}schedule:\s*$/m);
+    expect(evals).not.toMatch(/^\s{2}pull_request:\s*$/m);
+    expect(evals).not.toMatch(/^\s{2}push:\s*$/m);
+    expect(evals).toContain('cron: "37 10 * * 2"');
+    expect(evals).toContain(
+      "group: llm-evals-${{ github.repository }}-${{ github.ref_name || github.run_id }}",
+    );
+    expect(evals).toContain("cancel-in-progress: false");
+
+    expect(guard).toContain("if: github.repository == 'backblaze-labs/b2-mcp'");
+    expect(guard).toContain("checkout-sha: ${{ steps.ref.outputs.checkout_sha }}");
+    expect(guard).toContain("skip-reason: ${{ steps.ref.outputs.skip_reason }}");
+    expect(guard).toContain("workflow_dispatch|schedule");
+    expect(guard).toContain('[[ "$GITHUB_REF" != "refs/heads/main" ]]');
+    expect(guard).toContain("ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}");
+    expect(guard).toContain("OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}");
+    expect(guard).toContain("::add-mask::");
+    expect(guard).toContain("should_run=false");
+    expect(guard).toContain("missing provider secret(s)");
+    expect(guard).not.toContain("environment:");
+
+    expect(skipped).toContain("needs.guard.outputs.should-run != 'true'");
+    expect(skipped).toContain("LLM evals skipped");
+    expect(evalJob).toContain("needs.guard.outputs.should-run == 'true'");
+    expect(evalJob).toContain("ref: ${{ needs.guard.outputs.checkout-sha }}");
+    expect(evalJob).toContain("persist-credentials: false");
+  });
+
+  it("uploads bounded Claude-vs-OpenAI pass-rate artifacts without B2 secrets", () => {
+    const evalJob = workflowJobBlock(evals, "evals") ?? "";
+    const secretRefs = [...evals.matchAll(/secrets\.([A-Z0-9_]+)/g)].map((match) => match[1]);
+
+    expect([...new Set(secretRefs)].sort()).toEqual(["ANTHROPIC_API_KEY", "OPENAI_API_KEY"]);
+    expect(evalJob).not.toContain("LIVE_B2_");
+    expect(evalJob).not.toContain("B2_APPLICATION_KEY");
+    expect(evalJob).not.toContain("B2_MASTER_KEY");
+    expect(evalJob).toContain('RUN_LLM_EVALS: "1"');
+    expect(evalJob).toContain('RUN_LLM_PROVIDER_COMPARISON: "1"');
+    expect(evalJob).toContain("ANTHROPIC_EVAL_MODEL: claude-haiku-4-5-20251001");
+    expect(evalJob).toContain("OPENAI_EVAL_MODEL: gpt-5-nano");
+    expect(evalJob).toContain("LLM_EVAL_CASE_SET: ci-no-b2");
+    expect(evalJob).toContain('LLM_EVAL_CASE_LIMIT: "5"');
+    expect(evalJob).toContain('LLM_EVAL_BLOCK_SERVER_NETWORK: "1"');
+    expect(evalJob).toContain("LLM_EVAL_PASS_RATE_REPORT: reports/evals/provider-pass-rates.json");
+    expect(evalJob).toContain("evals/provider-comparison.eval.test.ts");
+    expect(evalJob).toContain(
+      '--testNamePattern "runs shared cases and emits a pass-rate comparison"',
+    );
+    expect(evalJob).not.toContain("pnpm run evals");
+    expect(evalJob).toContain("Claude vs OpenAI pass rates");
+    expect(evalJob).toContain("claude-openai-pass-rate-report");
+    expect(evalJob).toContain("path: reports/evals/provider-pass-rates.json");
+    expect(evalJob).toContain("if-no-files-found: warn");
+    expect(evalJob).not.toContain("path: reports/evals/**");
   });
 
   it("blocks publishing until the live contract suite passes for the publish ref", () => {

--- a/tests/unit/eval-pass-rate-report-script.unit.test.ts
+++ b/tests/unit/eval-pass-rate-report-script.unit.test.ts
@@ -74,13 +74,76 @@ describe("eval pass-rate report script", () => {
     expect(validation.stderr).not.toContain("sk-proj-secret123456789");
   });
 
+  it("requires exactly one Claude and one OpenAI provider", () => {
+    const path = tempReportPath();
+    writeFileSync(
+      path,
+      `${JSON.stringify(
+        report({
+          providers: [
+            { provider: "Other", model: "other-model", passed: 1, total: 1, passRate: 1 },
+          ],
+        }),
+      )}\n`,
+      "utf8",
+    );
+
+    const validation = runScript("validate", path);
+
+    expect(validation.status).not.toBe(0);
+    expect(validation.stderr).toContain("exactly one Claude and one OpenAI");
+  });
+
+  it("rejects provider rates that do not match case totals", () => {
+    const path = tempReportPath();
+    writeFileSync(
+      path,
+      `${JSON.stringify(
+        report({
+          providers: [
+            {
+              provider: "Claude",
+              model: "claude-haiku-4-5-20251001",
+              passed: 0,
+              total: 1,
+              passRate: 1,
+            },
+            { provider: "OpenAI", model: "gpt-5-nano", passed: 1, total: 2, passRate: 0.5 },
+          ],
+        }),
+      )}\n`,
+      "utf8",
+    );
+
+    const validation = runScript("validate", path);
+
+    expect(validation.status).not.toBe(0);
+    expect(validation.stderr).toMatch(/passRate must equal passed \/ total|total must equal/);
+  });
+
   it("rejects reports that include raw run payload fields", () => {
     const path = tempReportPath();
     writeFileSync(
       path,
       `${JSON.stringify(
         report({
+          providers: [
+            {
+              provider: "Claude",
+              model: "claude-haiku-4-5-20251001",
+              passed: 1,
+              total: 1,
+              passRate: 1,
+            },
+            { provider: "OpenAI", model: "gpt-5-nano", passed: 0, total: 1, passRate: 0 },
+          ],
           results: [
+            {
+              provider: "Claude",
+              caseName: "passed case",
+              status: "passed",
+              passed: true,
+            },
             {
               provider: "OpenAI",
               caseName: "failed case",

--- a/tests/unit/eval-pass-rate-report-script.unit.test.ts
+++ b/tests/unit/eval-pass-rate-report-script.unit.test.ts
@@ -1,0 +1,103 @@
+import { mkdtempSync, writeFileSync } from "fs";
+import { tmpdir } from "os";
+import { join } from "path";
+import { spawnSync } from "child_process";
+import { describe, expect, it } from "vitest";
+import { root } from "../contract/support";
+
+const script = join(root, "scripts/eval-pass-rate-report.mjs");
+
+function tempReportPath(): string {
+  return join(mkdtempSync(join(tmpdir(), "b2-mcp-eval-report-")), "report.json");
+}
+
+function report(overrides: Record<string, unknown> = {}): Record<string, unknown> {
+  return {
+    schemaVersion: 1,
+    generatedAt: "2026-08-24T00:00:00.000Z",
+    caseCount: 1,
+    providers: [
+      { provider: "Claude", model: "claude-haiku-4-5-20251001", passed: 1, total: 1, passRate: 1 },
+      { provider: "OpenAI", model: "gpt-5-nano", passed: 1, total: 1, passRate: 1 },
+    ],
+    summary:
+      "Pass-rate comparison (Claude vs OpenAI) across 1 shared case(s): " +
+      "Claude: 1/1 (100.0%); OpenAI: 1/1 (100.0%).",
+    results: [
+      { provider: "Claude", caseName: "blocked delete bucket", status: "passed", passed: true },
+      { provider: "OpenAI", caseName: "blocked delete bucket", status: "passed", passed: true },
+    ],
+    sensitivity: {
+      secretSafe: true,
+      omitted: ["provider API keys"],
+    },
+    ...overrides,
+  };
+}
+
+function runScript(command: string, path: string, env: NodeJS.ProcessEnv = {}) {
+  return spawnSync(process.execPath, [script, command, path], {
+    cwd: root,
+    env: { ...process.env, ...env },
+    encoding: "utf8",
+  });
+}
+
+describe("eval pass-rate report script", () => {
+  it("validates a schema-compatible report and renders the summary table", () => {
+    const path = tempReportPath();
+    writeFileSync(path, `${JSON.stringify(report())}\n`, "utf8");
+
+    const validation = runScript("validate", path);
+    const summary = runScript("summary", path);
+
+    expect(validation.status).toBe(0);
+    expect(summary.status).toBe(0);
+    expect(summary.stdout).toContain("## Claude vs OpenAI pass rates");
+    expect(summary.stdout).toContain("| OpenAI | gpt-5-nano | 1 | 1 | 100.0% |");
+  });
+
+  it("rejects reports containing exact provider secret values", () => {
+    const path = tempReportPath();
+    writeFileSync(
+      path,
+      `${JSON.stringify(report({ summary: "leaked sk-proj-secret123456789" }))}\n`,
+      "utf8",
+    );
+
+    const validation = runScript("validate", path, {
+      OPENAI_API_KEY: "sk-proj-secret123456789",
+    });
+
+    expect(validation.status).not.toBe(0);
+    expect(validation.stderr).toContain("provider secret value");
+    expect(validation.stderr).not.toContain("sk-proj-secret123456789");
+  });
+
+  it("rejects reports that include raw run payload fields", () => {
+    const path = tempReportPath();
+    writeFileSync(
+      path,
+      `${JSON.stringify(
+        report({
+          results: [
+            {
+              provider: "OpenAI",
+              caseName: "failed case",
+              status: "failed",
+              passed: false,
+              failure: "failed",
+              toolCalls: [{ name: "b2_list_buckets", args: {} }],
+            },
+          ],
+        }),
+      )}\n`,
+      "utf8",
+    );
+
+    const validation = runScript("validate", path);
+
+    expect(validation.status).not.toBe(0);
+    expect(validation.stderr).toContain("raw payload field");
+  });
+});

--- a/tests/unit/eval-pass-rate-report-script.unit.test.ts
+++ b/tests/unit/eval-pass-rate-report-script.unit.test.ts
@@ -121,7 +121,7 @@ describe("eval pass-rate report script", () => {
     expect(validation.stderr).toMatch(/passRate must equal passed \/ total|total must equal/);
   });
 
-  it("rejects reports that include raw run payload fields", () => {
+  it("rejects reports with unknown raw payload fields", () => {
     const path = tempReportPath();
     writeFileSync(
       path,
@@ -150,7 +150,7 @@ describe("eval pass-rate report script", () => {
               status: "failed",
               passed: false,
               failure: "failed",
-              toolCalls: [{ name: "b2_list_buckets", args: {} }],
+              response: { toolCalls: [{ name: "b2_list_buckets", args: {} }] },
             },
           ],
         }),
@@ -161,6 +161,79 @@ describe("eval pass-rate report script", () => {
     const validation = runScript("validate", path);
 
     expect(validation.status).not.toBe(0);
-    expect(validation.stderr).toContain("raw payload field");
+    expect(validation.stderr).toContain("report.results[1].response is not allowed");
+  });
+
+  it("rejects raw diagnostics in allowed result fields", () => {
+    const path = tempReportPath();
+    writeFileSync(
+      path,
+      `${JSON.stringify(
+        report({
+          providers: [
+            {
+              provider: "Claude",
+              model: "claude-haiku-4-5-20251001",
+              passed: 1,
+              total: 1,
+              passRate: 1,
+            },
+            { provider: "OpenAI", model: "gpt-5-nano", passed: 0, total: 1, passRate: 0 },
+          ],
+          results: [
+            {
+              provider: "Claude",
+              caseName: "passed case",
+              status: "passed",
+              passed: true,
+            },
+            {
+              provider: "OpenAI",
+              caseName: "errored case",
+              status: "errored",
+              passed: false,
+              error: "raw model text and tool payload",
+            },
+          ],
+        }),
+      )}\n`,
+      "utf8",
+    );
+
+    const validation = runScript("validate", path);
+
+    expect(validation.status).not.toBe(0);
+    expect(validation.stderr).toContain("bounded errored diagnostic");
+  });
+
+  it("requires result passed flags to match status", () => {
+    const path = tempReportPath();
+    writeFileSync(
+      path,
+      `${JSON.stringify(
+        report({
+          results: [
+            {
+              provider: "Claude",
+              caseName: "blocked delete bucket",
+              status: "passed",
+              passed: true,
+            },
+            {
+              provider: "OpenAI",
+              caseName: "blocked delete bucket",
+              status: "passed",
+              passed: false,
+            },
+          ],
+        }),
+      )}\n`,
+      "utf8",
+    );
+
+    const validation = runScript("validate", path);
+
+    expect(validation.status).not.toBe(0);
+    expect(validation.stderr).toContain("passed must equal whether status is passed");
   });
 });


### PR DESCRIPTION
## Summary

Adds a cost-controlled LLM eval workflow for Claude vs OpenAI pass-rate evidence. The workflow is scheduled/manual only, skips cleanly when provider secrets are missing, and validates the sanitized pass-rate report before summary publication or artifact upload.

## Changes

- Added `.github/workflows/evals.yml` with trusted-main guards, provider secret checks, and no pull request trigger.
- Added a bounded `ci-no-b2` provider comparison case set plus a server-child network guard so CI evals do not contact B2.
- Added sanitized pass-rate report generation for Claude/OpenAI results, committed report validation/summary tooling, and policy coverage for the new workflow.
- Hardened failed and errored case reporting so raw model text, tool calls, tool results, and exact provider secrets are not summarized or uploaded.
- Tightened the artifact gate with strict report key allowlists, provider/count consistency checks, and status/passed consistency checks.

## Linked Issues

- Closes #250

## Verification

- [x] `pnpm install --frozen-lockfile`
- [x] `pnpm test`
- [x] `pnpm run evals`
- [x] `pnpm run test:contract`
- [x] `pnpm run lint`
- [x] `pnpm run format:check`
- [x] CI required checks are expected to pass without B2 credentials

## Security / Credential Handling

- [x] Changes GitHub Actions, branch protection, publishing, or `ci-green`

Provider API keys are only referenced by the scheduled/manual eval workflow. The uploaded report omits raw model responses and tool payloads, uses fixed bounded diagnostics for failed and errored cases, and is validated against exact provider secret values plus a strict schema before the workflow writes a summary or uploads the artifact. The CI case set runs with marker B2 credentials plus a child-process network guard.

## Follow-up Notes

`pnpm run test:protocol`, `pnpm run test:package`, and production audits were not run because this change is limited to eval workflow/reporting behavior.