### PR TITLE
test(index): cover CLI dispatch and top-level fatal-error handling

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -59,12 +59,16 @@ export async function startStdio(): Promise<void> {
   logger.info({ transport: "stdio" }, "server.started");
 }
 
-async function startHttpTransport(options: { port?: number }): Promise<void> {
+export async function startHttpTransport(options: { port?: number }): Promise<void> {
   const { startHttp } = await import("./http-server.js");
   await startHttp({ port: options.port });
 }
 
-async function runCli(argv = process.argv.slice(2)): Promise<void> {
+// Exported so tests can drive dispatch and error handling in-process, rather
+// than only through the subprocess-spawning black-box tests below -- those
+// exercise real behavior but run outside this process, so v8/istanbul
+// coverage never attributes to the lines they execute.
+export async function runCli(argv = process.argv.slice(2)): Promise<void> {
   const options = parseCliArgs(argv);
   if (options.action === "help") {
     process.stdout.write(`${helpText()}\n`);

--- a/tests/unit/index.unit.test.ts
+++ b/tests/unit/index.unit.test.ts
@@ -3,14 +3,23 @@ import * as http from "http";
 import type { AddressInfo } from "net";
 import * as path from "path";
 import * as stdioTransport from "@modelcontextprotocol/server/stdio";
+import { helpText } from "../../src/cli";
 import { CredentialResolutionError } from "../../src/credentials";
-import { startStdio } from "../../src/index";
+import { runCli, startStdio } from "../../src/index";
 import * as serverModule from "../../src/server";
 import { logger } from "../../src/utils/logger";
 import type { B2Config } from "../../src/utils/types";
+import { VERSION } from "../../src/version";
 
 vi.mock("@modelcontextprotocol/server/stdio", () => ({
   serveStdio: vi.fn(),
+}));
+
+// runCli's http branch resolves this via a dynamic import(); mocking the
+// statically-imported specifier here still intercepts it, since Vitest keys
+// mocks by resolved module id rather than by import syntax.
+vi.mock("../../src/http-server", () => ({
+  startHttp: vi.fn(),
 }));
 
 const credentialEnvKeys = [
@@ -142,6 +151,79 @@ describe("stdio entry point", () => {
     expect(stderr).toHaveBeenCalledWith(
       "b2-mcp: B2_APPLICATION_KEY_ID and B2_APPLICATION_KEY are required for stdio\n",
     );
+  });
+});
+
+describe("runCli dispatch (in-process)", () => {
+  // These call the exported runCli() directly rather than spawning a
+  // subprocess, so v8 coverage attributes to the lines it executes -- the
+  // "executable CLI entry point" tests below exercise the same behavior
+  // black-box, through the real CLI, but coverage cannot see into a spawned
+  // child process.
+  afterEach(() => {
+    vi.restoreAllMocks();
+    vi.clearAllMocks();
+  });
+
+  it("--help prints usage and does not start a server", async () => {
+    const stdout = vi.spyOn(process.stdout, "write").mockImplementation(() => true);
+    const loadConfig = vi.spyOn(serverModule, "loadConfig");
+
+    await runCli(["--help"]);
+
+    expect(stdout).toHaveBeenCalledWith(`${helpText()}
+`);
+    expect(loadConfig).not.toHaveBeenCalled();
+  });
+
+  it("-h is the same as --help", async () => {
+    const stdout = vi.spyOn(process.stdout, "write").mockImplementation(() => true);
+
+    await runCli(["-h"]);
+
+    expect(stdout).toHaveBeenCalledWith(`${helpText()}
+`);
+  });
+
+  it("--version prints the package version and does not start a server", async () => {
+    const stdout = vi.spyOn(process.stdout, "write").mockImplementation(() => true);
+    const loadConfig = vi.spyOn(serverModule, "loadConfig");
+
+    await runCli(["--version"]);
+
+    expect(stdout).toHaveBeenCalledWith(`${VERSION}
+`);
+    expect(loadConfig).not.toHaveBeenCalled();
+  });
+
+  it("dispatches to the HTTP transport when transport is http", async () => {
+    const { startHttp } = await import("../../src/http-server");
+
+    await runCli(["http", "--port", "4321"]);
+
+    expect(vi.mocked(startHttp)).toHaveBeenCalledWith({ port: 4321 });
+  });
+
+  it("dispatches to startStdio by default", async () => {
+    const config = testConfig();
+    const server = { close: vi.fn(async () => undefined) };
+    vi.spyOn(serverModule, "createServer").mockReturnValue(server as never);
+    vi.spyOn(serverModule, "loadConfig").mockReturnValue(config);
+    vi.spyOn(serverModule, "fetchCapabilities").mockResolvedValue(["listBuckets"]);
+    const serveStdio = vi.mocked(stdioTransport.serveStdio).mockImplementation(
+      () =>
+        ({
+          close: vi.fn(async () => undefined),
+        }) as ReturnType<typeof stdioTransport.serveStdio>,
+    );
+
+    await runCli([]);
+
+    expect(serveStdio).toHaveBeenCalled();
+  });
+
+  it("propagates a CLI usage error to the caller rather than swallowing it", async () => {
+    await expect(runCli(["--transport", "sse"])).rejects.toThrow("Invalid transport: sse");
   });
 });
 


### PR DESCRIPTION
Part of #272, closes #273.

### Why coverage was 34% despite 3 existing CLI tests

`tests/unit/index.unit.test.ts` already had 3 subprocess tests (`spawnSync(tsx, ["src/index.ts", ...])`) exercising `--transport sse` (exit 2), missing-credentials (exit 1), and `EADDRINUSE` on the HTTP transport (exit 1). Those validate real, end-to-end behavior — but the code runs in a spawned child process, and v8/istanbul coverage in the parent Vitest process cannot see into it. Hence 34.28% lines / 26.31% branches on a file with three tests already covering most of its behavior at the black-box level.

### Change

Exported `runCli` and `startHttpTransport`, per the issue's suggested approach, and added 6 new **in-process** tests that call `runCli` directly:

| Test | Covers |
|---|---|
| `--help` / `-h` | help output, no `loadConfig` call |
| `--version` | version output, no `loadConfig` call |
| HTTP dispatch | mocks `../../src/http-server` for the `await import("./http-server.js")` branch |
| default stdio dispatch | reuses the existing `serverModule`/`stdioTransport` mocks, asserts `serveStdio` is reached via `runCli` rather than by calling `startStdio` directly |
| usage error propagation | `runCli(["--transport", "sse"])` rejects rather than being swallowed |

Left the 3 subprocess tests in place — they remain the only way to cover the top-level `require.main === module` handler, since `import()` never sets `require.main` the way running the file directly does. So that ~9-line guard block stays covered black-box; everything else in the acceptance criteria's line range is now covered in-process.

### Verification

- `pnpm run typecheck` — clean
- `npx vitest run --project=unit tests/unit/index.unit.test.ts` — the 6 new tests pass; the 9 that existed before still pass
- `npx vitest run --project=unit` (full project) — **identical failure count before and after my change**: 17 failed files / 87 failed tests either way, my change adds exactly +6 passing tests and 0 new failures. I diffed this explicitly by stashing.
- `node scripts/run-biome.mjs lint ...` — clean
- `node scripts/run-biome.mjs format .` — clean on my 2 files after normalizing to LF (see caveat below)

### Two things I want to flag rather than gloss over

**1. I could not measure the actual coverage percentage.** `pnpm run test:coverage` runs `pnpm run build` first, and the full build + coverage layer did not complete in the time I had. I have not verified the branches ≥85% / lines ≥90% acceptance numbers — only that the new tests exercise the specific paths the issue lists as untested (help/version/http-dispatch/stdio-dispatch) and that nothing regressed. If the percentages land short, I'm glad to add more cases.

**2. 3 pre-existing subprocess tests fail on my machine, unrelated to this change.** All three (`prints usage errors...`, `selects stdio by default...`, `selects HTTP transport...`) return `result.status: null` from `spawnSync` — this reproduces identically on a clean checkout of `main` before my change (I verified by stashing), so it is not something I introduced. It looks like a Windows-specific `spawnSync`/`tsx.cmd` interop issue in my local environment rather than a real bug; I have not touched those tests or the code paths they exercise. Also worth flagging: the repo checks out as CRLF on Windows by default, which fails `format` on essentially every file in the tree (308/308) until normalized to LF — I normalized only the 2 files I touched rather than the whole repo.