### PR TITLE
fix: fail evals when provider secrets are missing

### DIFF
--- a/.github/workflows/evals.yml
+++ b/.github/workflows/evals.yml
@@ -3,8 +3,9 @@ name: LLM Evals
 # Cost-controlled provider eval evidence. This workflow intentionally avoids
 # pull_request events so provider secrets never run against unreviewed fork code.
 #
-# Scheduled/manual runs are canonical-main only. Missing provider secrets are a
-# repository misconfiguration and fail in the guard job.
+# OpenAI is temporarily disabled (the account has no API credits), so scheduled
+# runs cover Anthropic only. Missing active provider secrets are a repository
+# misconfiguration and fail in the guard job.
 
 on:
   workflow_dispatch:
@@ -31,7 +32,6 @@ jobs:
         env:
           EVENT_NAME: ${{ github.event_name }}
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
-          OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
         run: |
           set -euo pipefail
           checkout_sha="${GITHUB_SHA}"
@@ -49,13 +49,12 @@ jobs:
               ;;
           esac
 
-          for value in "${ANTHROPIC_API_KEY:-}" "${OPENAI_API_KEY:-}"; do
+          for value in "${ANTHROPIC_API_KEY:-}"; do
             if [[ -n "$value" ]]; then echo "::add-mask::$value"; fi
           done
 
           missing=()
           if [[ -z "${ANTHROPIC_API_KEY:-}" ]]; then missing+=("ANTHROPIC_API_KEY"); fi
-          if [[ -z "${OPENAI_API_KEY:-}" ]]; then missing+=("OPENAI_API_KEY"); fi
           if [[ "${#missing[@]}" -gt 0 ]]; then
             echo "::error::missing provider secret(s): ${missing[*]}"
             exit 1
@@ -92,7 +91,6 @@ jobs:
           RUN_LLM_EVALS: "1"
           RUN_LLM_PROVIDER_COMPARISON: "1"
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
-          OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
           ANTHROPIC_EVAL_MODEL: claude-haiku-4-5-20251001
           LLM_EVAL_CASE_SET: ci-no-b2
           LLM_EVAL_CASE_LIMIT: "5"
@@ -107,7 +105,6 @@ jobs:
         if: always()
         env:
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
-          OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
         run: |
           set -euo pipefail
           node scripts/eval-pass-rate-report.mjs validate reports/evals/provider-pass-rates.json
@@ -121,12 +118,12 @@ jobs:
         if: ${{ always() && steps.validate_report.outcome == 'success' }}
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
         with:
-          name: provider-pass-rate-report
+          name: claude-pass-rate-report
           path: reports/evals/provider-pass-rates.json
           if-no-files-found: error
           retention-days: 14
       - name: Require eval pass-rate success
         if: ${{ always() && steps.run_evals.outcome != 'success' }}
         run: |
-          echo "::error::Claude eval pass-rate run failed"
+          echo "::error::provider eval pass-rate run failed"
           exit 1

--- a/.github/workflows/evals.yml
+++ b/.github/workflows/evals.yml
@@ -3,9 +3,8 @@ name: LLM Evals
 # Cost-controlled provider eval evidence. This workflow intentionally avoids
 # pull_request events so provider secrets never run against unreviewed fork code.
 #
-# OpenAI is temporarily disabled (the account has no API credits), so scheduled
-# runs cover Anthropic only. Re-enable OpenAI by restoring OPENAI_API_KEY to the
-# guard's required secrets and to the eval step env below.
+# Scheduled/manual runs are canonical-main only. Missing provider secrets are a
+# repository misconfiguration and fail in the guard job.
 
 on:
   workflow_dispatch:
@@ -25,20 +24,17 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 5
     outputs:
-      should-run: ${{ steps.ref.outputs.should_run }}
       checkout-sha: ${{ steps.ref.outputs.checkout_sha }}
-      skip-reason: ${{ steps.ref.outputs.skip_reason }}
     steps:
       - name: Resolve trusted eval ref and provider secrets
         id: ref
         env:
           EVENT_NAME: ${{ github.event_name }}
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+          OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
         run: |
           set -euo pipefail
-          should_run=true
           checkout_sha="${GITHUB_SHA}"
-          skip_reason=""
 
           case "${EVENT_NAME}" in
             workflow_dispatch|schedule)
@@ -53,39 +49,23 @@ jobs:
               ;;
           esac
 
