### PR TITLE
test(index): cover CLI dispatch and top-level fatal-error handling

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -59,12 +59,12 @@ export async function startStdio(): Promise<void> {
   logger.info({ transport: "stdio" }, "server.started");
 }
 
-async function startHttpTransport(options: { port?: number }): Promise<void> {
+export async function startHttpTransport(options: { port?: number }): Promise<void> {
   const { startHttp } = await import("./http-server.js");
   await startHttp({ port: options.port });
 }
 
-async function runCli(argv = process.argv.slice(2)): Promise<void> {
+export async function runCli(argv = process.argv.slice(2)): Promise<void> {
   const options = parseCliArgs(argv);
   if (options.action === "help") {
     process.stdout.write(`${helpText()}\n`);
@@ -83,18 +83,24 @@ async function runCli(argv = process.argv.slice(2)): Promise<void> {
   await startStdio();
 }
 
+/**
+ * Report a bootstrap failure and terminate: usage errors exit 2 with help,
+ * anything else exits 1 and is recorded as a fatal server event.
+ */
+export function exitOnFatalError(err: unknown): never {
+  if (err instanceof CliUsageError || err instanceof PortUsageError) {
+    process.stderr.write(`b2-mcp: ${err.message}\n\n${helpText()}\n`);
+    flushLogsSync();
+    process.exit(2);
+  }
+  const message = err instanceof Error ? err.message : String(err);
+  process.stderr.write(`b2-mcp: ${message}\n`);
+  logger.fatal({ err: message }, "server.fatal");
+  flushLogsSync();
+  process.exit(1);
+}
+
 // Only run when invoked directly (not when imported by tests).
 if (require.main === module) {
-  runCli().catch((err) => {
-    if (err instanceof CliUsageError || err instanceof PortUsageError) {
-      process.stderr.write(`b2-mcp: ${err.message}\n\n${helpText()}\n`);
-      flushLogsSync();
-      process.exit(2);
-    }
-    const message = err instanceof Error ? err.message : String(err);
-    process.stderr.write(`b2-mcp: ${message}\n`);
-    logger.fatal({ err: message }, "server.fatal");
-    flushLogsSync();
-    process.exit(1);
-  });
+  runCli().catch(exitOnFatalError);
 }

--- a/tests/unit/index.unit.test.ts
+++ b/tests/unit/index.unit.test.ts
@@ -3,14 +3,22 @@ import * as http from "http";
 import type { AddressInfo } from "net";
 import * as path from "path";
 import * as stdioTransport from "@modelcontextprotocol/server/stdio";
+import { CliUsageError, helpText } from "../../src/cli";
 import { CredentialResolutionError } from "../../src/credentials";
-import { startStdio } from "../../src/index";
+import { exitOnFatalError, runCli, startStdio } from "../../src/index";
+import * as httpServerModule from "../../src/http-server";
 import * as serverModule from "../../src/server";
+import { PortUsageError } from "../../src/utils/config";
 import { logger } from "../../src/utils/logger";
 import type { B2Config } from "../../src/utils/types";
+import { VERSION } from "../../src/version";
 
 vi.mock("@modelcontextprotocol/server/stdio", () => ({
   serveStdio: vi.fn(),
+}));
+
+vi.mock("../../src/http-server", () => ({
+  startHttp: vi.fn(async () => undefined),
 }));
 
 const credentialEnvKeys = [
@@ -131,6 +139,18 @@ describe("stdio entry point", () => {
     expect(createServer).toHaveBeenCalledWith(config, null);
   });
 
+  it("rethrows a capability failure that is not an upstream outage", async () => {
+    vi.spyOn(serverModule, "loadConfig").mockReturnValue(testConfig());
+    vi.spyOn(serverModule, "fetchCapabilities").mockRejectedValue(
+      new CredentialResolutionError("bad key", 401, "invalid_credentials"),
+    );
+
+    // Only capability_upstream_unavailable degrades to the full surface; an
+    // auth failure must fail closed rather than register every tool.
+    await expect(startStdio()).rejects.toMatchObject({ code: "invalid_credentials" });
+    expect(stdioTransport.serveStdio).not.toHaveBeenCalled();
+  });
+
   it("writes the missing-credential message and exits non-zero", async () => {
     for (const key of credentialEnvKeys) delete process.env[key];
     const stderr = vi.spyOn(process.stderr, "write").mockImplementation(() => true);
@@ -142,6 +162,119 @@ describe("stdio entry point", () => {
     expect(stderr).toHaveBeenCalledWith(
       "b2-mcp: B2_APPLICATION_KEY_ID and B2_APPLICATION_KEY are required for stdio\n",
     );
+  });
+});
+
+describe("runCli dispatch", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+    vi.clearAllMocks();
+  });
+
+  it("prints help and starts no transport", async () => {
+    const stdout = vi.spyOn(process.stdout, "write").mockImplementation(() => true);
+
+    await runCli(["--help"]);
+
+    expect(stdout).toHaveBeenCalledWith(`${helpText()}\n`);
+    expect(httpServerModule.startHttp).not.toHaveBeenCalled();
+    expect(stdioTransport.serveStdio).not.toHaveBeenCalled();
+  });
+
+  it("prints the package version and starts no transport", async () => {
+    const stdout = vi.spyOn(process.stdout, "write").mockImplementation(() => true);
+
+    await runCli(["--version"]);
+
+    expect(stdout).toHaveBeenCalledWith(`${VERSION}\n`);
+    expect(httpServerModule.startHttp).not.toHaveBeenCalled();
+    expect(stdioTransport.serveStdio).not.toHaveBeenCalled();
+  });
+
+  it("starts the HTTP transport with the requested port", async () => {
+    await runCli(["http", "--port", "4321"]);
+
+    expect(httpServerModule.startHttp).toHaveBeenCalledWith({ port: 4321 });
+    expect(stdioTransport.serveStdio).not.toHaveBeenCalled();
+  });
+
+  it("starts the HTTP transport without a port so the default applies", async () => {
+    await runCli(["--transport=http"]);
+
+    expect(httpServerModule.startHttp).toHaveBeenCalledWith({ port: undefined });
+  });
+
+  it("starts stdio by default", async () => {
+    const server = { close: vi.fn(async () => undefined) };
+    vi.spyOn(serverModule, "loadConfig").mockReturnValue(testConfig());
+    vi.spyOn(serverModule, "createServer").mockReturnValue(server as never);
+    vi.spyOn(serverModule, "fetchCapabilities").mockResolvedValue(["listBuckets"]);
+    const serveStdio = vi.mocked(stdioTransport.serveStdio).mockImplementation(
+      () =>
+        ({
+          close: vi.fn(async () => undefined),
+        }) as ReturnType<typeof stdioTransport.serveStdio>,
+    );
+
+    await runCli([]);
+
+    expect(serveStdio).toHaveBeenCalledTimes(1);
+    expect(httpServerModule.startHttp).not.toHaveBeenCalled();
+  });
+
+  it("rejects with the usage error instead of exiting", async () => {
+    await expect(runCli(["--transport", "sse"])).rejects.toBeInstanceOf(CliUsageError);
+  });
+});
+
+describe("exitOnFatalError", () => {
+  let stderr: ReturnType<typeof vi.spyOn>;
+  let exit: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    stderr = vi.spyOn(process.stderr, "write").mockImplementation(() => true);
+    exit = vi.spyOn(process, "exit").mockImplementation(((code?: number) => {
+      throw Object.assign(new Error(`process.exit(${code})`), { exitCode: code });
+    }) as typeof process.exit);
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    vi.clearAllMocks();
+  });
+
+  it("exits 2 with help for a CLI usage error", () => {
+    const fatal = vi.spyOn(logger, "fatal").mockImplementation(() => undefined);
+
+    expect(() => exitOnFatalError(new CliUsageError("Invalid transport: sse"))).toThrow(
+      "process.exit(2)",
+    );
+    expect(stderr).toHaveBeenCalledWith(`b2-mcp: Invalid transport: sse\n\n${helpText()}\n`);
+    // A usage error is user input, not a server failure: no fatal log.
+    expect(fatal).not.toHaveBeenCalled();
+  });
+
+  it("exits 2 with help for a port usage error", () => {
+    expect(() => exitOnFatalError(new PortUsageError("Invalid port: 0"))).toThrow(
+      "process.exit(2)",
+    );
+    expect(exit).toHaveBeenCalledWith(2);
+  });
+
+  it("exits 1 and logs a fatal event for an unexpected error", () => {
+    const fatal = vi.spyOn(logger, "fatal").mockImplementation(() => undefined);
+
+    expect(() => exitOnFatalError(new Error("listen EADDRINUSE"))).toThrow("process.exit(1)");
+    expect(stderr).toHaveBeenCalledWith("b2-mcp: listen EADDRINUSE\n");
+    expect(fatal).toHaveBeenCalledWith({ err: "listen EADDRINUSE" }, "server.fatal");
+  });
+
+  it("stringifies a non-Error rejection", () => {
+    const fatal = vi.spyOn(logger, "fatal").mockImplementation(() => undefined);
+
+    expect(() => exitOnFatalError("boom")).toThrow("process.exit(1)");
+    expect(stderr).toHaveBeenCalledWith("b2-mcp: boom\n");
+    expect(fatal).toHaveBeenCalledWith({ err: "boom" }, "server.fatal");
   });
 });
 


