### PR TITLE
docs: EVALS.md — running the LLM eval suite

### DIFF
--- a/README.md
+++ b/README.md
@@ -508,7 +508,7 @@ pnpm run test:live:b2-integration # live B2 tests; requires B2_APPLICATION_KEY_I
 pnpm run test:live:b2-contract    # live B2 request-shape checks; requires B2 credentials
 pnpm run test:live:b2             # both protected live B2 suites
 pnpm run evals                    # deterministic LLM eval harness; live provider cases skip by default
-pnpm run evals:provider-comparison # opt-in Claude vs OpenAI pass-rate comparison; requires provider keys
+pnpm run evals:provider-comparison # opt-in Claude vs OpenAI comparison; requires provider keys and current dist/
 pnpm start                        # stdio transport
 pnpm run start:http --port 3000   # MCP 2026-07-28 HTTP transport
 b2-mcp --help                     # installed package CLI help after publish/install

--- a/README.md
+++ b/README.md
@@ -507,6 +507,8 @@ pnpm run verify             # fast no-credential quality gate
 pnpm run test:live:b2-integration # live B2 tests; requires B2_APPLICATION_KEY_ID / B2_APPLICATION_KEY
 pnpm run test:live:b2-contract    # live B2 request-shape checks; requires B2 credentials
 pnpm run test:live:b2             # both protected live B2 suites
+pnpm run evals                    # deterministic LLM eval harness; live provider cases skip by default
+pnpm run evals:provider-comparison # opt-in Claude vs OpenAI pass-rate comparison; requires provider keys
 pnpm start                        # stdio transport
 pnpm run start:http --port 3000   # MCP 2026-07-28 HTTP transport
 b2-mcp --help                     # installed package CLI help after publish/install
@@ -532,6 +534,7 @@ committed lockfile and a sanitized temporary environment.
 - [`docs/TOOL_CONTRACT.md`](docs/TOOL_CONTRACT.md) — Phase 1 tool-contract policy
 - [`docs/TOOL_PROFILES.md`](docs/TOOL_PROFILES.md) — generated tool-profile reference
 - [`docs/TESTING.md`](docs/TESTING.md) — deterministic and live-test gate skeleton
+- [`docs/EVALS.md`](docs/EVALS.md) — LLM eval local and CI runbook
 - [`docs/SECURITY_REVIEW.md`](docs/SECURITY_REVIEW.md) — pre-public security and provenance review checklist
 - [`RELEASE.md`](RELEASE.md) — release process and `[Unreleased]` discipline
 - [`CHANGELOG.md`](CHANGELOG.md) — release notes

--- a/docs/EVALS.md
+++ b/docs/EVALS.md
@@ -72,9 +72,11 @@ failures in this mode.
 
 The Claude vs OpenAI comparison has a separate gate so ordinary live provider
 runs do not automatically re-run the comparison matrix. To run the CI-shaped