-          for value in "${ANTHROPIC_API_KEY:-}"; do
+          for value in "${ANTHROPIC_API_KEY:-}" "${OPENAI_API_KEY:-}"; do
             if [[ -n "$value" ]]; then echo "::add-mask::$value"; fi
           done
 
           missing=()
           if [[ -z "${ANTHROPIC_API_KEY:-}" ]]; then missing+=("ANTHROPIC_API_KEY"); fi
+          if [[ -z "${OPENAI_API_KEY:-}" ]]; then missing+=("OPENAI_API_KEY"); fi
           if [[ "${#missing[@]}" -gt 0 ]]; then
-            should_run=false
-            checkout_sha=""
-            skip_reason="missing provider secret(s): ${missing[*]}"
+            echo "::error::missing provider secret(s): ${missing[*]}"
+            exit 1
           fi
 
-          echo "should_run=${should_run}" >> "$GITHUB_OUTPUT"
           echo "checkout_sha=${checkout_sha}" >> "$GITHUB_OUTPUT"
-          echo "skip_reason=${skip_reason}" >> "$GITHUB_OUTPUT"
-
-  skipped:
-    name: LLM evals skipped
-    needs: guard
-    if: ${{ always() && needs.guard.result == 'success' && needs.guard.outputs.should-run != 'true' }}
-    runs-on: ubuntu-latest
-    timeout-minutes: 2
-    steps:
-      - name: Report skipped evals
-        env:
-          SKIP_REASON: ${{ needs.guard.outputs.skip-reason }}
-        run: |
-          echo "LLM evals skipped: ${SKIP_REASON}" >> "$GITHUB_STEP_SUMMARY"
 
   evals:
-    name: Claude pass rates
+    name: Provider pass rates
     needs: guard
-    if: needs.guard.outputs.should-run == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 20
     steps:
@@ -105,13 +85,14 @@ jobs:
           cache: pnpm
       - run: pnpm install --frozen-lockfile
       - run: pnpm run build
-      - name: Run Claude eval pass rates
+      - name: Run provider eval pass rates
         id: run_evals
         continue-on-error: true
         env:
           RUN_LLM_EVALS: "1"
           RUN_LLM_PROVIDER_COMPARISON: "1"
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+          OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
           ANTHROPIC_EVAL_MODEL: claude-haiku-4-5-20251001
           LLM_EVAL_CASE_SET: ci-no-b2
           LLM_EVAL_CASE_LIMIT: "5"
@@ -126,6 +107,7 @@ jobs:
         if: always()
         env:
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+          OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
         run: |
           set -euo pipefail
           node scripts/eval-pass-rate-report.mjs validate reports/evals/provider-pass-rates.json
@@ -135,11 +117,11 @@ jobs:
           set -euo pipefail
           node scripts/eval-pass-rate-report.mjs summary reports/evals/provider-pass-rates.json >> "$GITHUB_STEP_SUMMARY"
       # actions/upload-artifact v7, reviewed 2026-08-25.
-      - name: Upload Claude pass-rate report
+      - name: Upload provider pass-rate report
         if: ${{ always() && steps.validate_report.outcome == 'success' }}
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
         with:
-          name: claude-pass-rate-report
+          name: provider-pass-rate-report
           path: reports/evals/provider-pass-rates.json
           if-no-files-found: error
           retention-days: 14

--- a/docs/EVALS.md
+++ b/docs/EVALS.md
@@ -146,23 +146,19 @@ must not run against unreviewed code. It runs only on:
 - Manual `workflow_dispatch` runs on `main`.
 - The scheduled weekly run on `main`.
 
-> **OpenAI is temporarily disabled.** The OpenAI account has no API credits, so
-> scheduled and manual runs cover Anthropic only. The pass-rate runner degrades
-> to whichever provider keys are configured (`evals/run-provider-comparison.ts`
-> via `providersWithConfiguredKeys`). Re-enable OpenAI by restoring
-> `OPENAI_API_KEY` to the guard's required secrets and to the eval step env in
-> [`../.github/workflows/evals.yml`](../.github/workflows/evals.yml); no code
-> change is needed.
-
 The guard job checks that the repository is `backblaze-labs/b2-mcp`, the ref is
