### PR TITLE
test(s3/objects): cover object edge branches

### DIFF
--- a/tests/unit/s3-objects-fixtures.unit.test.ts
+++ b/tests/unit/s3-objects-fixtures.unit.test.ts
@@ -372,6 +372,8 @@ describe("S3 object tools with deterministic handler fake", () => {
     const large = await tools.call("s3_get_object", { bucket: "b", key: "large.bin" });
     expect(large.isError).toBe(true);
     expect(largeCanceled).toBe(1);
+    expect(parseResult(large)).toMatch(/s3_get_presigned_url/);
+    expect(parseResult(large)).toMatch(/saveToPath/);
   });
 
   it("streams saveToPath downloads to disk and reports unknown length", async () => {

--- a/tests/unit/s3-objects-fixtures.unit.test.ts
+++ b/tests/unit/s3-objects-fixtures.unit.test.ts
@@ -4,8 +4,14 @@ import * as fs from "node:fs";
 import * as os from "node:os";
 import * as path from "node:path";
 import { registerS3ObjectTools } from "../../src/s3/objects";
-import type { B2S3FileVersionBinding } from "../../src/utils/types";
-import type { B2S3DownloadedObject } from "../../src/s3/aws-sdk-adapter";
+import type { B2S3FileVersionBinding, B2S3VersionGuard } from "../../src/utils/types";
+import type {
+  B2S3DeleteObjectsOptions,
+  B2S3DownloadedObject,
+  B2S3ListObjectsV2Options,
+  B2S3ListObjectsV2Result,
+  B2S3PutObjectOptions,
+} from "../../src/s3/aws-sdk-adapter";
 import { runWithMcpRequestSignal } from "../../src/request-context";
 import {
   circuitBreaker,
@@ -13,7 +19,13 @@ import {
   s3TransferCircuitBreaker,
 } from "../../src/utils/circuit-breaker";
 import { parseErrorText } from "../../src/utils/errors";
-import { ToolHarness, parseResult, testConfig } from "../support/deterministic-fakes";
+import {
+  DeterministicS3ClientFake,
+  ToolHarness,
+  parseResult,
+  s3ServiceError,
+  testConfig,
+} from "../support/deterministic-fakes";
 
 const MAX_INLINE_OBJECT_BYTES = 1024 * 1024;
 
@@ -66,108 +78,36 @@ function notFound(message = "Object not found") {
   return Object.assign(new Error(message), { status: 404, code: "not_found" });
 }
 
-function s3Error(name: string, status: number, message: string, requestId = `${name}-request`) {
-  return Object.assign(new Error(message), {
-    name,
-    $metadata: { httpStatusCode: status, requestId },
-  });
-}
-
 describe("S3 object tools with deterministic handler fake", () => {
   let tools: ToolHarness;
-  let calls: Array<{ operation: string; input: any }> = [];
-  let nextDownload: B2S3DownloadedObject = downloadedObject();
+  let s3: DeterministicS3ClientFake;
   let currentVersion: B2S3FileVersionBinding | null = null;
-  let nextHeadObjectError: unknown = null;
   let nextCurrentVersionError: unknown = null;
   let nextBulkVersionLookupError: unknown = null;
-  let operationErrors = new Map<string, unknown>();
   const versions = new Map<string, B2S3FileVersionBinding>();
   const bucketIds = new Map([["b", "bucket-id"]]);
   let bulkVersionLookups: Array<{
     bucket: string;
     objects: Array<{ key: string; versionId?: string }>;
   }> = [];
-  let nextListObjects = {
-    objects: [],
-    commonPrefixes: [],
-    isTruncated: false,
-    keyCount: 0,
-  };
 
   beforeEach(() => {
-    calls = [];
-    nextDownload = downloadedObject();
+    s3 = new DeterministicS3ClientFake();
+    s3.allowDefault(
+      "putObject",
+      "deleteObject",
+      "deleteObjects",
+      "headObject",
+      "copyObject",
+      "listObjectsV2",
+      "listObjectVersions",
+    );
     currentVersion = null;
-    nextHeadObjectError = null;
     nextCurrentVersionError = null;
     nextBulkVersionLookupError = null;
-    operationErrors = new Map();
     versions.clear();
     bulkVersionLookups = [];
-    nextListObjects = {
-      objects: [],
-      commonPrefixes: [],
-      isTruncated: false,
-      keyCount: 0,
-    };
-    const s3 = {
-      async putObject(input: any) {
-        calls.push({ operation: "putObject", input });
-        if (operationErrors.has("putObject")) throw operationErrors.get("putObject");
-      },
-      async getObject(input: any) {
-        calls.push({ operation: "getObject", input });
-        if (operationErrors.has("getObject")) throw operationErrors.get("getObject");
-        return nextDownload;
-      },
-      async deleteObject(input: any) {
-        calls.push({ operation: "deleteObject", input });
-        if (operationErrors.has("deleteObject")) throw operationErrors.get("deleteObject");
-      },
-      async deleteObjects(input: any) {
-        calls.push({ operation: "deleteObjects", input });
-        if (operationErrors.has("deleteObjects")) throw operationErrors.get("deleteObjects");
-        return {
-          deleted: input.quiet ? [] : input.objects.map((object: any) => ({ Key: object.key })),
-          errors: [],
-          attempted: input.objects.length,
-          aborted: false,
-          maxConcurrency: 1,
-        };
-      },
-      async headObject(input: any) {
-        calls.push({ operation: "headObject", input });
-        if (operationErrors.has("headObject")) throw operationErrors.get("headObject");
-        if (nextHeadObjectError) throw nextHeadObjectError;
-        return {
-          ...downloadedObject(),
-          serverSideEncryption: "AES256",
-          deleteMarker: false,
-        };
-      },
-      async copyObject(input: any) {
-        calls.push({ operation: "copyObject", input });
-        if (operationErrors.has("copyObject")) throw operationErrors.get("copyObject");
-      },
-      async listObjectsV2(input: any) {
-        calls.push({ operation: "listObjectsV2", input });
-        if (operationErrors.has("listObjectsV2")) throw operationErrors.get("listObjectsV2");
-        return nextListObjects;
-      },
-      async listObjectVersions(input: any) {
-        calls.push({ operation: "listObjectVersions", input });
-        if (operationErrors.has("listObjectVersions"))
-          throw operationErrors.get("listObjectVersions");
-        return {
-          versions: [],
-          deleteMarkers: [],
-          commonPrefixes: [],
-          isTruncated: false,
-        };
-      },
-    };
-    const versionGuard = {
+    const versionGuard: B2S3VersionGuard = {
       async resolveS3FileVersion(input: { bucket: string; key: string; versionId: string }) {
         const version = versions.get(input.versionId);
         if (
@@ -208,7 +148,7 @@ describe("S3 object tools with deterministic handler fake", () => {
       },
     };
     tools = new ToolHarness();
-    registerS3ObjectTools(tools, s3 as any, versionGuard, testConfig);
+    registerS3ObjectTools(tools, s3.asPeerClient(), versionGuard, testConfig);
   });
 
   afterEach(() => {
@@ -216,6 +156,22 @@ describe("S3 object tools with deterministic handler fake", () => {
     s3CircuitBreaker.close();
     s3TransferCircuitBreaker.close();
   });
+
+  function queueGetObject(overrides: Partial<B2S3DownloadedObject> = {}) {
+    s3.respond("getObject", downloadedObject(overrides));
+  }
+
+  function firstRequest<TInput>(operation: string): TInput {
+    const request = s3.requestsFor(operation)[0];
+    if (!request) throw new Error(`No ${operation} request captured.`);
+    return request.input as TInput;
+  }
+
+  function putBodyBuffer(input: B2S3PutObjectOptions): Buffer {
+    if (typeof input.body === "string") return Buffer.from(input.body);
+    if (input.body instanceof Uint8Array) return Buffer.from(Array.from(input.body));
+    throw new Error("Expected inline object upload body to be bytes.");
+  }
 
   it("uploads base64 content without touching the filesystem", async () => {
     const result = await tools.call("s3_put_object", {
@@ -228,17 +184,15 @@ describe("S3 object tools with deterministic handler fake", () => {
     });
 
     expect(result.isError).toBeFalsy();
-    expect(calls[0]).toMatchObject({
-      operation: "putObject",
-      input: {
-        bucket: "b",
-        key: "hello.txt",
-        contentType: "text/plain",
-        metadata: { owner: "fixture" },
-        serverSideEncryption: "AES256",
-      },
+    const request = firstRequest<B2S3PutObjectOptions>("putObject");
+    expect(request).toMatchObject({
+      bucket: "b",
+      key: "hello.txt",
+      contentType: "text/plain",
+      metadata: { owner: "fixture" },
+      serverSideEncryption: "AES256",
     });
-    expect(Buffer.from(calls[0].input.body).toString()).toBe("hello");
+    expect(putBodyBuffer(request).toString()).toBe("hello");
   });
 
   it("requires an inline upload source before calling S3", async () => {
@@ -250,7 +204,7 @@ describe("S3 object tools with deterministic handler fake", () => {
 
     expect(result.isError).toBe(true);
     expect(parseResult(result)).toMatch(/Either filePath or content/);
-    expect(calls).toEqual([]);
+    expect(s3.requests).toEqual([]);
   });
 
   it("uploads a small local file through the inline filePath branch", async () => {
@@ -267,32 +221,32 @@ describe("S3 object tools with deterministic handler fake", () => {
       });
 
       expect(result.isError).toBeFalsy();
-      expect(calls[0]).toMatchObject({
-        operation: "putObject",
-        input: {
-          bucket: "b",
-          key: "manifest.json",
-          contentLength: 11,
-          contentType: "application/json",
-        },
+      const request = firstRequest<B2S3PutObjectOptions>("putObject");
+      expect(request).toMatchObject({
+        bucket: "b",
+        key: "manifest.json",
+        contentLength: 11,
+        contentType: "application/json",
       });
-      expect(Buffer.from(calls[0].input.body).toString()).toBe('{"ok":true}');
+      expect(putBodyBuffer(request).toString()).toBe('{"ok":true}');
     } finally {
       fs.rmSync(dir, { recursive: true, force: true });
     }
   });
 
   it("returns small inline objects and forwards list pagination arguments", async () => {
+    queueGetObject();
     const getResult = parseResult(
       await tools.call("s3_get_object", { bucket: "b", key: "hello.txt", range: "bytes=0-4" }),
     );
-    nextListObjects = {
+    const nextListObjects: B2S3ListObjectsV2Result = {
       objects: [{ Key: "a.txt", Size: 1, LastModified: new Date(), StorageClass: "STANDARD" }],
       commonPrefixes: [{ Prefix: "folder/" }],
       isTruncated: true,
       nextContinuationToken: "next",
       keyCount: 1,
-    } as any;
+    };
+    s3.respond("listObjectsV2", nextListObjects);
     const listResult = parseResult(
       await tools.call("s3_list_objects_v2", {
         bucket: "b",
@@ -311,7 +265,7 @@ describe("S3 object tools with deterministic handler fake", () => {
       nextContinuationToken: "next",
       keyCount: 1,
     });
-    expect(calls.find((call) => call.operation === "listObjectsV2")?.input).toMatchObject({
+    expect(firstRequest<B2S3ListObjectsV2Options>("listObjectsV2")).toMatchObject({
       bucket: "b",
       prefix: "a",
       delimiter: "/",
@@ -321,7 +275,7 @@ describe("S3 object tools with deterministic handler fake", () => {
   });
 
   it("reads inline objects from node and transformToWebStream bodies", async () => {
-    nextDownload = downloadedObject({
+    queueGetObject({
       contentLength: 5,
       body: Readable.from(["hello"]) as B2S3DownloadedObject["body"],
     });
@@ -329,7 +283,7 @@ describe("S3 object tools with deterministic handler fake", () => {
       await tools.call("s3_get_object", { bucket: "b", key: "node.txt" }),
     );
 
-    nextDownload = downloadedObject({
+    queueGetObject({
       contentLength: 13,
       body: {
         transformToWebStream: () =>
@@ -352,7 +306,7 @@ describe("S3 object tools with deterministic handler fake", () => {
   it("enforces the inline cap while reading an oversized node body", async () => {
     const body = Readable.from([Buffer.alloc(MAX_INLINE_OBJECT_BYTES + 1)]);
     const destroySpy = vi.spyOn(body, "destroy");
-    nextDownload = downloadedObject({
+    queueGetObject({
       contentLength: 1,
       body: body as B2S3DownloadedObject["body"],
     });
@@ -365,13 +319,13 @@ describe("S3 object tools with deterministic handler fake", () => {
   });
 
   it("reports missing get-object bodies for inline and saveToPath reads", async () => {
-    nextDownload = downloadedObject({ contentLength: 0, body: undefined });
+    queueGetObject({ contentLength: 0, body: undefined });
     const inline = await tools.call("s3_get_object", { bucket: "b", key: "empty-body.txt" });
 
     const dir = fs.mkdtempSync(path.join(os.tmpdir(), "b2-missing-body-"));
     const target = path.join(dir, "out.txt");
     try {
-      nextDownload = downloadedObject({ contentLength: 0, body: undefined });
+      queueGetObject({ contentLength: 0, body: undefined });
       const saved = await tools.call("s3_get_object", {
         bucket: "b",
         key: "empty-body.txt",
@@ -389,7 +343,7 @@ describe("S3 object tools with deterministic handler fake", () => {
 
   it("cancels inline reads with invalid or oversized content lengths", async () => {
     let invalidCanceled = 0;
-    nextDownload = downloadedObject({
+    queueGetObject({
       contentLength: -1,
       body: streamFrom([new Uint8Array([1])], () => invalidCanceled++),
     });
@@ -398,7 +352,7 @@ describe("S3 object tools with deterministic handler fake", () => {
     expect(invalidCanceled).toBe(1);
 
     let largeCanceled = 0;
-    nextDownload = downloadedObject({
+    queueGetObject({
       contentLength: 1024 * 1024 + 1,
       body: streamFrom([new Uint8Array([1])], () => largeCanceled++),
     });
@@ -410,7 +364,7 @@ describe("S3 object tools with deterministic handler fake", () => {
   it("streams saveToPath downloads to disk and reports unknown length", async () => {
     const dir = fs.mkdtempSync(path.join(os.tmpdir(), "b2-save-ok-"));
     const target = path.join(dir, "nested", "out.txt");
-    nextDownload = downloadedObject({
+    queueGetObject({
       contentLength: undefined,
       body: {
         transformToWebStream: () =>
@@ -449,7 +403,7 @@ describe("S3 object tools with deterministic handler fake", () => {
       },
     });
     const destroySpy = vi.spyOn(body, "destroy");
-    nextDownload = downloadedObject({
+    queueGetObject({
       contentLength: 1,
       body: body as B2S3DownloadedObject["body"],
     });
@@ -480,7 +434,7 @@ describe("S3 object tools with deterministic handler fake", () => {
       },
     });
     const destroySpy = vi.spyOn(body, "destroy");
-    nextDownload = downloadedObject({
+    queueGetObject({
       contentLength: 100,
       body: body as B2S3DownloadedObject["body"],
     });
@@ -515,7 +469,7 @@ describe("S3 object tools with deterministic handler fake", () => {
       cancel: vi.fn().mockResolvedValue(undefined),
       releaseLock: vi.fn(),
     };
-    nextDownload = downloadedObject({
+    queueGetObject({
       contentLength: 5,
       body: { getReader: () => reader } as unknown as B2S3DownloadedObject["body"],
     });
@@ -564,7 +518,7 @@ describe("S3 object tools with deterministic handler fake", () => {
         },
       ],
     });
-    expect(calls.find((call) => call.operation === "deleteObjects")?.input.objects).toEqual([
+    expect(firstRequest<B2S3DeleteObjectsOptions>("deleteObjects").objects).toEqual([
       { key: "latest.txt" },
     ]);
   });
@@ -585,7 +539,7 @@ describe("S3 object tools with deterministic handler fake", () => {
       aborted: false,
       maxConcurrency: 0,
     });
-    expect(calls.some((call) => call.operation === "deleteObjects")).toBe(false);
+    expect(s3.requestsFor("deleteObjects")).toHaveLength(0);
   });
 
   it("enforces destructive confirmation on object delete calls", async () => {
@@ -594,7 +548,7 @@ describe("S3 object tools with deterministic handler fake", () => {
       objects: [{ key: "a.txt" }],
     });
     expect(blocked.isError).toBe(true);
-    expect(calls.some((call) => call.operation === "deleteObjects")).toBe(false);
+    expect(s3.requestsFor("deleteObjects")).toHaveLength(0);
 
     const blockedBypass = parseResult(
       await tools.call("s3_delete_objects", {
@@ -604,7 +558,7 @@ describe("S3 object tools with deterministic handler fake", () => {
       }),
     );
     expect(blockedBypass).toContain("bypass governance-mode Object Lock retention");
-    expect(calls.some((call) => call.operation === "deleteObjects")).toBe(false);
+    expect(s3.requestsFor("deleteObjects")).toHaveLength(0);
 
     const allowed = parseResult(
       await tools.call("s3_delete_objects", {
@@ -615,7 +569,7 @@ describe("S3 object tools with deterministic handler fake", () => {
       }),
     );
     expect(allowed).toMatchObject({ attempted: 1, aborted: false, maxConcurrency: 1 });
-    expect(calls.find((call) => call.operation === "deleteObjects")?.input).toMatchObject({
+    expect(firstRequest<B2S3DeleteObjectsOptions>("deleteObjects")).toMatchObject({
       quiet: false,
     });
   });
@@ -669,11 +623,11 @@ describe("S3 object tools with deterministic handler fake", () => {
       ],
     });
     expect(copy.isError).toBe(true);
-    expect(calls.some((call) => call.operation === "getObject")).toBe(false);
-    expect(calls.some((call) => call.operation === "headObject")).toBe(false);
-    expect(calls.some((call) => call.operation === "deleteObject")).toBe(false);
-    expect(calls.some((call) => call.operation === "deleteObjects")).toBe(false);
-    expect(calls.some((call) => call.operation === "copyObject")).toBe(false);
+    expect(s3.requestsFor("getObject")).toHaveLength(0);
+    expect(s3.requestsFor("headObject")).toHaveLength(0);
+    expect(s3.requestsFor("deleteObject")).toHaveLength(0);
+    expect(s3.requestsFor("deleteObjects")).toHaveLength(0);
+    expect(s3.requestsFor("copyObject")).toHaveLength(0);
   });
 
   it("keeps bulk delete partial results when one version binding is invalid", async () => {
@@ -717,7 +671,7 @@ describe("S3 object tools with deterministic handler fake", () => {
         ],
       },
     ]);
-    expect(calls.find((call) => call.operation === "deleteObjects")?.input.objects).toEqual([
+    expect(firstRequest<B2S3DeleteObjectsOptions>("deleteObjects").objects).toEqual([
       { key: "public/allowed.txt", versionId: "allowed-version" },
       { key: "public/latest.txt" },
     ]);
@@ -725,16 +679,17 @@ describe("S3 object tools with deterministic handler fake", () => {
 
   it("reports deleteMarker for current and explicit hide-marker versions", async () => {
     currentVersion = fileVersion({ action: "hide", fileId: "hide-current" });
-    nextHeadObjectError = Object.assign(new Error("not found"), {
-      name: "NotFound",
-      $metadata: { httpHeaders: { "x-amz-delete-marker": "true" }, httpStatusCode: 404 },
-    });
+    s3.fail(
+      "headObject",
+      Object.assign(s3ServiceError("NotFound", "not found", 404), {
+        $metadata: { httpHeaders: { "x-amz-delete-marker": "true" }, httpStatusCode: 404 },
+      }),
+    );
     const current = parseResult(
       await tools.call("s3_head_object", { bucket: "b", key: "hello.txt" }),
     );
 
     versions.set("hide-explicit", fileVersion({ action: "hide", fileId: "hide-explicit" }));
-    nextHeadObjectError = null;
     const explicit = parseResult(
       await tools.call("s3_head_object", {
         bucket: "b",
@@ -753,17 +708,19 @@ describe("S3 object tools with deterministic handler fake", () => {
       versionId: "hide-explicit",
       deleteMarker: true,
     });
-    expect(calls.filter((call) => call.operation === "headObject")).toHaveLength(1);
+    expect(s3.requestsFor("headObject")).toHaveLength(1);
   });
 
   it("preserves the S3 head error when delete-marker fallback cannot synthesize one", async () => {
-    nextHeadObjectError = Object.assign(s3Error("NoSuchKey", 404, "missing", "rq-head"), {
+    const headError = Object.assign(s3ServiceError("NoSuchKey", "missing", 404, "rq-head"), {
       DeleteMarker: true,
     });
+    s3.fail("headObject", headError);
     currentVersion = fileVersion({ action: "upload" });
 
     const uploadVersion = await tools.call("s3_head_object", { bucket: "b", key: "hello.txt" });
 
+    s3.fail("headObject", headError);
     nextCurrentVersionError = new Error("native version lookup failed");
     const fallbackFailure = await tools.call("s3_head_object", {
       bucket: "b",
@@ -794,35 +751,35 @@ describe("S3 object tools with deterministic handler fake", () => {
         content: Buffer.from("hello").toString("base64"),
         contentType: "text/plain",
       },
-      error: s3Error("AccessDenied", 403, "denied", "rq-put"),
+      error: s3ServiceError("AccessDenied", "denied", 403, "rq-put"),
       expected: { code: "AccessDenied", status: 403, requestId: "rq-put" },
     },
     {
       tool: "s3_get_object",
       operation: "getObject",
       args: { bucket: "b", key: "missing.txt" },
-      error: s3Error("NoSuchKey", 404, "missing", "rq-get"),
+      error: s3ServiceError("NoSuchKey", "missing", 404, "rq-get"),
       expected: { code: "NoSuchKey", status: 404, requestId: "rq-get" },
     },
     {
       tool: "s3_delete_object",
       operation: "deleteObject",
       args: { bucket: "b", key: "locked.txt", confirm: true },
-      error: s3Error("AccessDenied", 403, "delete denied", "rq-delete"),
+      error: s3ServiceError("AccessDenied", "delete denied", 403, "rq-delete"),
       expected: { code: "AccessDenied", status: 403, requestId: "rq-delete" },
     },
     {
       tool: "s3_delete_objects",
       operation: "deleteObjects",
       args: { bucket: "b", objects: [{ key: "locked.txt" }], confirm: true },
-      error: s3Error("AccessDenied", 403, "bulk delete denied", "rq-delete-many"),
+      error: s3ServiceError("AccessDenied", "bulk delete denied", 403, "rq-delete-many"),
       expected: { code: "AccessDenied", status: 403, requestId: "rq-delete-many" },
     },
     {
       tool: "s3_head_object",
       operation: "headObject",
       args: { bucket: "b", key: "missing.txt" },
-      error: s3Error("NoSuchKey", 404, "missing", "rq-head-mapping"),
+      error: s3ServiceError("NoSuchKey", "missing", 404, "rq-head-mapping"),
       expected: { code: "NoSuchKey", status: 404, requestId: "rq-head-mapping" },
     },
     {
@@ -834,27 +791,27 @@ describe("S3 object tools with deterministic handler fake", () => {
         destinationBucket: "b",
         destinationKey: "dest.txt",
       },
-      error: s3Error("PreconditionFailed", 412, "condition failed", "rq-copy"),
+      error: s3ServiceError("PreconditionFailed", "condition failed", 412, "rq-copy"),
       expected: { code: "PreconditionFailed", status: 412, requestId: "rq-copy" },
     },
     {
       tool: "s3_list_objects_v2",
       operation: "listObjectsV2",
       args: { bucket: "b" },
-      error: s3Error("AccessDenied", 403, "list denied", "rq-list"),
+      error: s3ServiceError("AccessDenied", "list denied", 403, "rq-list"),
       expected: { code: "AccessDenied", status: 403, requestId: "rq-list" },
     },
     {
       tool: "s3_list_object_versions",
       operation: "listObjectVersions",
       args: { bucket: "b" },
-      error: s3Error("AccessDenied", 403, "versions denied", "rq-versions"),
+      error: s3ServiceError("AccessDenied", "versions denied", 403, "rq-versions"),
       expected: { code: "AccessDenied", status: 403, requestId: "rq-versions" },
     },
   ])(
     "maps $tool S3 errors into MCP error text",
     async ({ tool, operation, args, error, expected }) => {
-      operationErrors.set(operation, error);
+      s3.fail(operation, error);
 
       const result = await tools.call(tool, args);
 

--- a/tests/unit/s3-objects-fixtures.unit.test.ts
+++ b/tests/unit/s3-objects-fixtures.unit.test.ts
@@ -12,7 +12,10 @@ import {
   s3CircuitBreaker,
   s3TransferCircuitBreaker,
 } from "../../src/utils/circuit-breaker";
+import { parseErrorText } from "../../src/utils/errors";
 import { ToolHarness, parseResult, testConfig } from "../support/deterministic-fakes";
+
+const MAX_INLINE_OBJECT_BYTES = 1024 * 1024;
 
 function streamFrom(
   chunks: Uint8Array[],
@@ -63,12 +66,22 @@ function notFound(message = "Object not found") {
   return Object.assign(new Error(message), { status: 404, code: "not_found" });
 }
 
+function s3Error(name: string, status: number, message: string, requestId = `${name}-request`) {
+  return Object.assign(new Error(message), {
+    name,
+    $metadata: { httpStatusCode: status, requestId },
+  });
+}
+
 describe("S3 object tools with deterministic handler fake", () => {
   let tools: ToolHarness;
   let calls: Array<{ operation: string; input: any }> = [];
   let nextDownload: B2S3DownloadedObject = downloadedObject();
   let currentVersion: B2S3FileVersionBinding | null = null;
   let nextHeadObjectError: unknown = null;
+  let nextCurrentVersionError: unknown = null;
+  let nextBulkVersionLookupError: unknown = null;
+  let operationErrors = new Map<string, unknown>();
   const versions = new Map<string, B2S3FileVersionBinding>();
   const bucketIds = new Map([["b", "bucket-id"]]);
   let bulkVersionLookups: Array<{
@@ -87,6 +100,9 @@ describe("S3 object tools with deterministic handler fake", () => {
     nextDownload = downloadedObject();
     currentVersion = null;
     nextHeadObjectError = null;
+    nextCurrentVersionError = null;
+    nextBulkVersionLookupError = null;
+    operationErrors = new Map();
     versions.clear();
     bulkVersionLookups = [];
     nextListObjects = {
@@ -98,16 +114,20 @@ describe("S3 object tools with deterministic handler fake", () => {
     const s3 = {
       async putObject(input: any) {
         calls.push({ operation: "putObject", input });
+        if (operationErrors.has("putObject")) throw operationErrors.get("putObject");
       },
       async getObject(input: any) {
         calls.push({ operation: "getObject", input });
+        if (operationErrors.has("getObject")) throw operationErrors.get("getObject");
         return nextDownload;
       },
       async deleteObject(input: any) {
         calls.push({ operation: "deleteObject", input });
+        if (operationErrors.has("deleteObject")) throw operationErrors.get("deleteObject");
       },
       async deleteObjects(input: any) {
         calls.push({ operation: "deleteObjects", input });
+        if (operationErrors.has("deleteObjects")) throw operationErrors.get("deleteObjects");
         return {
           deleted: input.quiet ? [] : input.objects.map((object: any) => ({ Key: object.key })),
           errors: [],
@@ -118,6 +138,7 @@ describe("S3 object tools with deterministic handler fake", () => {
       },
       async headObject(input: any) {
         calls.push({ operation: "headObject", input });
+        if (operationErrors.has("headObject")) throw operationErrors.get("headObject");
         if (nextHeadObjectError) throw nextHeadObjectError;
         return {
           ...downloadedObject(),
@@ -127,13 +148,17 @@ describe("S3 object tools with deterministic handler fake", () => {
       },
       async copyObject(input: any) {
         calls.push({ operation: "copyObject", input });
+        if (operationErrors.has("copyObject")) throw operationErrors.get("copyObject");
       },
       async listObjectsV2(input: any) {
         calls.push({ operation: "listObjectsV2", input });
+        if (operationErrors.has("listObjectsV2")) throw operationErrors.get("listObjectsV2");
         return nextListObjects;
       },
       async listObjectVersions(input: any) {
         calls.push({ operation: "listObjectVersions", input });
+        if (operationErrors.has("listObjectVersions"))
+          throw operationErrors.get("listObjectVersions");
         return {
           versions: [],
           deleteMarkers: [],
@@ -158,6 +183,7 @@ describe("S3 object tools with deterministic handler fake", () => {
         bucket: string;
         objects: Array<{ key: string; versionId?: string }>;
       }) {
+        if (nextBulkVersionLookupError) throw nextBulkVersionLookupError;
         bulkVersionLookups.push(input);
         return input.objects.map((object) => {
           if (object.versionId === undefined) return { object, version: null };
@@ -177,6 +203,7 @@ describe("S3 object tools with deterministic handler fake", () => {
         });
       },
       async getCurrentS3FileVersion() {
+        if (nextCurrentVersionError) throw nextCurrentVersionError;
         return currentVersion;
       },
     };
@@ -212,6 +239,47 @@ describe("S3 object tools with deterministic handler fake", () => {
       },
     });
     expect(Buffer.from(calls[0].input.body).toString()).toBe("hello");
+  });
+
+  it("requires an inline upload source before calling S3", async () => {
+    const result = await tools.call("s3_put_object", {
+      bucket: "b",
+      key: "empty.txt",
+      contentType: "text/plain",
+    });
+
+    expect(result.isError).toBe(true);
+    expect(parseResult(result)).toMatch(/Either filePath or content/);
+    expect(calls).toEqual([]);
+  });
+
+  it("uploads a small local file through the inline filePath branch", async () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), "b2-inline-put-"));
+    const filePath = path.join(dir, "manifest.json");
+    try {
+      fs.writeFileSync(filePath, '{"ok":true}');
+
+      const result = await tools.call("s3_put_object", {
+        bucket: "b",
+        key: "manifest.json",
+        filePath,
+        contentType: "application/json",
+      });
+
+      expect(result.isError).toBeFalsy();
+      expect(calls[0]).toMatchObject({
+        operation: "putObject",
+        input: {
+          bucket: "b",
+          key: "manifest.json",
+          contentLength: 11,
+          contentType: "application/json",
+        },
+      });
+      expect(Buffer.from(calls[0].input.body).toString()).toBe('{"ok":true}');
+    } finally {
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
   });
 
   it("returns small inline objects and forwards list pagination arguments", async () => {
@@ -252,6 +320,73 @@ describe("S3 object tools with deterministic handler fake", () => {
     });
   });
 
+  it("reads inline objects from node and transformToWebStream bodies", async () => {
+    nextDownload = downloadedObject({
+      contentLength: 5,
+      body: Readable.from(["hello"]) as B2S3DownloadedObject["body"],
+    });
+    const nodeResult = parseResult(
+      await tools.call("s3_get_object", { bucket: "b", key: "node.txt" }),
+    );
+
+    nextDownload = downloadedObject({
+      contentLength: 13,
+      body: {
+        transformToWebStream: () =>
+          new ReadableStream<Uint8Array>({
+            start(controller) {
+              controller.enqueue(new TextEncoder().encode("via-transform"));
+              controller.close();
+            },
+          }),
+      } as unknown as B2S3DownloadedObject["body"],
+    });
+    const transformResult = parseResult(
+      await tools.call("s3_get_object", { bucket: "b", key: "transform.txt" }),
+    );
+
+    expect(nodeResult.content).toBe(Buffer.from("hello").toString("base64"));
+    expect(transformResult.content).toBe(Buffer.from("via-transform").toString("base64"));
+  });
+
+  it("enforces the inline cap while reading an oversized node body", async () => {
+    const body = Readable.from([Buffer.alloc(MAX_INLINE_OBJECT_BYTES + 1)]);
+    const destroySpy = vi.spyOn(body, "destroy");
+    nextDownload = downloadedObject({
+      contentLength: 1,
+      body: body as B2S3DownloadedObject["body"],
+    });
+
+    const result = await tools.call("s3_get_object", { bucket: "b", key: "lying.bin" });
+
+    expect(result.isError).toBe(true);
+    expect(parseResult(result)).toMatch(/inline read limit|exceeded/i);
+    expect(destroySpy).toHaveBeenCalled();
+  });
+
+  it("reports missing get-object bodies for inline and saveToPath reads", async () => {
+    nextDownload = downloadedObject({ contentLength: 0, body: undefined });
+    const inline = await tools.call("s3_get_object", { bucket: "b", key: "empty-body.txt" });
+
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), "b2-missing-body-"));
+    const target = path.join(dir, "out.txt");
+    try {
+      nextDownload = downloadedObject({ contentLength: 0, body: undefined });
+      const saved = await tools.call("s3_get_object", {
+        bucket: "b",
+        key: "empty-body.txt",
+        saveToPath: target,
+      });
+
+      expect(inline.isError).toBe(true);
+      expect(saved.isError).toBe(true);
+      expect(parseResult(inline)).toMatch(/readable body/i);
+      expect(parseResult(saved)).toMatch(/readable body/i);
+    } finally {
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
   it("cancels inline reads with invalid or oversized content lengths", async () => {
     let invalidCanceled = 0;
     nextDownload = downloadedObject({
@@ -270,6 +405,37 @@ describe("S3 object tools with deterministic handler fake", () => {
     const large = await tools.call("s3_get_object", { bucket: "b", key: "large.bin" });
     expect(large.isError).toBe(true);
     expect(largeCanceled).toBe(1);
+  });
+
+  it("streams saveToPath downloads to disk and reports unknown length", async () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), "b2-save-ok-"));
+    const target = path.join(dir, "nested", "out.txt");
+    nextDownload = downloadedObject({
+      contentLength: undefined,
+      body: {
+        transformToWebStream: () =>
+          new ReadableStream<Uint8Array>({
+            start(controller) {
+              controller.enqueue(new TextEncoder().encode("saved through stream"));
+              controller.close();
+            },
+          }),
+      } as unknown as B2S3DownloadedObject["body"],
+    });
+
+    try {
+      const result = await tools.call("s3_get_object", {
+        bucket: "b",
+        key: "hello.txt",
+        saveToPath: target,
+      });
+
+      expect(result.isError).toBeFalsy();
+      expect(parseResult(result)).toContain("unknown bytes");
+      expect(fs.readFileSync(target, "utf8")).toBe("saved through stream");
+    } finally {
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
   });
 
   it("destroys the body when inline reading aborts after headers", async () => {
@@ -367,6 +533,59 @@ describe("S3 object tools with deterministic handler fake", () => {
     expect(parseResult(result)).toMatch(/client disconnected|aborted/i);
     expect(reader.cancel).toHaveBeenCalled();
     expect(reader.releaseLock).toHaveBeenCalled();
+  });
+
+  it("preserves unversioned deletes when bulk version validation throws", async () => {
+    nextBulkVersionLookupError = Object.assign(new Error("version lookup failed"), {
+      status: 503,
+      code: "version_lookup_failed",
+      requestId: "rq-version-lookup",
+    });
+
+    const result = parseResult(
+      await tools.call("s3_delete_objects", {
+        bucket: "b",
+        objects: [{ key: "latest.txt" }, { key: "old.txt", versionId: "v1" }],
+        quiet: false,
+        confirm: true,
+      }),
+    );
+
+    expect(result).toMatchObject({
+      deleted: [{ Key: "latest.txt" }],
+      attempted: 2,
+      errors: [
+        {
+          Key: "old.txt",
+          VersionId: "v1",
+          Code: "version_lookup_failed",
+          Message: "version lookup failed",
+          RequestId: "rq-version-lookup",
+        },
+      ],
+    });
+    expect(calls.find((call) => call.operation === "deleteObjects")?.input.objects).toEqual([
+      { key: "latest.txt" },
+    ]);
+  });
+
+  it("returns an empty deleteObjects result without calling S3", async () => {
+    const result = parseResult(
+      await tools.call("s3_delete_objects", {
+        bucket: "b",
+        objects: [],
+        confirm: true,
+      }),
+    );
+
+    expect(result).toMatchObject({
+      deleted: [],
+      errors: [],
+      attempted: 0,
+      aborted: false,
+      maxConcurrency: 0,
+    });
+    expect(calls.some((call) => call.operation === "deleteObjects")).toBe(false);
   });
 
   it("enforces destructive confirmation on object delete calls", async () => {
@@ -536,4 +755,111 @@ describe("S3 object tools with deterministic handler fake", () => {
     });
     expect(calls.filter((call) => call.operation === "headObject")).toHaveLength(1);
   });
+
+  it("preserves the S3 head error when delete-marker fallback cannot synthesize one", async () => {
+    nextHeadObjectError = Object.assign(s3Error("NoSuchKey", 404, "missing", "rq-head"), {
+      DeleteMarker: true,
+    });
+    currentVersion = fileVersion({ action: "upload" });
+
+    const uploadVersion = await tools.call("s3_head_object", { bucket: "b", key: "hello.txt" });
+
+    nextCurrentVersionError = new Error("native version lookup failed");
+    const fallbackFailure = await tools.call("s3_head_object", {
+      bucket: "b",
+      key: "hello.txt",
+    });
+
+    expect(uploadVersion.isError).toBe(true);
+    expect(fallbackFailure.isError).toBe(true);
+    expect(parseErrorText(parseResult(uploadVersion))).toMatchObject({
+      code: "NoSuchKey",
+      status: 404,
+      requestId: "rq-head",
+    });
+    expect(parseErrorText(parseResult(fallbackFailure))).toMatchObject({
+      code: "NoSuchKey",
+      status: 404,
+      requestId: "rq-head",
+    });
+  });
+
+  it.each([
+    {
+      tool: "s3_put_object",
+      operation: "putObject",
+      args: {
+        bucket: "b",
+        key: "put.txt",
+        content: Buffer.from("hello").toString("base64"),
+        contentType: "text/plain",
+      },
+      error: s3Error("AccessDenied", 403, "denied", "rq-put"),
+      expected: { code: "AccessDenied", status: 403, requestId: "rq-put" },
+    },
+    {
+      tool: "s3_get_object",
+      operation: "getObject",
+      args: { bucket: "b", key: "missing.txt" },
+      error: s3Error("NoSuchKey", 404, "missing", "rq-get"),
+      expected: { code: "NoSuchKey", status: 404, requestId: "rq-get" },
+    },
+    {
+      tool: "s3_delete_object",
+      operation: "deleteObject",
+      args: { bucket: "b", key: "locked.txt", confirm: true },
+      error: s3Error("AccessDenied", 403, "delete denied", "rq-delete"),
+      expected: { code: "AccessDenied", status: 403, requestId: "rq-delete" },
+    },
+    {
+      tool: "s3_delete_objects",
+      operation: "deleteObjects",
+      args: { bucket: "b", objects: [{ key: "locked.txt" }], confirm: true },
+      error: s3Error("AccessDenied", 403, "bulk delete denied", "rq-delete-many"),
+      expected: { code: "AccessDenied", status: 403, requestId: "rq-delete-many" },
+    },
+    {
+      tool: "s3_head_object",
+      operation: "headObject",
+      args: { bucket: "b", key: "missing.txt" },
+      error: s3Error("NoSuchKey", 404, "missing", "rq-head-mapping"),
+      expected: { code: "NoSuchKey", status: 404, requestId: "rq-head-mapping" },
+    },
+    {
+      tool: "s3_copy_object",
+      operation: "copyObject",
+      args: {
+        sourceBucket: "b",
+        sourceKey: "source.txt",
+        destinationBucket: "b",
+        destinationKey: "dest.txt",
+      },
+      error: s3Error("PreconditionFailed", 412, "condition failed", "rq-copy"),
+      expected: { code: "PreconditionFailed", status: 412, requestId: "rq-copy" },
+    },
+    {
+      tool: "s3_list_objects_v2",
+      operation: "listObjectsV2",
+      args: { bucket: "b" },
+      error: s3Error("AccessDenied", 403, "list denied", "rq-list"),
+      expected: { code: "AccessDenied", status: 403, requestId: "rq-list" },
+    },
+    {
+      tool: "s3_list_object_versions",
+      operation: "listObjectVersions",
+      args: { bucket: "b" },
+      error: s3Error("AccessDenied", 403, "versions denied", "rq-versions"),
+      expected: { code: "AccessDenied", status: 403, requestId: "rq-versions" },
+    },
+  ])(
+    "maps $tool S3 errors into MCP error text",
+    async ({ tool, operation, args, error, expected }) => {
+      operationErrors.set(operation, error);
+
+      const result = await tools.call(tool, args);
+
+      expect(result.isError).toBe(true);
+      expect(parseErrorText(parseResult(result))).toMatchObject(expected);
+    },
+  );
 });

--- a/tests/unit/s3-objects-fixtures.unit.test.ts
+++ b/tests/unit/s3-objects-fixtures.unit.test.ts
@@ -207,6 +207,19 @@ describe("S3 object tools with deterministic handler fake", () => {
     expect(s3.requests).toEqual([]);
   });
 
+  it("refuses oversized inline uploads before calling S3", async () => {
+    const result = await tools.call("s3_put_object", {
+      bucket: "b",
+      key: "large.bin",
+      content: Buffer.alloc(MAX_INLINE_OBJECT_BYTES + 1).toString("base64"),
+      contentType: "application/octet-stream",
+    });
+
+    expect(result.isError).toBe(true);
+    expect(parseResult(result)).toMatch(/inline limit|s3_get_presigned_url|multipart tools/i);
+    expect(s3.requestsFor("putObject")).toHaveLength(0);
+  });
+
   it("uploads a small local file through the inline filePath branch", async () => {
     const dir = fs.mkdtempSync(path.join(os.tmpdir(), "b2-inline-put-"));
     const filePath = path.join(dir, "manifest.json");


### PR DESCRIPTION
## Summary
- Adds deterministic S3 object fixture coverage for inline upload/read size guards, including oversized s3_put_object and s3_get_object refusals with presigned/multipart guidance.
- Covers local file upload, saveToPath streaming success/failure, missing bodies, bulk delete validation fallback, delete-marker fallback, and mapped S3 errors.
- Refactors object fixtures onto the shared typed DeterministicS3ClientFake and s3ServiceError helpers so tests compile against the S3 peer client contract.
- Asserts the oversized s3_get_object error text steers callers to s3_get_presigned_url and saveToPath, so the guidance cannot silently regress (review follow-up).
- Confirms src/s3/objects.ts branch coverage increases from 74.72% to 87.36%.

## Commits
- ebfa351 test: cover s3 object edge branches
- c36c29c test: use typed s3 object fake
- 466e0e8 test: cover oversized object upload
- e68aea6 test: assert presigned guidance on oversized get

## Linked Issue
Closes #275

## Tests
- pnpm run typecheck
- pnpm exec vitest run --config vitest.config.mts --project=unit tests/unit/s3-objects-fixtures.unit.test.ts
- pnpm run test:coverage