-bounded comparison locally:
+bounded comparison locally, build first so the harness evaluates the current
+`dist/index.js` output:
 
 ```bash
+pnpm run build
 RUN_LLM_EVALS=1 \
 RUN_LLM_PROVIDER_COMPARISON=1 \
 ANTHROPIC_API_KEY=your-anthropic-api-key \
@@ -93,7 +95,8 @@ For a full local comparison, omit `LLM_EVAL_CASE_SET` and
 `LLM_EVAL_BLOCK_SERVER_NETWORK=1` unless you are debugging the eval server's
 network boundary; it imports [`../scripts/no-network-guard.mjs`](../scripts/no-network-guard.mjs)
 inside the server child process while still allowing provider API calls from the
-test runner.
+test runner. Re-run `pnpm run build` after source changes before collecting
+provider comparison evidence.
 
 ## Required Environment
 
@@ -170,7 +173,9 @@ and fails the job if the comparison command did not succeed.
 
 The full-profile coverage guard is
 [`../tests/contract/eval-coverage.contract.test.ts`](../tests/contract/eval-coverage.contract.test.ts).
-It runs in `pnpm run test:contract` and therefore in `pnpm run verify`.
+It runs in `pnpm run test:contract`, which is a distinct deterministic layer and
+not part of `pnpm run verify`; run `pnpm run test:contract` explicitly to
+exercise the guard.
 
 The guard checks that:
 

--- a/docs/EVALS.md
+++ b/docs/EVALS.md
@@ -1,0 +1,222 @@
+# LLM Eval Suite
+
+Owner: Sophie / Quality Keeper (QK) (`@sophiecarreras`). Implementation owner: Gonza
+(`@goanpeca`).
+
+Status: active. This runbook covers the deterministic eval harness, the opt-in
+LLM-backed provider evals, and the Claude vs OpenAI pass-rate comparison added
+for issue [#251](https://github.com/backblaze-labs/b2-mcp/issues/251).
+
+## What The Suite Covers
+
+The eval suite lives under [`../evals/`](../evals/) and uses the built stdio
+server from `dist/index.js`. The deterministic tests
+exercise the harness, provider adapters, prompt-to-tool assertions, provider
+comparison logic, report validation, and full-profile case definitions. They do
+not call Anthropic, OpenAI, or live Backblaze B2.
+
+The live provider tests are opt-in and run the same MCP eval case definitions
+through real LLM APIs. The harness starts b2-mcp with marker B2 credentials,
+`B2_ALLOW_LOCAL_FILES=false`, `B2_SECRET_SINK=off`, and a default
+`B2_DESTRUCTIVE_POLICY=block`. Tool-shape cases that must pass through a
+destructive handler can only opt into `destructivePolicy: "allow"` through typed
+eval case options. The child-process environment is validated before spawn, so
+live provider evidence still avoids real B2 credentials.
+
+## Local Deterministic Run
+
+Use this for normal PR work and before changing eval code:
+
+```bash
+pnpm install --frozen-lockfile
+pnpm run evals
+```
+
+`pnpm run evals` builds the package and runs `vitest` with
+[`../evals/vitest.config.mts`](../evals/vitest.config.mts). Leave
+`RUN_LLM_EVALS` unset for this mode. Provider-backed cases skip, while the
+deterministic harness and adapter tests still run.
+
+## Local LLM Runs
+
+Set `RUN_LLM_EVALS=1` plus the provider key for the live provider you want to
+exercise:
+
+```bash
+RUN_LLM_EVALS=1 \
+ANTHROPIC_API_KEY=your-anthropic-api-key \
+pnpm run evals
+```
+
+```bash
+RUN_LLM_EVALS=1 \
+OPENAI_API_KEY=your-openai-api-key \
+pnpm run evals
+```
+
+Setting both provider keys runs both single-provider live suites:
+
+```bash
+RUN_LLM_EVALS=1 \
+ANTHROPIC_API_KEY=your-anthropic-api-key \
+OPENAI_API_KEY=your-openai-api-key \
+pnpm run evals
+```
+
+Single-provider live suites iterate over `FULL_PROFILE_EVAL_CASES`, so expect
+them to take longer and consume more provider quota than the deterministic run.
+Provider failures, rate limits, model behavior drift, and timeouts are real
+failures in this mode.
+
+## Provider Comparison
+
+The Claude vs OpenAI comparison has a separate gate so ordinary live provider
+runs do not automatically re-run the comparison matrix. To run the CI-shaped
+bounded comparison locally:
+
+```bash
+RUN_LLM_EVALS=1 \
+RUN_LLM_PROVIDER_COMPARISON=1 \
+ANTHROPIC_API_KEY=your-anthropic-api-key \
+OPENAI_API_KEY=your-openai-api-key \
+ANTHROPIC_EVAL_MODEL=claude-haiku-4-5-20251001 \
+OPENAI_EVAL_MODEL=gpt-5-nano \
+LLM_EVAL_CASE_SET=ci-no-b2 \
+LLM_EVAL_CASE_LIMIT=5 \
+LLM_EVAL_BLOCK_SERVER_NETWORK=1 \
+LLM_EVAL_PASS_RATE_REPORT=reports/evals/provider-pass-rates.json \
+pnpm run evals:provider-comparison
+```
+
+For a full local comparison, omit `LLM_EVAL_CASE_SET` and
+`LLM_EVAL_CASE_LIMIT`, or set `LLM_EVAL_CASE_SET=full` explicitly. Keep
+`LLM_EVAL_BLOCK_SERVER_NETWORK=1` unless you are debugging the eval server's
+network boundary; it imports [`../scripts/no-network-guard.mjs`](../scripts/no-network-guard.mjs)
+inside the server child process while still allowing provider API calls from the
+test runner.
+
+## Required Environment
+
+| Variable | Required for | Notes |
+| --- | --- | --- |
+| `RUN_LLM_EVALS=1` | All live LLM evals | Enables provider-backed cases. Leave unset for deterministic PR work. |
+| `ANTHROPIC_API_KEY` | Anthropic live evals and Claude vs OpenAI comparison | Required by the Anthropic driver. |
+| `OPENAI_API_KEY` | OpenAI live evals and Claude vs OpenAI comparison | Required by the OpenAI driver. |
+| `RUN_LLM_PROVIDER_COMPARISON=1` | Claude vs OpenAI comparison | Required in addition to `RUN_LLM_EVALS=1`. |
+| `ANTHROPIC_EVAL_MODEL` | Anthropic model override | Defaults to `claude-haiku-4-5-20251001`. |
+| `OPENAI_EVAL_MODEL` | OpenAI model override | Defaults to `gpt-5-nano`. |
+| `LLM_EVAL_CASE_SET` | Provider comparison case selection | Defaults to `full`; CI uses `ci-no-b2`. |
+| `LLM_EVAL_CASE_LIMIT` | Provider comparison case cap | Positive integer; applied after case-set selection. |
+| `LLM_EVAL_BLOCK_SERVER_NETWORK=1` | Server child-process network guard | Recommended for provider comparison and CI parity. |
+| `LLM_EVAL_PASS_RATE_REPORT` | Provider comparison report path | Defaults to `reports/evals/provider-pass-rates.json` in the CLI. |
+
+Do not set real `B2_APPLICATION_KEY_ID`, `B2_APPLICATION_KEY`,
+`B2_MASTER_KEY_ID`, or `B2_MASTER_KEY` for eval runs. The harness replaces them
+with marker values and refuses non-marker B2 credentials in the server child
+process.
+
+## Model Selection
+
+The Anthropic driver defaults to `claude-haiku-4-5-20251001`. Override it with:
+
+```bash
+ANTHROPIC_EVAL_MODEL=claude-haiku-4-5-20251001
+```
+
+The OpenAI Chat Completions driver defaults to `gpt-5-nano`. Override it with:
+
+```bash
+OPENAI_EVAL_MODEL=gpt-5-nano
+```
+
+When changing defaults, update the provider driver, the deterministic tests, the
+CI workflow environment in [`../.github/workflows/evals.yml`](../.github/workflows/evals.yml),
+and this document in the same PR. Record whether pass-rate changes come from
+model behavior, eval case changes, or harness changes.
+
+## CI
+
+The LLM eval workflow is [`../.github/workflows/evals.yml`](../.github/workflows/evals.yml).
+It is intentionally not a pull-request or push workflow because provider secrets
+must not run against unreviewed code. It runs only on:
+
+- Manual `workflow_dispatch` runs on `main`.
+- The scheduled weekly run on `main`.
+
+The guard job checks that the repository is `backblaze-labs/b2-mcp`, the ref is
+`refs/heads/main`, and both `ANTHROPIC_API_KEY` and `OPENAI_API_KEY` repository
+secrets are present. Missing provider secrets produce a skipped summary instead
+of a failed eval job.
+
+The eval job installs with the pinned package manager, builds once, then runs:
+
+```bash
+RUN_LLM_EVALS=1 \
+RUN_LLM_PROVIDER_COMPARISON=1 \
+ANTHROPIC_EVAL_MODEL=claude-haiku-4-5-20251001 \
+OPENAI_EVAL_MODEL=gpt-5-nano \
+LLM_EVAL_CASE_SET=ci-no-b2 \
+LLM_EVAL_CASE_LIMIT=5 \
+LLM_EVAL_BLOCK_SERVER_NETWORK=1 \
+LLM_EVAL_PASS_RATE_REPORT=reports/evals/provider-pass-rates.json \
+pnpm run evals:provider-comparison
+```
+
+The workflow validates the JSON report, writes a Markdown summary to the GitHub
+step summary, uploads the `claude-openai-pass-rate-report` artifact for 14 days,
+and fails the job if the comparison command did not succeed.
+
+## Coverage Guard
+
+The full-profile coverage guard is
+[`../tests/contract/eval-coverage.contract.test.ts`](../tests/contract/eval-coverage.contract.test.ts).
+It runs in `pnpm run test:contract` and therefore in `pnpm run verify`.
+
+The guard checks that:
+
+- Every full-profile tool in [`tool-profile-contract.json`](tool-profile-contract.json)
+  has at least one eval case.
+- Eval cases do not reference tools outside the full profile.
+- Each case is bound to exactly one expected tool and all required arguments.
+- MCP error expectations include stable, non-empty text snippets.
+- Every destructive `confirmTools` entry is covered under the default `block`
+  and `confirm` policies, with destructive shape cases opting into `allow`
+  only through typed eval server options.
+
+When adding, renaming, or removing a tool, update [`../evals/cases.ts`](../evals/cases.ts)
+with the tool's eval case in the same PR. If the CI comparison should exercise
+the tool without live B2 access, also update `CI_PROVIDER_COMPARISON_EVAL_CASES`.
+
+## Reading Pass-Rate Comparisons
+
+The comparison summary has this shape:
+
+```text
+Pass-rate comparison (Claude vs OpenAI) across 5 shared case(s): Claude: 5/5 (100.0%); OpenAI: 5/5 (100.0%).
+```
+
+Read it as a same-case-set comparison, not as independent provider samples. The
+denominator is the selected eval case count, after `LLM_EVAL_CASE_SET` and
+`LLM_EVAL_CASE_LIMIT` are applied. The pass-rate threshold for the CLI is 100%.
+Any provider error also fails the comparison, even if a relaxed pass-rate
+threshold would otherwise pass.
+
+The JSON report includes:
+
+- `providers[]`: provider name, model, passed count, total count, and decimal
+  `passRate`.
+- `results[]`: sanitized per-provider, per-case status entries with `passed`,
+  `failed`, or `errored`.
+- `sensitivity`: the fields intentionally omitted from the artifact.
+
+`failed` means the provider ran the case but the eval assertion did not pass.
+`errored` means the provider call, harness, timeout, or setup failed before a
+valid case result could be evaluated. Raw model responses, tool result payloads,
+B2 marker credentials, and provider API keys are intentionally omitted from the
+artifact.
+
+Use the summary for the high-level comparison, then inspect `results[]` to find
+the specific provider and case name that failed. A provider that accumulates
+three provider errors stops receiving new calls, and remaining cases for that
+provider are marked errored so bad credentials, rate limits, or repeated
+timeouts fail fast.

--- a/docs/PUBLIC_CONTRACTS.md
+++ b/docs/PUBLIC_CONTRACTS.md
@@ -19,6 +19,7 @@ current with code, CI, and GitHub release metadata.
 | [`TOOL_CONTRACT.md`](TOOL_CONTRACT.md)                 | Gonza              | Tool-profile contract policy, backing taxonomy, and fixture requirements | #49, #59                     |
 | [`TOOL_PROFILES.md`](TOOL_PROFILES.md)                 | Gonza              | Generated Phase 1 tool-profile reference with availability annotations  | #49                          |
 | [`TESTING.md`](TESTING.md)                             | Sophie / QK        | Deterministic PR gates, contract evidence, and live B2 smoke policy     | #50, #51, #52, #60, #61, #63 |
+| [`EVALS.md`](EVALS.md)                                 | Sophie / QK        | LLM eval local and CI runbook                                           | #251                         |
 | [`SECURITY_REVIEW.md`](SECURITY_REVIEW.md)             | Sophie / QK        | Pre-public secret scanning, provenance, and legal review checklist      | #62, #66, #67                |
 | [`SUPPLY_CHAIN_SECURITY.md`](SUPPLY_CHAIN_SECURITY.md) | Sophie / QK        | npm/GHCR compromise denylist, branch/artifact scan, and incident runbook | #89, #106                    |
 | [`../SECURITY.md`](../SECURITY.md)                     | Backblaze Security | Vulnerability reporting and support scope                               | #66                          |

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -43,6 +43,9 @@ The individual deterministic layers are:
 
 ## LLM Eval Harness
 
+Detailed local, CI, model-selection, coverage-guard, and pass-rate reporting
+instructions are in [`EVALS.md`](EVALS.md).
+
 `pnpm run evals` builds the stdio server, then runs the deterministic eval
 harness and provider-adapter tests under `evals/`. These tests do not require
 real B2 credentials. The harness starts b2-mcp with marker B2 credentials,


### PR DESCRIPTION
## Summary
- Add docs/EVALS.md covering local deterministic evals, opt-in live provider runs, CI, required env/keys, model selection, the coverage guard, and pass-rate reports.
- Link the eval runbook from README.md and docs/TESTING.md, and register it in docs/PUBLIC_CONTRACTS.md.
- Clarify that local provider comparisons need a current build and that the eval coverage guard runs via pnpm run test:contract.

## Linked Issue
Closes #251.

## Tests Run
- pnpm run lint:docs
- pnpm run lint:links
- pnpm run spell
- git diff --check

## Follow-up Notes
- None.