-`refs/heads/main`, and the `ANTHROPIC_API_KEY` repository secret is present.
-Missing provider secrets produce a skipped summary instead of a failed eval job.
+`refs/heads/main`, and the `ANTHROPIC_API_KEY` and `OPENAI_API_KEY` repository
+secrets are present. Missing provider secrets produce a masked GitHub Actions
+`::error::` annotation and fail the guard job so scheduled/manual
+misconfigurations do not skip green.
 
 The eval job installs with the pinned package manager, builds once, then runs:
 
 ```bash
 RUN_LLM_EVALS=1 \
 RUN_LLM_PROVIDER_COMPARISON=1 \
+ANTHROPIC_API_KEY=... \
+OPENAI_API_KEY=... \
 ANTHROPIC_EVAL_MODEL=claude-haiku-4-5-20251001 \
 LLM_EVAL_CASE_SET=ci-no-b2 \
 LLM_EVAL_CASE_LIMIT=5 \
@@ -172,7 +168,7 @@ pnpm run evals:provider-comparison
 ```
 
 The workflow validates the JSON report, writes a Markdown summary to the GitHub
-step summary, uploads the `claude-pass-rate-report` artifact for 14 days, and
+step summary, uploads the `provider-pass-rate-report` artifact for 14 days, and
 fails the job if the pass-rate command did not succeed.
 
 ## Coverage Guard

--- a/docs/EVALS.md
+++ b/docs/EVALS.md
@@ -146,9 +146,15 @@ must not run against unreviewed code. It runs only on:
 - Manual `workflow_dispatch` runs on `main`.
 - The scheduled weekly run on `main`.
 
+> **OpenAI is temporarily disabled.** The OpenAI account has no API credits, so
+> scheduled and manual runs cover Anthropic only. The pass-rate runner degrades
+> to whichever provider keys are configured (`evals/run-provider-comparison.ts`
+> via `providersWithConfiguredKeys`). Do not expose `OPENAI_API_KEY` to the
+> scheduled eval command until credits are restored.
+
 The guard job checks that the repository is `backblaze-labs/b2-mcp`, the ref is
-`refs/heads/main`, and the `ANTHROPIC_API_KEY` and `OPENAI_API_KEY` repository
-secrets are present. Missing provider secrets produce a masked GitHub Actions
+`refs/heads/main`, and the active `ANTHROPIC_API_KEY` repository secret is
+present. Missing active provider secrets produce a masked GitHub Actions
 `::error::` annotation and fail the guard job so scheduled/manual
 misconfigurations do not skip green.
 
@@ -158,7 +164,6 @@ The eval job installs with the pinned package manager, builds once, then runs:
 RUN_LLM_EVALS=1 \
 RUN_LLM_PROVIDER_COMPARISON=1 \
 ANTHROPIC_API_KEY=... \
-OPENAI_API_KEY=... \
 ANTHROPIC_EVAL_MODEL=claude-haiku-4-5-20251001 \
 LLM_EVAL_CASE_SET=ci-no-b2 \
 LLM_EVAL_CASE_LIMIT=5 \
