### PR TITLE
test(coverage): ratchet coverage thresholds

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -125,7 +125,7 @@ jobs:
         run: |
           echo "## Coverage summary" >> "$GITHUB_STEP_SUMMARY"
           echo "Node.js ${{ matrix.node-version }}" >> "$GITHUB_STEP_SUMMARY"
-          echo "Required: statements 94.1%, branches 87.8%, functions 97.2%, lines 96.5%." >> "$GITHUB_STEP_SUMMARY"
+          echo "Required: statements 94.3%, branches 88%, functions 97.2%, lines 96.6%." >> "$GITHUB_STEP_SUMMARY"
           echo '```' >> "$GITHUB_STEP_SUMMARY"
           if [ -f coverage/coverage-summary.json ]; then
             node -e "

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -125,7 +125,7 @@ jobs:
         run: |
           echo "## Coverage summary" >> "$GITHUB_STEP_SUMMARY"
           echo "Node.js ${{ matrix.node-version }}" >> "$GITHUB_STEP_SUMMARY"
-          echo "Required: statements 90.5%, branches 81.8%, functions 94.6%, lines 93.8%." >> "$GITHUB_STEP_SUMMARY"
+          echo "Required: statements 94.1%, branches 87.8%, functions 97.2%, lines 96.5%." >> "$GITHUB_STEP_SUMMARY"
           echo '```' >> "$GITHUB_STEP_SUMMARY"
           if [ -f coverage/coverage-summary.json ]; then
             node -e "

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 [![TypeScript](https://img.shields.io/badge/TypeScript-6.x-3178c6?logo=typescript&logoColor=white)](https://www.typescriptlang.org/)
 [![Node.js](https://img.shields.io/badge/Node.js-22.3%2B%20%7C%2024%20%7C%2026-339933?logo=nodedotjs&logoColor=white)](https://nodejs.org/)
 [![MCP](https://img.shields.io/badge/MCP-2026--07--28-5b5fc7)](https://modelcontextprotocol.io/specification/2026-07-28)
-[![Coverage floors](https://img.shields.io/badge/coverage-S%2094.1%20%7C%20B%2087.8%20%7C%20F%2097.2%20%7C%20L%2096.5-brightgreen)](docs/TESTING.md)
+[![Coverage floors](https://img.shields.io/badge/coverage-S%2094.3%20%7C%20B%2088%20%7C%20F%2097.2%20%7C%20L%2096.6-brightgreen)](docs/TESTING.md)
 [![Runtime dependencies](https://img.shields.io/badge/runtime_dependencies-9-blue)](package-budget.json)
 
 A [Model Context Protocol](https://modelcontextprotocol.io) server for [Backblaze B2 Cloud Storage](https://www.backblaze.com/cloud-storage). It lets any MCP-compatible AI client (Claude, and others) operate B2 through a focused, safe set of tools.

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 [![TypeScript](https://img.shields.io/badge/TypeScript-6.x-3178c6?logo=typescript&logoColor=white)](https://www.typescriptlang.org/)
 [![Node.js](https://img.shields.io/badge/Node.js-22.3%2B%20%7C%2024%20%7C%2026-339933?logo=nodedotjs&logoColor=white)](https://nodejs.org/)
 [![MCP](https://img.shields.io/badge/MCP-2026--07--28-5b5fc7)](https://modelcontextprotocol.io/specification/2026-07-28)
-[![Coverage floors](https://img.shields.io/badge/coverage-S%2090.5%20%7C%20B%2081.8%20%7C%20F%2094.6%20%7C%20L%2093.8-brightgreen)](docs/TESTING.md)
+[![Coverage floors](https://img.shields.io/badge/coverage-S%2094.1%20%7C%20B%2087.8%20%7C%20F%2097.2%20%7C%20L%2096.5-brightgreen)](docs/TESTING.md)
 [![Runtime dependencies](https://img.shields.io/badge/runtime_dependencies-9-blue)](package-budget.json)
 
 A [Model Context Protocol](https://modelcontextprotocol.io) server for [Backblaze B2 Cloud Storage](https://www.backblaze.com/cloud-storage). It lets any MCP-compatible AI client (Claude, and others) operate B2 through a focused, safe set of tools.

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -151,8 +151,8 @@ The stable required PR check names are:
 - `slow/lifecycle`
 - `cross-platform minimum`
 
-Global V8 coverage must remain at or above 94.1% statements, 87.8% branches,
-97.2% functions, and 96.5% lines. Raise these floors as coverage improves;
+Global V8 coverage must remain at or above 94.3% statements, 88% branches,
+97.2% functions, and 96.6% lines. Raise these floors as coverage improves;
 lowering them requires explicit review and justification. Coverage collection is source
 only: `src/**/*.ts`, excluding `dist/`, declarations, generated files, and test
 files. The current Phase 1 floor is a ratchet: when `coverage/coverage-summary.json`
@@ -174,9 +174,10 @@ to the global floor:
 | Logger destination   | `src/utils/logger.ts`                                                                       | `B2_LOG_FILE` import safety, async file/stderr routing, redaction, POSIX owner-only permissions, Windows rejection, symlink/FIFO/hard-link rejection, SIGHUP reopen, stderr fallback, and startup/shutdown tests |
 | Transport boundary   | `src/http-server.ts`, `src/utils/node-web-bridge.ts`, stdio and HTTP protocol suites        | Close/abort/listener tests      |
 
-The v1.0.0 target is 90% statements, 80% branches, 90% functions, and 90% lines
-globally, with credential/redaction/destructive/filesystem modules kept at 95%+
-statements or covered by explicit invariant tests. The SDK reference baseline is
+The historical v1.0.0 minimum baseline was 90% statements, 80% branches, 90%
+functions, and 90% lines globally; it does not supersede the active ratcheted
+floors above. Credential/redaction/destructive/filesystem modules stay at 95%+
+statements or are covered by explicit invariant tests. The SDK reference baseline is
 tracked as comparison evidence for test design, especially simulator behavior,
 retry ownership, pagination, and cancellation. Matching SDK parity is not a
 release blocker for this MCP package; regressions in this repository's critical

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -151,8 +151,8 @@ The stable required PR check names are:
 - `slow/lifecycle`
 - `cross-platform minimum`
 
-Global V8 coverage must remain at or above 90.5% statements, 81.8% branches,
-94.6% functions, and 93.8% lines. Raise these floors as coverage improves;
+Global V8 coverage must remain at or above 94.1% statements, 87.8% branches,
+97.2% functions, and 96.5% lines. Raise these floors as coverage improves;
 lowering them requires explicit review and justification. Coverage collection is source
 only: `src/**/*.ts`, excluding `dist/`, declarations, generated files, and test
 files. The current Phase 1 floor is a ratchet: when `coverage/coverage-summary.json`

--- a/tests/contract/test-layering.contract.test.ts
+++ b/tests/contract/test-layering.contract.test.ts
@@ -371,20 +371,20 @@ describe("test layer naming", () => {
     const ciWorkflow = readFileSync(join(root, ".github/workflows/test.yml"), "utf8");
 
     expect(vitestConfig).toMatch(
-      /thresholds:\s*{\s*statements:\s*90\.5,\s*branches:\s*81\.8,\s*functions:\s*94\.6,\s*lines:\s*93\.8,?\s*}/,
+      /thresholds:\s*{\s*statements:\s*94\.1,\s*branches:\s*87\.8,\s*functions:\s*97\.2,\s*lines:\s*96\.5,?\s*}/,
     );
     expect(vitestConfig).toContain('include: ["src/**/*.ts"]');
     expect(vitestConfig).toContain('"html"');
     expect(vitestConfig).toContain('"lcov"');
     expect(vitestConfig).toContain('"cobertura"');
     expect(readme).toContain(
-      "coverage-S%2090.5%20%7C%20B%2081.8%20%7C%20F%2094.6%20%7C%20L%2093.8-brightgreen",
+      "coverage-S%2094.1%20%7C%20B%2087.8%20%7C%20F%2097.2%20%7C%20L%2096.5-brightgreen",
     );
     expect(testingGuide).toMatch(
-      /Global V8 coverage must remain at or above 90\.5% statements,\s*81\.8% branches,\s*94\.6% functions, and 93\.8% lines\./,
+      /Global V8 coverage must remain at or above 94\.1% statements,\s*87\.8% branches,\s*97\.2% functions, and 96\.5% lines\./,
     );
     expect(ciWorkflow).toContain(
-      "Required: statements 90.5%, branches 81.8%, functions 94.6%, lines 93.8%.",
+      "Required: statements 94.1%, branches 87.8%, functions 97.2%, lines 96.5%.",
     );
   });
 

--- a/tests/contract/test-layering.contract.test.ts
+++ b/tests/contract/test-layering.contract.test.ts
@@ -371,20 +371,20 @@ describe("test layer naming", () => {
     const ciWorkflow = readFileSync(join(root, ".github/workflows/test.yml"), "utf8");
 
     expect(vitestConfig).toMatch(
-      /thresholds:\s*{\s*statements:\s*94\.1,\s*branches:\s*87\.8,\s*functions:\s*97\.2,\s*lines:\s*96\.5,?\s*}/,
+      /thresholds:\s*{\s*statements:\s*94\.3,\s*branches:\s*88,\s*functions:\s*97\.2,\s*lines:\s*96\.6,?\s*}/,
     );
     expect(vitestConfig).toContain('include: ["src/**/*.ts"]');
     expect(vitestConfig).toContain('"html"');
     expect(vitestConfig).toContain('"lcov"');
     expect(vitestConfig).toContain('"cobertura"');
     expect(readme).toContain(
-      "coverage-S%2094.1%20%7C%20B%2087.8%20%7C%20F%2097.2%20%7C%20L%2096.5-brightgreen",
+      "coverage-S%2094.3%20%7C%20B%2088%20%7C%20F%2097.2%20%7C%20L%2096.6-brightgreen",
     );
     expect(testingGuide).toMatch(
-      /Global V8 coverage must remain at or above 94\.1% statements,\s*87\.8% branches,\s*97\.2% functions, and 96\.5% lines\./,
+      /Global V8 coverage must remain at or above 94\.3% statements,\s*88% branches,\s*97\.2% functions, and 96\.6% lines\./,
     );
     expect(ciWorkflow).toContain(
-      "Required: statements 94.1%, branches 87.8%, functions 97.2%, lines 96.5%.",
+      "Required: statements 94.3%, branches 88%, functions 97.2%, lines 96.6%.",
     );
   });
 

--- a/tests/unit/errors.unit.test.ts
+++ b/tests/unit/errors.unit.test.ts
@@ -1,4 +1,5 @@
 import {
+  badRequest,
   parseB2Error,
   formatB2Error,
   parseErrorText,
@@ -106,6 +107,69 @@ describe("parseB2Error", () => {
 
     expect(parsed.message).toContain("applicationKey");
     expect(parsed.message).toContain(CANARY);
+  });
+
+  it("uses safe fallbacks for malformed legacy response errors", () => {
+    const parsed = parseB2Error({
+      response: {
+        status: "not-a-number",
+        data: "not-a-response-body",
+        headers: null,
+      },
+    });
+
+    expect(parsed).toEqual({
+      status: 500,
+      code: "unknown_error",
+      message: "An unknown error occurred",
+      requestId: undefined,
+    });
+  });
+
+  it("falls back for incomplete AWS SDK metadata errors", () => {
+    const parsed = parseB2Error({
+      Code: "",
+      name: "",
+      message: undefined,
+      $metadata: {
+        requestId: 42,
+        extendedRequestId: false,
+      },
+    });
+
+    expect(parsed).toEqual({
+      status: 500,
+      code: "unknown_error",
+      message: "An unknown error occurred",
+      requestId: undefined,
+      extendedRequestId: undefined,
+    });
+  });
+
+  it("normalizes already parsed B2 errors with optional fields missing", () => {
+    expect(parseB2Error({ code: "already_parsed", message: "done", requestId: 42 })).toEqual({
+      status: 500,
+      code: "already_parsed",
+      message: "done",
+      requestId: undefined,
+    });
+  });
+
+  it("stringifies provider messages that cannot be JSON encoded", () => {
+    const circular: Record<string, unknown> = {};
+    circular.self = circular;
+
+    expect(parseB2Error({ message: circular })).toEqual({
+      status: 500,
+      code: "internal_error",
+      message: "[object Object]",
+    });
+  });
+
+  it("throws a normalized bad request object", () => {
+    expect(() => badRequest("bad input")).toThrow(
+      expect.objectContaining({ status: 400, code: "bad_request", message: "bad input" }),
+    );
   });
 });
 

--- a/tests/unit/result-serializer.unit.test.ts
+++ b/tests/unit/result-serializer.unit.test.ts
@@ -6,6 +6,7 @@ import {
   preflightMcpOutputFormat,
   runWithResultSerializationOptions,
   serializeStructuredToolResult,
+  serializeUnsanitizedStructuredToolResult,
   TOON_IMPLEMENTATION,
   TOON_SPEC_VERSION,
 } from "../../src/utils/result-serializer";
@@ -161,6 +162,18 @@ describe("result serializer", () => {
     await expect(decodeToon(result.content[0].text)).resolves.toEqual(result.structuredContent);
   });
 
+  it("serializes unsanitized compatible output in the selected text format", async () => {
+    const result = serializeUnsanitizedStructuredToolResult({ ok: true }, "toon");
+
+    expect(result.structuredContent).toEqual({ ok: true });
+    expect(result.content[0].text).toBe("ok: true");
+    await expect(decodeToon(result.content[0].text)).resolves.toEqual(result.structuredContent);
+  });
+
+  it("rejects unsanitized values that cannot become structured JSON", () => {
+    expect(() => serializeUnsanitizedStructuredToolResult(undefined)).toThrow(/JSON-compatible/);
+  });
+
   it("emits visible text for an empty object in TOON mode", async () => {
     const result = await runWithResultSerializationOptions({ outputFormat: "toon" }, () =>
       toolJson({ omitted: undefined }),
@@ -213,6 +226,20 @@ describe("result serializer", () => {
   it("preflights TOON mode with a smoke serialization", () => {
     expect(() => preflightMcpOutputFormat("json")).not.toThrow();
     expect(() => preflightMcpOutputFormat("toon")).not.toThrow();
+  });
+
+  it("fails TOON preflight when the encoder contract drifts", async () => {
+    vi.resetModules();
+    vi.doMock("../../src/utils/toon-encoder", () => ({
+      encodeToon: () => "ok: false",
+    }));
+    try {
+      const serializer = await import("../../src/utils/result-serializer");
+      expect(() => serializer.preflightMcpOutputFormat("toon")).toThrow(/preflight failed/);
+    } finally {
+      vi.doUnmock("../../src/utils/toon-encoder");
+      vi.resetModules();
+    }
   });
 
   it("does not load the npm TOON package when JSON mode serializes text", async () => {

--- a/tests/unit/utility-branches.unit.test.ts
+++ b/tests/unit/utility-branches.unit.test.ts
@@ -1,0 +1,55 @@
+import { dateFromTimestamp } from "../../src/utils/date";
+import {
+  contentLengthExceedsLimit,
+  MAX_MCP_BODY_BYTES,
+  readCappedBodyBytes,
+} from "../../src/utils/http-body-limit";
+import { forEachBounded } from "../../src/utils/concurrency";
+
+describe("small utility branch coverage", () => {
+  it("converts numeric timestamps and ignores omitted values", () => {
+    expect(dateFromTimestamp(0)?.toISOString()).toBe("1970-01-01T00:00:00.000Z");
+    expect(dateFromTimestamp(undefined)).toBeUndefined();
+  });
+
+  it("treats invalid content-length values as within the body limit", () => {
+    expect(contentLengthExceedsLimit(new Headers({ "content-length": "not-a-number" }))).toBe(
+      false,
+    );
+    expect(
+      contentLengthExceedsLimit(new Headers({ "content-length": String(MAX_MCP_BODY_BYTES + 1) })),
+    ).toBe(true);
+  });
+
+  it("returns an empty body when the request has no stream", async () => {
+    await expect(
+      readCappedBodyBytes(new Request("https://example.test", { method: "POST" })),
+    ).resolves.toHaveLength(0);
+  });
+
+  it("reports aborted empty bounded work without calling the worker", async () => {
+    const controller = new AbortController();
+    controller.abort();
+    const worker = vi.fn<() => Promise<void>>();
+
+    await expect(forEachBounded([], { signal: controller.signal }, worker)).resolves.toEqual({
+      maxConcurrency: 0,
+      aborted: true,
+    });
+    expect(worker).not.toHaveBeenCalled();
+  });
+
+  it("stops bounded workers before processing when the signal is already aborted", async () => {
+    const controller = new AbortController();
+    controller.abort();
+    const worker = vi.fn<() => Promise<void>>();
+
+    await expect(
+      forEachBounded(["a", "b"], { signal: controller.signal }, worker),
+    ).resolves.toEqual({
+      maxConcurrency: 2,
+      aborted: true,
+    });
+    expect(worker).not.toHaveBeenCalled();
+  });
+});

--- a/vitest.config.mts
+++ b/vitest.config.mts
@@ -34,10 +34,10 @@ export default defineConfig({
       include: ["src/**/*.ts"],
       exclude: ["dist/**", "tests/**", "**/*.d.ts", "**/*.test.ts", "**/generated/**"],
       thresholds: {
-        statements: 94.1,
-        branches: 87.8,
+        statements: 94.3,
+        branches: 88,
         functions: 97.2,
-        lines: 96.5,
+        lines: 96.6,
       },
     },
     projects: layerProjectNamesForConfig().map((name) =>

--- a/vitest.config.mts
+++ b/vitest.config.mts
@@ -34,10 +34,10 @@ export default defineConfig({
       include: ["src/**/*.ts"],
       exclude: ["dist/**", "tests/**", "**/*.d.ts", "**/*.test.ts", "**/generated/**"],
       thresholds: {
-        statements: 90.5,
-        branches: 81.8,
-        functions: 94.6,
-        lines: 93.8,
+        statements: 94.1,
+        branches: 87.8,
+        functions: 97.2,
+        lines: 96.5,
       },
     },
     projects: layerProjectNamesForConfig().map((name) =>


### PR DESCRIPTION
## Summary
- Add focused unit coverage for utility, result serialization, and error fallback branches so measured branch coverage clears 88%.
- Raise global V8 coverage floors to statements 94.3%, branches 88%, functions 97.2%, and lines 96.6%.
- Update the README badge, testing guide, CI coverage summary, and contract guard to match the new ratchet.
- Clarify that the older v1.0.0 coverage target is historical and does not supersede the active ratcheted floors.

Closes #280

## Tests
- `pnpm exec vitest run --config vitest.config.mts --project=unit tests/unit/errors.unit.test.ts tests/unit/result-serializer.unit.test.ts tests/unit/utility-branches.unit.test.ts`
- `pnpm exec vitest run --config vitest.config.mts --project=contract tests/contract/test-layering.contract.test.ts --testNamePattern "enforces the current global coverage floors"`
- `pnpm run typecheck`
- `pnpm run format:check`
- `pnpm run test:coverage`

## Follow-up notes
- Final measured totals were statements 94.31%, branches 88.10%, functions 97.21%, and lines 96.63%.
- All configured thresholds remain below the measured totals.