### PR TITLE
test(security): cover secret redaction branches

### DIFF
--- a/src/utils/secret-sanitizer.ts
+++ b/src/utils/secret-sanitizer.ts
@@ -218,8 +218,8 @@ export function sanitizerOptionsFromConfig(config?: SanitizerSecretConfig): Sani
   return { secrets: configuredSecretValuesFromConfig(config) };
 }
 
-export function sanitizeText(text: string, options: SanitizerOptions = {}): string {
-  let safe = text;
+export function sanitizeText(text: unknown, options: SanitizerOptions = {}): string {
+  let safe = typeof text === "string" ? text : String(text);
   for (const secret of configuredSecretValues(options).sort((a, b) => b.length - a.length)) {
     safe = safe.split(secret).join(REDACTED);
   }

--- a/src/utils/secret-sanitizer.ts
+++ b/src/utils/secret-sanitizer.ts
@@ -219,8 +219,8 @@ export function sanitizerOptionsFromConfig(config?: SanitizerSecretConfig): Sani
 }
 
 export function sanitizeText(text: string, options: SanitizerOptions = {}): string {
-  let safe = typeof text === "string" ? text : String(text);
-  for (const secret of configuredSecretValues(options)) {
+  let safe = text;
+  for (const secret of configuredSecretValues(options).sort((a, b) => b.length - a.length)) {
     safe = safe.split(secret).join(REDACTED);
   }
   return safe
@@ -397,7 +397,10 @@ function sanitizedIdentifier(
   return allowed.test(value) ? value : REDACTED;
 }
 
-export function sanitizeProviderCode(code: string, options: SanitizerOptions = {}): string {
+export function sanitizeProviderCode(
+  code: string | undefined,
+  options: SanitizerOptions = {},
+): string {
   return (
     sanitizedIdentifier(code, /^[A-Za-z0-9][A-Za-z0-9_.-]{0,127}$/, options) ?? "unknown_error"
   );

--- a/src/utils/secret-sanitizer.ts
+++ b/src/utils/secret-sanitizer.ts
@@ -219,7 +219,7 @@ export function sanitizerOptionsFromConfig(config?: SanitizerSecretConfig): Sani
 }
 
 export function sanitizeText(text: unknown, options: SanitizerOptions = {}): string {
-  let safe = typeof text === "string" ? text : String(text);
+  let safe = String(text);
   for (const secret of configuredSecretValues(options).sort((a, b) => b.length - a.length)) {
     safe = safe.split(secret).join(REDACTED);
   }

--- a/src/utils/secret-sink.ts
+++ b/src/utils/secret-sink.ts
@@ -19,13 +19,6 @@ export const APPLICATION_KEY_REDACTED = "[redacted]";
 export const INLINE_SECRET_WARNING =
   "B2_SECRET_SINK=inline: this application key secret was returned into the model context and may be logged or retained by the client. Rotate it after use.";
 
-type SecretSinkWriteSync = (
-  fd: number,
-  buffer: Uint8Array,
-  offset: number,
-  length: number,
-) => number;
-
 const SECRET_SINK_FILE_ENV = "B2_SECRET_SINK_FILE";
 const SECRET_SINK_PARENT_MODE = 0o700;
 const HTTP_INLINE_OPT_IN_ENV = "B2_ALLOW_INLINE_SECRETS";
@@ -40,24 +33,17 @@ export const secretSinkFileOpsForTests = {
   renameSync: fs.renameSync,
 };
 
-const secretSinkSensitiveWriteOpsForTests: { writeSync: SecretSinkWriteSync } = {
-  writeSync: fs.writeSync,
-};
+type SinkWrite = (fd: number, buffer: Uint8Array, offset: number, length: number) => number;
 
-export function withSecretSinkSensitiveWriteOpsForTests<T>(
-  ops: Partial<typeof secretSinkSensitiveWriteOpsForTests>,
-  callback: () => T,
-): T {
+let secretSinkWrite: SinkWrite = fs.writeSync;
+
+export function setSinkWriteForTests(writeSync: SinkWrite): SinkWrite {
   if (process.env.NODE_ENV !== "test") {
-    throw new Error("Secret sink sensitive write hooks are only available in tests");
+    throw new Error("test only");
   }
-  const previous = { ...secretSinkSensitiveWriteOpsForTests };
-  Object.assign(secretSinkSensitiveWriteOpsForTests, ops);
-  try {
-    return callback();
-  } finally {
-    Object.assign(secretSinkSensitiveWriteOpsForTests, previous);
-  }
+  const previous = secretSinkWrite;
+  secretSinkWrite = writeSync;
+  return previous;
 }
 
 let inlineWarningEmitted = false;
@@ -301,12 +287,7 @@ function writeAll(fd: number, line: string): void {
   const buffer = new TextEncoder().encode(line);
   let offset = 0;
   while (offset < buffer.length) {
-    const written = secretSinkSensitiveWriteOpsForTests.writeSync(
-      fd,
-      buffer,
-      offset,
-      buffer.length - offset,
-    );
+    const written = secretSinkWrite(fd, buffer, offset, buffer.length - offset);
     if (written <= 0) {
       throw new Error(`${SECRET_SINK_FILE_ENV} write made no progress`);
     }

--- a/src/utils/secret-sink.ts
+++ b/src/utils/secret-sink.ts
@@ -19,6 +19,13 @@ export const APPLICATION_KEY_REDACTED = "[redacted]";
 export const INLINE_SECRET_WARNING =
   "B2_SECRET_SINK=inline: this application key secret was returned into the model context and may be logged or retained by the client. Rotate it after use.";
 
+type SecretSinkWriteSync = (
+  fd: number,
+  buffer: Uint8Array,
+  offset: number,
+  length: number,
+) => number;
+
 const SECRET_SINK_FILE_ENV = "B2_SECRET_SINK_FILE";
 const SECRET_SINK_PARENT_MODE = 0o700;
 const HTTP_INLINE_OPT_IN_ENV = "B2_ALLOW_INLINE_SECRETS";
@@ -31,8 +38,27 @@ export const secretSinkFileOpsForTests = {
   fsyncSync: fs.fsyncSync,
   unlinkSync: fs.unlinkSync,
   renameSync: fs.renameSync,
+};
+
+const secretSinkSensitiveWriteOpsForTests: { writeSync: SecretSinkWriteSync } = {
   writeSync: fs.writeSync,
 };
+
+export function withSecretSinkSensitiveWriteOpsForTests<T>(
+  ops: Partial<typeof secretSinkSensitiveWriteOpsForTests>,
+  callback: () => T,
+): T {
+  if (process.env.NODE_ENV !== "test") {
+    throw new Error("Secret sink sensitive write hooks are only available in tests");
+  }
+  const previous = { ...secretSinkSensitiveWriteOpsForTests };
+  Object.assign(secretSinkSensitiveWriteOpsForTests, ops);
+  try {
+    return callback();
+  } finally {
+    Object.assign(secretSinkSensitiveWriteOpsForTests, previous);
+  }
+}
 
 let inlineWarningEmitted = false;
 
@@ -275,7 +301,12 @@ function writeAll(fd: number, line: string): void {
   const buffer = new TextEncoder().encode(line);
   let offset = 0;
   while (offset < buffer.length) {
-    const written = secretSinkFileOpsForTests.writeSync(fd, buffer, offset, buffer.length - offset);
+    const written = secretSinkSensitiveWriteOpsForTests.writeSync(
+      fd,
+      buffer,
+      offset,
+      buffer.length - offset,
+    );
     if (written <= 0) {
       throw new Error(`${SECRET_SINK_FILE_ENV} write made no progress`);
     }

--- a/src/utils/secret-sink.ts
+++ b/src/utils/secret-sink.ts
@@ -31,6 +31,7 @@ export const secretSinkFileOpsForTests = {
   fsyncSync: fs.fsyncSync,
   unlinkSync: fs.unlinkSync,
   renameSync: fs.renameSync,
+  writeSync: fs.writeSync,
 };
 
 let inlineWarningEmitted = false;
@@ -274,7 +275,7 @@ function writeAll(fd: number, line: string): void {
   const buffer = new TextEncoder().encode(line);
   let offset = 0;
   while (offset < buffer.length) {
-    const written = fs.writeSync(fd, buffer, offset, buffer.length - offset);
+    const written = secretSinkFileOpsForTests.writeSync(fd, buffer, offset, buffer.length - offset);
     if (written <= 0) {
       throw new Error(`${SECRET_SINK_FILE_ENV} write made no progress`);
     }

--- a/tests/unit/secret-sanitizer.unit.test.ts
+++ b/tests/unit/secret-sanitizer.unit.test.ts
@@ -228,6 +228,7 @@ describe("secret sanitizer canary policy", () => {
     expect(safe.nested.uploadToken).toBe(SECRET_SANITIZER_REDACTION);
     expect(safe.nested.nextToken).toBe("page-token");
     expect(safe.arrayPayload.authorization).toBe(SECRET_SANITIZER_REDACTION);
+    expect(safe.arrayPayload[0]).toBe(SECRET_SANITIZER_REDACTION);
     expectNoCanary(safe);
     expect(JSON.stringify(safe)).not.toContain(overlappingSecret);
     expect(JSON.stringify(safe)).not.toContain(longerOverlappingSecret);
@@ -317,14 +318,12 @@ describe("secret sanitizer canary policy", () => {
     expectNoCanary(safe);
   });
 
-  it("handles configured secret edge values and non-string text inputs", () => {
+  it("handles configured secret edge values and already masked text inputs", () => {
     const secret = "configured-edge-secret";
     const longerSecret = `${secret}-extended`;
 
     const sanitized = sanitizeText(
-      {
-        toString: () => `applicationKey=${longerSecret} ${secret} appKey=[redacted] not-json-token`,
-      } as never,
+      `applicationKey=${longerSecret} ${secret} appKey=[redacted] not-json-token`,
       {
         secrets: [undefined, "", "   ", "short", SECRET_SANITIZER_REDACTION, secret, longerSecret],
       },
@@ -668,7 +667,7 @@ describe("secret sanitizer canary policy", () => {
     expect(
       sanitizeProviderCode(CONFIGURED_APPLICATION_KEY, { secrets: [CONFIGURED_APPLICATION_KEY] }),
     ).toBe(SECRET_SANITIZER_REDACTION);
-    expect(sanitizeProviderCode(undefined as never)).toBe("unknown_error");
+    expect(sanitizeProviderCode(undefined)).toBe("unknown_error");
     expect(sanitizeProviderRequestId("request/id:1")).toBe("request/id:1");
     expect(sanitizeProviderRequestId(undefined)).toBeUndefined();
     expect(sanitizeProviderRequestId(`request-${CANARY}`)).toBe(SECRET_SANITIZER_REDACTION);

--- a/tests/unit/secret-sanitizer.unit.test.ts
+++ b/tests/unit/secret-sanitizer.unit.test.ts
@@ -318,12 +318,14 @@ describe("secret sanitizer canary policy", () => {
     expectNoCanary(safe);
   });
 
-  it("handles configured secret edge values and already masked text inputs", () => {
+  it("handles configured secret edge values and non-string text inputs", () => {
     const secret = "configured-edge-secret";
     const longerSecret = `${secret}-extended`;
 
     const sanitized = sanitizeText(
-      `applicationKey=${longerSecret} ${secret} appKey=[redacted] not-json-token`,
+      {
+        toString: () => `applicationKey=${longerSecret} ${secret} appKey=[redacted] not-json-token`,
+      },
       {
         secrets: [undefined, "", "   ", "short", SECRET_SANITIZER_REDACTION, secret, longerSecret],
       },
@@ -335,6 +337,7 @@ describe("secret sanitizer canary policy", () => {
     expect(sanitizeText("applicationKey=[redacted]")).toBe(
       `applicationKey=${SECRET_SANITIZER_REDACTION}`,
     );
+    expect(sanitizeText(404)).toBe("404");
     expect(sanitizeError({ toString: () => `failed ${CANARY}` }).message).not.toContain(CANARY);
   });
 

--- a/tests/unit/secret-sanitizer.unit.test.ts
+++ b/tests/unit/secret-sanitizer.unit.test.ts
@@ -7,6 +7,8 @@ import {
   LOG_SANITIZER_FAILURE,
   sanitizeForMcpOutput,
   sanitizeError,
+  sanitizeProviderCode,
+  sanitizeProviderRequestId,
   sanitizeStructuredLogValue,
   sanitizeText,
   SECRET_SANITIZER_REDACTION,
@@ -171,6 +173,66 @@ describe("secret sanitizer canary policy", () => {
     expectNoCanary(safe);
   });
 
+  it("redacts nested MCP output values without invoking hostile accessors", () => {
+    const overlappingSecret = "configured-overlap-secret";
+    const longerOverlappingSecret = `${overlappingSecret}-extended`;
+    const payload: Record<string, unknown> = {
+      headers: {
+        cookie: longerOverlappingSecret,
+        "set-cookie": "session=configured-cookie-secret",
+        "x-b2-key": "configured-header-secret",
+      },
+      nested: {
+        secretName: "public-secret-name",
+        temporarySecret: CANARY,
+        uploadToken: "configured-upload-token-secret",
+        nextToken: "page-token",
+      },
+    };
+    const arrayPayload = [longerOverlappingSecret, { note: CANARY }];
+    Object.defineProperty(arrayPayload, "authorization", {
+      enumerable: true,
+      value: "Bearer configured-array-token-secret",
+    });
+    payload.arrayPayload = arrayPayload;
+    payload.self = payload;
+    let getterReads = 0;
+    Object.defineProperty(payload, "hostile", {
+      enumerable: true,
+      get() {
+        getterReads++;
+        throw new Error(CANARY);
+      },
+    });
+    Object.defineProperty(payload, "nonEnumerableSecret", {
+      enumerable: false,
+      value: CANARY,
+    });
+
+    const safe = sanitizeForMcpOutput(payload, {
+      secrets: [
+        overlappingSecret,
+        longerOverlappingSecret,
+        "configured-cookie-secret",
+        "configured-header-secret",
+        "configured-upload-token-secret",
+        "configured-array-token-secret",
+      ],
+    }) as Record<string, any>;
+
+    expect(getterReads).toBe(0);
+    expect(safe.hostile).toBe("[accessor]");
+    expect(safe.self).toBe("[circular]");
+    expect(safe.nested.secretName).toBe("public-secret-name");
+    expect(safe.nested.temporarySecret).toBe(SECRET_SANITIZER_REDACTION);
+    expect(safe.nested.uploadToken).toBe(SECRET_SANITIZER_REDACTION);
+    expect(safe.nested.nextToken).toBe("page-token");
+    expect(safe.arrayPayload.authorization).toBe(SECRET_SANITIZER_REDACTION);
+    expectNoCanary(safe);
+    expect(JSON.stringify(safe)).not.toContain(overlappingSecret);
+    expect(JSON.stringify(safe)).not.toContain(longerOverlappingSecret);
+  });
+
   it("sanitizes proxied log arrays without reading length getters", () => {
     const payload = [{ applicationKey: CANARY }];
     let lengthReads = 0;
@@ -255,6 +317,28 @@ describe("secret sanitizer canary policy", () => {
     expectNoCanary(safe);
   });
 
+  it("handles configured secret edge values and non-string text inputs", () => {
+    const secret = "configured-edge-secret";
+    const longerSecret = `${secret}-extended`;
+
+    const sanitized = sanitizeText(
+      {
+        toString: () => `applicationKey=${longerSecret} ${secret} appKey=[redacted] not-json-token`,
+      } as never,
+      {
+        secrets: [undefined, "", "   ", "short", SECRET_SANITIZER_REDACTION, secret, longerSecret],
+      },
+    );
+
+    expect(sanitized).not.toContain(secret);
+    expect(sanitized).not.toContain(longerSecret);
+    expect(sanitized).toContain(`appKey=${SECRET_SANITIZER_REDACTION}`);
+    expect(sanitizeText("applicationKey=[redacted]")).toBe(
+      `applicationKey=${SECRET_SANITIZER_REDACTION}`,
+    );
+    expect(sanitizeError({ toString: () => `failed ${CANARY}` }).message).not.toContain(CANARY);
+  });
+
   it("keeps MCP output representations for callables and built-ins", () => {
     const safe = sanitizeForMcpOutput({
       createdAt: new Date("2026-08-21T00:00:00.000Z"),
@@ -330,6 +414,50 @@ describe("secret sanitizer canary policy", () => {
     expect(safe.name).toBe("[accessor]");
     expect(safe.stack).toBe("[accessor]");
     expectNoCanary(safe);
+  });
+
+  it("sanitizes circular Error metadata and non-string Error core fields", () => {
+    const err = new Error("placeholder");
+    Object.defineProperty(err, "message", {
+      configurable: true,
+      enumerable: true,
+      value: 404,
+    });
+    Object.defineProperty(err, "name", {
+      configurable: true,
+      enumerable: true,
+      value: true,
+    });
+    Object.defineProperty(err, "stack", {
+      configurable: true,
+      enumerable: true,
+      value: 123n,
+    });
+    (err as any).self = err;
+    const circularDetails: Record<string, unknown> = {};
+    circularDetails.self = circularDetails;
+    (err as any).details = circularDetails;
+
+    const safe = sanitizeStructuredLogValue(err) as Error & {
+      details?: { self?: unknown };
+      self?: unknown;
+    };
+
+    expect(safe.message).toBe("404");
+    expect(safe.name).toBe("true");
+    expect(safe.stack).toBe("123");
+    expect(safe.self).toBe("[circular]");
+    expect(safe.details?.self).toBe("[circular]");
+  });
+
+  it("keeps constructor stack fallback when the original Error stack is missing", () => {
+    const err = new Error("no stack");
+    delete err.stack;
+
+    const safe = sanitizeStructuredLogValue(err) as Error;
+
+    expect(safe.message).toBe("no stack");
+    expect(safe.stack).toContain("Error: no stack");
   });
 
   it("redacts logger-only credential handles at arbitrary log depths", () => {
@@ -531,6 +659,19 @@ describe("secret sanitizer canary policy", () => {
       CONFIGURED_APP_KEY,
       CONFIGURED_MASTER_KEY,
     ]);
+    expect(configuredSecretValuesFromConfig()).toEqual([]);
+  });
+
+  it("sanitizes provider identifiers by configured secrets and allowed shapes", () => {
+    expect(sanitizeProviderCode("valid.code-1")).toBe("valid.code-1");
+    expect(sanitizeProviderCode("bad code")).toBe(SECRET_SANITIZER_REDACTION);
+    expect(
+      sanitizeProviderCode(CONFIGURED_APPLICATION_KEY, { secrets: [CONFIGURED_APPLICATION_KEY] }),
+    ).toBe(SECRET_SANITIZER_REDACTION);
+    expect(sanitizeProviderCode(undefined as never)).toBe("unknown_error");
+    expect(sanitizeProviderRequestId("request/id:1")).toBe("request/id:1");
+    expect(sanitizeProviderRequestId(undefined)).toBeUndefined();
+    expect(sanitizeProviderRequestId(`request-${CANARY}`)).toBe(SECRET_SANITIZER_REDACTION);
   });
 
   it("keeps sanitizer and logger secret field vocabularies aligned", () => {

--- a/tests/unit/secret-sink.unit.test.ts
+++ b/tests/unit/secret-sink.unit.test.ts
@@ -24,7 +24,7 @@ import {
   resetSecretSinkWarningForTests,
   resolveSecretSinkConfig,
   secretSinkFileOpsForTests,
-  withSecretSinkSensitiveWriteOpsForTests,
+  setSinkWriteForTests,
 } from "../../src/utils/secret-sink";
 import { logger } from "../../src/utils/logger";
 
@@ -1468,9 +1468,7 @@ describe("secret sink file writer", () => {
     try {
       process.env.NODE_ENV = "production";
 
-      expect(() => withSecretSinkSensitiveWriteOpsForTests({}, () => undefined)).toThrow(
-        /only available in tests/,
-      );
+      expect(() => setSinkWriteForTests(() => 0)).toThrow(/test only/);
     } finally {
       if (originalNodeEnv === undefined) {
         delete process.env.NODE_ENV;
@@ -1483,14 +1481,17 @@ describe("secret sink file writer", () => {
   it("cleans up lock files when a lock write makes no progress", () => {
     const dir = tempDir();
     const file = join(dir, "secrets.jsonl");
+    const previousWrite = setSinkWriteForTests(() => 0);
 
-    expect(() =>
-      withSecretSinkSensitiveWriteOpsForTests({ writeSync: () => 0 }, () =>
+    try {
+      expect(() =>
         appendSecretSinkRecord({ mode: "file", filePath: file }, "b2_create_key", {
           applicationKey: "B2_MCP_CANARY_SECRET_lock_write_no_progress",
         }),
-      ),
-    ).toThrow(/write made no progress/);
+      ).toThrow(/write made no progress/);
+    } finally {
+      setSinkWriteForTests(previousWrite);
+    }
 
     expect(appendLockNames(dir)).toHaveLength(0);
   });

--- a/tests/unit/secret-sink.unit.test.ts
+++ b/tests/unit/secret-sink.unit.test.ts
@@ -45,6 +45,43 @@ function deferred<T>() {
   return { promise, resolve, reject };
 }
 
+function testIdempotency(idempotencyKey: string, normalizedInput?: unknown) {
+  return durableSecretIdempotency({
+    toolName: "b2_create_key",
+    idempotencyKey,
+    callerFingerprint: "credential-fingerprint",
+    normalizedInput: normalizedInput ?? {
+      keyName: idempotencyKey,
+      capabilities: ["listBuckets"],
+    },
+  });
+}
+
+function durableSecretTestOptions(
+  file: string,
+  idempotency: ReturnType<typeof durableSecretIdempotency>,
+  extra: {
+    diagnostics?: (result: Record<string, unknown>) => Record<string, unknown>;
+    recoverAfterSinkFailure?: (result: Record<string, unknown>, err: unknown) => unknown;
+  } = {},
+) {
+  return {
+    secretSink: { mode: "file" as const, filePath: file },
+    toolName: "b2_create_key",
+    idempotency,
+    projectRedacted: (created: Record<string, unknown>, pointer: unknown) => ({
+      ...created,
+      applicationKey: "[redacted]",
+      secretSink: pointer,
+    }),
+    projectInline: (created: Record<string, unknown>, warning: string) => ({
+      ...created,
+      warning,
+    }),
+    ...extra,
+  };
+}
+
 describe("secret sink configuration", () => {
   afterEach(() => {
     vi.restoreAllMocks();
@@ -77,6 +114,31 @@ describe("secret sink configuration", () => {
         preflight: false,
       }),
     ).toThrow(/B2_SECRET_SINK_FILE/);
+    expect(
+      resolveSecretSinkConfig({
+        transport: "http",
+        env: {
+          B2_SECRET_SINK: "file",
+          B2_ALLOW_LOCAL_FILES: "true",
+          B2_SECRET_SINK_FILE: path,
+        },
+        preflight: false,
+      }),
+    ).toEqual({ mode: "file", filePath: path });
+  });
+
+  it("uses process.env when no explicit environment is supplied", () => {
+    const previousMode = process.env.B2_SECRET_SINK;
+    delete process.env.B2_SECRET_SINK;
+
+    try {
+      expect(resolveSecretSinkConfig({ transport: "http", preflight: false })).toEqual({
+        mode: "off",
+      });
+    } finally {
+      if (previousMode === undefined) delete process.env.B2_SECRET_SINK;
+      else process.env.B2_SECRET_SINK = previousMode;
+    }
   });
 
   it("emits the inline warning once", () => {
@@ -117,6 +179,23 @@ describe("secret sink configuration", () => {
         preflight: false,
       }),
     ).toThrow(/Invalid B2_SECRET_SINK/);
+  });
+
+  it("preflights sink files when the runtime has no getuid helper", () => {
+    const originalGetuid = process.getuid;
+    const file = join(tempDir(), "secrets.jsonl");
+    Object.defineProperty(process, "getuid", { configurable: true, value: undefined });
+
+    try {
+      expect(
+        resolveSecretSinkConfig({
+          transport: "stdio",
+          env: { B2_SECRET_SINK_FILE: file },
+        }),
+      ).toEqual({ mode: "file", filePath: file });
+    } finally {
+      Object.defineProperty(process, "getuid", { configurable: true, value: originalGetuid });
+    }
   });
 
   it("falls back to off when the stdio default file cannot be opened", () => {
@@ -172,6 +251,10 @@ describe("secret sink configuration", () => {
   it("rejects a secret sink path that resolves to the log file", () => {
     const file = join(tempDir(), "shared.jsonl");
     const missingParentFile = join(tempDir(), "missing", "shared.jsonl");
+    const distinctSinkFile = join(tempDir(), "secrets.jsonl");
+    const distinctLogFile = join(tempDir(), "b2.log");
+    const fileParent = join(tempDir(), "not-a-directory");
+    writeFileSync(fileParent, "", { mode: 0o600 });
 
     expect(() =>
       resolveSecretSinkConfig({
@@ -187,6 +270,23 @@ describe("secret sink configuration", () => {
         preflight: false,
       }),
     ).toThrow(/B2_SECRET_SINK_FILE must not resolve to B2_LOG_FILE/);
+    expect(
+      resolveSecretSinkConfig({
+        transport: "stdio",
+        env: { B2_SECRET_SINK_FILE: distinctSinkFile, B2_LOG_FILE: distinctLogFile },
+        preflight: false,
+      }),
+    ).toEqual({ mode: "file", filePath: distinctSinkFile });
+    expect(() =>
+      resolveSecretSinkConfig({
+        transport: "stdio",
+        env: {
+          B2_SECRET_SINK_FILE: join(fileParent, "child"),
+          B2_LOG_FILE: distinctLogFile,
+        },
+        preflight: false,
+      }),
+    ).toThrow();
   });
 });
 
@@ -1073,6 +1173,40 @@ describe("secret sink file writer", () => {
     expect(JSON.stringify(warnSpy.mock.calls)).not.toContain("claim_cleanup_failed");
   });
 
+  it("cleans up the pending claim when the post-claim fsync fails", async () => {
+    const warnSpy = vi.spyOn(logger, "warn").mockImplementation(() => undefined as never);
+    const dir = tempDir();
+    const file = join(dir, "secrets.jsonl");
+    const idempotency = testIdempotency("post-claim-fsync-failure");
+    const pendingPath = `${file}.${idempotency.claimFingerprint}.pending`;
+    const fsync = secretSinkFileOpsForTests.fsyncSync;
+    let pendingDurabilityCalls = 0;
+    vi.spyOn(secretSinkFileOpsForTests, "fsyncSync").mockImplementation((fd) => {
+      if (existsSync(pendingPath)) {
+        pendingDurabilityCalls++;
+        if (pendingDurabilityCalls === 2) {
+          throw new Error("simulated post-claim fsync failure");
+        }
+      }
+      return fsync(fd);
+    });
+    let createCalls = 0;
+
+    await expect(
+      executeDurableSecretOperation({
+        ...durableSecretTestOptions(file, idempotency),
+        create: async () => {
+          createCalls++;
+          return { applicationKey: "B2_MCP_CANARY_SECRET_unreached" };
+        },
+      }),
+    ).rejects.toThrow(/post-claim fsync/);
+
+    expect(createCalls).toBe(0);
+    expect(existsSync(pendingPath)).toBe(false);
+    expect(JSON.stringify(warnSpy.mock.calls)).not.toContain("claim_cleanup_failed");
+  });
+
   it("does not compensate a committed credential when claim cleanup fails", async () => {
     const warnSpy = vi.spyOn(logger, "warn").mockImplementation(() => undefined as never);
     const recoverSpy = vi.fn();
@@ -1164,6 +1298,35 @@ describe("secret sink file writer", () => {
     expect(createCalls).toBe(0);
   });
 
+  it("treats array-shaped pending claim metadata as pending", async () => {
+    for (const [suffix, payload] of [
+      ["top-array", []],
+      ["idempotency-array", { idempotency: [] }],
+    ] as const) {
+      const dir = tempDir();
+      const file = join(dir, "secrets.jsonl");
+      const idempotency = testIdempotency(`malformed-pending-${suffix}`);
+      writeFileSync(
+        `${file}.${idempotency.claimFingerprint}.pending`,
+        `${JSON.stringify(payload)}\n`,
+        { mode: 0o600 },
+      );
+      let createCalls = 0;
+
+      await expect(
+        executeDurableSecretOperation({
+          ...durableSecretTestOptions(file, idempotency),
+          create: async () => {
+            createCalls++;
+            return { applicationKey: "B2_MCP_CANARY_SECRET_duplicate" };
+          },
+        }),
+      ).rejects.toMatchObject({ code: "idempotency_key_pending" });
+
+      expect(createCalls).toBe(0);
+    }
+  });
+
   it("returns a stable failure when committed idempotency metadata cannot be stored", async () => {
     const fatalSpy = vi.spyOn(logger, "fatal").mockImplementation(() => undefined as never);
     const recoverSpy = vi.fn();
@@ -1233,6 +1396,610 @@ describe("secret sink file writer", () => {
     expect(JSON.stringify(fatalSpy.mock.calls)).toContain(
       "secret_sink.idempotency_claim_retained_after_index_failure",
     );
+  });
+
+  it("cleans up lock files when a lock write makes no progress", () => {
+    const dir = tempDir();
+    const file = join(dir, "secrets.jsonl");
+    vi.spyOn(secretSinkFileOpsForTests, "writeSync").mockReturnValue(0);
+
+    expect(() =>
+      appendSecretSinkRecord({ mode: "file", filePath: file }, "b2_create_key", {
+        applicationKey: "B2_MCP_CANARY_SECRET_lock_write_no_progress",
+      }),
+    ).toThrow(/write made no progress/);
+
+    expect(readdirSync(dir).filter((name) => name.endsWith(".append.lock"))).toHaveLength(0);
+  });
+
+  it("logs close failures before an uncommitted append is rolled back", () => {
+    const warnSpy = vi.spyOn(logger, "warn").mockImplementation(() => undefined as never);
+    const dir = tempDir();
+    const file = join(dir, "secrets.jsonl");
+    const secret = "B2_MCP_CANARY_SECRET_close_before_commit";
+    const fsync = secretSinkFileOpsForTests.fsyncSync;
+    let recordFsyncFailed = false;
+    vi.spyOn(secretSinkFileOpsForTests, "fsyncSync").mockImplementation((fd) => {
+      if (!recordFsyncFailed && existsSync(file) && readFileSync(file, "utf8").includes(secret)) {
+        recordFsyncFailed = true;
+        throw new Error("simulated record fsync failure");
+      }
+      return fsync(fd);
+    });
+    vi.spyOn(secretSinkFileOpsForTests, "closeSync").mockImplementation(() => {
+      throw new Error("simulated close before commit");
+    });
+
+    expect(() =>
+      appendSecretSinkRecord({ mode: "file", filePath: file }, "b2_create_key", {
+        applicationKey: secret,
+      }),
+    ).toThrow(/simulated record fsync failure/);
+
+    expect(JSON.stringify(warnSpy.mock.calls)).toContain("close_failed_before_commit");
+    expect(readFileSync(file, "utf8")).toBe("");
+  });
+
+  it("rejects a torn trailing ledger record beyond the recovery window", () => {
+    const dir = tempDir();
+    const file = join(dir, "secrets.jsonl");
+    writeFileSync(file, "x".repeat(1024 * 1024 + 1), { mode: 0o600 });
+
+    expect(() =>
+      appendSecretSinkRecord({ mode: "file", filePath: file }, "b2_create_key", {
+        applicationKey: "B2_MCP_CANARY_SECRET_large_torn_tail",
+      }),
+    ).toThrow(/trailing JSONL record exceeds bounded recovery window/);
+  });
+
+  it("propagates non-ENOENT tail read failures during recovery", () => {
+    const dir = tempDir();
+    const file = join(dir, "secrets-directory");
+    mkdirSync(file, { mode: 0o700 });
+
+    expect(() =>
+      appendSecretSinkRecord({ mode: "file", filePath: file }, "b2_create_key", {
+        applicationKey: "B2_MCP_CANARY_SECRET_directory_tail",
+      }),
+    ).toThrow();
+  });
+
+  it("continues past unrelated legacy ledger records before creating a credential", async () => {
+    const dir = tempDir();
+    const file = join(dir, "secrets.jsonl");
+    const idempotency = testIdempotency("legacy-miss");
+    writeFileSync(
+      file,
+      [
+        JSON.stringify({
+          ts: "2026-08-18T12:00:00Z",
+          tool: "other_tool",
+          recordId: "wrong-tool",
+          idempotency,
+          result: { applicationKey: "B2_MCP_CANARY_SECRET_wrong_tool" },
+        }),
+        JSON.stringify({
+          ts: "2026-08-18T12:01:00Z",
+          tool: "b2_create_key",
+          recordId: "missing-idempotency",
+          result: { applicationKey: "B2_MCP_CANARY_SECRET_missing_idempotency" },
+        }),
+        JSON.stringify({
+          ts: "2026-08-18T12:02:00Z",
+          tool: "b2_create_key",
+          recordId: "wrong-key",
+          idempotency: { key: "other-key", fingerprint: idempotency.fingerprint },
+          result: { applicationKey: "B2_MCP_CANARY_SECRET_wrong_key" },
+        }),
+        JSON.stringify({
+          ts: "2026-08-18T12:03:00Z",
+          tool: "b2_create_key",
+          recordId: "wrong-claim",
+          idempotency: { ...idempotency, claimFingerprint: "other-claim" },
+          result: { applicationKey: "B2_MCP_CANARY_SECRET_wrong_claim" },
+        }),
+      ].join("\n") + "\n",
+      { mode: 0o600 },
+    );
+    let createCalls = 0;
+
+    const result = await executeDurableSecretOperation({
+      ...durableSecretTestOptions(file, idempotency),
+      create: async () => {
+        createCalls++;
+        return {
+          applicationKeyId: "key-id",
+          applicationKey: "B2_MCP_CANARY_SECRET_legacy_miss_created",
+        };
+      },
+    });
+
+    expect(createCalls).toBe(1);
+    expect(result.structuredContent).toMatchObject({
+      applicationKeyId: "key-id",
+      applicationKey: "[redacted]",
+      secretSink: { type: "file", path: file },
+    });
+  });
+
+  it("rejects conflicting legacy ledger records with the same idempotency key", async () => {
+    const dir = tempDir();
+    const file = join(dir, "secrets.jsonl");
+    const idempotency = testIdempotency("legacy-conflict");
+    writeFileSync(
+      file,
+      `${JSON.stringify({
+        ts: "2026-08-18T12:00:00Z",
+        tool: "b2_create_key",
+        recordId: "legacy-conflict-record",
+        idempotency: { key: idempotency.key, fingerprint: "different-fingerprint" },
+        result: { applicationKey: "B2_MCP_CANARY_SECRET_legacy_conflict" },
+      })}\n`,
+      { mode: 0o600 },
+    );
+    let createCalls = 0;
+
+    await expect(
+      executeDurableSecretOperation({
+        ...durableSecretTestOptions(file, idempotency),
+        create: async () => {
+          createCalls++;
+          return { applicationKey: "B2_MCP_CANARY_SECRET_unreached" };
+        },
+      }),
+    ).rejects.toMatchObject({ code: "idempotency_key_conflict" });
+
+    expect(createCalls).toBe(0);
+  });
+
+  it("ignores committed idempotency markers that do not match the request", async () => {
+    for (const [suffix, committedIdempotency] of [
+      ["missing-idempotency", undefined],
+      [
+        "wrong-claim",
+        {
+          key: "wrong-claim",
+          claimFingerprint: "other-claim",
+          fingerprint: "other-fingerprint",
+        },
+      ],
+    ] as const) {
+      const dir = tempDir();
+      const file = join(dir, "secrets.jsonl");
+      const idempotency = testIdempotency(`committed-${suffix}`);
+      writeFileSync(
+        `${file}.${idempotency.claimFingerprint}.committed.json`,
+        `${JSON.stringify({
+          ts: "2026-08-18T12:00:00Z",
+          tool: "b2_create_key",
+          recordId: `committed-${suffix}-record`,
+          ...(committedIdempotency ? { idempotency: committedIdempotency } : {}),
+          result: { applicationKey: "B2_MCP_CANARY_SECRET_stale_committed" },
+        })}\n`,
+        { mode: 0o600 },
+      );
+      let createCalls = 0;
+
+      const result = await executeDurableSecretOperation({
+        ...durableSecretTestOptions(file, idempotency),
+        create: async () => {
+          createCalls++;
+          return {
+            applicationKeyId: `key-id-${suffix}`,
+            applicationKey: "B2_MCP_CANARY_SECRET_committed_miss_created",
+          };
+        },
+      });
+
+      expect(createCalls).toBe(1);
+      expect(result.structuredContent).toMatchObject({
+        applicationKeyId: `key-id-${suffix}`,
+        applicationKey: "[redacted]",
+      });
+    }
+  });
+
+  it("rejects committed idempotency markers with conflicting fingerprints", async () => {
+    const dir = tempDir();
+    const file = join(dir, "secrets.jsonl");
+    const idempotency = testIdempotency("committed-conflict");
+    writeFileSync(
+      `${file}.${idempotency.claimFingerprint}.committed.json`,
+      `${JSON.stringify({
+        ts: "2026-08-18T12:00:00Z",
+        tool: "b2_create_key",
+        recordId: "committed-conflict-record",
+        idempotency: { ...idempotency, fingerprint: "different-fingerprint" },
+        result: { applicationKey: "B2_MCP_CANARY_SECRET_committed_conflict" },
+      })}\n`,
+      { mode: 0o600 },
+    );
+    let createCalls = 0;
+
+    await expect(
+      executeDurableSecretOperation({
+        ...durableSecretTestOptions(file, idempotency),
+        create: async () => {
+          createCalls++;
+          return { applicationKey: "B2_MCP_CANARY_SECRET_unreached" };
+        },
+      }),
+    ).rejects.toMatchObject({ code: "idempotency_key_conflict" });
+
+    expect(createCalls).toBe(0);
+  });
+
+  it("propagates malformed committed idempotency marker JSON", async () => {
+    const dir = tempDir();
+    const file = join(dir, "secrets.jsonl");
+    const idempotency = testIdempotency("committed-malformed-json");
+    writeFileSync(`${file}.${idempotency.claimFingerprint}.committed.json`, "not-json\n", {
+      mode: 0o600,
+    });
+    let createCalls = 0;
+
+    await expect(
+      executeDurableSecretOperation({
+        ...durableSecretTestOptions(file, idempotency),
+        create: async () => {
+          createCalls++;
+          return { applicationKey: "B2_MCP_CANARY_SECRET_unreached" };
+        },
+      }),
+    ).rejects.toThrow();
+
+    expect(createCalls).toBe(0);
+  });
+
+  it("keeps replay metadata sanitized when the audit index append fails", async () => {
+    const warnSpy = vi.spyOn(logger, "warn").mockImplementation(() => undefined as never);
+    const dir = tempDir();
+    const file = join(dir, "secrets.jsonl");
+    const indexTarget = join(dir, "index-target.jsonl");
+    const indexPath = `${file}.idempotency.jsonl`;
+    const idempotency = testIdempotency("audit-index-symlink");
+    writeFileSync(indexTarget, "", { mode: 0o600 });
+    symlinkSync(indexTarget, indexPath);
+
+    const result = await executeDurableSecretOperation({
+      ...durableSecretTestOptions(file, idempotency),
+      create: async () => ({
+        applicationKeyId: "key-id",
+        applicationKey: "B2_MCP_CANARY_SECRET_audit_index",
+        nested: {
+          appKey: "B2_MCP_CANARY_SECRET_nested_audit_index",
+        },
+      }),
+    });
+
+    const committed = readFileSync(
+      `${file}.${idempotency.claimFingerprint}.committed.json`,
+      "utf8",
+    );
+    expect(result.structuredContent).toMatchObject({
+      applicationKeyId: "key-id",
+      applicationKey: "[redacted]",
+    });
+    expect(committed).not.toContain("B2_MCP_CANARY_SECRET_audit_index");
+    expect(committed).not.toContain("B2_MCP_CANARY_SECRET_nested_audit_index");
+    expect(JSON.stringify(warnSpy.mock.calls)).toContain("idempotency_audit_append_failed");
+  });
+
+  it("returns inline durable secrets only for the explicit inline sink", async () => {
+    const idempotency = testIdempotency("inline-secret");
+    const result = await executeDurableSecretOperation({
+      secretSink: { mode: "inline" },
+      toolName: "b2_create_key",
+      idempotency,
+      create: async () => ({
+        applicationKeyId: "key-id",
+        applicationKey: "B2_MCP_CANARY_SECRET_inline",
+      }),
+      projectRedacted: (created: Record<string, unknown>, pointer) => ({
+        ...created,
+        applicationKey: "[redacted]",
+        secretSink: pointer,
+      }),
+      projectInline: (created: Record<string, unknown>, warning: string) => ({
+        ...created,
+        warning,
+      }),
+    });
+
+    expect(result.structuredContent).toMatchObject({
+      applicationKeyId: "key-id",
+      applicationKey: "B2_MCP_CANARY_SECRET_inline",
+      warning: INLINE_SECRET_WARNING,
+    });
+  });
+
+  it("redacts projected durable-secret output without invoking hostile accessors", async () => {
+    const dir = tempDir();
+    const file = join(dir, "secrets.jsonl");
+    const idempotency = testIdempotency("hostile-redacted-output");
+    let getterReads = 0;
+
+    const result = await executeDurableSecretOperation({
+      ...durableSecretTestOptions(file, idempotency),
+      create: async () => ({
+        applicationKeyId: "key-id",
+        applicationKey: "B2_MCP_CANARY_SECRET_plain_sink_record",
+      }),
+      projectRedacted: (_created: Record<string, unknown>, pointer) => {
+        const projected: Record<string, unknown> = {
+          secretSink: pointer,
+          nested: {
+            applicationKey: "B2_MCP_CANARY_SECRET_projected_nested",
+          },
+          arrayPayload: [{ appKey: "B2_MCP_CANARY_SECRET_projected_array" }],
+        };
+        projected.self = projected;
+        Object.defineProperty(projected, "hostile", {
+          enumerable: true,
+          get() {
+            getterReads++;
+            throw new Error("B2_MCP_CANARY_SECRET_projected_getter");
+          },
+        });
+        return projected;
+      },
+    });
+
+    expect(getterReads).toBe(0);
+    expect(JSON.stringify(result)).not.toContain("B2_MCP_CANARY_SECRET_projected");
+    expect(result.structuredContent).toMatchObject({
+      hostile: "[accessor]",
+      self: "[circular]",
+      nested: { applicationKey: "[redacted]" },
+      arrayPayload: [{ appKey: "[redacted]" }],
+    });
+  });
+
+  it("reclaims stale append locks whose payload is not an object", () => {
+    const warnSpy = vi.spyOn(logger, "warn").mockImplementation(() => undefined as never);
+    const dir = tempDir();
+    const file = join(dir, "secrets.jsonl");
+    const appendLock = `${file}.append.lock`;
+    writeFileSync(file, "", { mode: 0o600 });
+    writeFileSync(appendLock, "[]\n", { mode: 0o600 });
+    const stale = new Date(Date.now() - 10 * 60 * 1000);
+    utimesSync(appendLock, stale, stale);
+
+    const pointer = appendSecretSinkRecord({ mode: "file", filePath: file }, "b2_create_key", {
+      applicationKey: "B2_MCP_CANARY_SECRET_array_lock_payload",
+    });
+
+    expect(pointer.recordId).toEqual(expect.any(String));
+    expect(JSON.stringify(warnSpy.mock.calls)).toContain("stale_append_lock_reclaimed");
+  });
+
+  it("continues when a stale append lock disappears during reclaim", () => {
+    const dir = tempDir();
+    const file = join(dir, "secrets.jsonl");
+    const appendLock = `${file}.append.lock`;
+    writeFileSync(file, "", { mode: 0o600 });
+    writeFileSync(appendLock, `${JSON.stringify({ status: "appending" })}\n`, { mode: 0o600 });
+    const stale = new Date(Date.now() - 10 * 60 * 1000);
+    utimesSync(appendLock, stale, stale);
+    const unlink = secretSinkFileOpsForTests.unlinkSync;
+    let disappeared = false;
+    vi.spyOn(secretSinkFileOpsForTests, "unlinkSync").mockImplementation((path) => {
+      if (!disappeared && path === appendLock) {
+        disappeared = true;
+        unlink(path);
+        const err = new Error("lock disappeared") as NodeJS.ErrnoException;
+        err.code = "ENOENT";
+        throw err;
+      }
+      return unlink(path);
+    });
+
+    const pointer = appendSecretSinkRecord({ mode: "file", filePath: file }, "b2_create_key", {
+      applicationKey: "B2_MCP_CANARY_SECRET_disappeared_lock",
+    });
+
+    expect(pointer.recordId).toEqual(expect.any(String));
+    expect(disappeared).toBe(true);
+  });
+
+  it("waits once for a live append lock before timing out", () => {
+    const dir = tempDir();
+    const file = join(dir, "secrets.jsonl");
+    const appendLock = `${file}.append.lock`;
+    writeFileSync(file, "", { mode: 0o600 });
+    writeFileSync(
+      appendLock,
+      `${JSON.stringify({
+        ts: "2026-08-18T12:00:00Z",
+        tool: "b2_create_key",
+        pid: process.pid,
+        token: "live-lock",
+        status: "appending",
+      })}\n`,
+      { mode: 0o600 },
+    );
+    const now = Date.now();
+    let nowCalls = 0;
+    vi.spyOn(Date, "now").mockImplementation(() => {
+      nowCalls++;
+      return nowCalls < 4 ? now : now + 31_000;
+    });
+
+    expect(() =>
+      appendSecretSinkRecord({ mode: "file", filePath: file }, "b2_create_key", {
+        applicationKey: "B2_MCP_CANARY_SECRET_live_lock_timeout",
+      }),
+    ).toThrow(/EEXIST|file already exists/i);
+
+    expect(nowCalls).toBeGreaterThanOrEqual(4);
+    expect(existsSync(appendLock)).toBe(true);
+  });
+
+  it("releases the pending claim when sink failure recovery deletes the provider result", async () => {
+    const fatalSpy = vi.spyOn(logger, "fatal").mockImplementation(() => undefined as never);
+    const dir = tempDir();
+    const file = join(dir, "secrets.jsonl");
+    const secret = "B2_MCP_CANARY_SECRET_recovered_delete";
+    const fsync = secretSinkFileOpsForTests.fsyncSync;
+    let recordFsyncFailed = false;
+    vi.spyOn(secretSinkFileOpsForTests, "fsyncSync").mockImplementation((fd) => {
+      if (!recordFsyncFailed && existsSync(file) && readFileSync(file, "utf8").includes(secret)) {
+        recordFsyncFailed = true;
+        throw new Error("simulated sink fsync failure");
+      }
+      return fsync(fd);
+    });
+    const recoverSpy = vi.fn().mockReturnValue({ status: "deleted" });
+    const idempotency = testIdempotency("recovered-delete");
+
+    await expect(
+      executeDurableSecretOperation({
+        ...durableSecretTestOptions(file, idempotency, {
+          diagnostics: (created) => ({ applicationKeyId: created.applicationKeyId }),
+          recoverAfterSinkFailure: recoverSpy,
+        }),
+        create: async () => ({
+          applicationKeyId: "key-id",
+          applicationKey: secret,
+        }),
+      }),
+    ).rejects.toMatchObject({ code: "secret_sink_write_failed" });
+
+    expect(recoverSpy).toHaveBeenCalledOnce();
+    expect(readdirSync(dir).filter((name) => name.endsWith(".pending"))).toHaveLength(0);
+    expect(JSON.stringify(fatalSpy.mock.calls)).toContain("write_failed_after_provider_create");
+  });
+
+  it("keeps the pending claim when sink failure recovery is inconclusive", async () => {
+    const fatalSpy = vi.spyOn(logger, "fatal").mockImplementation(() => undefined as never);
+    const dir = tempDir();
+    const file = join(dir, "secrets.jsonl");
+    const secret = "B2_MCP_CANARY_SECRET_recovery_unknown";
+    const fsync = secretSinkFileOpsForTests.fsyncSync;
+    let recordFsyncFailed = false;
+    vi.spyOn(secretSinkFileOpsForTests, "fsyncSync").mockImplementation((fd) => {
+      if (!recordFsyncFailed && existsSync(file) && readFileSync(file, "utf8").includes(secret)) {
+        recordFsyncFailed = true;
+        throw { code: "sink_write_failed" };
+      }
+      return fsync(fd);
+    });
+    const idempotency = testIdempotency("recovery-unknown");
+
+    await expect(
+      executeDurableSecretOperation({
+        ...durableSecretTestOptions(file, idempotency, {
+          recoverAfterSinkFailure: () => "manual-review",
+        }),
+        create: async () => ({
+          applicationKeyId: "key-id",
+          applicationKey: secret,
+        }),
+      }),
+    ).rejects.toMatchObject({ code: "secret_sink_write_failed" });
+
+    expect(readdirSync(dir).some((name) => name.endsWith(".pending"))).toBe(true);
+    expect(JSON.stringify(fatalSpy.mock.calls)).toContain("manual-review");
+  });
+
+  it("keeps the default recovery status when recovery returns undefined", async () => {
+    const fatalSpy = vi.spyOn(logger, "fatal").mockImplementation(() => undefined as never);
+    const dir = tempDir();
+    const file = join(dir, "secrets.jsonl");
+    const secret = "B2_MCP_CANARY_SECRET_recovery_undefined";
+    const fsync = secretSinkFileOpsForTests.fsyncSync;
+    let recordFsyncFailed = false;
+    vi.spyOn(secretSinkFileOpsForTests, "fsyncSync").mockImplementation((fd) => {
+      if (!recordFsyncFailed && existsSync(file) && readFileSync(file, "utf8").includes(secret)) {
+        recordFsyncFailed = true;
+        throw new Error("simulated sink fsync failure");
+      }
+      return fsync(fd);
+    });
+    const idempotency = testIdempotency("recovery-undefined");
+
+    await expect(
+      executeDurableSecretOperation({
+        ...durableSecretTestOptions(file, idempotency, {
+          recoverAfterSinkFailure: () => undefined,
+        }),
+        create: async () => ({
+          applicationKeyId: "key-id",
+          applicationKey: secret,
+        }),
+      }),
+    ).rejects.toMatchObject({ code: "secret_sink_write_failed" });
+
+    expect(readdirSync(dir).some((name) => name.endsWith(".pending"))).toBe(true);
+    expect(JSON.stringify(fatalSpy.mock.calls)).toContain("not_configured");
+  });
+
+  it("records recovery errors without releasing the pending claim", async () => {
+    const fatalSpy = vi.spyOn(logger, "fatal").mockImplementation(() => undefined as never);
+    const dir = tempDir();
+    const file = join(dir, "secrets.jsonl");
+    const secret = "B2_MCP_CANARY_SECRET_recovery_error";
+    const fsync = secretSinkFileOpsForTests.fsyncSync;
+    let recordFsyncFailed = false;
+    vi.spyOn(secretSinkFileOpsForTests, "fsyncSync").mockImplementation((fd) => {
+      if (!recordFsyncFailed && existsSync(file) && readFileSync(file, "utf8").includes(secret)) {
+        recordFsyncFailed = true;
+        throw new Error("simulated sink fsync failure");
+      }
+      return fsync(fd);
+    });
+    const idempotency = testIdempotency("recovery-error");
+
+    await expect(
+      executeDurableSecretOperation({
+        ...durableSecretTestOptions(file, idempotency, {
+          recoverAfterSinkFailure: () => {
+            throw "cleanup failed";
+          },
+        }),
+        create: async () => ({
+          applicationKeyId: "key-id",
+          applicationKey: secret,
+        }),
+      }),
+    ).rejects.toMatchObject({ code: "secret_sink_write_failed" });
+
+    expect(readdirSync(dir).some((name) => name.endsWith(".pending"))).toBe(true);
+    expect(JSON.stringify(fatalSpy.mock.calls)).toContain("cleanup failed");
+  });
+
+  it("records Error recovery messages without releasing the pending claim", async () => {
+    const fatalSpy = vi.spyOn(logger, "fatal").mockImplementation(() => undefined as never);
+    const dir = tempDir();
+    const file = join(dir, "secrets.jsonl");
+    const secret = "B2_MCP_CANARY_SECRET_recovery_error_object";
+    const fsync = secretSinkFileOpsForTests.fsyncSync;
+    let recordFsyncFailed = false;
+    vi.spyOn(secretSinkFileOpsForTests, "fsyncSync").mockImplementation((fd) => {
+      if (!recordFsyncFailed && existsSync(file) && readFileSync(file, "utf8").includes(secret)) {
+        recordFsyncFailed = true;
+        throw new Error("simulated sink fsync failure");
+      }
+      return fsync(fd);
+    });
+    const idempotency = testIdempotency("recovery-error-object");
+
+    await expect(
+      executeDurableSecretOperation({
+        ...durableSecretTestOptions(file, idempotency, {
+          recoverAfterSinkFailure: () => {
+            throw new Error("cleanup failed with Error");
+          },
+        }),
+        create: async () => ({
+          applicationKeyId: "key-id",
+          applicationKey: secret,
+        }),
+      }),
+    ).rejects.toMatchObject({ code: "secret_sink_write_failed" });
+
+    expect(readdirSync(dir).some((name) => name.endsWith(".pending"))).toBe(true);
+    expect(JSON.stringify(fatalSpy.mock.calls)).toContain("cleanup failed with Error");
   });
 
   it("keeps the pending claim when rollback after write failure is unconfirmed", async () => {

--- a/tests/unit/secret-sink.unit.test.ts
+++ b/tests/unit/secret-sink.unit.test.ts
@@ -221,7 +221,7 @@ describe("secret sink configuration", () => {
   });
 
   it("preflights sink files when the runtime has no getuid helper", () => {
-    const originalGetuid = process.getuid;
+    const originalGetuidDescriptor = Object.getOwnPropertyDescriptor(process, "getuid");
     const file = join(tempDir(), "secrets.jsonl");
     Object.defineProperty(process, "getuid", { configurable: true, value: undefined });
 
@@ -233,7 +233,11 @@ describe("secret sink configuration", () => {
         }),
       ).toEqual({ mode: "file", filePath: file });
     } finally {
-      Object.defineProperty(process, "getuid", { configurable: true, value: originalGetuid });
+      if (originalGetuidDescriptor) {
+        Object.defineProperty(process, "getuid", originalGetuidDescriptor);
+      } else {
+        delete (process as NodeJS.Process & { getuid?: unknown }).getuid;
+      }
     }
   });
 

--- a/tests/unit/secret-sink.unit.test.ts
+++ b/tests/unit/secret-sink.unit.test.ts
@@ -24,8 +24,19 @@ import {
   resetSecretSinkWarningForTests,
   resolveSecretSinkConfig,
   secretSinkFileOpsForTests,
+  withSecretSinkSensitiveWriteOpsForTests,
 } from "../../src/utils/secret-sink";
 import { logger } from "../../src/utils/logger";
+
+const APPEND_LOCK_SUFFIX = ".append.lock";
+const APPEND_RECLAIM_LOCK_SUFFIX = ".reclaim";
+const APPEND_LOCK_WAIT_TIMEOUT_MS = 30_000;
+const APPEND_LOCK_WAIT_TIMEOUT_MARGIN_MS = 1_000;
+const COMMITTED_IDEMPOTENCY_MARKER_SUFFIX = ".committed.json";
+const IDEMPOTENCY_INDEX_SUFFIX = ".idempotency.jsonl";
+const PENDING_CLAIM_MARKER_SUFFIX = ".pending";
+
+type TestIdempotency = ReturnType<typeof durableSecretIdempotency>;
 
 function tempDir(): string {
   return mkdtempSync(join(tmpdir(), "b2-mcp-secret-sink-"));
@@ -55,6 +66,34 @@ function testIdempotency(idempotencyKey: string, normalizedInput?: unknown) {
       capabilities: ["listBuckets"],
     },
   });
+}
+
+function appendLockPath(file: string): string {
+  return `${file}${APPEND_LOCK_SUFFIX}`;
+}
+
+function appendReclaimLockPath(file: string): string {
+  return `${appendLockPath(file)}${APPEND_RECLAIM_LOCK_SUFFIX}`;
+}
+
+function idempotencyIndexPath(file: string): string {
+  return `${file}${IDEMPOTENCY_INDEX_SUFFIX}`;
+}
+
+function pendingClaimPath(file: string, idempotency: TestIdempotency): string {
+  return `${file}.${idempotency.claimFingerprint}${PENDING_CLAIM_MARKER_SUFFIX}`;
+}
+
+function committedIdempotencyMarkerPath(file: string, idempotency: TestIdempotency): string {
+  return `${file}.${idempotency.claimFingerprint}${COMMITTED_IDEMPOTENCY_MARKER_SUFFIX}`;
+}
+
+function pendingClaimNames(dir: string): string[] {
+  return readdirSync(dir).filter((name) => name.endsWith(PENDING_CLAIM_MARKER_SUFFIX));
+}
+
+function appendLockNames(dir: string): string[] {
+  return readdirSync(dir).filter((name) => name.endsWith(APPEND_LOCK_SUFFIX));
 }
 
 function durableSecretTestOptions(
@@ -505,7 +544,7 @@ describe("secret sink file writer", () => {
     const warnSpy = vi.spyOn(logger, "warn").mockImplementation(() => undefined as never);
     const dir = tempDir();
     const file = join(dir, "secrets.jsonl");
-    const appendLock = `${file}.append.lock`;
+    const appendLock = appendLockPath(file);
     writeFileSync(file, "", { mode: 0o600 });
     writeFileSync(appendLock, `${JSON.stringify({ status: "appending" })}\n`, { mode: 0o600 });
     const stale = new Date(Date.now() - 10 * 60 * 1000);
@@ -524,7 +563,7 @@ describe("secret sink file writer", () => {
     const warnSpy = vi.spyOn(logger, "warn").mockImplementation(() => undefined as never);
     const dir = tempDir();
     const file = join(dir, "secrets.jsonl");
-    const appendLock = `${file}.append.lock`;
+    const appendLock = appendLockPath(file);
     writeFileSync(file, "", { mode: 0o600 });
     writeFileSync(appendLock, "not-json\n", { mode: 0o600 });
     const stale = new Date(Date.now() - 10 * 60 * 1000);
@@ -543,8 +582,8 @@ describe("secret sink file writer", () => {
     const warnSpy = vi.spyOn(logger, "warn").mockImplementation(() => undefined as never);
     const dir = tempDir();
     const file = join(dir, "secrets.jsonl");
-    const appendLock = `${file}.append.lock`;
-    const reclaimLock = `${appendLock}.reclaim`;
+    const appendLock = appendLockPath(file);
+    const reclaimLock = appendReclaimLockPath(file);
     writeFileSync(file, "", { mode: 0o600 });
     writeFileSync(appendLock, `${JSON.stringify({ status: "appending" })}\n`, { mode: 0o600 });
     writeFileSync(
@@ -812,7 +851,7 @@ describe("secret sink file writer", () => {
 
     expect(createCalls).toBe(1);
     expect(second.structuredContent).toEqual(first.structuredContent);
-    const index = readFileSync(`${file}.idempotency.jsonl`, "utf8");
+    const index = readFileSync(idempotencyIndexPath(file), "utf8");
     expect(index).toContain("ledger-rotated");
     expect(index).not.toContain("B2_MCP_CANARY_SECRET_indexed");
   });
@@ -881,12 +920,12 @@ describe("secret sink file writer", () => {
       normalizedInput: { keyName: "raced-commit", capabilities: ["listBuckets"] },
     });
     const pointer = { type: "file" as const, path: file, recordId: "raced-record" };
-    const markerPath = `${file}.${idempotency.claimFingerprint}.committed.json`;
+    const markerPath = committedIdempotencyMarkerPath(file, idempotency);
     const fsync = secretSinkFileOpsForTests.fsyncSync;
     let markerWritten = false;
     vi.spyOn(secretSinkFileOpsForTests, "fsyncSync").mockImplementation((fd) => {
       const result = fsync(fd);
-      if (!markerWritten && existsSync(`${file}.${idempotency.claimFingerprint}.pending`)) {
+      if (!markerWritten && existsSync(pendingClaimPath(file, idempotency))) {
         markerWritten = true;
         writeFileSync(
           markerPath,
@@ -930,7 +969,7 @@ describe("secret sink file writer", () => {
       applicationKey: "[redacted]",
       secretSink: pointer,
     });
-    expect(readdirSync(dir).filter((name) => name.endsWith(".pending"))).toHaveLength(0);
+    expect(pendingClaimNames(dir)).toHaveLength(0);
   });
 
   it("rejects conflicting input on the same pending idempotency claim", async () => {
@@ -995,7 +1034,7 @@ describe("secret sink file writer", () => {
     await first;
 
     expect(createCalls).toBe(1);
-    expect(readdirSync(dir).filter((name) => name.endsWith(".pending"))).toHaveLength(0);
+    expect(pendingClaimNames(dir)).toHaveLength(0);
   });
 
   it("leaves an ambiguous provider outcome pending instead of retrying creation", async () => {
@@ -1044,7 +1083,7 @@ describe("secret sink file writer", () => {
     ).rejects.toMatchObject({ code: "idempotency_key_pending" });
 
     expect(createCalls).toBe(1);
-    expect(readdirSync(dir).some((name) => name.endsWith(".pending"))).toBe(true);
+    expect(pendingClaimNames(dir).length).toBeGreaterThan(0);
   });
 
   it("releases the pending claim after a known provider rejection", async () => {
@@ -1076,7 +1115,7 @@ describe("secret sink file writer", () => {
       }),
     ).rejects.toMatchObject({ status: 403 });
 
-    expect(readdirSync(dir).filter((name) => name.endsWith(".pending"))).toHaveLength(0);
+    expect(pendingClaimNames(dir)).toHaveLength(0);
   });
 
   it("keeps the pending claim after an HTTP 408 provider timeout", async () => {
@@ -1125,7 +1164,7 @@ describe("secret sink file writer", () => {
     ).rejects.toMatchObject({ code: "idempotency_key_pending" });
 
     expect(createCalls).toBe(1);
-    expect(readdirSync(dir).some((name) => name.endsWith(".pending"))).toBe(true);
+    expect(pendingClaimNames(dir).length).toBeGreaterThan(0);
   });
 
   it("releases the pending claim when pre-provider claim durability fails", async () => {
@@ -1169,7 +1208,7 @@ describe("secret sink file writer", () => {
     ).rejects.toThrow(/claim directory fsync/);
 
     expect(createCalls).toBe(0);
-    expect(readdirSync(dir).filter((name) => name.endsWith(".pending"))).toHaveLength(0);
+    expect(pendingClaimNames(dir)).toHaveLength(0);
     expect(JSON.stringify(warnSpy.mock.calls)).not.toContain("claim_cleanup_failed");
   });
 
@@ -1178,7 +1217,7 @@ describe("secret sink file writer", () => {
     const dir = tempDir();
     const file = join(dir, "secrets.jsonl");
     const idempotency = testIdempotency("post-claim-fsync-failure");
-    const pendingPath = `${file}.${idempotency.claimFingerprint}.pending`;
+    const pendingPath = pendingClaimPath(file, idempotency);
     const fsync = secretSinkFileOpsForTests.fsyncSync;
     let pendingDurabilityCalls = 0;
     vi.spyOn(secretSinkFileOpsForTests, "fsyncSync").mockImplementation((fd) => {
@@ -1213,7 +1252,7 @@ describe("secret sink file writer", () => {
     const unlink = secretSinkFileOpsForTests.unlinkSync;
     let failedPendingCleanup = false;
     vi.spyOn(secretSinkFileOpsForTests, "unlinkSync").mockImplementation((path) => {
-      if (!failedPendingCleanup && String(path).endsWith(".pending")) {
+      if (!failedPendingCleanup && String(path).endsWith(PENDING_CLAIM_MARKER_SUFFIX)) {
         failedPendingCleanup = true;
         throw new Error("simulated claim cleanup failure");
       }
@@ -1267,7 +1306,7 @@ describe("secret sink file writer", () => {
       normalizedInput: { keyName: "malformed-pending", capabilities: ["listBuckets"] },
     });
     writeFileSync(
-      `${file}.${idempotency.claimFingerprint}.pending`,
+      pendingClaimPath(file, idempotency),
       `${JSON.stringify({
         idempotency: { key: idempotency.key, claimFingerprint: idempotency.claimFingerprint },
       })}\n`,
@@ -1306,11 +1345,9 @@ describe("secret sink file writer", () => {
       const dir = tempDir();
       const file = join(dir, "secrets.jsonl");
       const idempotency = testIdempotency(`malformed-pending-${suffix}`);
-      writeFileSync(
-        `${file}.${idempotency.claimFingerprint}.pending`,
-        `${JSON.stringify(payload)}\n`,
-        { mode: 0o600 },
-      );
+      writeFileSync(pendingClaimPath(file, idempotency), `${JSON.stringify(payload)}\n`, {
+        mode: 0o600,
+      });
       let createCalls = 0;
 
       await expect(
@@ -1332,7 +1369,7 @@ describe("secret sink file writer", () => {
     const recoverSpy = vi.fn();
     const rename = secretSinkFileOpsForTests.renameSync;
     vi.spyOn(secretSinkFileOpsForTests, "renameSync").mockImplementation((oldPath, newPath) => {
-      if (String(newPath).endsWith(".committed.json")) {
+      if (String(newPath).endsWith(COMMITTED_IDEMPOTENCY_MARKER_SUFFIX)) {
         throw new Error("simulated committed marker rename failure");
       }
       return rename(oldPath, newPath);
@@ -1392,24 +1429,66 @@ describe("secret sink file writer", () => {
     expect(createCalls).toBe(1);
     expect(recoverSpy).not.toHaveBeenCalled();
     expect(readFileSync(file, "utf8")).toContain(secret);
-    expect(readdirSync(dir).some((name) => name.endsWith(".pending"))).toBe(true);
+    expect(pendingClaimNames(dir).length).toBeGreaterThan(0);
     expect(JSON.stringify(fatalSpy.mock.calls)).toContain(
       "secret_sink.idempotency_claim_retained_after_index_failure",
     );
   });
 
+  it("does not expose plaintext writes through exported file test helpers", () => {
+    const dir = tempDir();
+    const file = join(dir, "secrets.jsonl");
+    const secret = "B2_MCP_CANARY_SECRET_exported_write_seam";
+    const exportedOps = secretSinkFileOpsForTests as Record<string, unknown>;
+    const interceptedWrite = vi.fn(() => {
+      throw new Error("intercepted plaintext write");
+    });
+
+    try {
+      expect(exportedOps.writeSync).toBeUndefined();
+      exportedOps.writeSync = interceptedWrite;
+      const pointer = appendSecretSinkRecord({ mode: "file", filePath: file }, "b2_create_key", {
+        applicationKey: secret,
+      });
+
+      expect(pointer.recordId).toEqual(expect.any(String));
+      expect(interceptedWrite).not.toHaveBeenCalled();
+      expect(readFileSync(file, "utf8")).toContain(secret);
+    } finally {
+      delete exportedOps.writeSync;
+    }
+  });
+
+  it("guards sensitive write overrides outside the test environment", () => {
+    const originalNodeEnv = process.env.NODE_ENV;
+    try {
+      process.env.NODE_ENV = "production";
+
+      expect(() => withSecretSinkSensitiveWriteOpsForTests({}, () => undefined)).toThrow(
+        /only available in tests/,
+      );
+    } finally {
+      if (originalNodeEnv === undefined) {
+        delete process.env.NODE_ENV;
+      } else {
+        process.env.NODE_ENV = originalNodeEnv;
+      }
+    }
+  });
+
   it("cleans up lock files when a lock write makes no progress", () => {
     const dir = tempDir();
     const file = join(dir, "secrets.jsonl");
-    vi.spyOn(secretSinkFileOpsForTests, "writeSync").mockReturnValue(0);
 
     expect(() =>
-      appendSecretSinkRecord({ mode: "file", filePath: file }, "b2_create_key", {
-        applicationKey: "B2_MCP_CANARY_SECRET_lock_write_no_progress",
-      }),
+      withSecretSinkSensitiveWriteOpsForTests({ writeSync: () => 0 }, () =>
+        appendSecretSinkRecord({ mode: "file", filePath: file }, "b2_create_key", {
+          applicationKey: "B2_MCP_CANARY_SECRET_lock_write_no_progress",
+        }),
+      ),
     ).toThrow(/write made no progress/);
 
-    expect(readdirSync(dir).filter((name) => name.endsWith(".append.lock"))).toHaveLength(0);
+    expect(appendLockNames(dir)).toHaveLength(0);
   });
 
   it("logs close failures before an uncommitted append is rolled back", () => {
@@ -1568,7 +1647,7 @@ describe("secret sink file writer", () => {
       const file = join(dir, "secrets.jsonl");
       const idempotency = testIdempotency(`committed-${suffix}`);
       writeFileSync(
-        `${file}.${idempotency.claimFingerprint}.committed.json`,
+        committedIdempotencyMarkerPath(file, idempotency),
         `${JSON.stringify({
           ts: "2026-08-18T12:00:00Z",
           tool: "b2_create_key",
@@ -1604,7 +1683,7 @@ describe("secret sink file writer", () => {
     const file = join(dir, "secrets.jsonl");
     const idempotency = testIdempotency("committed-conflict");
     writeFileSync(
-      `${file}.${idempotency.claimFingerprint}.committed.json`,
+      committedIdempotencyMarkerPath(file, idempotency),
       `${JSON.stringify({
         ts: "2026-08-18T12:00:00Z",
         tool: "b2_create_key",
@@ -1633,7 +1712,7 @@ describe("secret sink file writer", () => {
     const dir = tempDir();
     const file = join(dir, "secrets.jsonl");
     const idempotency = testIdempotency("committed-malformed-json");
-    writeFileSync(`${file}.${idempotency.claimFingerprint}.committed.json`, "not-json\n", {
+    writeFileSync(committedIdempotencyMarkerPath(file, idempotency), "not-json\n", {
       mode: 0o600,
     });
     let createCalls = 0;
@@ -1656,7 +1735,7 @@ describe("secret sink file writer", () => {
     const dir = tempDir();
     const file = join(dir, "secrets.jsonl");
     const indexTarget = join(dir, "index-target.jsonl");
-    const indexPath = `${file}.idempotency.jsonl`;
+    const indexPath = idempotencyIndexPath(file);
     const idempotency = testIdempotency("audit-index-symlink");
     writeFileSync(indexTarget, "", { mode: 0o600 });
     symlinkSync(indexTarget, indexPath);
@@ -1672,10 +1751,7 @@ describe("secret sink file writer", () => {
       }),
     });
 
-    const committed = readFileSync(
-      `${file}.${idempotency.claimFingerprint}.committed.json`,
-      "utf8",
-    );
+    const committed = readFileSync(committedIdempotencyMarkerPath(file, idempotency), "utf8");
     expect(result.structuredContent).toMatchObject({
       applicationKeyId: "key-id",
       applicationKey: "[redacted]",
@@ -1759,7 +1835,7 @@ describe("secret sink file writer", () => {
     const warnSpy = vi.spyOn(logger, "warn").mockImplementation(() => undefined as never);
     const dir = tempDir();
     const file = join(dir, "secrets.jsonl");
-    const appendLock = `${file}.append.lock`;
+    const appendLock = appendLockPath(file);
     writeFileSync(file, "", { mode: 0o600 });
     writeFileSync(appendLock, "[]\n", { mode: 0o600 });
     const stale = new Date(Date.now() - 10 * 60 * 1000);
@@ -1776,7 +1852,7 @@ describe("secret sink file writer", () => {
   it("continues when a stale append lock disappears during reclaim", () => {
     const dir = tempDir();
     const file = join(dir, "secrets.jsonl");
-    const appendLock = `${file}.append.lock`;
+    const appendLock = appendLockPath(file);
     writeFileSync(file, "", { mode: 0o600 });
     writeFileSync(appendLock, `${JSON.stringify({ status: "appending" })}\n`, { mode: 0o600 });
     const stale = new Date(Date.now() - 10 * 60 * 1000);
@@ -1805,7 +1881,7 @@ describe("secret sink file writer", () => {
   it("waits once for a live append lock before timing out", () => {
     const dir = tempDir();
     const file = join(dir, "secrets.jsonl");
-    const appendLock = `${file}.append.lock`;
+    const appendLock = appendLockPath(file);
     writeFileSync(file, "", { mode: 0o600 });
     writeFileSync(
       appendLock,
@@ -1819,11 +1895,19 @@ describe("secret sink file writer", () => {
       { mode: 0o600 },
     );
     const now = Date.now();
-    let nowCalls = 0;
-    vi.spyOn(Date, "now").mockImplementation(() => {
-      nowCalls++;
-      return nowCalls < 4 ? now : now + 31_000;
+    const unlink = secretSinkFileOpsForTests.unlinkSync;
+    let firstReclaimAttemptFinished = false;
+    vi.spyOn(secretSinkFileOpsForTests, "unlinkSync").mockImplementation((path) => {
+      if (String(path) === appendReclaimLockPath(file)) {
+        firstReclaimAttemptFinished = true;
+      }
+      return unlink(path);
     });
+    vi.spyOn(Date, "now").mockImplementation(() =>
+      firstReclaimAttemptFinished
+        ? now + APPEND_LOCK_WAIT_TIMEOUT_MS + APPEND_LOCK_WAIT_TIMEOUT_MARGIN_MS
+        : now,
+    );
 
     expect(() =>
       appendSecretSinkRecord({ mode: "file", filePath: file }, "b2_create_key", {
@@ -1831,7 +1915,7 @@ describe("secret sink file writer", () => {
       }),
     ).toThrow(/EEXIST|file already exists/i);
 
-    expect(nowCalls).toBeGreaterThanOrEqual(4);
+    expect(firstReclaimAttemptFinished).toBe(true);
     expect(existsSync(appendLock)).toBe(true);
   });
 
@@ -1866,7 +1950,7 @@ describe("secret sink file writer", () => {
     ).rejects.toMatchObject({ code: "secret_sink_write_failed" });
 
     expect(recoverSpy).toHaveBeenCalledOnce();
-    expect(readdirSync(dir).filter((name) => name.endsWith(".pending"))).toHaveLength(0);
+    expect(pendingClaimNames(dir)).toHaveLength(0);
     expect(JSON.stringify(fatalSpy.mock.calls)).toContain("write_failed_after_provider_create");
   });
 
@@ -1898,7 +1982,7 @@ describe("secret sink file writer", () => {
       }),
     ).rejects.toMatchObject({ code: "secret_sink_write_failed" });
 
-    expect(readdirSync(dir).some((name) => name.endsWith(".pending"))).toBe(true);
+    expect(pendingClaimNames(dir).length).toBeGreaterThan(0);
     expect(JSON.stringify(fatalSpy.mock.calls)).toContain("manual-review");
   });
 
@@ -1930,7 +2014,7 @@ describe("secret sink file writer", () => {
       }),
     ).rejects.toMatchObject({ code: "secret_sink_write_failed" });
 
-    expect(readdirSync(dir).some((name) => name.endsWith(".pending"))).toBe(true);
+    expect(pendingClaimNames(dir).length).toBeGreaterThan(0);
     expect(JSON.stringify(fatalSpy.mock.calls)).toContain("not_configured");
   });
 
@@ -1964,7 +2048,7 @@ describe("secret sink file writer", () => {
       }),
     ).rejects.toMatchObject({ code: "secret_sink_write_failed" });
 
-    expect(readdirSync(dir).some((name) => name.endsWith(".pending"))).toBe(true);
+    expect(pendingClaimNames(dir).length).toBeGreaterThan(0);
     expect(JSON.stringify(fatalSpy.mock.calls)).toContain("cleanup failed");
   });
 
@@ -1998,7 +2082,7 @@ describe("secret sink file writer", () => {
       }),
     ).rejects.toMatchObject({ code: "secret_sink_write_failed" });
 
-    expect(readdirSync(dir).some((name) => name.endsWith(".pending"))).toBe(true);
+    expect(pendingClaimNames(dir).length).toBeGreaterThan(0);
     expect(JSON.stringify(fatalSpy.mock.calls)).toContain("cleanup failed with Error");
   });
 
@@ -2077,7 +2161,7 @@ describe("secret sink file writer", () => {
 
     expect(createCalls).toBe(0);
     expect(recoverSpy).not.toHaveBeenCalled();
-    expect(readdirSync(dir).some((name) => name.endsWith(".pending"))).toBe(true);
+    expect(pendingClaimNames(dir).length).toBeGreaterThan(0);
     expect(JSON.stringify(fatalSpy.mock.calls)).toContain("pending_reconciliation");
   });
 });


### PR DESCRIPTION
## Summary
- Adds adversarial sanitizer coverage for nested objects/arrays, circular refs, hostile accessors, overlapping and edge configured secrets, provider identifier redaction, and non-string text fallback inputs.
- Redacts overlapping configured secrets longest-first so shorter prefixes cannot leave sensitive suffixes behind.
- Keeps plaintext secret-sink writes off the exported file-op test helper, adds a guarded private write override for deterministic failure coverage, centralizes private marker path helpers, restores process.getuid test state by descriptor, and trims the test hook to stay within package budget.

## Linked issue
Closes #277

## Tests
- pnpm run typecheck
- pnpm exec vitest run --config vitest.config.mts --project=unit tests/unit/secret-sanitizer.unit.test.ts tests/unit/secret-sink.unit.test.ts --coverage=false
- pnpm run check:package-budget (unpacked package bytes 2267952 / 2268000)
- pnpm run test:coverage (secret-sanitizer branches 94.53%, secret-sink branches 90.41%)

## Follow-up notes
None.