@@ -168,7 +173,7 @@ pnpm run evals:provider-comparison
 ```
 
 The workflow validates the JSON report, writes a Markdown summary to the GitHub
-step summary, uploads the `provider-pass-rate-report` artifact for 14 days, and
+step summary, uploads the `claude-pass-rate-report` artifact for 14 days, and
 fails the job if the pass-rate command did not succeed.
 
 ## Coverage Guard

--- a/evals/run-provider-comparison.ts
+++ b/evals/run-provider-comparison.ts
@@ -18,8 +18,8 @@ async function main(): Promise<void> {
     throw new Error(`Provider pass-rate gate disabled: ${gate.reason}`);
   }
 
-  // Run whichever providers have a key configured. The scheduled workflow guard
-  // requires both provider secrets; ad-hoc runs can still exercise a subset.
+  // Run whichever providers have a key configured. The scheduled workflow keeps
+  // OpenAI out of the environment until account credits are restored.
   const providers = providersWithConfiguredKeys();
   const cases = selectProviderComparisonCases({
     full: FULL_PROFILE_EVAL_CASES,

--- a/evals/run-provider-comparison.ts
+++ b/evals/run-provider-comparison.ts
@@ -18,8 +18,8 @@ async function main(): Promise<void> {
     throw new Error(`Provider pass-rate gate disabled: ${gate.reason}`);
   }
 
-  // Run whichever providers have a key configured. OpenAI is currently unconfigured
-  // (no account credits), so this resolves to an Anthropic-only run until it returns.
+  // Run whichever providers have a key configured. The scheduled workflow guard
+  // requires both provider secrets; ad-hoc runs can still exercise a subset.
   const providers = providersWithConfiguredKeys();
   const cases = selectProviderComparisonCases({
     full: FULL_PROFILE_EVAL_CASES,

--- a/tests/contract/ci-workflow-policy.contract.test.ts
+++ b/tests/contract/ci-workflow-policy.contract.test.ts
@@ -390,7 +390,6 @@ describe("CI workflow policy", () => {
 
   it("runs provider evals only from trusted scheduled or manual main refs", () => {
     const guard = workflowJobBlock(evals, "guard") ?? "";
-    const skipped = workflowJobBlock(evals, "skipped");
     const evalJob = workflowJobBlock(evals, "evals") ?? "";
 
     expect(evals).toMatch(topLevelMappingEntry("permissions", "contents", "read"));
@@ -412,15 +411,17 @@ describe("CI workflow policy", () => {
     expect(guard).toContain("workflow_dispatch|schedule");
     expect(guard).toContain('[[ "$GITHUB_REF" != "refs/heads/main" ]]');
     expect(guard).toContain("ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}");
-    expect(guard).toContain("OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}");
+    // OpenAI is temporarily disabled (no account credits); the fail-loud guard
+    // requires the active Anthropic secret only.
+    expect(guard).not.toContain("OPENAI_API_KEY");
     expect(guard).toContain("::add-mask::");
     expect(guard).toContain('missing+=("ANTHROPIC_API_KEY")');
-    expect(guard).toContain('missing+=("OPENAI_API_KEY")');
+    expect(guard).not.toContain('missing+=("OPENAI_API_KEY")');
     expect(guard).toContain('echo "::error::missing provider secret(s): ${missing[*]}"');
     expect(guard).toContain("exit 1");
     expect(guard).not.toContain("environment:");
 
-    expect(skipped).toBeNull();
+    expect(workflowJobBlock(evals, "skipped")).toBeNull();
     expect(evals).not.toContain("LLM evals skipped");
     expect(evalJob).not.toContain("needs.guard.outputs.should-run");
     expect(evalJob).toContain("ref: ${{ needs.guard.outputs.checkout-sha }}");
@@ -436,7 +437,7 @@ describe("CI workflow policy", () => {
     const requireSuccess = workflowStepBlock(evals, "Require eval pass-rate success");
     const secretRefs = [...evals.matchAll(/secrets\.([A-Z0-9_]+)/g)].map((match) => match[1]);
 
-    expect([...new Set(secretRefs)].sort()).toEqual(["ANTHROPIC_API_KEY", "OPENAI_API_KEY"]);
+    expect([...new Set(secretRefs)].sort()).toEqual(["ANTHROPIC_API_KEY"]);
     expect(packageJson.scripts?.["evals:provider-comparison"]).toBe(
       "tsx evals/run-provider-comparison.ts",
     );
@@ -448,7 +449,8 @@ describe("CI workflow policy", () => {
     expect(run).toContain('RUN_LLM_EVALS: "1"');
     expect(run).toContain('RUN_LLM_PROVIDER_COMPARISON: "1"');
     expect(run).toContain("ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}");
-    expect(run).toContain("OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}");
+    expect(run).not.toContain("OPENAI_API_KEY");
+    expect(run).not.toMatch(/ANTHROPIC_API_KEY:[\s\S]*OPENAI_API_KEY:/);
     expect(run).toContain("ANTHROPIC_EVAL_MODEL: claude-haiku-4-5-20251001");
     expect(run).toContain("LLM_EVAL_CASE_SET: ci-no-b2");
     expect(run).toContain('LLM_EVAL_CASE_LIMIT: "5"');
@@ -463,7 +465,7 @@ describe("CI workflow policy", () => {
     expect(validate).toContain("id: validate_report");
     expect(validate).toContain("if: always()");
     expect(validate).toContain("ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}");
-    expect(validate).toContain("OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}");
+    expect(validate).not.toContain("OPENAI_API_KEY");
     expect(validate).toContain(
       "node scripts/eval-pass-rate-report.mjs validate reports/evals/provider-pass-rates.json",
     );
@@ -473,10 +475,12 @@ describe("CI workflow policy", () => {
     );
     expect(evalJob).toContain("Provider pass rates");
     expect(upload).toContain("steps.validate_report.outcome == 'success'");
-    expect(upload).toContain("provider-pass-rate-report");
+    expect(upload).toContain("claude-pass-rate-report");
     expect(upload).toContain("path: reports/evals/provider-pass-rates.json");
     expect(upload).toContain("if-no-files-found: error");
     expect(requireSuccess).toContain("steps.run_evals.outcome != 'success'");
+    expect(requireSuccess).toContain("provider eval pass-rate run failed");
+    expect(requireSuccess).not.toContain("Claude eval pass-rate run failed");
     expect(requireSuccess).toContain("exit 1");
     expect(evalJob).not.toContain("path: reports/evals/**");
   });

--- a/tests/contract/ci-workflow-policy.contract.test.ts
+++ b/tests/contract/ci-workflow-policy.contract.test.ts
@@ -390,7 +390,7 @@ describe("CI workflow policy", () => {
 
   it("runs provider evals only from trusted scheduled or manual main refs", () => {
     const guard = workflowJobBlock(evals, "guard") ?? "";
-    const skipped = workflowJobBlock(evals, "skipped") ?? "";
+    const skipped = workflowJobBlock(evals, "skipped");
     const evalJob = workflowJobBlock(evals, "evals") ?? "";
 
     expect(evals).toMatch(topLevelMappingEntry("permissions", "contents", "read"));
@@ -406,40 +406,37 @@ describe("CI workflow policy", () => {
 
     expect(guard).toContain("if: github.repository == 'backblaze-labs/b2-mcp'");
     expect(guard).toContain("checkout-sha: ${{ steps.ref.outputs.checkout_sha }}");
-    expect(guard).toContain("skip-reason: ${{ steps.ref.outputs.skip_reason }}");
+    expect(guard).not.toContain("should-run:");
+    expect(guard).not.toContain("skip-reason:");
     expect(guard).toContain("timeout-minutes: 5");
     expect(guard).toContain("workflow_dispatch|schedule");
     expect(guard).toContain('[[ "$GITHUB_REF" != "refs/heads/main" ]]');
     expect(guard).toContain("ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}");
-    // OpenAI is temporarily disabled (no account credits); the guard requires
-    // Anthropic only and must not reference the OpenAI secret.
-    expect(guard).not.toContain("OPENAI_API_KEY");
+    expect(guard).toContain("OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}");
     expect(guard).toContain("::add-mask::");
-    expect(guard).toContain("should_run=false");
-    expect(guard).toContain("missing provider secret(s)");
+    expect(guard).toContain('missing+=("ANTHROPIC_API_KEY")');
+    expect(guard).toContain('missing+=("OPENAI_API_KEY")');
+    expect(guard).toContain('echo "::error::missing provider secret(s): ${missing[*]}"');
+    expect(guard).toContain("exit 1");
     expect(guard).not.toContain("environment:");
 
-    expect(skipped).toContain("needs.guard.outputs.should-run != 'true'");
-    expect(skipped).toContain("LLM evals skipped");
-    expect(skipped).toContain("SKIP_REASON: ${{ needs.guard.outputs.skip-reason }}");
-    expect(skipped).toContain('echo "LLM evals skipped: ${SKIP_REASON}"');
-    expect(skipped).not.toContain("LLM evals skipped: ${{");
-    expect(evalJob).toContain("needs.guard.outputs.should-run == 'true'");
+    expect(skipped).toBeNull();
+    expect(evals).not.toContain("LLM evals skipped");
+    expect(evalJob).not.toContain("needs.guard.outputs.should-run");
     expect(evalJob).toContain("ref: ${{ needs.guard.outputs.checkout-sha }}");
     expect(evalJob).toContain("persist-credentials: false");
   });
 
-  it("uploads bounded Claude pass-rate artifacts without B2 secrets", () => {
+  it("uploads bounded provider pass-rate artifacts without B2 secrets", () => {
     const evalJob = workflowJobBlock(evals, "evals") ?? "";
-    const run = workflowStepBlock(evals, "Run Claude eval pass rates");
+    const run = workflowStepBlock(evals, "Run provider eval pass rates");
     const validate = workflowStepBlock(evals, "Validate pass-rate report");
     const summary = workflowStepBlock(evals, "Publish pass-rate summary");
-    const upload = workflowStepBlock(evals, "Upload Claude pass-rate report");
+    const upload = workflowStepBlock(evals, "Upload provider pass-rate report");
     const requireSuccess = workflowStepBlock(evals, "Require eval pass-rate success");
     const secretRefs = [...evals.matchAll(/secrets\.([A-Z0-9_]+)/g)].map((match) => match[1]);
 
-    // OpenAI disabled (no account credits): Anthropic is the only provider secret.
-    expect([...new Set(secretRefs)].sort()).toEqual(["ANTHROPIC_API_KEY"]);
+    expect([...new Set(secretRefs)].sort()).toEqual(["ANTHROPIC_API_KEY", "OPENAI_API_KEY"]);
     expect(packageJson.scripts?.["evals:provider-comparison"]).toBe(
       "tsx evals/run-provider-comparison.ts",
     );
@@ -450,8 +447,9 @@ describe("CI workflow policy", () => {
     expect(run).toContain("continue-on-error: true");
     expect(run).toContain('RUN_LLM_EVALS: "1"');
     expect(run).toContain('RUN_LLM_PROVIDER_COMPARISON: "1"');
+    expect(run).toContain("ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}");
+    expect(run).toContain("OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}");
     expect(run).toContain("ANTHROPIC_EVAL_MODEL: claude-haiku-4-5-20251001");
-    expect(run).not.toContain("OPENAI");
     expect(run).toContain("LLM_EVAL_CASE_SET: ci-no-b2");
     expect(run).toContain('LLM_EVAL_CASE_LIMIT: "5"');
     expect(run).toContain('LLM_EVAL_BLOCK_SERVER_NETWORK: "1"');
@@ -465,7 +463,7 @@ describe("CI workflow policy", () => {
     expect(validate).toContain("id: validate_report");
     expect(validate).toContain("if: always()");
     expect(validate).toContain("ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}");
-    expect(validate).not.toContain("OPENAI_API_KEY");
+    expect(validate).toContain("OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}");
     expect(validate).toContain(
       "node scripts/eval-pass-rate-report.mjs validate reports/evals/provider-pass-rates.json",
     );
@@ -473,9 +471,9 @@ describe("CI workflow policy", () => {
     expect(summary).toContain(
       'node scripts/eval-pass-rate-report.mjs summary reports/evals/provider-pass-rates.json >> "$GITHUB_STEP_SUMMARY"',
     );
-    expect(evalJob).toContain("Claude pass rates");
+    expect(evalJob).toContain("Provider pass rates");
     expect(upload).toContain("steps.validate_report.outcome == 'success'");
-    expect(upload).toContain("claude-pass-rate-report");
+    expect(upload).toContain("provider-pass-rate-report");
     expect(upload).toContain("path: reports/evals/provider-pass-rates.json");
     expect(upload).toContain("if-no-files-found: error");
     expect(requireSuccess).toContain("steps.run_evals.outcome != 'success'");

--- a/tests/contract/ci-workflow-policy.contract.test.ts
+++ b/tests/contract/ci-workflow-policy.contract.test.ts
@@ -417,8 +417,10 @@ describe("CI workflow policy", () => {
     expect(guard).toContain("::add-mask::");
     expect(guard).toContain('missing+=("ANTHROPIC_API_KEY")');
     expect(guard).not.toContain('missing+=("OPENAI_API_KEY")');
-    expect(guard).toContain('echo "::error::missing provider secret(s): ${missing[*]}"');
-    expect(guard).toContain("exit 1");
+    expect(guard).toContain(`if [[ "\${#missing[@]}" -gt 0 ]]; then
+            echo "::error::missing provider secret(s): \${missing[*]}"
+            exit 1
+          fi`);
     expect(guard).not.toContain("environment:");
 
     expect(workflowJobBlock(evals, "skipped")).toBeNull();


### PR DESCRIPTION
## Summary
- Fail the evals guard with a masked `::error::` when the active `ANTHROPIC_API_KEY` provider secret is missing.
- Remove the green skipped-evals path while keeping scheduled evals Anthropic-only until OpenAI credits are restored.
- Keep `OPENAI_API_KEY` out of the scheduled eval command environment and preserve the legacy `claude-pass-rate-report` artifact name.
- Use provider-neutral eval labels/errors while preserving the legacy artifact handle.
- Update eval docs and CI workflow policy contracts, including an assertion that the missing-secret error branch exits immediately.

## Linked issue
Closes #271

## Tests
- `pnpm run build`
- `pnpm run test:contract`
- `pnpm run format:check`
- `pnpm run typecheck`

## Follow-up notes
- Ensure `ANTHROPIC_API_KEY` is configured before scheduled/manual eval runs use this workflow.
- Restore `OPENAI_API_KEY` to a separate least-privilege eval path only after OpenAI account credits are available.