### PR DESCRIPTION
Closes #273.

`src/index.ts` was the least-covered file in the repo at **31.42% lines / 21.05% branches**. Everything below `startStdio()` — the whole CLI dispatch and the top-level failure handler — was only reachable by spawning the entry point as a subprocess, so the existing tests could assert on exit codes but not on which transport was chosen or what was logged.

## Test seam

Two minimal export changes, no behavior change:

- `runCli` and `startHttpTransport` are exported so dispatch can be driven directly with an explicit `argv`.
- The inline `.catch(...)` callback is lifted into a named `exitOnFatalError(err): never`. The `require.main === module` guard now reads `runCli().catch(exitOnFatalError)`, and the error policy is testable without spawning a process.

## Tests

11 new deterministic cases, no credentials:

**`runCli` dispatch** — `--help` writes `helpText()`, `--version` writes `VERSION`, and neither starts a transport; `http --port 4321` reaches `startHttp({ port: 4321 })`; `--transport=http` passes `port: undefined` so the server default applies; a bare argv starts stdio and does *not* touch HTTP; a bad transport rejects with `CliUsageError` rather than exiting (the exit is the caller's job).

`src/http-server.ts` is mocked at the module level, so the HTTP branch is covered without binding a port — the previous HTTP test had to occupy a port and provoke `EADDRINUSE`.

**`exitOnFatalError`** — `CliUsageError` and `PortUsageError` both exit 2 with the message plus help, and the usage path asserts `logger.fatal` is *not* called (a usage error is user input, not a server failure); a generic `Error` exits 1 and logs `server.fatal`; a non-`Error` rejection is stringified rather than surfacing as `undefined`.

**`startStdio`** — added the missing negative case for the degraded-capability branch: a `CredentialResolutionError` whose code is *not* `capability_upstream_unavailable` (e.g. `invalid_credentials`) must propagate instead of falling back to `capabilities = null`. Without it, only the fallback direction was pinned, so widening the catch to swallow auth failures — registering the full tool surface for a key that cannot use it — would have gone unnoticed.

The existing subprocess tests are kept: they still prove the shebang path, `require.main` wiring, and real process exit codes, which in-process tests cannot.

## Coverage

`src/index.ts`, unit layer:

| Metric | Before | After | Target (#273) |
|---|---|---|---|
| Lines | 31.42% | **97.14%** | ≥ 90% |
| Branches | 21.05% | **94.73%** | ≥ 85% |
| Statements | 33.33% | **97.22%** | — |
| Functions | 50% | **100%** | — |

The one remaining uncovered line is the `require.main === module` bootstrap, which by construction cannot execute under an import.

## Validation

- `pnpm run typecheck` — clean
- `pnpm run lint` — clean (280 files)
- `pnpm run format:check` — clean
- `pnpm test` — 1325 passed

`pnpm test` also reports 5 failures in `package-surface-policy`, `release-scripts`, and `supply-chain-denylist`. Those reproduce identically on an unmodified checkout of `main` in this environment (they shell out to `npm pack` / the pnpm version lifecycle) and are untouched by this change; the delta is +11 passing.
