### PR TITLE
docs: add Deploy API Docs workflow

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,3 +1,5 @@
+# Builds the TypeDoc API reference and publishes api-docs/ to GitHub Pages from
+# main only. Requires repo Pages source: GitHub Actions. Uses no B2 credentials.
 name: Deploy API Docs
 
 on:
@@ -16,6 +18,7 @@ jobs:
   build:
     name: Build API docs
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     steps:
       # actions/checkout v7, reviewed 2026-08-25.
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
@@ -30,8 +33,18 @@ jobs:
         with:
           node-version: 22.23.1
           cache: pnpm
-      - run: pnpm install --frozen-lockfile
+      - run: pnpm install --frozen-lockfile --ignore-scripts
+        env:
+          ACTIONS_CACHE_URL: ""
+          ACTIONS_RESULTS_URL: ""
+          ACTIONS_RUNTIME_TOKEN: ""
+          ACTIONS_RUNTIME_URL: ""
       - run: pnpm run docs
+        env:
+          ACTIONS_CACHE_URL: ""
+          ACTIONS_RESULTS_URL: ""
+          ACTIONS_RUNTIME_TOKEN: ""
+          ACTIONS_RUNTIME_URL: ""
       # actions/upload-pages-artifact v5, reviewed 2026-08-27.
       - uses: actions/upload-pages-artifact@fc324d3547104276b827a68afc52ff2a11cc49c9
         with:
@@ -40,11 +53,16 @@ jobs:
   deploy:
     name: Deploy API docs
     needs: build
+    if: github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     permissions:
       pages: write
       id-token: write
-    environment: github-pages
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
     steps:
       # actions/deploy-pages v5, reviewed 2026-08-27.
-      - uses: actions/deploy-pages@cd2ce8fcbc39b97be8ca5fce6e763baed58fa128
+      - id: deployment
+        uses: actions/deploy-pages@cd2ce8fcbc39b97be8ca5fce6e763baed58fa128

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,50 @@
+name: Deploy API Docs
+
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: pages
+  cancel-in-progress: false
+
+jobs:
+  build:
+    name: Build API docs
+    runs-on: ubuntu-latest
+    steps:
+      # actions/checkout v7, reviewed 2026-08-25.
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
+        with:
+          persist-credentials: false
+      # pnpm/action-setup v6.0.10, reviewed 2026-08-06.
+      - uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86
+        with:
+          run_install: false
+      # actions/setup-node v7, reviewed 2026-08-06.
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020
+        with:
+          node-version: 22.23.1
+          cache: pnpm
+      - run: pnpm install --frozen-lockfile
+      - run: pnpm run docs
+      # actions/upload-pages-artifact v5, reviewed 2026-08-27.
+      - uses: actions/upload-pages-artifact@fc324d3547104276b827a68afc52ff2a11cc49c9
+        with:
+          path: api-docs
+
+  deploy:
+    name: Deploy API docs
+    needs: build
+    runs-on: ubuntu-latest
+    permissions:
+      pages: write
+      id-token: write
+    environment: github-pages
+    steps:
+      # actions/deploy-pages v5, reviewed 2026-08-27.
+      - uses: actions/deploy-pages@cd2ce8fcbc39b97be8ca5fce6e763baed58fa128

--- a/scripts/check-runtime-policy.mjs
+++ b/scripts/check-runtime-policy.mjs
@@ -78,12 +78,50 @@ function workflowJobBlocks(relativePath) {
 }
 
 function workflowStepBlocks(jobBlockText) {
-  const matches = [...jobBlockText.matchAll(/^ {6}-\s/gm)];
-  return matches.map((match, index) => {
-    const start = match.index ?? 0;
-    const end = matches[index + 1]?.index ?? jobBlockText.length;
-    return jobBlockText.slice(start, end);
-  });
+  const lines = jobBlockText.split(/\r?\n/);
+  const topLevelIndent = blockChildIndent(jobBlockText);
+  if (topLevelIndent === null) return [];
+
+  const blocks = [];
+  for (let index = 0; index < lines.length; index += 1) {
+    const line = lines[index];
+    if (!line.trim()) continue;
+    const indent = line.match(/^ */)?.[0].length ?? 0;
+    if (indent !== topLevelIndent || !/^steps:\s*(?:#.*)?$/.test(line.slice(indent))) continue;
+
+    const stepsIndent = indent;
+    let stepIndent = null;
+    let currentStart = null;
+    let stepsEnd = index + 1;
+    for (let child = index + 1; child < lines.length; child += 1) {
+      const childLine = lines[child];
+      stepsEnd = child;
+      if (childLine.trim()) {
+        const childIndent = childLine.match(/^ */)?.[0].length ?? 0;
+        if (childIndent <= stepsIndent) {
+          stepsEnd = child;
+          break;
+        }
+
+        if (stepIndent === null && childLine.slice(childIndent).startsWith("- ")) {
+          stepIndent = childIndent;
+          currentStart = child;
+        } else if (
+          stepIndent !== null &&
+          childIndent === stepIndent &&
+          childLine.slice(childIndent).startsWith("- ")
+        ) {
+          blocks.push(lines.slice(currentStart, child).join("\n"));
+          currentStart = child;
+        }
+      }
+      stepsEnd = child + 1;
+    }
+
+    if (currentStart !== null) blocks.push(lines.slice(currentStart, stepsEnd).join("\n"));
+  }
+
+  return blocks;
 }
 
 function stripYamlInlineComment(value) {
@@ -101,21 +139,64 @@ function unquoteWorkflowScalar(value) {
   return trimmed;
 }
 
-function stepTopLevelEntry(line) {
-  const firstEntry = line.match(/^ {6}-\s+([A-Za-z0-9_-]+):\s*(.*)$/);
-  if (firstEntry) return { key: firstEntry[1], rawValue: firstEntry[2], indent: 8 };
+function blockChildIndent(blockText) {
+  const lines = blockText.split(/\r?\n/);
+  const firstIndex = lines.findIndex((line) => line.trim());
+  if (firstIndex === -1) return null;
 
-  const entry = line.match(/^ {8}([A-Za-z0-9_-]+):\s*(.*)$/);
-  if (entry) return { key: entry[1], rawValue: entry[2], indent: 8 };
+  const match = lines[firstIndex].match(/^(\s*)[^:#]+:\s*(?:#.*)?$/);
+  if (!match) return null;
+  const parentIndent = match[1].length;
+
+  const childIndents = [];
+  for (const line of lines.slice(firstIndex + 1)) {
+    if (!line.trim() || line.trimStart().startsWith("#")) continue;
+    const indent = line.match(/^ */)?.[0].length ?? 0;
+    if (indent <= parentIndent) break;
+    childIndents.push(indent);
+  }
+
+  return childIndents.length > 0 ? Math.min(...childIndents) : parentIndent + 2;
+}
+
+function blockTopLevelValue(blockText, key) {
+  const keyIndent = blockChildIndent(blockText);
+  if (keyIndent === null) return null;
+
+  for (const line of blockText.split(/\r?\n/)) {
+    const entry = topLevelMappingEntry(line, keyIndent);
+    if (entry?.key === key) return unquoteWorkflowScalar(entry.rawValue);
+  }
+
+  return null;
+}
+
+function topLevelMappingEntry(line, keyIndent) {
+  const entry = line.match(/^(\s*)([A-Za-z0-9_-]+):\s*(.*)$/);
+  if (!entry || entry[1].length !== keyIndent) return null;
+  return { key: entry[2], rawValue: entry[3], indent: keyIndent };
+}
+
+function stepTopLevelEntry(line, keyIndent) {
+  const firstEntry = line.match(/^(\s*)-\s+([A-Za-z0-9_-]+):\s*(.*)$/);
+  if (firstEntry && firstEntry[1].length + 2 === keyIndent) {
+    return { key: firstEntry[2], rawValue: firstEntry[3], indent: keyIndent };
+  }
+
+  const entry = topLevelMappingEntry(line, keyIndent);
+  if (entry) return entry;
 
   return null;
 }
 
 function stepTopLevelValue(stepBlock, key) {
   const lines = stepBlock.split(/\r?\n/);
+  const stepStart = stepBlock.match(/^(\s*)-\s/);
+  if (!stepStart) return null;
+  const keyIndent = stepStart[1].length + 2;
 
   for (let index = 0; index < lines.length; index += 1) {
-    const entry = stepTopLevelEntry(lines[index]);
+    const entry = stepTopLevelEntry(lines[index], keyIndent);
     if (!entry || entry.key !== key) continue;
 
     const rawValue = stripYamlInlineComment(entry.rawValue);
@@ -158,9 +239,12 @@ function parseInlineEnvMapping(rawValue) {
 
 function stepEnvMapping(stepBlock) {
   const lines = stepBlock.split(/\r?\n/);
+  const stepStart = stepBlock.match(/^(\s*)-\s/);
+  if (!stepStart) return null;
+  const keyIndent = stepStart[1].length + 2;
 
   for (let index = 0; index < lines.length; index += 1) {
-    const entry = stepTopLevelEntry(lines[index]);
+    const entry = stepTopLevelEntry(lines[index], keyIndent);
     if (!entry || entry.key !== "env") continue;
 
     const inlineMapping = parseInlineEnvMapping(entry.rawValue);
@@ -197,9 +281,10 @@ function requirePagesDeploysFromMainOnly() {
   for (const workflow of workflowFilesWithPagesDeploy()) {
     for (const job of workflowJobBlocks(workflow)) {
       if (!job.block.includes("actions/deploy-pages@")) continue;
+      const condition = blockTopLevelValue(job.block, "if");
       if (
-        !/^ {4}if:\s*(?:\$\{\{\s*)?github\.ref == ['"]refs\/heads\/main['"](?:\s*\}\})?\s*$/m.test(
-          job.block,
+        !/^(?:\$\{\{\s*)?github\.ref == ['"]refs\/heads\/main['"](?:\s*\}\})?$/.test(
+          condition ?? "",
         )
       ) {
         fail(
@@ -219,7 +304,7 @@ function requirePagesJobTimeouts() {
       ) {
         continue;
       }
-      if (!/^ {4}timeout-minutes:\s*[1-9][0-9]*\s*$/m.test(job.block)) {
+      if (!/^[1-9][0-9]*$/.test(blockTopLevelValue(job.block, "timeout-minutes") ?? "")) {
         fail(`${workflow}: Pages job ${job.name} must declare timeout-minutes`);
       }
     }

--- a/scripts/check-runtime-policy.mjs
+++ b/scripts/check-runtime-policy.mjs
@@ -95,7 +95,7 @@ function workflowStepBlocks(jobBlockText) {
     let stepsEnd = index + 1;
     for (let child = index + 1; child < lines.length; child += 1) {
       const childLine = lines[child];
-      if (childLine.trim()) {
+      if (childLine.trim() && !childLine.trimStart().startsWith("#")) {
         const childIndent = childLine.match(/^ */)?.[0].length ?? 0;
         if (childIndent <= stepsIndent) {
           stepsEnd = child;

--- a/scripts/check-runtime-policy.mjs
+++ b/scripts/check-runtime-policy.mjs
@@ -9,7 +9,6 @@ const root = process.env.B2_MCP_RUNTIME_POLICY_ROOT
   ? path.resolve(process.env.B2_MCP_RUNTIME_POLICY_ROOT)
   : path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
 const require = createRequire(import.meta.url);
-const { parseDocument } = require("yaml");
 const { readPackageManagerLock } = require("./lib/pnpm-lock.cjs");
 const errors = [];
 const {
@@ -78,99 +77,324 @@ function workflowJobBlocks(relativePath) {
   return parseWorkflowJobBlocks(read(relativePath));
 }
 
-const parsedWorkflowCache = new Map();
+function workflowStepBlocks(jobBlockText) {
+  const lines = jobBlockText.split(/\r?\n/);
+  const topLevelIndent = blockChildIndent(jobBlockText);
+  if (topLevelIndent === null) return [];
 
-function parsedWorkflow(relativePath) {
-  if (parsedWorkflowCache.has(relativePath)) return parsedWorkflowCache.get(relativePath);
+  const blocks = [];
+  for (let index = 0; index < lines.length; index += 1) {
+    const line = lines[index];
+    if (!line.trim()) continue;
+    const indent = line.match(/^ */)?.[0].length ?? 0;
+    if (indent !== topLevelIndent || !/^steps:\s*(?:#.*)?$/.test(line.slice(indent))) continue;
 
-  const document = parseDocument(read(relativePath));
-  if (document.errors.length > 0) {
-    fail(`${relativePath}: workflow YAML must parse without errors`);
-    parsedWorkflowCache.set(relativePath, null);
-    return null;
+    const stepsIndent = indent;
+    let stepIndent = null;
+    let currentStart = null;
+    let stepsEnd = index + 1;
+    for (let child = index + 1; child < lines.length; child += 1) {
+      const childLine = lines[child];
+      if (childLine.trim() && !childLine.trimStart().startsWith("#")) {
+        const childIndent = childLine.match(/^ */)?.[0].length ?? 0;
+        if (childIndent <= stepsIndent) {
+          stepsEnd = child;
+          break;
+        }
+
+        if (stepIndent === null && childLine.slice(childIndent).startsWith("- ")) {
+          stepIndent = childIndent;
+          currentStart = child;
+        } else if (
+          stepIndent !== null &&
+          childIndent === stepIndent &&
+          childLine.slice(childIndent).startsWith("- ")
+        ) {
+          blocks.push(lines.slice(currentStart, child).join("\n"));
+          currentStart = child;
+        }
+      }
+      stepsEnd = child + 1;
+    }
+
+    if (currentStart !== null) blocks.push(lines.slice(currentStart, stepsEnd).join("\n"));
   }
 
-  const value = document.toJS({ maxAliasCount: 100 });
-  if (value === null || typeof value !== "object" || Array.isArray(value)) {
-    fail(`${relativePath}: workflow YAML must be a mapping`);
-    parsedWorkflowCache.set(relativePath, null);
-    return null;
-  }
+  return blocks;
+}
 
-  parsedWorkflowCache.set(relativePath, value);
+function stripYamlInlineComment(value) {
+  let quote = null;
+  for (let index = 0; index < value.length; index += 1) {
+    const char = value[index];
+    if (quote === "'") {
+      if (char === "'" && value[index + 1] === "'") index += 1;
+      else if (char === "'") quote = null;
+      continue;
+    }
+    if (quote === '"') {
+      if (char === "\\") index += 1;
+      else if (char === '"') quote = null;
+      continue;
+    }
+    if (char === "'" || char === '"') {
+      quote = char;
+      continue;
+    }
+    if (char === "#" && (index === 0 || /\s/.test(value[index - 1]))) {
+      return value.slice(0, index).trim();
+    }
+  }
+  return value.trim();
+}
+
+function parseQuotedScalar(value, relativePath) {
+  if (value.startsWith('"') && value.endsWith('"')) {
+    try {
+      return JSON.parse(value);
+    } catch {
+      fail(`${relativePath}: workflow double-quoted scalar must parse`);
+      return value.slice(1, -1);
+    }
+  }
+  if (value.startsWith("'") && value.endsWith("'")) {
+    return value.slice(1, -1).replace(/''/g, "'");
+  }
   return value;
 }
 
-function isMapping(value) {
-  return value !== null && typeof value === "object" && !Array.isArray(value);
+function parseWorkflowScalar(rawValue, anchors, relativePath) {
+  const value = stripYamlInlineComment(rawValue);
+  const anchored = value.match(/^&([^\s]+)(?:\s+(.*))?$/);
+  if (anchored) {
+    const resolved = parseQuotedScalar(anchored[2] ?? "", relativePath);
+    anchors.set(anchored[1], resolved);
+    return resolved;
+  }
+
+  const alias = value.match(/^\*([^\s]+)$/);
+  if (alias) return anchors.get(alias[1]) ?? value;
+
+  return parseQuotedScalar(value, relativePath);
 }
 
-function parsedWorkflowJobs(relativePath) {
-  const jobs = parsedWorkflow(relativePath)?.jobs;
-  if (!isMapping(jobs)) return [];
-  return Object.entries(jobs)
-    .filter(([, job]) => isMapping(job))
-    .map(([name, job]) => ({ name, job }));
+const scalarAnchorCache = new Map();
+
+function workflowScalarAnchors(relativePath) {
+  if (scalarAnchorCache.has(relativePath)) return scalarAnchorCache.get(relativePath);
+
+  const anchors = new Map();
+  for (const line of read(relativePath).split(/\r?\n/)) {
+    if (!line.trim() || line.trimStart().startsWith("#")) continue;
+    const entry = line.match(/^(?:\s*-\s+)?\s*[A-Za-z0-9_-]+:\s*(.*)$/);
+    if (entry) parseWorkflowScalar(entry[1], anchors, relativePath);
+  }
+
+  scalarAnchorCache.set(relativePath, anchors);
+  return anchors;
 }
 
-function parsedJobSteps(job) {
-  return Array.isArray(job.steps) ? job.steps.filter(isMapping) : [];
+function blockChildIndent(blockText) {
+  const lines = blockText.split(/\r?\n/);
+  const firstIndex = lines.findIndex((line) => line.trim());
+  if (firstIndex === -1) return null;
+
+  const match = lines[firstIndex].match(/^(\s*)[^:#]+:\s*(?:&\S+)?\s*(?:#.*)?$/);
+  if (!match) return null;
+  const parentIndent = match[1].length;
+
+  const childIndents = [];
+  for (const line of lines.slice(firstIndex + 1)) {
+    if (!line.trim() || line.trimStart().startsWith("#")) continue;
+    const indent = line.match(/^ */)?.[0].length ?? 0;
+    if (indent <= parentIndent) break;
+    childIndents.push(indent);
+  }
+
+  return childIndents.length > 0 ? Math.min(...childIndents) : parentIndent + 2;
 }
 
-function stepUsesAction(step, action) {
-  return typeof step.uses === "string" && step.uses.startsWith(`${action}@`);
+function blockTopLevelValue(relativePath, blockText, key) {
+  const keyIndent = blockChildIndent(blockText);
+  if (keyIndent === null) return null;
+
+  for (const line of blockText.split(/\r?\n/)) {
+    const entry = topLevelMappingEntry(line, keyIndent);
+    if (entry?.key === key) {
+      return parseWorkflowScalar(entry.rawValue, workflowScalarAnchors(relativePath), relativePath);
+    }
+  }
+
+  return null;
 }
 
-function jobUsesAction(job, action) {
-  return parsedJobSteps(job).some((step) => stepUsesAction(step, action));
+function topLevelMappingEntry(line, keyIndent) {
+  const entry = line.match(/^(\s*)([A-Za-z0-9_-]+):\s*(.*)$/);
+  if (!entry || entry[1].length !== keyIndent) return null;
+  return { key: entry[2], rawValue: entry[3], indent: keyIndent };
+}
+
+function stepTopLevelEntry(line, keyIndent) {
+  const firstEntry = line.match(/^(\s*)-\s+([A-Za-z0-9_-]+):\s*(.*)$/);
+  if (firstEntry && firstEntry[1].length + 2 === keyIndent) {
+    return { key: firstEntry[2], rawValue: firstEntry[3], indent: keyIndent };
+  }
+
+  const entry = topLevelMappingEntry(line, keyIndent);
+  if (entry) return entry;
+
+  return null;
+}
+
+function stepTopLevelValue(relativePath, stepBlock, key) {
+  const lines = stepBlock.split(/\r?\n/);
+  const stepStart = stepBlock.match(/^(\s*)-\s/);
+  if (!stepStart) return null;
+  const keyIndent = stepStart[1].length + 2;
+
+  for (let index = 0; index < lines.length; index += 1) {
+    const entry = stepTopLevelEntry(lines[index], keyIndent);
+    if (!entry || entry.key !== key) continue;
+
+    const rawValue = stripYamlInlineComment(entry.rawValue);
+    if (/^[|>][+-]?$/.test(rawValue)) {
+      const blockLines = [];
+      for (let child = index + 1; child < lines.length; child += 1) {
+        const childLine = lines[child];
+        if (childLine.trim()) {
+          const childIndent = childLine.match(/^ */)?.[0].length ?? 0;
+          if (childIndent <= entry.indent) break;
+        }
+        blockLines.push(childLine.trim());
+      }
+      return blockLines.join("\n");
+    }
+
+    return parseWorkflowScalar(entry.rawValue, workflowScalarAnchors(relativePath), relativePath);
+  }
+
+  return null;
+}
+
+function parseInlineEnvMapping(relativePath, rawValue) {
+  const trimmed = stripYamlInlineComment(rawValue);
+  if (!trimmed.startsWith("{") || !trimmed.endsWith("}")) return null;
+
+  const mapping = {};
+  const body = trimmed.slice(1, -1).trim();
+  if (!body) return mapping;
+
+  for (const part of body.split(",")) {
+    const separator = part.indexOf(":");
+    if (separator === -1) continue;
+    const anchors = workflowScalarAnchors(relativePath);
+    const key = parseWorkflowScalar(part.slice(0, separator), anchors, relativePath);
+    mapping[key] = parseWorkflowScalar(part.slice(separator + 1), anchors, relativePath);
+  }
+
+  return mapping;
+}
+
+function stepEnvMapping(relativePath, stepBlock) {
+  const lines = stepBlock.split(/\r?\n/);
+  const stepStart = stepBlock.match(/^(\s*)-\s/);
+  if (!stepStart) return null;
+  const keyIndent = stepStart[1].length + 2;
+
+  for (let index = 0; index < lines.length; index += 1) {
+    const entry = stepTopLevelEntry(lines[index], keyIndent);
+    if (!entry || entry.key !== "env") continue;
+
+    const inlineMapping = parseInlineEnvMapping(relativePath, entry.rawValue);
+    if (inlineMapping) return inlineMapping;
+
+    const rawValue = stripYamlInlineComment(entry.rawValue);
+    if (rawValue) return {};
+
+    const mapping = {};
+    for (let child = index + 1; child < lines.length; child += 1) {
+      const childLine = lines[child];
+      if (!childLine.trim() || childLine.trimStart().startsWith("#")) continue;
+
+      const childIndent = childLine.match(/^ */)?.[0].length ?? 0;
+      if (childIndent <= entry.indent) break;
+      if (childIndent !== entry.indent + 2) continue;
+
+      const childEntry = childLine.slice(childIndent).match(/^([A-Za-z_][A-Za-z0-9_]*):\s*(.*)$/);
+      if (childEntry) {
+        mapping[childEntry[1]] = parseWorkflowScalar(
+          childEntry[2],
+          workflowScalarAnchors(relativePath),
+          relativePath,
+        );
+      }
+    }
+    return mapping;
+  }
+
+  return null;
+}
+
+function stepUsesAction(relativePath, stepBlock, action) {
+  const uses = stepTopLevelValue(relativePath, stepBlock, "uses");
+  return typeof uses === "string" && uses.startsWith(`${action}@`);
+}
+
+function jobUsesAction(relativePath, jobBlock, action) {
+  return workflowStepBlocks(jobBlock).some((stepBlock) =>
+    stepUsesAction(relativePath, stepBlock, action),
+  );
 }
 
 function workflowFilesWithPagesDeploy() {
   return listFiles(".github/workflows").filter((workflow) =>
-    parsedWorkflowJobs(workflow).some(({ job }) => jobUsesAction(job, "actions/deploy-pages")),
+    workflowJobBlocks(workflow).some((job) =>
+      jobUsesAction(workflow, job.block, "actions/deploy-pages"),
+    ),
   );
 }
 
 function requirePagesDeploysFromMainOnly() {
   for (const workflow of workflowFilesWithPagesDeploy()) {
-    for (const { name, job } of parsedWorkflowJobs(workflow)) {
-      if (!jobUsesAction(job, "actions/deploy-pages")) continue;
+    for (const job of workflowJobBlocks(workflow)) {
+      if (!jobUsesAction(workflow, job.block, "actions/deploy-pages")) continue;
+      const condition = blockTopLevelValue(workflow, job.block, "if");
       if (
-        typeof job.if !== "string" ||
-        !/^(?:\$\{\{\s*)?github\.ref == ['"]refs\/heads\/main['"](?:\s*\}\})?$/.test(job.if)
+        typeof condition !== "string" ||
+        !/^(?:\$\{\{\s*)?github\.ref == ['"]refs\/heads\/main['"](?:\s*\}\})?$/.test(condition)
       ) {
-        fail(`${workflow}: Pages deploy job ${name} must require github.ref == refs/heads/main`);
+        fail(
+          `${workflow}: Pages deploy job ${job.name} must require github.ref == refs/heads/main`,
+        );
       }
     }
   }
 }
 
 function hasPositiveInteger(value) {
-  return (
-    (Number.isInteger(value) && value > 0) ||
-    (typeof value === "string" && /^[1-9][0-9]*$/.test(value))
-  );
+  return typeof value === "string" && /^[1-9][0-9]*$/.test(value);
 }
 
 function requirePagesJobTimeouts() {
   for (const workflow of workflowFilesWithPagesDeploy()) {
-    for (const { name, job } of parsedWorkflowJobs(workflow)) {
+    for (const job of workflowJobBlocks(workflow)) {
       if (
-        !jobUsesAction(job, "actions/upload-pages-artifact") &&
-        !jobUsesAction(job, "actions/deploy-pages")
+        !jobUsesAction(workflow, job.block, "actions/upload-pages-artifact") &&
+        !jobUsesAction(workflow, job.block, "actions/deploy-pages")
       ) {
         continue;
       }
-      if (!hasPositiveInteger(job["timeout-minutes"])) {
-        fail(`${workflow}: Pages job ${name} must declare timeout-minutes`);
+      if (!hasPositiveInteger(blockTopLevelValue(workflow, job.block, "timeout-minutes"))) {
+        fail(`${workflow}: Pages job ${job.name} must declare timeout-minutes`);
       }
     }
   }
 }
 
-function requireBlankActionsRuntimeEnv(relativePath, env, label) {
+function requireBlankActionsRuntimeEnv(relativePath, stepBlock, label) {
+  const env = stepEnvMapping(relativePath, stepBlock);
   for (const key of ACTIONS_RUNTIME_ENV_KEYS) {
-    if (!isMapping(env) || env[key] !== "") {
+    if (env?.[key] !== "") {
       fail(`${relativePath}: ${label} must blank ${key}`);
     }
   }
@@ -178,15 +402,15 @@ function requireBlankActionsRuntimeEnv(relativePath, env, label) {
 
 function requirePagesPackageExecutionHardening() {
   for (const workflow of workflowFilesWithPagesDeploy()) {
-    for (const { name, job } of parsedWorkflowJobs(workflow)) {
-      if (!jobUsesAction(job, "actions/upload-pages-artifact")) continue;
+    for (const job of workflowJobBlocks(workflow)) {
+      if (!jobUsesAction(workflow, job.block, "actions/upload-pages-artifact")) continue;
 
       let hasInstallStep = false;
       let hasDocsStep = false;
 
-      for (const step of parsedJobSteps(job)) {
-        if (typeof step.run !== "string") continue;
-        const runCommand = step.run;
+      for (const stepBlock of workflowStepBlocks(job.block)) {
+        const runCommand = stepTopLevelValue(workflow, stepBlock, "run");
+        if (typeof runCommand !== "string") continue;
         const normalizedRunCommand = runCommand.trim();
 
         const runsPnpmInstall = normalizedRunCommand === PAGES_DOCS_INSTALL_COMMAND;
@@ -194,12 +418,12 @@ function requirePagesPackageExecutionHardening() {
 
         if (runsPnpmInstall) {
           hasInstallStep = true;
-          requireBlankActionsRuntimeEnv(workflow, step.env, "Pages pnpm install step");
+          requireBlankActionsRuntimeEnv(workflow, stepBlock, "Pages pnpm install step");
         }
 
         if (runsDocsBuild) {
           hasDocsStep = true;
-          requireBlankActionsRuntimeEnv(workflow, step.env, "Pages docs build step");
+          requireBlankActionsRuntimeEnv(workflow, stepBlock, "Pages docs build step");
         }
 
         if (
@@ -213,15 +437,17 @@ function requirePagesPackageExecutionHardening() {
           ) {
             fail(`${workflow}: Pages pnpm install step must use --ignore-scripts`);
           }
-          fail(`${workflow}: Pages artifact job ${name} has unexpected package command`);
+          fail(`${workflow}: Pages artifact job ${job.name} has unexpected package command`);
         }
       }
 
       if (!hasInstallStep) {
-        fail(`${workflow}: Pages artifact job ${name} must run pnpm install with --ignore-scripts`);
+        fail(
+          `${workflow}: Pages artifact job ${job.name} must run pnpm install with --ignore-scripts`,
+        );
       }
       if (!hasDocsStep) {
-        fail(`${workflow}: Pages artifact job ${name} must run pnpm run docs`);
+        fail(`${workflow}: Pages artifact job ${job.name} must run pnpm run docs`);
       }
     }
   }

--- a/scripts/check-runtime-policy.mjs
+++ b/scripts/check-runtime-policy.mjs
@@ -226,12 +226,15 @@ function workflowScalarAnchors(relativePath) {
 }
 
 function workflowLineMappingEntry(line) {
-  const entry = yamlMappingEntry(line);
-  if (entry) return entry;
-
+  // Parse the sequence-item mapping first: a step whose first key sits on the
+  // dash line (`- shell: custom {0}`) would otherwise parse to key `- shell`,
+  // hiding a step-level shell or anchor from order-independent scanning.
   const sequence = line.match(/^(\s*)-\s+(.+)$/);
-  if (!sequence) return null;
-  return yamlMappingEntry(`${" ".repeat(sequence[1].length + 2)}${sequence[2]}`);
+  if (sequence) {
+    const inner = yamlMappingEntry(`${" ".repeat(sequence[1].length + 2)}${sequence[2]}`);
+    if (inner) return inner;
+  }
+  return yamlMappingEntry(line);
 }
 
 function hasEmptyOrAnchorValue(rawValue) {
@@ -431,9 +434,52 @@ function unsupportedStepForms(jobBlock) {
   return reasons;
 }
 
+// A double-quoted scalar that opens on a line but does not close on it is a
+// multi-line/continued scalar. A `\`-newline join (`"actions/deploy-\` then
+// `pages@sha"`) resolves to a structural token this line-local parser cannot
+// see, so action discovery would omit the workflow. Fail closed on it instead.
+function opensUnterminatedDoubleQuote(rawValue) {
+  const value = rawValue.trimStart();
+  if (!value.startsWith('"')) return false;
+  for (let index = 1; index < value.length; index += 1) {
+    const char = value[index];
+    if (char === "\\") {
+      index += 1;
+      continue;
+    }
+    if (char === '"') return false;
+  }
+  return true;
+}
+
+function hasContinuedQuotedScalar(relativePath) {
+  let blockScalarParentIndent = null;
+  for (const line of read(relativePath).split(/\r?\n/)) {
+    if (blockScalarParentIndent !== null) {
+      if (!line.trim()) continue;
+      const indent = line.match(/^ */)?.[0].length ?? 0;
+      if (indent > blockScalarParentIndent) continue;
+      blockScalarParentIndent = null;
+    }
+    if (!line.trim() || line.trimStart().startsWith("#")) continue;
+    const entry = workflowLineMappingEntry(line);
+    if (!entry) continue;
+    const rawValue = stripYamlInlineComment(entry.rawValue);
+    if (/^[|>](?:[+-]?\d+|\d+[+-]?)?$/.test(rawValue)) {
+      blockScalarParentIndent = entry.indent;
+      continue;
+    }
+    if (opensUnterminatedDoubleQuote(entry.rawValue)) return true;
+  }
+  return false;
+}
+
 function requireParseableWorkflowJobs() {
   for (const workflow of listFiles(".github/workflows")) {
     const text = read(workflow);
+    if (hasContinuedQuotedScalar(workflow)) {
+      fail(`${workflow}: continued double-quoted scalar is not supported`);
+    }
     for (const name of parseUnsupportedWorkflowJobForms(text)) {
       fail(`${workflow}: job ${name} uses an unsupported inline mapping form`);
     }

--- a/scripts/check-runtime-policy.mjs
+++ b/scripts/check-runtime-policy.mjs
@@ -143,7 +143,7 @@ function blockChildIndent(blockText) {
   const firstIndex = lines.findIndex((line) => line.trim());
   if (firstIndex === -1) return null;
 
-  const match = lines[firstIndex].match(/^(\s*)[^:#]+:\s*(?:#.*)?$/);
+  const match = lines[firstIndex].match(/^(\s*)[^:#]+:\s*(?:&\S+)?\s*(?:#.*)?$/);
   if (!match) return null;
   const parentIndent = match[1].length;
 

--- a/scripts/check-runtime-policy.mjs
+++ b/scripts/check-runtime-policy.mjs
@@ -11,7 +11,19 @@ const root = process.env.B2_MCP_RUNTIME_POLICY_ROOT
 const require = createRequire(import.meta.url);
 const { readPackageManagerLock } = require("./lib/pnpm-lock.cjs");
 const errors = [];
-const { valuesEqual, workflowJobBlock: parseWorkflowJobBlock, yamlValuesForKey } = workflowYaml;
+const {
+  valuesEqual,
+  workflowJobBlock: parseWorkflowJobBlock,
+  workflowJobBlocks: parseWorkflowJobBlocks,
+  yamlValuesForKey,
+} = workflowYaml;
+
+const ACTIONS_RUNTIME_ENV_KEYS = [
+  "ACTIONS_CACHE_URL",
+  "ACTIONS_RESULTS_URL",
+  "ACTIONS_RUNTIME_TOKEN",
+  "ACTIONS_RUNTIME_URL",
+];
 
 function read(relativePath) {
   return readFileSync(path.join(root, relativePath), "utf8");
@@ -57,6 +69,89 @@ function workflowJobBlock(relativePath, jobName) {
     return "";
   }
   return block;
+}
+
+function workflowJobBlocks(relativePath) {
+  return parseWorkflowJobBlocks(read(relativePath));
+}
+
+function workflowStepBlocks(jobBlockText) {
+  const matches = [...jobBlockText.matchAll(/^ {6}-\s/gm)];
+  return matches.map((match, index) => {
+    const start = match.index ?? 0;
+    const end = matches[index + 1]?.index ?? jobBlockText.length;
+    return jobBlockText.slice(start, end);
+  });
+}
+
+function workflowFilesWithPagesDeploy() {
+  return listFiles(".github/workflows").filter((workflow) =>
+    read(workflow).includes("actions/deploy-pages@"),
+  );
+}
+
+function requirePagesDeploysFromMainOnly() {
+  for (const workflow of workflowFilesWithPagesDeploy()) {
+    for (const job of workflowJobBlocks(workflow)) {
+      if (!job.block.includes("actions/deploy-pages@")) continue;
+      if (
+        !/^ {4}if:\s*(?:\$\{\{\s*)?github\.ref == ['"]refs\/heads\/main['"](?:\s*\}\})?\s*$/m.test(
+          job.block,
+        )
+      ) {
+        fail(
+          `${workflow}: Pages deploy job ${job.name} must require github.ref == refs/heads/main`,
+        );
+      }
+    }
+  }
+}
+
+function requirePagesJobTimeouts() {
+  for (const workflow of workflowFilesWithPagesDeploy()) {
+    for (const job of workflowJobBlocks(workflow)) {
+      if (
+        !job.block.includes("actions/upload-pages-artifact@") &&
+        !job.block.includes("actions/deploy-pages@")
+      ) {
+        continue;
+      }
+      if (!/^ {4}timeout-minutes:\s*[1-9][0-9]*\s*$/m.test(job.block)) {
+        fail(`${workflow}: Pages job ${job.name} must declare timeout-minutes`);
+      }
+    }
+  }
+}
+
+function requireBlankActionsRuntimeEnv(relativePath, stepBlock, label) {
+  for (const key of ACTIONS_RUNTIME_ENV_KEYS) {
+    const pattern = new RegExp(`^\\s+${key}:\\s*(?:""|''|)$`, "m");
+    if (!pattern.test(stepBlock)) {
+      fail(`${relativePath}: ${label} must blank ${key}`);
+    }
+  }
+}
+
+function requirePagesPackageExecutionHardening() {
+  for (const workflow of workflowFilesWithPagesDeploy()) {
+    for (const job of workflowJobBlocks(workflow)) {
+      if (!job.block.includes("actions/upload-pages-artifact@")) continue;
+      for (const stepBlock of workflowStepBlocks(job.block)) {
+        if (!/^\s*(?:-\s*)?run:/m.test(stepBlock)) continue;
+
+        if (/\bpnpm\s+install\b/.test(stepBlock)) {
+          if (!/(?:^|\s)--ignore-scripts(?:\s|$)/m.test(stepBlock)) {
+            fail(`${workflow}: Pages pnpm install step must use --ignore-scripts`);
+          }
+          requireBlankActionsRuntimeEnv(workflow, stepBlock, "Pages pnpm install step");
+        }
+
+        if (/\bpnpm\s+run\s+docs\b/.test(stepBlock)) {
+          requireBlankActionsRuntimeEnv(workflow, stepBlock, "Pages docs build step");
+        }
+      }
+    }
+  }
 }
 
 function parseNodeVersion(value) {
@@ -287,6 +382,9 @@ requireWorkflowMatrixInJob(
   policy.liveNodeMatrix,
 );
 requireSupportedRuntimeJobs(policy);
+requirePagesDeploysFromMainOnly();
+requirePagesJobTimeouts();
+requirePagesPackageExecutionHardening();
 
 for (const workflow of [".github/workflows/contract.yml", ".github/workflows/smoke.yml"]) {
   requireWorkflowScalar(workflow, "max-parallel", "1", "live matrix serialization");

--- a/scripts/check-runtime-policy.mjs
+++ b/scripts/check-runtime-policy.mjs
@@ -9,6 +9,7 @@ const root = process.env.B2_MCP_RUNTIME_POLICY_ROOT
   ? path.resolve(process.env.B2_MCP_RUNTIME_POLICY_ROOT)
   : path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
 const require = createRequire(import.meta.url);
+const { parseDocument } = require("yaml");
 const { readPackageManagerLock } = require("./lib/pnpm-lock.cjs");
 const errors = [];
 const {
@@ -77,243 +78,99 @@ function workflowJobBlocks(relativePath) {
   return parseWorkflowJobBlocks(read(relativePath));
 }
 
-function workflowStepBlocks(jobBlockText) {
-  const lines = jobBlockText.split(/\r?\n/);
-  const topLevelIndent = blockChildIndent(jobBlockText);
-  if (topLevelIndent === null) return [];
+const parsedWorkflowCache = new Map();
 
-  const blocks = [];
-  for (let index = 0; index < lines.length; index += 1) {
-    const line = lines[index];
-    if (!line.trim()) continue;
-    const indent = line.match(/^ */)?.[0].length ?? 0;
-    if (indent !== topLevelIndent || !/^steps:\s*(?:#.*)?$/.test(line.slice(indent))) continue;
+function parsedWorkflow(relativePath) {
+  if (parsedWorkflowCache.has(relativePath)) return parsedWorkflowCache.get(relativePath);
 
-    const stepsIndent = indent;
-    let stepIndent = null;
-    let currentStart = null;
-    let stepsEnd = index + 1;
-    for (let child = index + 1; child < lines.length; child += 1) {
-      const childLine = lines[child];
-      if (childLine.trim() && !childLine.trimStart().startsWith("#")) {
-        const childIndent = childLine.match(/^ */)?.[0].length ?? 0;
-        if (childIndent <= stepsIndent) {
-          stepsEnd = child;
-          break;
-        }
-
-        if (stepIndent === null && childLine.slice(childIndent).startsWith("- ")) {
-          stepIndent = childIndent;
-          currentStart = child;
-        } else if (
-          stepIndent !== null &&
-          childIndent === stepIndent &&
-          childLine.slice(childIndent).startsWith("- ")
-        ) {
-          blocks.push(lines.slice(currentStart, child).join("\n"));
-          currentStart = child;
-        }
-      }
-      stepsEnd = child + 1;
-    }
-
-    if (currentStart !== null) blocks.push(lines.slice(currentStart, stepsEnd).join("\n"));
+  const document = parseDocument(read(relativePath));
+  if (document.errors.length > 0) {
+    fail(`${relativePath}: workflow YAML must parse without errors`);
+    parsedWorkflowCache.set(relativePath, null);
+    return null;
   }
 
-  return blocks;
-}
-
-function stripYamlInlineComment(value) {
-  return value.replace(/\s+#.*$/, "").trim();
-}
-
-function unquoteWorkflowScalar(value) {
-  const trimmed = stripYamlInlineComment(value);
-  if (
-    (trimmed.startsWith("'") && trimmed.endsWith("'")) ||
-    (trimmed.startsWith('"') && trimmed.endsWith('"'))
-  ) {
-    return trimmed.slice(1, -1);
-  }
-  return trimmed;
-}
-
-function blockChildIndent(blockText) {
-  const lines = blockText.split(/\r?\n/);
-  const firstIndex = lines.findIndex((line) => line.trim());
-  if (firstIndex === -1) return null;
-
-  const match = lines[firstIndex].match(/^(\s*)[^:#]+:\s*(?:&\S+)?\s*(?:#.*)?$/);
-  if (!match) return null;
-  const parentIndent = match[1].length;
-
-  const childIndents = [];
-  for (const line of lines.slice(firstIndex + 1)) {
-    if (!line.trim() || line.trimStart().startsWith("#")) continue;
-    const indent = line.match(/^ */)?.[0].length ?? 0;
-    if (indent <= parentIndent) break;
-    childIndents.push(indent);
+  const value = document.toJS({ maxAliasCount: 100 });
+  if (value === null || typeof value !== "object" || Array.isArray(value)) {
+    fail(`${relativePath}: workflow YAML must be a mapping`);
+    parsedWorkflowCache.set(relativePath, null);
+    return null;
   }
 
-  return childIndents.length > 0 ? Math.min(...childIndents) : parentIndent + 2;
+  parsedWorkflowCache.set(relativePath, value);
+  return value;
 }
 
-function blockTopLevelValue(blockText, key) {
-  const keyIndent = blockChildIndent(blockText);
-  if (keyIndent === null) return null;
-
-  for (const line of blockText.split(/\r?\n/)) {
-    const entry = topLevelMappingEntry(line, keyIndent);
-    if (entry?.key === key) return unquoteWorkflowScalar(entry.rawValue);
-  }
-
-  return null;
+function isMapping(value) {
+  return value !== null && typeof value === "object" && !Array.isArray(value);
 }
 
-function topLevelMappingEntry(line, keyIndent) {
-  const entry = line.match(/^(\s*)([A-Za-z0-9_-]+):\s*(.*)$/);
-  if (!entry || entry[1].length !== keyIndent) return null;
-  return { key: entry[2], rawValue: entry[3], indent: keyIndent };
+function parsedWorkflowJobs(relativePath) {
+  const jobs = parsedWorkflow(relativePath)?.jobs;
+  if (!isMapping(jobs)) return [];
+  return Object.entries(jobs)
+    .filter(([, job]) => isMapping(job))
+    .map(([name, job]) => ({ name, job }));
 }
 
-function stepTopLevelEntry(line, keyIndent) {
-  const firstEntry = line.match(/^(\s*)-\s+([A-Za-z0-9_-]+):\s*(.*)$/);
-  if (firstEntry && firstEntry[1].length + 2 === keyIndent) {
-    return { key: firstEntry[2], rawValue: firstEntry[3], indent: keyIndent };
-  }
-
-  const entry = topLevelMappingEntry(line, keyIndent);
-  if (entry) return entry;
-
-  return null;
+function parsedJobSteps(job) {
+  return Array.isArray(job.steps) ? job.steps.filter(isMapping) : [];
 }
 
-function stepTopLevelValue(stepBlock, key) {
-  const lines = stepBlock.split(/\r?\n/);
-  const stepStart = stepBlock.match(/^(\s*)-\s/);
-  if (!stepStart) return null;
-  const keyIndent = stepStart[1].length + 2;
-
-  for (let index = 0; index < lines.length; index += 1) {
-    const entry = stepTopLevelEntry(lines[index], keyIndent);
-    if (!entry || entry.key !== key) continue;
-
-    const rawValue = stripYamlInlineComment(entry.rawValue);
-    if (/^[|>][+-]?$/.test(rawValue)) {
-      const blockLines = [];
-      for (let child = index + 1; child < lines.length; child += 1) {
-        const childLine = lines[child];
-        if (childLine.trim()) {
-          const childIndent = childLine.match(/^ */)?.[0].length ?? 0;
-          if (childIndent <= entry.indent) break;
-        }
-        blockLines.push(childLine.trim());
-      }
-      return blockLines.join("\n");
-    }
-
-    return unquoteWorkflowScalar(rawValue);
-  }
-
-  return null;
+function stepUsesAction(step, action) {
+  return typeof step.uses === "string" && step.uses.startsWith(`${action}@`);
 }
 
-function parseInlineEnvMapping(rawValue) {
-  const trimmed = stripYamlInlineComment(rawValue);
-  if (!trimmed.startsWith("{") || !trimmed.endsWith("}")) return null;
-
-  const mapping = {};
-  const body = trimmed.slice(1, -1).trim();
-  if (!body) return mapping;
-
-  for (const part of body.split(",")) {
-    const separator = part.indexOf(":");
-    if (separator === -1) continue;
-    const key = unquoteWorkflowScalar(part.slice(0, separator));
-    mapping[key] = unquoteWorkflowScalar(part.slice(separator + 1));
-  }
-
-  return mapping;
-}
-
-function stepEnvMapping(stepBlock) {
-  const lines = stepBlock.split(/\r?\n/);
-  const stepStart = stepBlock.match(/^(\s*)-\s/);
-  if (!stepStart) return null;
-  const keyIndent = stepStart[1].length + 2;
-
-  for (let index = 0; index < lines.length; index += 1) {
-    const entry = stepTopLevelEntry(lines[index], keyIndent);
-    if (!entry || entry.key !== "env") continue;
-
-    const inlineMapping = parseInlineEnvMapping(entry.rawValue);
-    if (inlineMapping) return inlineMapping;
-
-    const rawValue = stripYamlInlineComment(entry.rawValue);
-    if (rawValue) return {};
-
-    const mapping = {};
-    for (let child = index + 1; child < lines.length; child += 1) {
-      const childLine = lines[child];
-      if (!childLine.trim() || childLine.trimStart().startsWith("#")) continue;
-
-      const childIndent = childLine.match(/^ */)?.[0].length ?? 0;
-      if (childIndent <= entry.indent) break;
-      if (childIndent !== entry.indent + 2) continue;
-
-      const childEntry = childLine.slice(childIndent).match(/^([A-Za-z_][A-Za-z0-9_]*):\s*(.*)$/);
-      if (childEntry) mapping[childEntry[1]] = unquoteWorkflowScalar(childEntry[2]);
-    }
-    return mapping;
-  }
-
-  return null;
+function jobUsesAction(job, action) {
+  return parsedJobSteps(job).some((step) => stepUsesAction(step, action));
 }
 
 function workflowFilesWithPagesDeploy() {
   return listFiles(".github/workflows").filter((workflow) =>
-    read(workflow).includes("actions/deploy-pages@"),
+    parsedWorkflowJobs(workflow).some(({ job }) => jobUsesAction(job, "actions/deploy-pages")),
   );
 }
 
 function requirePagesDeploysFromMainOnly() {
   for (const workflow of workflowFilesWithPagesDeploy()) {
-    for (const job of workflowJobBlocks(workflow)) {
-      if (!job.block.includes("actions/deploy-pages@")) continue;
-      const condition = blockTopLevelValue(job.block, "if");
+    for (const { name, job } of parsedWorkflowJobs(workflow)) {
+      if (!jobUsesAction(job, "actions/deploy-pages")) continue;
       if (
-        !/^(?:\$\{\{\s*)?github\.ref == ['"]refs\/heads\/main['"](?:\s*\}\})?$/.test(
-          condition ?? "",
-        )
+        typeof job.if !== "string" ||
+        !/^(?:\$\{\{\s*)?github\.ref == ['"]refs\/heads\/main['"](?:\s*\}\})?$/.test(job.if)
       ) {
-        fail(
-          `${workflow}: Pages deploy job ${job.name} must require github.ref == refs/heads/main`,
-        );
+        fail(`${workflow}: Pages deploy job ${name} must require github.ref == refs/heads/main`);
       }
     }
   }
+}
+
+function hasPositiveInteger(value) {
+  return (
+    (Number.isInteger(value) && value > 0) ||
+    (typeof value === "string" && /^[1-9][0-9]*$/.test(value))
+  );
 }
 
 function requirePagesJobTimeouts() {
   for (const workflow of workflowFilesWithPagesDeploy()) {
-    for (const job of workflowJobBlocks(workflow)) {
+    for (const { name, job } of parsedWorkflowJobs(workflow)) {
       if (
-        !job.block.includes("actions/upload-pages-artifact@") &&
-        !job.block.includes("actions/deploy-pages@")
+        !jobUsesAction(job, "actions/upload-pages-artifact") &&
+        !jobUsesAction(job, "actions/deploy-pages")
       ) {
         continue;
       }
-      if (!/^[1-9][0-9]*$/.test(blockTopLevelValue(job.block, "timeout-minutes") ?? "")) {
-        fail(`${workflow}: Pages job ${job.name} must declare timeout-minutes`);
+      if (!hasPositiveInteger(job["timeout-minutes"])) {
+        fail(`${workflow}: Pages job ${name} must declare timeout-minutes`);
       }
     }
   }
 }
 
-function requireBlankActionsRuntimeEnv(relativePath, stepBlock, label) {
-  const env = stepEnvMapping(stepBlock);
+function requireBlankActionsRuntimeEnv(relativePath, env, label) {
   for (const key of ACTIONS_RUNTIME_ENV_KEYS) {
-    if (env?.[key] !== "") {
+    if (!isMapping(env) || env[key] !== "") {
       fail(`${relativePath}: ${label} must blank ${key}`);
     }
   }
@@ -321,15 +178,15 @@ function requireBlankActionsRuntimeEnv(relativePath, stepBlock, label) {
 
 function requirePagesPackageExecutionHardening() {
   for (const workflow of workflowFilesWithPagesDeploy()) {
-    for (const job of workflowJobBlocks(workflow)) {
-      if (!job.block.includes("actions/upload-pages-artifact@")) continue;
+    for (const { name, job } of parsedWorkflowJobs(workflow)) {
+      if (!jobUsesAction(job, "actions/upload-pages-artifact")) continue;
 
       let hasInstallStep = false;
       let hasDocsStep = false;
 
-      for (const stepBlock of workflowStepBlocks(job.block)) {
-        const runCommand = stepTopLevelValue(stepBlock, "run");
-        if (runCommand === null) continue;
+      for (const step of parsedJobSteps(job)) {
+        if (typeof step.run !== "string") continue;
+        const runCommand = step.run;
         const normalizedRunCommand = runCommand.trim();
 
         const runsPnpmInstall = normalizedRunCommand === PAGES_DOCS_INSTALL_COMMAND;
@@ -337,12 +194,12 @@ function requirePagesPackageExecutionHardening() {
 
         if (runsPnpmInstall) {
           hasInstallStep = true;
-          requireBlankActionsRuntimeEnv(workflow, stepBlock, "Pages pnpm install step");
+          requireBlankActionsRuntimeEnv(workflow, step.env, "Pages pnpm install step");
         }
 
         if (runsDocsBuild) {
           hasDocsStep = true;
-          requireBlankActionsRuntimeEnv(workflow, stepBlock, "Pages docs build step");
+          requireBlankActionsRuntimeEnv(workflow, step.env, "Pages docs build step");
         }
 
         if (
@@ -356,17 +213,15 @@ function requirePagesPackageExecutionHardening() {
           ) {
             fail(`${workflow}: Pages pnpm install step must use --ignore-scripts`);
           }
-          fail(`${workflow}: Pages artifact job ${job.name} has unexpected package command`);
+          fail(`${workflow}: Pages artifact job ${name} has unexpected package command`);
         }
       }
 
       if (!hasInstallStep) {
-        fail(
-          `${workflow}: Pages artifact job ${job.name} must run pnpm install with --ignore-scripts`,
-        );
+        fail(`${workflow}: Pages artifact job ${name} must run pnpm install with --ignore-scripts`);
       }
       if (!hasDocsStep) {
-        fail(`${workflow}: Pages artifact job ${job.name} must run pnpm run docs`);
+        fail(`${workflow}: Pages artifact job ${name} must run pnpm run docs`);
       }
     }
   }

--- a/scripts/check-runtime-policy.mjs
+++ b/scripts/check-runtime-policy.mjs
@@ -95,7 +95,6 @@ function workflowStepBlocks(jobBlockText) {
     let stepsEnd = index + 1;
     for (let child = index + 1; child < lines.length; child += 1) {
       const childLine = lines[child];
-      stepsEnd = child;
       if (childLine.trim()) {
         const childIndent = childLine.match(/^ */)?.[0].length ?? 0;
         if (childIndent <= stepsIndent) {

--- a/scripts/check-runtime-policy.mjs
+++ b/scripts/check-runtime-policy.mjs
@@ -415,9 +415,10 @@ function jobUsesAction(relativePath, jobBlock, action) {
 
 // Fail closed on step forms workflowStepBlocks cannot turn into a step block.
 // A flow-style steps list (`steps: [ ... ]`), an aliased steps value
-// (`steps: *foo`), or an individual flow-mapping/alias step (`- { uses: ... }`,
-// `- *step`) is valid YAML that this parser skips, so a Pages action hidden in
-// that form would otherwise dodge every Pages check.
+// (`steps: *foo`), an individual flow-mapping/alias step (`- { uses: ... }`,
+// `- *step`), or an indentationless block sequence (`steps:` with `- uses:` at
+// the same indent) is valid YAML that this parser skips, so a Pages action
+// hidden in that form would otherwise dodge every Pages check.
 function unsupportedStepForms(jobBlock) {
   const topLevelIndent = blockChildIndent(jobBlock);
   if (topLevelIndent === null) return [];
@@ -431,16 +432,23 @@ function unsupportedStepForms(jobBlock) {
     if (!entry || entry.key !== "steps") continue;
 
     if (!hasEmptyOrAnchorValue(entry.rawValue)) {
-      reasons.push("steps");
+      reasons.push("inline steps");
       continue;
     }
     for (let child = index + 1; child < lines.length; child += 1) {
       const childLine = lines[child];
       if (!childLine.trim() || childLine.trimStart().startsWith("#")) continue;
       const childIndent = childLine.match(/^ */)?.[0].length ?? 0;
-      if (childIndent <= topLevelIndent) break;
+      const isSequenceItem = /^-(?:\s|$)/.test(childLine.slice(childIndent));
+      if (childIndent < topLevelIndent) break;
+      if (childIndent === topLevelIndent) {
+        // A sequence item at the steps indent is an indentationless block
+        // sequence this parser cannot walk; a mapping key here is a sibling.
+        if (isSequenceItem) reasons.push("indentationless steps");
+        break;
+      }
       const item = childLine.slice(childIndent).match(/^-\s+(.+)$/);
-      if (item && /^[[{*]/.test(item[1].trim())) reasons.push("step");
+      if (item && /^[[{*]/.test(item[1].trim())) reasons.push("inline step");
     }
   }
   return reasons;
@@ -509,7 +517,7 @@ function requireParseableWorkflowJobs() {
     }
     for (const job of parseWorkflowJobBlocks(text)) {
       for (const reason of unsupportedStepForms(job.block)) {
-        fail(`${workflow}: job ${job.name} uses an unsupported inline ${reason} form`);
+        fail(`${workflow}: job ${job.name} uses an unsupported ${reason} form`);
       }
     }
   }

--- a/scripts/check-runtime-policy.mjs
+++ b/scripts/check-runtime-policy.mjs
@@ -464,6 +464,17 @@ function opensUnterminatedDoubleQuote(rawValue) {
   return true;
 }
 
+// A continued double-quoted key opens a scalar the mapping parser never turns
+// into an entry (`"r\` then `un": npm install` resolves to key `run`), so check
+// the key position on the raw line rather than only a parsed value.
+function lineOpensUnterminatedQuotedKey(line) {
+  const trimmed = line.trimStart();
+  const sequence = trimmed.match(/^-\s+(.*)$/);
+  const keyStart = sequence ? sequence[1] : trimmed;
+  if (!keyStart.startsWith('"')) return false;
+  return opensUnterminatedDoubleQuote(keyStart);
+}
+
 function hasContinuedQuotedScalar(relativePath) {
   let blockScalarParentIndent = null;
   for (const line of read(relativePath).split(/\r?\n/)) {
@@ -474,6 +485,7 @@ function hasContinuedQuotedScalar(relativePath) {
       blockScalarParentIndent = null;
     }
     if (!line.trim() || line.trimStart().startsWith("#")) continue;
+    if (lineOpensUnterminatedQuotedKey(line)) return true;
     const entry = workflowLineMappingEntry(line);
     if (!entry) continue;
     const rawValue = stripYamlInlineComment(entry.rawValue);

--- a/scripts/check-runtime-policy.mjs
+++ b/scripts/check-runtime-policy.mjs
@@ -12,6 +12,7 @@ const require = createRequire(import.meta.url);
 const { readPackageManagerLock } = require("./lib/pnpm-lock.cjs");
 const errors = [];
 const {
+  decodeYamlDoubleQuoted,
   valuesEqual,
   workflowJobBlock: parseWorkflowJobBlock,
   workflowJobBlocks: parseWorkflowJobBlocks,
@@ -155,14 +156,12 @@ function stripYamlInlineComment(value) {
   return value.trim();
 }
 
-function parseQuotedScalar(value, relativePath) {
+function parseQuotedScalar(value) {
+  // Decode YAML double-quoted escapes (including \xXX and \U00XXXXXX) rather than
+  // relying on JSON.parse, so an escaped action or key cannot slip past a raw
+  // substring check while GitHub resolves it to a structural token.
   if (value.startsWith('"') && value.endsWith('"')) {
-    try {
-      return JSON.parse(value);
-    } catch {
-      fail(`${relativePath}: workflow double-quoted scalar must parse`);
-      return value.slice(1, -1);
-    }
+    return decodeYamlDoubleQuoted(value.slice(1, -1));
   }
   if (value.startsWith("'") && value.endsWith("'")) {
     return value.slice(1, -1).replace(/''/g, "'");
@@ -175,7 +174,7 @@ function parseWorkflowScalar(rawValue, context, relativePath) {
   const value = stripYamlInlineComment(rawValue);
   const anchored = value.match(/^&([^\s]+)(?:\s+(.*))?$/);
   if (anchored) {
-    const resolved = parseQuotedScalar(anchored[2] ?? "", relativePath);
+    const resolved = parseQuotedScalar(anchored[2] ?? "");
     if (!anchors.has(anchored[1])) anchors.set(anchored[1], resolved);
     return resolved;
   }
@@ -192,7 +191,7 @@ function parseWorkflowScalar(rawValue, context, relativePath) {
     return anchors.has(alias[1]) ? anchors.get(alias[1]) : value;
   }
 
-  return parseQuotedScalar(value, relativePath);
+  return parseQuotedScalar(value);
 }
 
 const scalarAnchorCache = new Map();
@@ -399,10 +398,49 @@ function jobUsesAction(relativePath, jobBlock, action) {
   );
 }
 
+// Fail closed on step forms workflowStepBlocks cannot turn into a step block.
+// A flow-style steps list (`steps: [ ... ]`), an aliased steps value
+// (`steps: *foo`), or an individual flow-mapping/alias step (`- { uses: ... }`,
+// `- *step`) is valid YAML that this parser skips, so a Pages action hidden in
+// that form would otherwise dodge every Pages check.
+function unsupportedStepForms(jobBlock) {
+  const topLevelIndent = blockChildIndent(jobBlock);
+  if (topLevelIndent === null) return [];
+
+  const lines = jobBlock.split(/\r?\n/);
+  const reasons = [];
+  for (let index = 0; index < lines.length; index += 1) {
+    const line = lines[index];
+    if (!line.trim() || line.trimStart().startsWith("#")) continue;
+    const entry = topLevelMappingEntry(line, topLevelIndent);
+    if (!entry || entry.key !== "steps") continue;
+
+    if (!hasEmptyOrAnchorValue(entry.rawValue)) {
+      reasons.push("steps");
+      continue;
+    }
+    for (let child = index + 1; child < lines.length; child += 1) {
+      const childLine = lines[child];
+      if (!childLine.trim() || childLine.trimStart().startsWith("#")) continue;
+      const childIndent = childLine.match(/^ */)?.[0].length ?? 0;
+      if (childIndent <= topLevelIndent) break;
+      const item = childLine.slice(childIndent).match(/^-\s+(.+)$/);
+      if (item && /^[[{*]/.test(item[1].trim())) reasons.push("step");
+    }
+  }
+  return reasons;
+}
+
 function requireParseableWorkflowJobs() {
   for (const workflow of listFiles(".github/workflows")) {
-    for (const name of parseUnsupportedWorkflowJobForms(read(workflow))) {
+    const text = read(workflow);
+    for (const name of parseUnsupportedWorkflowJobForms(text)) {
       fail(`${workflow}: job ${name} uses an unsupported inline mapping form`);
+    }
+    for (const job of parseWorkflowJobBlocks(text)) {
+      for (const reason of unsupportedStepForms(job.block)) {
+        fail(`${workflow}: job ${job.name} uses an unsupported inline ${reason} form`);
+      }
     }
   }
 }
@@ -520,6 +558,50 @@ function requirePagesPackageExecutionHardening() {
       }
       if (!hasDocsStep) {
         fail(`${workflow}: Pages artifact job ${job.name} must run pnpm run docs`);
+      }
+    }
+  }
+}
+
+// GitHub's default runner shell (bash on the ubuntu Pages runner) runs the step
+// script verbatim. A custom `shell:` (step-level or via job/workflow
+// `defaults.run.shell`) can be a wrapper that runs `npm install` before the
+// approved command while the run text still matches, so any non-default shell in
+// a Pages workflow must fail closed.
+const TRUSTED_WORKFLOW_SHELLS = new Set(["bash", "sh"]);
+
+function workflowShellValues(relativePath) {
+  const values = [];
+  let blockScalarParentIndent = null;
+  for (const line of read(relativePath).split(/\r?\n/)) {
+    if (blockScalarParentIndent !== null) {
+      if (!line.trim()) continue;
+      const indent = line.match(/^ */)?.[0].length ?? 0;
+      if (indent > blockScalarParentIndent) continue;
+      blockScalarParentIndent = null;
+    }
+    if (!line.trim() || line.trimStart().startsWith("#")) continue;
+    const entry = workflowLineMappingEntry(line);
+    if (!entry) continue;
+    const rawValue = stripYamlInlineComment(entry.rawValue);
+    if (/^[|>](?:[+-]?\d+|\d+[+-]?)?$/.test(rawValue)) {
+      blockScalarParentIndent = entry.indent;
+      continue;
+    }
+    if (entry.key === "shell") {
+      values.push(
+        parseWorkflowScalar(entry.rawValue, workflowScalarAnchors(relativePath), relativePath),
+      );
+    }
+  }
+  return values;
+}
+
+function requirePagesTrustedShells() {
+  for (const workflow of workflowFilesWithPagesDeploy()) {
+    for (const shell of workflowShellValues(workflow)) {
+      if (!TRUSTED_WORKFLOW_SHELLS.has(String(shell).trim())) {
+        fail(`${workflow}: Pages workflow must use a trusted default shell, got ${shell}`);
       }
     }
   }
@@ -757,6 +839,7 @@ requireParseableWorkflowJobs();
 requirePagesDeploysFromMainOnly();
 requirePagesJobTimeouts();
 requirePagesPackageExecutionHardening();
+requirePagesTrustedShells();
 
 for (const workflow of [".github/workflows/contract.yml", ".github/workflows/smoke.yml"]) {
   requireWorkflowScalar(workflow, "max-parallel", "1", "live matrix serialization");

--- a/scripts/check-runtime-policy.mjs
+++ b/scripts/check-runtime-policy.mjs
@@ -84,6 +84,107 @@ function workflowStepBlocks(jobBlockText) {
   });
 }
 
+function stripYamlInlineComment(value) {
+  return value.replace(/\s+#.*$/, "").trim();
+}
+
+function unquoteWorkflowScalar(value) {
+  const trimmed = stripYamlInlineComment(value);
+  if (
+    (trimmed.startsWith("'") && trimmed.endsWith("'")) ||
+    (trimmed.startsWith('"') && trimmed.endsWith('"'))
+  ) {
+    return trimmed.slice(1, -1);
+  }
+  return trimmed;
+}
+
+function stepTopLevelEntry(line) {
+  const firstEntry = line.match(/^ {6}-\s+([A-Za-z0-9_-]+):\s*(.*)$/);
+  if (firstEntry) return { key: firstEntry[1], rawValue: firstEntry[2], indent: 8 };
+
+  const entry = line.match(/^ {8}([A-Za-z0-9_-]+):\s*(.*)$/);
+  if (entry) return { key: entry[1], rawValue: entry[2], indent: 8 };
+
+  return null;
+}
+
+function stepTopLevelValue(stepBlock, key) {
+  const lines = stepBlock.split(/\r?\n/);
+
+  for (let index = 0; index < lines.length; index += 1) {
+    const entry = stepTopLevelEntry(lines[index]);
+    if (!entry || entry.key !== key) continue;
+
+    const rawValue = stripYamlInlineComment(entry.rawValue);
+    if (/^[|>][+-]?$/.test(rawValue)) {
+      const blockLines = [];
+      for (let child = index + 1; child < lines.length; child += 1) {
+        const childLine = lines[child];
+        if (childLine.trim()) {
+          const childIndent = childLine.match(/^ */)?.[0].length ?? 0;
+          if (childIndent <= entry.indent) break;
+        }
+        blockLines.push(childLine.trim());
+      }
+      return blockLines.join("\n");
+    }
+
+    return unquoteWorkflowScalar(rawValue);
+  }
+
+  return null;
+}
+
+function parseInlineEnvMapping(rawValue) {
+  const trimmed = stripYamlInlineComment(rawValue);
+  if (!trimmed.startsWith("{") || !trimmed.endsWith("}")) return null;
+
+  const mapping = {};
+  const body = trimmed.slice(1, -1).trim();
+  if (!body) return mapping;
+
+  for (const part of body.split(",")) {
+    const separator = part.indexOf(":");
+    if (separator === -1) continue;
+    const key = unquoteWorkflowScalar(part.slice(0, separator));
+    mapping[key] = unquoteWorkflowScalar(part.slice(separator + 1));
+  }
+
+  return mapping;
+}
+
+function stepEnvMapping(stepBlock) {
+  const lines = stepBlock.split(/\r?\n/);
+
+  for (let index = 0; index < lines.length; index += 1) {
+    const entry = stepTopLevelEntry(lines[index]);
+    if (!entry || entry.key !== "env") continue;
+
+    const inlineMapping = parseInlineEnvMapping(entry.rawValue);
+    if (inlineMapping) return inlineMapping;
+
+    const rawValue = stripYamlInlineComment(entry.rawValue);
+    if (rawValue) return {};
+
+    const mapping = {};
+    for (let child = index + 1; child < lines.length; child += 1) {
+      const childLine = lines[child];
+      if (!childLine.trim() || childLine.trimStart().startsWith("#")) continue;
+
+      const childIndent = childLine.match(/^ */)?.[0].length ?? 0;
+      if (childIndent <= entry.indent) break;
+      if (childIndent !== entry.indent + 2) continue;
+
+      const childEntry = childLine.slice(childIndent).match(/^([A-Za-z_][A-Za-z0-9_]*):\s*(.*)$/);
+      if (childEntry) mapping[childEntry[1]] = unquoteWorkflowScalar(childEntry[2]);
+    }
+    return mapping;
+  }
+
+  return null;
+}
+
 function workflowFilesWithPagesDeploy() {
   return listFiles(".github/workflows").filter((workflow) =>
     read(workflow).includes("actions/deploy-pages@"),
@@ -124,9 +225,9 @@ function requirePagesJobTimeouts() {
 }
 
 function requireBlankActionsRuntimeEnv(relativePath, stepBlock, label) {
+  const env = stepEnvMapping(stepBlock);
   for (const key of ACTIONS_RUNTIME_ENV_KEYS) {
-    const pattern = new RegExp(`^\\s+${key}:\\s*(?:""|''|)$`, "m");
-    if (!pattern.test(stepBlock)) {
+    if (env?.[key] !== "") {
       fail(`${relativePath}: ${label} must blank ${key}`);
     }
   }
@@ -136,19 +237,45 @@ function requirePagesPackageExecutionHardening() {
   for (const workflow of workflowFilesWithPagesDeploy()) {
     for (const job of workflowJobBlocks(workflow)) {
       if (!job.block.includes("actions/upload-pages-artifact@")) continue;
-      for (const stepBlock of workflowStepBlocks(job.block)) {
-        if (!/^\s*(?:-\s*)?run:/m.test(stepBlock)) continue;
 
-        if (/\bpnpm\s+install\b/.test(stepBlock)) {
-          if (!/(?:^|\s)--ignore-scripts(?:\s|$)/m.test(stepBlock)) {
+      let hasInstallStep = false;
+      let hasDocsStep = false;
+
+      for (const stepBlock of workflowStepBlocks(job.block)) {
+        const runCommand = stepTopLevelValue(stepBlock, "run");
+        if (runCommand === null) continue;
+
+        const runsPnpmInstall = /\bpnpm\s+install\b/.test(runCommand);
+        const runsDocsBuild = /\bpnpm\s+run\s+docs\b/.test(runCommand);
+
+        if (runsPnpmInstall) {
+          hasInstallStep = true;
+          if (!/(?:^|\s)--ignore-scripts(?:\s|$)/m.test(runCommand)) {
             fail(`${workflow}: Pages pnpm install step must use --ignore-scripts`);
           }
           requireBlankActionsRuntimeEnv(workflow, stepBlock, "Pages pnpm install step");
         }
 
-        if (/\bpnpm\s+run\s+docs\b/.test(stepBlock)) {
+        if (runsDocsBuild) {
+          hasDocsStep = true;
           requireBlankActionsRuntimeEnv(workflow, stepBlock, "Pages docs build step");
         }
+
+        const unexpectedPackageCommands = runCommand
+          .replace(/\bpnpm\s+install\b[^\n;&|]*/g, "")
+          .replace(/\bpnpm\s+run\s+docs\b[^\n;&|]*/g, "");
+        if (/\b(?:corepack|npm|npx|pnpm|yarn)\b/.test(unexpectedPackageCommands)) {
+          fail(`${workflow}: Pages artifact job ${job.name} has unexpected package command`);
+        }
+      }
+
+      if (!hasInstallStep) {
+        fail(
+          `${workflow}: Pages artifact job ${job.name} must run pnpm install with --ignore-scripts`,
+        );
+      }
+      if (!hasDocsStep) {
+        fail(`${workflow}: Pages artifact job ${job.name} must run pnpm run docs`);
       }
     }
   }

--- a/scripts/check-runtime-policy.mjs
+++ b/scripts/check-runtime-policy.mjs
@@ -15,6 +15,7 @@ const {
   valuesEqual,
   workflowJobBlock: parseWorkflowJobBlock,
   workflowJobBlocks: parseWorkflowJobBlocks,
+  unsupportedWorkflowJobForms: parseUnsupportedWorkflowJobForms,
   yamlMappingEntry,
   yamlValuesForKey,
 } = workflowYaml;
@@ -169,7 +170,8 @@ function parseQuotedScalar(value, relativePath) {
   return value;
 }
 
-function parseWorkflowScalar(rawValue, anchors, relativePath) {
+function parseWorkflowScalar(rawValue, context, relativePath) {
+  const { anchors, duplicates } = context;
   const value = stripYamlInlineComment(rawValue);
   const anchored = value.match(/^&([^\s]+)(?:\s+(.*))?$/);
   if (anchored) {
@@ -179,7 +181,16 @@ function parseWorkflowScalar(rawValue, anchors, relativePath) {
   }
 
   const alias = value.match(/^\*([^\s]+)$/);
-  if (alias) return anchors.get(alias[1]) ?? value;
+  if (alias) {
+    // Fail closed: a redefined anchor resolves to its most recent preceding
+    // definition in real YAML, so trusting the cached first definition would let
+    // `&cmd` masquerade as the approved command while `*cmd` runs a later one.
+    if (duplicates.has(alias[1])) {
+      fail(`${relativePath}: alias *${alias[1]} resolves a redefined anchor`);
+      return value;
+    }
+    return anchors.has(alias[1]) ? anchors.get(alias[1]) : value;
+  }
 
   return parseQuotedScalar(value, relativePath);
 }
@@ -189,7 +200,7 @@ const scalarAnchorCache = new Map();
 function workflowScalarAnchors(relativePath) {
   if (scalarAnchorCache.has(relativePath)) return scalarAnchorCache.get(relativePath);
 
-  const anchors = new Map();
+  const context = { anchors: new Map(), duplicates: new Set() };
   let blockScalarParentIndent = null;
   for (const line of read(relativePath).split(/\r?\n/)) {
     if (blockScalarParentIndent !== null) {
@@ -206,11 +217,13 @@ function workflowScalarAnchors(relativePath) {
       blockScalarParentIndent = entry.indent;
       continue;
     }
-    parseWorkflowScalar(entry.rawValue, anchors, relativePath);
+    const anchored = rawValue.match(/^&([^\s]+)/);
+    if (anchored && context.anchors.has(anchored[1])) context.duplicates.add(anchored[1]);
+    parseWorkflowScalar(entry.rawValue, context, relativePath);
   }
 
-  scalarAnchorCache.set(relativePath, anchors);
-  return anchors;
+  scalarAnchorCache.set(relativePath, context);
+  return context;
 }
 
 function workflowLineMappingEntry(line) {
@@ -322,9 +335,9 @@ function parseInlineEnvMapping(relativePath, rawValue) {
   for (const part of body.split(",")) {
     const separator = part.indexOf(":");
     if (separator === -1) continue;
-    const anchors = workflowScalarAnchors(relativePath);
-    const key = parseWorkflowScalar(part.slice(0, separator), anchors, relativePath);
-    mapping[key] = parseWorkflowScalar(part.slice(separator + 1), anchors, relativePath);
+    const context = workflowScalarAnchors(relativePath);
+    const key = parseWorkflowScalar(part.slice(0, separator), context, relativePath);
+    mapping[key] = parseWorkflowScalar(part.slice(separator + 1), context, relativePath);
   }
 
   return mapping;
@@ -384,6 +397,14 @@ function jobUsesAction(relativePath, jobBlock, action) {
   return workflowStepBlocks(jobBlock).some((stepBlock) =>
     stepUsesAction(relativePath, stepBlock, action),
   );
+}
+
+function requireParseableWorkflowJobs() {
+  for (const workflow of listFiles(".github/workflows")) {
+    for (const name of parseUnsupportedWorkflowJobForms(read(workflow))) {
+      fail(`${workflow}: job ${name} uses an unsupported inline mapping form`);
+    }
+  }
 }
 
 function workflowFilesWithPagesDeploy() {
@@ -732,6 +753,7 @@ requireWorkflowMatrixInJob(
   policy.liveNodeMatrix,
 );
 requireSupportedRuntimeJobs(policy);
+requireParseableWorkflowJobs();
 requirePagesDeploysFromMainOnly();
 requirePagesJobTimeouts();
 requirePagesPackageExecutionHardening();

--- a/scripts/check-runtime-policy.mjs
+++ b/scripts/check-runtime-policy.mjs
@@ -174,7 +174,7 @@ function parseWorkflowScalar(rawValue, anchors, relativePath) {
   const anchored = value.match(/^&([^\s]+)(?:\s+(.*))?$/);
   if (anchored) {
     const resolved = parseQuotedScalar(anchored[2] ?? "", relativePath);
-    anchors.set(anchored[1], resolved);
+    if (!anchors.has(anchored[1])) anchors.set(anchored[1], resolved);
     return resolved;
   }
 
@@ -190,10 +190,23 @@ function workflowScalarAnchors(relativePath) {
   if (scalarAnchorCache.has(relativePath)) return scalarAnchorCache.get(relativePath);
 
   const anchors = new Map();
+  let blockScalarParentIndent = null;
   for (const line of read(relativePath).split(/\r?\n/)) {
+    if (blockScalarParentIndent !== null) {
+      if (!line.trim()) continue;
+      const indent = line.match(/^ */)?.[0].length ?? 0;
+      if (indent > blockScalarParentIndent) continue;
+      blockScalarParentIndent = null;
+    }
     if (!line.trim() || line.trimStart().startsWith("#")) continue;
     const entry = workflowLineMappingEntry(line);
-    if (entry) parseWorkflowScalar(entry.rawValue, anchors, relativePath);
+    if (!entry) continue;
+    const rawValue = stripYamlInlineComment(entry.rawValue);
+    if (/^[|>](?:[+-]?\d+|\d+[+-]?)?$/.test(rawValue)) {
+      blockScalarParentIndent = entry.indent;
+      continue;
+    }
+    parseWorkflowScalar(entry.rawValue, anchors, relativePath);
   }
 
   scalarAnchorCache.set(relativePath, anchors);
@@ -364,7 +377,7 @@ function stepKeyIndent(stepBlock) {
 
 function stepUsesAction(relativePath, stepBlock, action) {
   const uses = stepTopLevelValue(relativePath, stepBlock, "uses");
-  return typeof uses === "string" && uses.startsWith(`${action}@`);
+  return typeof uses === "string" && uses.toLowerCase().startsWith(`${action.toLowerCase()}@`);
 }
 
 function jobUsesAction(relativePath, jobBlock, action) {
@@ -379,7 +392,7 @@ function workflowFilesWithPagesDeploy() {
     const hasParsedDeployJob = jobs.some((job) =>
       jobUsesAction(workflow, job.block, "actions/deploy-pages"),
     );
-    if (!hasParsedDeployJob && read(workflow).includes("actions/deploy-pages@")) {
+    if (!hasParsedDeployJob && read(workflow).toLowerCase().includes("actions/deploy-pages@")) {
       fail(`${workflow}: deploy-pages action must be inside a parsed workflow job`);
     }
     return hasParsedDeployJob;
@@ -435,7 +448,11 @@ function requireBlankActionsRuntimeEnv(relativePath, stepBlock, label) {
 function requirePagesPackageExecutionHardening() {
   for (const workflow of workflowFilesWithPagesDeploy()) {
     for (const job of workflowJobBlocks(workflow)) {
-      if (!jobUsesAction(workflow, job.block, "actions/upload-pages-artifact")) continue;
+      const uploadsPagesArtifact = jobUsesAction(
+        workflow,
+        job.block,
+        "actions/upload-pages-artifact",
+      );
 
       let hasInstallStep = false;
       let hasDocsStep = false;
@@ -448,6 +465,11 @@ function requirePagesPackageExecutionHardening() {
         const runsPnpmInstall = normalizedRunCommand === PAGES_DOCS_INSTALL_COMMAND;
         const runsDocsBuild = normalizedRunCommand === PAGES_DOCS_BUILD_COMMAND;
 
+        if (!uploadsPagesArtifact) {
+          fail(`${workflow}: Pages job ${job.name} must not run shell commands`);
+          continue;
+        }
+
         if (runsPnpmInstall) {
           hasInstallStep = true;
           requireBlankActionsRuntimeEnv(workflow, stepBlock, "Pages pnpm install step");
@@ -458,11 +480,7 @@ function requirePagesPackageExecutionHardening() {
           requireBlankActionsRuntimeEnv(workflow, stepBlock, "Pages docs build step");
         }
 
-        if (
-          /\b(?:corepack|npm|npx|pnpm|yarn)\b/.test(normalizedRunCommand) &&
-          !runsPnpmInstall &&
-          !runsDocsBuild
-        ) {
+        if (!runsPnpmInstall && !runsDocsBuild) {
           if (
             /\bpnpm\s+install\b/.test(normalizedRunCommand) &&
             !/(?:^|\s)--ignore-scripts(?:\s|$)/m.test(normalizedRunCommand)
@@ -473,6 +491,7 @@ function requirePagesPackageExecutionHardening() {
         }
       }
 
+      if (!uploadsPagesArtifact) continue;
       if (!hasInstallStep) {
         fail(
           `${workflow}: Pages artifact job ${job.name} must run pnpm install with --ignore-scripts`,

--- a/scripts/check-runtime-policy.mjs
+++ b/scripts/check-runtime-policy.mjs
@@ -24,6 +24,8 @@ const ACTIONS_RUNTIME_ENV_KEYS = [
   "ACTIONS_RUNTIME_TOKEN",
   "ACTIONS_RUNTIME_URL",
 ];
+const PAGES_DOCS_INSTALL_COMMAND = "pnpm install --frozen-lockfile --ignore-scripts";
+const PAGES_DOCS_BUILD_COMMAND = "pnpm run docs";
 
 function read(relativePath) {
   return readFileSync(path.join(root, relativePath), "utf8");
@@ -244,15 +246,13 @@ function requirePagesPackageExecutionHardening() {
       for (const stepBlock of workflowStepBlocks(job.block)) {
         const runCommand = stepTopLevelValue(stepBlock, "run");
         if (runCommand === null) continue;
+        const normalizedRunCommand = runCommand.trim();
 
-        const runsPnpmInstall = /\bpnpm\s+install\b/.test(runCommand);
-        const runsDocsBuild = /\bpnpm\s+run\s+docs\b/.test(runCommand);
+        const runsPnpmInstall = normalizedRunCommand === PAGES_DOCS_INSTALL_COMMAND;
+        const runsDocsBuild = normalizedRunCommand === PAGES_DOCS_BUILD_COMMAND;
 
         if (runsPnpmInstall) {
           hasInstallStep = true;
-          if (!/(?:^|\s)--ignore-scripts(?:\s|$)/m.test(runCommand)) {
-            fail(`${workflow}: Pages pnpm install step must use --ignore-scripts`);
-          }
           requireBlankActionsRuntimeEnv(workflow, stepBlock, "Pages pnpm install step");
         }
 
@@ -261,10 +261,17 @@ function requirePagesPackageExecutionHardening() {
           requireBlankActionsRuntimeEnv(workflow, stepBlock, "Pages docs build step");
         }
 
-        const unexpectedPackageCommands = runCommand
-          .replace(/\bpnpm\s+install\b[^\n;&|]*/g, "")
-          .replace(/\bpnpm\s+run\s+docs\b[^\n;&|]*/g, "");
-        if (/\b(?:corepack|npm|npx|pnpm|yarn)\b/.test(unexpectedPackageCommands)) {
+        if (
+          /\b(?:corepack|npm|npx|pnpm|yarn)\b/.test(normalizedRunCommand) &&
+          !runsPnpmInstall &&
+          !runsDocsBuild
+        ) {
+          if (
+            /\bpnpm\s+install\b/.test(normalizedRunCommand) &&
+            !/(?:^|\s)--ignore-scripts(?:\s|$)/m.test(normalizedRunCommand)
+          ) {
+            fail(`${workflow}: Pages pnpm install step must use --ignore-scripts`);
+          }
           fail(`${workflow}: Pages artifact job ${job.name} has unexpected package command`);
         }
       }

--- a/scripts/check-runtime-policy.mjs
+++ b/scripts/check-runtime-policy.mjs
@@ -319,7 +319,10 @@ function stepTopLevelValue(relativePath, stepBlock, key) {
     if (!entry || entry.key !== key) continue;
 
     const rawValue = stripYamlInlineComment(entry.rawValue);
-    if (/^[|>][+-]?$/.test(rawValue)) {
+    // Accept explicit block-scalar indicators (`|2-`, `>-2`, ...) like the other
+    // scanners, so a command written with an indentation indicator is read from
+    // its body rather than returned as the literal `|2-` and skipped.
+    if (/^[|>](?:[+-]?\d+|\d+[+-]?)?$/.test(rawValue)) {
       const blockLines = [];
       for (let child = index + 1; child < lines.length; child += 1) {
         const childLine = lines[child];
@@ -675,8 +678,37 @@ function workflowShellValues(relativePath) {
   return values;
 }
 
+// A flow-style `defaults` mapping (`defaults: { run: { shell: "custom {0}" } }`)
+// or a flow-style `run` mapping under it hides a custom shell from the
+// line-level shell scan, so reject those forms in Pages workflows rather than
+// letting a wrapper shell run extra commands.
+function hasFlowStyleDefaults(relativePath) {
+  let blockScalarParentIndent = null;
+  for (const line of read(relativePath).split(/\r?\n/)) {
+    if (blockScalarParentIndent !== null) {
+      if (!line.trim()) continue;
+      const indent = line.match(/^ */)?.[0].length ?? 0;
+      if (indent > blockScalarParentIndent) continue;
+      blockScalarParentIndent = null;
+    }
+    if (!line.trim() || line.trimStart().startsWith("#")) continue;
+    const entry = workflowLineMappingEntry(line);
+    if (!entry) continue;
+    const rawValue = stripYamlInlineComment(entry.rawValue);
+    if (/^[|>](?:[+-]?\d+|\d+[+-]?)?$/.test(rawValue)) {
+      blockScalarParentIndent = entry.indent;
+      continue;
+    }
+    if ((entry.key === "defaults" || entry.key === "run") && rawValue.startsWith("{")) return true;
+  }
+  return false;
+}
+
 function requirePagesTrustedShells() {
   for (const workflow of workflowFilesWithPagesDeploy()) {
+    if (hasFlowStyleDefaults(workflow)) {
+      fail(`${workflow}: Pages workflow must not use a flow-style defaults mapping`);
+    }
     for (const shell of workflowShellValues(workflow)) {
       if (!TRUSTED_WORKFLOW_SHELLS.has(String(shell).trim())) {
         fail(`${workflow}: Pages workflow must use a trusted default shell, got ${shell}`);

--- a/scripts/check-runtime-policy.mjs
+++ b/scripts/check-runtime-policy.mjs
@@ -451,7 +451,11 @@ function unsupportedStepForms(jobBlock) {
         break;
       }
       const item = childLine.slice(childIndent).match(/^-\s+(.+)$/);
-      if (item && /^[[{*]/.test(item[1].trim())) reasons.push("inline step");
+      // Strip a leading anchor (`- &deploy { ... }`) before classifying the item
+      // so an anchored flow-mapping or alias step is still rejected.
+      if (item && /^[[{*]/.test(item[1].trim().replace(/^&[^\s]+\s*/, ""))) {
+        reasons.push("inline step");
+      }
     }
   }
   return reasons;

--- a/scripts/check-runtime-policy.mjs
+++ b/scripts/check-runtime-policy.mjs
@@ -188,7 +188,15 @@ function parseWorkflowScalar(rawValue, context, relativePath) {
       fail(`${relativePath}: alias *${alias[1]} resolves a redefined anchor`);
       return value;
     }
-    return anchors.has(alias[1]) ? anchors.get(alias[1]) : value;
+    // Fail closed: the prescan only captures anchors defined at a mapping value
+    // start, so an anchor nested in a flow collection (`[&pages "..."]`) stays
+    // unknown here. GitHub still resolves the alias, possibly to a hidden
+    // action, so reject it instead of returning the unresolved literal.
+    if (!anchors.has(alias[1])) {
+      fail(`${relativePath}: alias *${alias[1]} refers to an unresolved anchor`);
+      return value;
+    }
+    return anchors.get(alias[1]);
   }
 
   return parseQuotedScalar(value);
@@ -216,9 +224,13 @@ function workflowScalarAnchors(relativePath) {
       blockScalarParentIndent = entry.indent;
       continue;
     }
+    // Only anchor definitions populate the map; skip alias lines here so an
+    // unresolved alias is reported once during resolution, not during prescan.
     const anchored = rawValue.match(/^&([^\s]+)/);
-    if (anchored && context.anchors.has(anchored[1])) context.duplicates.add(anchored[1]);
-    parseWorkflowScalar(entry.rawValue, context, relativePath);
+    if (anchored) {
+      if (context.anchors.has(anchored[1])) context.duplicates.add(anchored[1]);
+      parseWorkflowScalar(entry.rawValue, context, relativePath);
+    }
   }
 
   scalarAnchorCache.set(relativePath, context);

--- a/scripts/check-runtime-policy.mjs
+++ b/scripts/check-runtime-policy.mjs
@@ -15,6 +15,7 @@ const {
   valuesEqual,
   workflowJobBlock: parseWorkflowJobBlock,
   workflowJobBlocks: parseWorkflowJobBlocks,
+  yamlMappingEntry,
   yamlValuesForKey,
 } = workflowYaml;
 
@@ -87,7 +88,8 @@ function workflowStepBlocks(jobBlockText) {
     const line = lines[index];
     if (!line.trim()) continue;
     const indent = line.match(/^ */)?.[0].length ?? 0;
-    if (indent !== topLevelIndent || !/^steps:\s*(?:#.*)?$/.test(line.slice(indent))) continue;
+    const entry = topLevelMappingEntry(line, topLevelIndent);
+    if (!entry || entry.key !== "steps" || !hasEmptyOrAnchorValue(entry.rawValue)) continue;
 
     const stepsIndent = indent;
     let stepIndent = null;
@@ -102,13 +104,13 @@ function workflowStepBlocks(jobBlockText) {
           break;
         }
 
-        if (stepIndent === null && childLine.slice(childIndent).startsWith("- ")) {
+        if (stepIndent === null && isYamlSequenceItemStart(childLine.slice(childIndent))) {
           stepIndent = childIndent;
           currentStart = child;
         } else if (
           stepIndent !== null &&
           childIndent === stepIndent &&
-          childLine.slice(childIndent).startsWith("- ")
+          isYamlSequenceItemStart(childLine.slice(childIndent))
         ) {
           blocks.push(lines.slice(currentStart, child).join("\n"));
           currentStart = child;
@@ -121,6 +123,10 @@ function workflowStepBlocks(jobBlockText) {
   }
 
   return blocks;
+}
+
+function isYamlSequenceItemStart(value) {
+  return /^-(?:\s|$)/.test(value);
 }
 
 function stripYamlInlineComment(value) {
@@ -186,12 +192,26 @@ function workflowScalarAnchors(relativePath) {
   const anchors = new Map();
   for (const line of read(relativePath).split(/\r?\n/)) {
     if (!line.trim() || line.trimStart().startsWith("#")) continue;
-    const entry = line.match(/^(?:\s*-\s+)?\s*[A-Za-z0-9_-]+:\s*(.*)$/);
-    if (entry) parseWorkflowScalar(entry[1], anchors, relativePath);
+    const entry = workflowLineMappingEntry(line);
+    if (entry) parseWorkflowScalar(entry.rawValue, anchors, relativePath);
   }
 
   scalarAnchorCache.set(relativePath, anchors);
   return anchors;
+}
+
+function workflowLineMappingEntry(line) {
+  const entry = yamlMappingEntry(line);
+  if (entry) return entry;
+
+  const sequence = line.match(/^(\s*)-\s+(.+)$/);
+  if (!sequence) return null;
+  return yamlMappingEntry(`${" ".repeat(sequence[1].length + 2)}${sequence[2]}`);
+}
+
+function hasEmptyOrAnchorValue(rawValue) {
+  const value = stripYamlInlineComment(rawValue);
+  return value === "" || /^&[^\s]+$/.test(value);
 }
 
 function blockChildIndent(blockText) {
@@ -199,9 +219,9 @@ function blockChildIndent(blockText) {
   const firstIndex = lines.findIndex((line) => line.trim());
   if (firstIndex === -1) return null;
 
-  const match = lines[firstIndex].match(/^(\s*)[^:#]+:\s*(?:&\S+)?\s*(?:#.*)?$/);
-  if (!match) return null;
-  const parentIndent = match[1].length;
+  const entry = yamlMappingEntry(lines[firstIndex]);
+  if (!entry) return null;
+  const parentIndent = entry.indent;
 
   const childIndents = [];
   for (const line of lines.slice(firstIndex + 1)) {
@@ -229,15 +249,18 @@ function blockTopLevelValue(relativePath, blockText, key) {
 }
 
 function topLevelMappingEntry(line, keyIndent) {
-  const entry = line.match(/^(\s*)([A-Za-z0-9_-]+):\s*(.*)$/);
-  if (!entry || entry[1].length !== keyIndent) return null;
-  return { key: entry[2], rawValue: entry[3], indent: keyIndent };
+  const entry = yamlMappingEntry(line);
+  if (!entry || entry.indent !== keyIndent) return null;
+  return { key: entry.key, rawValue: entry.rawValue, indent: keyIndent };
 }
 
 function stepTopLevelEntry(line, keyIndent) {
-  const firstEntry = line.match(/^(\s*)-\s+([A-Za-z0-9_-]+):\s*(.*)$/);
+  const firstEntry = line.match(/^(\s*)-\s+(.+)$/);
   if (firstEntry && firstEntry[1].length + 2 === keyIndent) {
-    return { key: firstEntry[2], rawValue: firstEntry[3], indent: keyIndent };
+    const inlineEntry = yamlMappingEntry(`${" ".repeat(keyIndent)}${firstEntry[2]}`);
+    if (inlineEntry?.indent === keyIndent) {
+      return { key: inlineEntry.key, rawValue: inlineEntry.rawValue, indent: keyIndent };
+    }
   }
 
   const entry = topLevelMappingEntry(line, keyIndent);
@@ -248,9 +271,8 @@ function stepTopLevelEntry(line, keyIndent) {
 
 function stepTopLevelValue(relativePath, stepBlock, key) {
   const lines = stepBlock.split(/\r?\n/);
-  const stepStart = stepBlock.match(/^(\s*)-\s/);
-  if (!stepStart) return null;
-  const keyIndent = stepStart[1].length + 2;
+  const keyIndent = stepKeyIndent(stepBlock);
+  if (keyIndent === null) return null;
 
   for (let index = 0; index < lines.length; index += 1) {
     const entry = stepTopLevelEntry(lines[index], keyIndent);
@@ -297,9 +319,8 @@ function parseInlineEnvMapping(relativePath, rawValue) {
 
 function stepEnvMapping(relativePath, stepBlock) {
   const lines = stepBlock.split(/\r?\n/);
-  const stepStart = stepBlock.match(/^(\s*)-\s/);
-  if (!stepStart) return null;
-  const keyIndent = stepStart[1].length + 2;
+  const keyIndent = stepKeyIndent(stepBlock);
+  if (keyIndent === null) return null;
 
   for (let index = 0; index < lines.length; index += 1) {
     const entry = stepTopLevelEntry(lines[index], keyIndent);
@@ -335,6 +356,12 @@ function stepEnvMapping(relativePath, stepBlock) {
   return null;
 }
 
+function stepKeyIndent(stepBlock) {
+  const firstLine = stepBlock.split(/\r?\n/).find((line) => line.trim());
+  const stepStart = firstLine?.match(/^(\s*)-(?:\s|$)/);
+  return stepStart ? stepStart[1].length + 2 : null;
+}
+
 function stepUsesAction(relativePath, stepBlock, action) {
   const uses = stepTopLevelValue(relativePath, stepBlock, "uses");
   return typeof uses === "string" && uses.startsWith(`${action}@`);
@@ -347,11 +374,16 @@ function jobUsesAction(relativePath, jobBlock, action) {
 }
 
 function workflowFilesWithPagesDeploy() {
-  return listFiles(".github/workflows").filter((workflow) =>
-    workflowJobBlocks(workflow).some((job) =>
+  return listFiles(".github/workflows").filter((workflow) => {
+    const jobs = workflowJobBlocks(workflow);
+    const hasParsedDeployJob = jobs.some((job) =>
       jobUsesAction(workflow, job.block, "actions/deploy-pages"),
-    ),
-  );
+    );
+    if (!hasParsedDeployJob && read(workflow).includes("actions/deploy-pages@")) {
+      fail(`${workflow}: deploy-pages action must be inside a parsed workflow job`);
+    }
+    return hasParsedDeployJob;
+  });
 }
 
 function requirePagesDeploysFromMainOnly() {

--- a/scripts/lib/workflow-yaml.cjs
+++ b/scripts/lib/workflow-yaml.cjs
@@ -1,9 +1,26 @@
-function escapeRegExp(value) {
-  return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
-}
-
 function stripInlineComment(value) {
-  return value.replace(/\s+#.*$/, "").trim();
+  let quote = null;
+  for (let index = 0; index < value.length; index += 1) {
+    const char = value[index];
+    if (quote === "'") {
+      if (char === "'" && value[index + 1] === "'") index += 1;
+      else if (char === "'") quote = null;
+      continue;
+    }
+    if (quote === '"') {
+      if (char === "\\") index += 1;
+      else if (char === '"') quote = null;
+      continue;
+    }
+    if (char === "'" || char === '"') {
+      quote = char;
+      continue;
+    }
+    if (char === "#" && (index === 0 || /\s/.test(value[index - 1]))) {
+      return value.slice(0, index).trim();
+    }
+  }
+  return value.trim();
 }
 
 // Workflow policy tests need only small GitHub Actions snippets and deliberately
@@ -12,13 +29,59 @@ function stripInlineComment(value) {
 // interchangeable YAML primitives.
 function unquoteYamlScalar(value) {
   const trimmed = stripInlineComment(value);
-  if (
-    (trimmed.startsWith("'") && trimmed.endsWith("'")) ||
-    (trimmed.startsWith('"') && trimmed.endsWith('"'))
-  ) {
-    return trimmed.slice(1, -1);
+  if (trimmed.startsWith('"') && trimmed.endsWith('"')) {
+    try {
+      return JSON.parse(trimmed);
+    } catch {
+      return trimmed.slice(1, -1);
+    }
+  }
+  if (trimmed.startsWith("'") && trimmed.endsWith("'")) {
+    return trimmed.slice(1, -1).replace(/''/g, "'");
   }
   return trimmed;
+}
+
+function yamlMappingEntry(line) {
+  const indent = line.match(/^\s*/)?.[0].length ?? 0;
+  const body = line.slice(indent);
+  let quote = null;
+
+  for (let index = 0; index < body.length; index += 1) {
+    const char = body[index];
+    if (quote === "'") {
+      if (char === "'" && body[index + 1] === "'") index += 1;
+      else if (char === "'") quote = null;
+      continue;
+    }
+    if (quote === '"') {
+      if (char === "\\") index += 1;
+      else if (char === '"') quote = null;
+      continue;
+    }
+    if (char === "'" || char === '"') {
+      quote = char;
+      continue;
+    }
+    if (char === "#" && (index === 0 || /\s/.test(body[index - 1]))) break;
+    if (char !== ":") continue;
+    if (body[index + 1] && !/\s|#/.test(body[index + 1])) continue;
+
+    const rawKey = body.slice(0, index).trim();
+    if (!rawKey) return null;
+    return {
+      indent,
+      key: unquoteYamlScalar(rawKey),
+      rawValue: body.slice(index + 1).trim(),
+    };
+  }
+
+  return null;
+}
+
+function hasEmptyOrAnchorValue(rawValue) {
+  const value = stripInlineComment(rawValue);
+  return value === "" || /^&[^\s]+$/.test(value);
 }
 
 function parseInlineYamlList(value) {
@@ -33,17 +96,16 @@ function parseInlineYamlList(value) {
 
 function yamlBlockForKey(text, key) {
   const lines = text.split(/\r?\n/);
-  const keyPattern = new RegExp(`^(\\s*)${escapeRegExp(key)}:\\s*(?:#.*)?$`);
 
   for (let index = 0; index < lines.length; index += 1) {
-    const match = lines[index].match(keyPattern);
-    if (!match) continue;
+    const entry = yamlMappingEntry(lines[index]);
+    if (!entry || entry.key !== key || !hasEmptyOrAnchorValue(entry.rawValue)) continue;
 
-    const indent = match[1].length;
+    const indent = entry.indent;
     const blockLines = [];
     for (let child = index + 1; child < lines.length; child += 1) {
       const childLine = lines[child];
-      if (childLine.trim()) {
+      if (childLine.trim() && !childLine.trimStart().startsWith("#")) {
         const childIndent = childLine.match(/^\s*/)?.[0].length ?? 0;
         if (childIndent <= indent) break;
       }
@@ -69,28 +131,25 @@ function yamlMappingForKey(text, key) {
   const mapping = {};
   for (const line of lines) {
     if (!line.trim() || line.trim().startsWith("#")) continue;
-    const indent = line.match(/^\s*/)?.[0].length ?? 0;
-    if (indent !== childIndent) continue;
-    const match = line.slice(childIndent).match(/^([^:#]+):\s*(.*)$/);
-    if (!match) continue;
-    const rawValue = match[2].trim();
+    const entry = yamlMappingEntry(line);
+    if (!entry || entry.indent !== childIndent) continue;
+    const rawValue = entry.rawValue.trim();
     const inlineList = parseInlineYamlList(rawValue);
-    mapping[match[1].trim()] = inlineList ?? unquoteYamlScalar(rawValue);
+    mapping[entry.key] = inlineList ?? unquoteYamlScalar(rawValue);
   }
   return mapping;
 }
 
 function yamlValuesForKey(text, key) {
   const lines = text.split(/\r?\n/);
-  const keyPattern = new RegExp(`^(\\s*)${escapeRegExp(key)}:\\s*(.*)$`);
   const values = [];
 
   for (let index = 0; index < lines.length; index += 1) {
-    const match = lines[index].match(keyPattern);
-    if (!match) continue;
+    const entry = yamlMappingEntry(lines[index]);
+    if (!entry || entry.key !== key) continue;
 
-    const indent = match[1].length;
-    const rawValue = match[2].trim();
+    const indent = entry.indent;
+    const rawValue = entry.rawValue.trim();
     const inlineList = parseInlineYamlList(rawValue);
     if (inlineList) {
       values.push(inlineList);
@@ -131,8 +190,10 @@ function workflowJobBlocks(text) {
   const lines = text.split(/\r?\n/);
   const jobsEntries = lines
     .map((line, index) => {
-      const match = line.match(/^(\s*)jobs:\s*(?:#.*)?$/);
-      return match ? { index, indent: match[1].length } : null;
+      const entry = yamlMappingEntry(line);
+      return entry?.key === "jobs" && hasEmptyOrAnchorValue(entry.rawValue)
+        ? { index, indent: entry.indent }
+        : null;
     })
     .filter(Boolean);
   if (jobsEntries.length === 0) return [];
@@ -157,21 +218,23 @@ function workflowJobBlocks(text) {
   if (jobIndents.length === 0) return [];
 
   const jobIndent = Math.min(...jobIndents);
-  const jobsText = jobsLines.join("\n");
-  const matches = [
-    ...jobsText.matchAll(
-      new RegExp(`^ {${jobIndent}}([A-Za-z0-9_-]+):\\s*(?:&\\S+)?\\s*(?:#.*)?$`, "gm"),
-    ),
-  ];
+  const matches = jobsLines
+    .map((line, index) => {
+      const entry = yamlMappingEntry(line);
+      return entry?.indent === jobIndent && hasEmptyOrAnchorValue(entry.rawValue)
+        ? { index, name: entry.key }
+        : null;
+    })
+    .filter(Boolean);
   return matches.map((match, index) => {
-    const start = match.index ?? 0;
-    const end = matches[index + 1]?.index ?? jobsText.length;
-    return { name: match[1], block: jobsText.slice(start, end) };
+    const end = matches[index + 1]?.index ?? jobsLines.length;
+    return { name: match.name, block: jobsLines.slice(match.index, end).join("\n") };
   });
 }
 
 module.exports = {
   yamlValuesForKey,
+  yamlMappingEntry,
   yamlBlockForKey,
   yamlMappingForKey,
   valuesEqual,

--- a/scripts/lib/workflow-yaml.cjs
+++ b/scripts/lib/workflow-yaml.cjs
@@ -128,10 +128,32 @@ function workflowJobBlock(text, jobName) {
 }
 
 function workflowJobBlocks(text) {
-  const jobsStart = text.search(/^jobs:\s*$/m);
-  if (jobsStart === -1) return [];
-  const jobsText = text.slice(jobsStart);
-  const matches = [...jobsText.matchAll(/^ {2}([A-Za-z0-9_-]+):\s*$/gm)];
+  const lines = text.split(/\r?\n/);
+  const jobsIndex = lines.findIndex((line) => /^\s*jobs:\s*(?:#.*)?$/.test(line));
+  if (jobsIndex === -1) return [];
+
+  const jobsIndent = lines[jobsIndex].match(/^\s*/)?.[0].length ?? 0;
+  const jobsLines = [];
+  for (let index = jobsIndex + 1; index < lines.length; index += 1) {
+    const line = lines[index];
+    if (line.trim()) {
+      const indent = line.match(/^\s*/)?.[0].length ?? 0;
+      if (indent <= jobsIndent) break;
+    }
+    jobsLines.push(line);
+  }
+
+  const jobIndents = jobsLines
+    .filter((line) => line.trim() && !line.trimStart().startsWith("#"))
+    .map((line) => line.match(/^\s*/)?.[0].length ?? 0)
+    .filter((indent) => indent > jobsIndent);
+  if (jobIndents.length === 0) return [];
+
+  const jobIndent = Math.min(...jobIndents);
+  const jobsText = jobsLines.join("\n");
+  const matches = [
+    ...jobsText.matchAll(new RegExp(`^ {${jobIndent}}([A-Za-z0-9_-]+):\\s*$`, "gm")),
+  ];
   return matches.map((match, index) => {
     const start = match.index ?? 0;
     const end = matches[index + 1]?.index ?? jobsText.length;

--- a/scripts/lib/workflow-yaml.cjs
+++ b/scripts/lib/workflow-yaml.cjs
@@ -23,6 +23,66 @@ function stripInlineComment(value) {
   return value.trim();
 }
 
+// Single-character YAML double-quote escapes. JSON.parse handles a subset of
+// these plus \uXXXX, but YAML also supports \xXX, \U00XXXXXX, and letter
+// escapes like \N/\_/\L/\P that JSON rejects. Decoding them ourselves keeps the
+// parser fail-closed: an escaped structural token such as "u\x73es" resolves to
+// `uses`, so leaving it undecoded would let an escaped key hide an action.
+const YAML_SIMPLE_ESCAPES = {
+  0: "\0",
+  a: "\x07",
+  b: "\b",
+  t: "\t",
+  n: "\n",
+  v: "\v",
+  f: "\f",
+  r: "\r",
+  e: "\x1b",
+  " ": " ",
+  '"': '"',
+  "/": "/",
+  "\\": "\\",
+  N: "\u0085",
+  _: "\u00a0",
+  L: "\u2028",
+  P: "\u2029",
+};
+
+function decodeYamlDoubleQuoted(inner) {
+  let out = "";
+  for (let index = 0; index < inner.length; index += 1) {
+    const char = inner[index];
+    if (char !== "\\") {
+      out += char;
+      continue;
+    }
+    const next = inner[index + 1];
+    if (next === undefined) {
+      out += char;
+      break;
+    }
+    if (next === "x" || next === "u" || next === "U") {
+      const width = next === "x" ? 2 : next === "u" ? 4 : 8;
+      const hex = inner.slice(index + 2, index + 2 + width);
+      if (hex.length === width && /^[0-9a-fA-F]+$/.test(hex)) {
+        out += String.fromCodePoint(Number.parseInt(hex, 16));
+        index += 1 + width;
+        continue;
+      }
+      // Malformed hex escape: leave it undecoded so it cannot spell a token.
+      out += char;
+      continue;
+    }
+    if (Object.prototype.hasOwnProperty.call(YAML_SIMPLE_ESCAPES, next)) {
+      out += YAML_SIMPLE_ESCAPES[next];
+      index += 1;
+      continue;
+    }
+    out += char;
+  }
+  return out;
+}
+
 // Workflow policy tests need only small GitHub Actions snippets and deliberately
 // strip inline comments. pnpm-lock.cjs has a separate fail-closed parser for the
 // stricter pnpm-lock.yaml trust boundary, so these helpers are not
@@ -30,11 +90,7 @@ function stripInlineComment(value) {
 function unquoteYamlScalar(value) {
   const trimmed = stripInlineComment(value);
   if (trimmed.startsWith('"') && trimmed.endsWith('"')) {
-    try {
-      return JSON.parse(trimmed);
-    } catch {
-      return trimmed.slice(1, -1);
-    }
+    return decodeYamlDoubleQuoted(trimmed.slice(1, -1));
   }
   if (trimmed.startsWith("'") && trimmed.endsWith("'")) {
     return trimmed.slice(1, -1).replace(/''/g, "'");
@@ -260,6 +316,7 @@ function unsupportedWorkflowJobForms(text) {
 }
 
 module.exports = {
+  decodeYamlDoubleQuoted,
   yamlValuesForKey,
   yamlMappingEntry,
   yamlBlockForKey,

--- a/scripts/lib/workflow-yaml.cjs
+++ b/scripts/lib/workflow-yaml.cjs
@@ -136,7 +136,7 @@ function workflowJobBlocks(text) {
   const jobsLines = [];
   for (let index = jobsIndex + 1; index < lines.length; index += 1) {
     const line = lines[index];
-    if (line.trim()) {
+    if (line.trim() && !line.trimStart().startsWith("#")) {
       const indent = line.match(/^\s*/)?.[0].length ?? 0;
       if (indent <= jobsIndent) break;
     }

--- a/scripts/lib/workflow-yaml.cjs
+++ b/scripts/lib/workflow-yaml.cjs
@@ -129,10 +129,17 @@ function workflowJobBlock(text, jobName) {
 
 function workflowJobBlocks(text) {
   const lines = text.split(/\r?\n/);
-  const jobsIndex = lines.findIndex((line) => /^\s*jobs:\s*(?:#.*)?$/.test(line));
-  if (jobsIndex === -1) return [];
+  const jobsEntries = lines
+    .map((line, index) => {
+      const match = line.match(/^(\s*)jobs:\s*(?:#.*)?$/);
+      return match ? { index, indent: match[1].length } : null;
+    })
+    .filter(Boolean);
+  if (jobsEntries.length === 0) return [];
 
-  const jobsIndent = lines[jobsIndex].match(/^\s*/)?.[0].length ?? 0;
+  const { index: jobsIndex, indent: jobsIndent } = jobsEntries.reduce((least, entry) =>
+    entry.indent < least.indent ? entry : least,
+  );
   const jobsLines = [];
   for (let index = jobsIndex + 1; index < lines.length; index += 1) {
     const line = lines[index];
@@ -152,7 +159,9 @@ function workflowJobBlocks(text) {
   const jobIndent = Math.min(...jobIndents);
   const jobsText = jobsLines.join("\n");
   const matches = [
-    ...jobsText.matchAll(new RegExp(`^ {${jobIndent}}([A-Za-z0-9_-]+):\\s*(?:#.*)?$`, "gm")),
+    ...jobsText.matchAll(
+      new RegExp(`^ {${jobIndent}}([A-Za-z0-9_-]+):\\s*(?:&\\S+)?\\s*(?:#.*)?$`, "gm"),
+    ),
   ];
   return matches.map((match, index) => {
     const start = match.index ?? 0;

--- a/scripts/lib/workflow-yaml.cjs
+++ b/scripts/lib/workflow-yaml.cjs
@@ -152,7 +152,7 @@ function workflowJobBlocks(text) {
   const jobIndent = Math.min(...jobIndents);
   const jobsText = jobsLines.join("\n");
   const matches = [
-    ...jobsText.matchAll(new RegExp(`^ {${jobIndent}}([A-Za-z0-9_-]+):\\s*$`, "gm")),
+    ...jobsText.matchAll(new RegExp(`^ {${jobIndent}}([A-Za-z0-9_-]+):\\s*(?:#.*)?$`, "gm")),
   ];
   return matches.map((match, index) => {
     const start = match.index ?? 0;

--- a/scripts/lib/workflow-yaml.cjs
+++ b/scripts/lib/workflow-yaml.cjs
@@ -186,7 +186,7 @@ function workflowJobBlock(text, jobName) {
   return job?.block ?? null;
 }
 
-function workflowJobBlocks(text) {
+function workflowJobsRegion(text) {
   const lines = text.split(/\r?\n/);
   const jobsEntries = lines
     .map((line, index) => {
@@ -196,7 +196,7 @@ function workflowJobBlocks(text) {
         : null;
     })
     .filter(Boolean);
-  if (jobsEntries.length === 0) return [];
+  if (jobsEntries.length === 0) return null;
 
   const { index: jobsIndex, indent: jobsIndent } = jobsEntries.reduce((least, entry) =>
     entry.indent < least.indent ? entry : least,
@@ -215,9 +215,16 @@ function workflowJobBlocks(text) {
     .filter((line) => line.trim() && !line.trimStart().startsWith("#"))
     .map((line) => line.match(/^\s*/)?.[0].length ?? 0)
     .filter((indent) => indent > jobsIndent);
-  if (jobIndents.length === 0) return [];
+  if (jobIndents.length === 0) return null;
 
-  const jobIndent = Math.min(...jobIndents);
+  return { jobsLines, jobIndent: Math.min(...jobIndents) };
+}
+
+function workflowJobBlocks(text) {
+  const region = workflowJobsRegion(text);
+  if (!region) return [];
+
+  const { jobsLines, jobIndent } = region;
   const matches = jobsLines
     .map((line, index) => {
       const entry = yamlMappingEntry(line);
@@ -232,6 +239,26 @@ function workflowJobBlocks(text) {
   });
 }
 
+// Fail closed on job keys this block parser cannot turn into a step block. A
+// flow-style mapping (`deploy: { steps: [...] }`) or any inline scalar value at
+// job indent is skipped by workflowJobBlocks, so callers that only inspect
+// parsed job blocks would never see a Pages action hidden in that form. Callers
+// treat a non-empty return as a policy failure instead of silently proceeding.
+function unsupportedWorkflowJobForms(text) {
+  const region = workflowJobsRegion(text);
+  if (!region) return [];
+
+  const { jobsLines, jobIndent } = region;
+  return jobsLines
+    .map((line) => {
+      const entry = yamlMappingEntry(line);
+      return entry?.indent === jobIndent && !hasEmptyOrAnchorValue(entry.rawValue)
+        ? entry.key
+        : null;
+    })
+    .filter(Boolean);
+}
+
 module.exports = {
   yamlValuesForKey,
   yamlMappingEntry,
@@ -240,4 +267,5 @@ module.exports = {
   valuesEqual,
   workflowJobBlock,
   workflowJobBlocks,
+  unsupportedWorkflowJobForms,
 };

--- a/tests/contract/ci-workflow-policy.contract.test.ts
+++ b/tests/contract/ci-workflow-policy.contract.test.ts
@@ -36,6 +36,7 @@ const workflowPaths = [
   ".github/workflows/smoke.yml",
   ".github/workflows/evals.yml",
   ".github/workflows/publish.yml",
+  ".github/workflows/docs.yml",
 ];
 const requiredJobNames = [
   "format/lint/typecheck",

--- a/tests/unit/runtime-policy.unit.test.ts
+++ b/tests/unit/runtime-policy.unit.test.ts
@@ -1309,4 +1309,49 @@ describe("runtime policy", () => {
       );
     });
   });
+
+  it("rejects Pages step keys split across continued quoted scalars", () => {
+    withRuntimePolicyFixture((fixtureRoot) => {
+      writeFixtureFile(
+        fixtureRoot,
+        ".github/workflows/docs.yml",
+        [
+          "on:",
+          "  workflow_dispatch:",
+          "jobs:",
+          "  build:",
+          "    runs-on: ubuntu-latest",
+          "    timeout-minutes: 15",
+          "    steps:",
+          '      - "r\\',
+          'un": npm install',
+          "      - run: pnpm run docs",
+          "        env:",
+          '          ACTIONS_CACHE_URL: ""',
+          '          ACTIONS_RESULTS_URL: ""',
+          '          ACTIONS_RUNTIME_TOKEN: ""',
+          '          ACTIONS_RUNTIME_URL: ""',
+          "      - uses: actions/upload-pages-artifact@abc",
+          "  deploy:",
+          "    if: github.ref == 'refs/heads/main'",
+          "    runs-on: ubuntu-latest",
+          "    timeout-minutes: 10",
+          "    steps:",
+          "      - uses: actions/deploy-pages@def",
+          "",
+        ].join("\n"),
+      );
+
+      const result = spawnSync(process.execPath, ["scripts/check-runtime-policy.mjs"], {
+        cwd: root,
+        env: { ...process.env, B2_MCP_RUNTIME_POLICY_ROOT: fixtureRoot },
+        encoding: "utf8",
+      });
+
+      expect(result.status).not.toBe(0);
+      expect(result.stderr).toContain(
+        ".github/workflows/docs.yml: continued double-quoted scalar is not supported",
+      );
+    });
+  });
 });

--- a/tests/unit/runtime-policy.unit.test.ts
+++ b/tests/unit/runtime-policy.unit.test.ts
@@ -317,14 +317,14 @@ describe("runtime policy", () => {
           "  workflow_dispatch:",
           "jobs:",
           "# comment before build",
-          "  build:",
+          "  build: # docs job",
           "    runs-on: ubuntu-latest",
           "    timeout-minutes: 15",
           "    steps:",
           "      - run: npm install",
           "      - uses: actions/upload-pages-artifact@abc",
           "# comment before deploy",
-          "  deploy:",
+          "  deploy: # pages job",
           "    if: github.ref == 'refs/heads/main'",
           "    runs-on: ubuntu-latest",
           "    timeout-minutes: 10",
@@ -352,6 +352,60 @@ describe("runtime policy", () => {
       );
       expect(result.stderr).toContain(
         ".github/workflows/docs.yml: Pages artifact job build must run pnpm run docs",
+      );
+    });
+  });
+
+  it("rejects Pages package commands after comment-only step lines", () => {
+    withRuntimePolicyFixture((fixtureRoot) => {
+      writeFixtureFile(
+        fixtureRoot,
+        ".github/workflows/docs.yml",
+        [
+          "on:",
+          "  workflow_dispatch:",
+          "jobs:",
+          "  build:",
+          "    runs-on: ubuntu-latest",
+          "    timeout-minutes: 15",
+          "    steps:",
+          "      - run: pnpm install --frozen-lockfile --ignore-scripts",
+          "        env:",
+          '          ACTIONS_CACHE_URL: ""',
+          '          ACTIONS_RESULTS_URL: ""',
+          '          ACTIONS_RUNTIME_TOKEN: ""',
+          '          ACTIONS_RUNTIME_URL: ""',
+          "      - run: pnpm run docs",
+          "        env:",
+          '          ACTIONS_CACHE_URL: ""',
+          '          ACTIONS_RESULTS_URL: ""',
+          '          ACTIONS_RUNTIME_TOKEN: ""',
+          '          ACTIONS_RUNTIME_URL: ""',
+          "# comment before unexpected command",
+          "      - run: npm install",
+          "      - uses: actions/upload-pages-artifact@abc",
+          "  deploy:",
+          "    if: github.ref == 'refs/heads/main'",
+          "    runs-on: ubuntu-latest",
+          "    timeout-minutes: 10",
+          "    permissions:",
+          "      pages: write",
+          "      id-token: write",
+          "    steps:",
+          "      - uses: actions/deploy-pages@def",
+          "",
+        ].join("\n"),
+      );
+
+      const result = spawnSync(process.execPath, ["scripts/check-runtime-policy.mjs"], {
+        cwd: root,
+        env: { ...process.env, B2_MCP_RUNTIME_POLICY_ROOT: fixtureRoot },
+        encoding: "utf8",
+      });
+
+      expect(result.status).not.toBe(0);
+      expect(result.stderr).toContain(
+        ".github/workflows/docs.yml: Pages artifact job build has unexpected package command",
       );
     });
   });

--- a/tests/unit/runtime-policy.unit.test.ts
+++ b/tests/unit/runtime-policy.unit.test.ts
@@ -410,6 +410,57 @@ describe("runtime policy", () => {
     });
   });
 
+  it("rejects anchored Pages workflows after nested jobs metadata", () => {
+    withRuntimePolicyFixture((fixtureRoot) => {
+      writeFixtureFile(
+        fixtureRoot,
+        ".github/workflows/docs.yml",
+        [
+          "on:",
+          "  workflow_call:",
+          "    inputs:",
+          "      jobs:",
+          "        type: string",
+          "jobs:",
+          "  build: &docs-build",
+          "    runs-on: ubuntu-latest",
+          "    timeout-minutes: 15",
+          "    steps:",
+          "      - run: npm install",
+          "      - uses: actions/upload-pages-artifact@abc",
+          "  deploy: &pages-deploy",
+          "    runs-on: ubuntu-latest",
+          "    permissions:",
+          "      pages: write",
+          "      id-token: write",
+          "    steps:",
+          "      - uses: actions/deploy-pages@def",
+          "",
+        ].join("\n"),
+      );
+
+      const result = spawnSync(process.execPath, ["scripts/check-runtime-policy.mjs"], {
+        cwd: root,
+        env: { ...process.env, B2_MCP_RUNTIME_POLICY_ROOT: fixtureRoot },
+        encoding: "utf8",
+      });
+
+      expect(result.status).not.toBe(0);
+      expect(result.stderr).toContain(
+        ".github/workflows/docs.yml: Pages deploy job deploy must require github.ref == refs/heads/main",
+      );
+      expect(result.stderr).toContain(
+        ".github/workflows/docs.yml: Pages job deploy must declare timeout-minutes",
+      );
+      expect(result.stderr).toContain(
+        ".github/workflows/docs.yml: Pages artifact job build has unexpected package command",
+      );
+      expect(result.stderr).toContain(
+        ".github/workflows/docs.yml: Pages artifact job build must run pnpm install with --ignore-scripts",
+      );
+    });
+  });
+
   it("rejects Pages artifact jobs missing the expected package steps", () => {
     withRuntimePolicyFixture((fixtureRoot) => {
       writeFixtureFile(

--- a/tests/unit/runtime-policy.unit.test.ts
+++ b/tests/unit/runtime-policy.unit.test.ts
@@ -1402,4 +1402,108 @@ describe("runtime policy", () => {
       );
     });
   });
+
+  it("reads Pages commands from block scalars with an indentation indicator", () => {
+    withRuntimePolicyFixture((fixtureRoot) => {
+      writeFixtureFile(
+        fixtureRoot,
+        ".github/workflows/docs.yml",
+        [
+          "on:",
+          "  workflow_dispatch:",
+          "jobs:",
+          "  build:",
+          "    runs-on: ubuntu-latest",
+          "    timeout-minutes: 15",
+          "    steps:",
+          "      - run: |2-",
+          "          pnpm install --frozen-lockfile --ignore-scripts",
+          "        env:",
+          '          ACTIONS_CACHE_URL: ""',
+          '          ACTIONS_RESULTS_URL: ""',
+          '          ACTIONS_RUNTIME_TOKEN: ""',
+          '          ACTIONS_RUNTIME_URL: ""',
+          "      - run: pnpm run docs",
+          "        env:",
+          '          ACTIONS_CACHE_URL: ""',
+          '          ACTIONS_RESULTS_URL: ""',
+          '          ACTIONS_RUNTIME_TOKEN: ""',
+          '          ACTIONS_RUNTIME_URL: ""',
+          "      - uses: actions/upload-pages-artifact@abc",
+          "  deploy:",
+          "    if: github.ref == 'refs/heads/main'",
+          "    runs-on: ubuntu-latest",
+          "    timeout-minutes: 10",
+          "    steps:",
+          "      - uses: actions/deploy-pages@def",
+          "",
+        ].join("\n"),
+      );
+
+      const result = spawnSync(process.execPath, ["scripts/check-runtime-policy.mjs"], {
+        cwd: root,
+        env: { ...process.env, B2_MCP_RUNTIME_POLICY_ROOT: fixtureRoot },
+        encoding: "utf8",
+      });
+
+      // The indented-indicator block scalar must resolve to the approved install
+      // command, so neither the unexpected-command nor missing-install error fires.
+      expect(result.stderr).not.toContain(
+        ".github/workflows/docs.yml: Pages artifact job build has unexpected package command",
+      );
+      expect(result.stderr).not.toContain(
+        ".github/workflows/docs.yml: Pages artifact job build must run pnpm install with --ignore-scripts",
+      );
+    });
+  });
+
+  it("rejects a custom shell hidden in flow-style defaults", () => {
+    withRuntimePolicyFixture((fixtureRoot) => {
+      writeFixtureFile(
+        fixtureRoot,
+        ".github/workflows/docs.yml",
+        [
+          "on:",
+          "  workflow_dispatch:",
+          'defaults: { run: { shell: "custom-wrapper {0}" } }',
+          "jobs:",
+          "  build:",
+          "    runs-on: ubuntu-latest",
+          "    timeout-minutes: 15",
+          "    steps:",
+          "      - run: pnpm install --frozen-lockfile --ignore-scripts",
+          "        env:",
+          '          ACTIONS_CACHE_URL: ""',
+          '          ACTIONS_RESULTS_URL: ""',
+          '          ACTIONS_RUNTIME_TOKEN: ""',
+          '          ACTIONS_RUNTIME_URL: ""',
+          "      - run: pnpm run docs",
+          "        env:",
+          '          ACTIONS_CACHE_URL: ""',
+          '          ACTIONS_RESULTS_URL: ""',
+          '          ACTIONS_RUNTIME_TOKEN: ""',
+          '          ACTIONS_RUNTIME_URL: ""',
+          "      - uses: actions/upload-pages-artifact@abc",
+          "  deploy:",
+          "    if: github.ref == 'refs/heads/main'",
+          "    runs-on: ubuntu-latest",
+          "    timeout-minutes: 10",
+          "    steps:",
+          "      - uses: actions/deploy-pages@def",
+          "",
+        ].join("\n"),
+      );
+
+      const result = spawnSync(process.execPath, ["scripts/check-runtime-policy.mjs"], {
+        cwd: root,
+        env: { ...process.env, B2_MCP_RUNTIME_POLICY_ROOT: fixtureRoot },
+        encoding: "utf8",
+      });
+
+      expect(result.status).not.toBe(0);
+      expect(result.stderr).toContain(
+        ".github/workflows/docs.yml: Pages workflow must not use a flow-style defaults mapping",
+      );
+    });
+  });
 });

--- a/tests/unit/runtime-policy.unit.test.ts
+++ b/tests/unit/runtime-policy.unit.test.ts
@@ -246,7 +246,7 @@ describe("runtime policy", () => {
         ".github/workflows/docs.yml: Pages pnpm install step must use --ignore-scripts",
       );
       expect(result.stderr).toContain(
-        ".github/workflows/docs.yml: Pages pnpm install step must blank ACTIONS_RUNTIME_TOKEN",
+        ".github/workflows/docs.yml: Pages artifact job build must run pnpm install with --ignore-scripts",
       );
       expect(result.stderr).toContain(
         ".github/workflows/docs.yml: Pages docs build step must blank ACTIONS_RUNTIME_TOKEN",
@@ -301,6 +301,56 @@ describe("runtime policy", () => {
     });
   });
 
+  it("rejects Pages exact package steps without blanked env", () => {
+    withRuntimePolicyFixture((fixtureRoot) => {
+      writeFixtureFile(
+        fixtureRoot,
+        ".github/workflows/docs.yml",
+        [
+          "on:",
+          "  workflow_dispatch:",
+          "jobs:",
+          "  build:",
+          "    runs-on: ubuntu-latest",
+          "    timeout-minutes: 15",
+          "    steps:",
+          "      - run: pnpm install --frozen-lockfile --ignore-scripts",
+          "      - run: pnpm run docs",
+          "        env:",
+          '          ACTIONS_CACHE_URL: ""',
+          '          ACTIONS_RESULTS_URL: ""',
+          '          ACTIONS_RUNTIME_TOKEN: ""',
+          '          ACTIONS_RUNTIME_URL: ""',
+          "      - uses: actions/upload-pages-artifact@abc",
+          "  deploy:",
+          "    if: github.ref == 'refs/heads/main'",
+          "    runs-on: ubuntu-latest",
+          "    timeout-minutes: 10",
+          "    permissions:",
+          "      pages: write",
+          "      id-token: write",
+          "    steps:",
+          "      - uses: actions/deploy-pages@def",
+          "",
+        ].join("\n"),
+      );
+
+      const result = spawnSync(process.execPath, ["scripts/check-runtime-policy.mjs"], {
+        cwd: root,
+        env: { ...process.env, B2_MCP_RUNTIME_POLICY_ROOT: fixtureRoot },
+        encoding: "utf8",
+      });
+
+      expect(result.status).not.toBe(0);
+      expect(result.stderr).toContain(
+        ".github/workflows/docs.yml: Pages pnpm install step must blank ACTIONS_RUNTIME_TOKEN",
+      );
+      expect(result.stderr).not.toContain(
+        ".github/workflows/docs.yml: Pages docs build step must blank ACTIONS_RUNTIME_TOKEN",
+      );
+    });
+  });
+
   it("rejects Pages package steps with heredoc-spoofed env blanks", () => {
     withRuntimePolicyFixture((fixtureRoot) => {
       writeFixtureFile(
@@ -350,10 +400,68 @@ describe("runtime policy", () => {
 
       expect(result.status).not.toBe(0);
       expect(result.stderr).toContain(
-        ".github/workflows/docs.yml: Pages pnpm install step must blank ACTIONS_RUNTIME_TOKEN",
+        ".github/workflows/docs.yml: Pages artifact job build has unexpected package command",
       );
-      expect(result.stderr).not.toContain(
-        ".github/workflows/docs.yml: Pages docs build step must blank ACTIONS_RUNTIME_TOKEN",
+      expect(result.stderr).toContain(
+        ".github/workflows/docs.yml: Pages artifact job build must run pnpm install with --ignore-scripts",
+      );
+    });
+  });
+
+  it("rejects Pages commands present only in heredoc or comment text", () => {
+    withRuntimePolicyFixture((fixtureRoot) => {
+      writeFixtureFile(
+        fixtureRoot,
+        ".github/workflows/docs.yml",
+        [
+          "on:",
+          "  workflow_dispatch:",
+          "jobs:",
+          "  build:",
+          "    runs-on: ubuntu-latest",
+          "    timeout-minutes: 15",
+          "    steps:",
+          "      - run: |",
+          "          cat <<'EOF'",
+          "          pnpm install --frozen-lockfile --ignore-scripts",
+          "          pnpm run docs",
+          "          EOF",
+          "          # pnpm install --frozen-lockfile --ignore-scripts",
+          "          # pnpm run docs",
+          "        env:",
+          '          ACTIONS_CACHE_URL: ""',
+          '          ACTIONS_RESULTS_URL: ""',
+          '          ACTIONS_RUNTIME_TOKEN: ""',
+          '          ACTIONS_RUNTIME_URL: ""',
+          "      - uses: actions/upload-pages-artifact@abc",
+          "  deploy:",
+          "    if: github.ref == 'refs/heads/main'",
+          "    runs-on: ubuntu-latest",
+          "    timeout-minutes: 10",
+          "    permissions:",
+          "      pages: write",
+          "      id-token: write",
+          "    steps:",
+          "      - uses: actions/deploy-pages@def",
+          "",
+        ].join("\n"),
+      );
+
+      const result = spawnSync(process.execPath, ["scripts/check-runtime-policy.mjs"], {
+        cwd: root,
+        env: { ...process.env, B2_MCP_RUNTIME_POLICY_ROOT: fixtureRoot },
+        encoding: "utf8",
+      });
+
+      expect(result.status).not.toBe(0);
+      expect(result.stderr).toContain(
+        ".github/workflows/docs.yml: Pages artifact job build has unexpected package command",
+      );
+      expect(result.stderr).toContain(
+        ".github/workflows/docs.yml: Pages artifact job build must run pnpm install with --ignore-scripts",
+      );
+      expect(result.stderr).toContain(
+        ".github/workflows/docs.yml: Pages artifact job build must run pnpm run docs",
       );
     });
   });

--- a/tests/unit/runtime-policy.unit.test.ts
+++ b/tests/unit/runtime-policy.unit.test.ts
@@ -254,6 +254,59 @@ describe("runtime policy", () => {
     });
   });
 
+  it("rejects indented Pages workflows without package hardening", () => {
+    withRuntimePolicyFixture((fixtureRoot) => {
+      writeFixtureFile(
+        fixtureRoot,
+        ".github/workflows/docs.yml",
+        [
+          "on:",
+          "  workflow_dispatch:",
+          "jobs:",
+          "    build:",
+          "        runs-on: ubuntu-latest",
+          "        steps:",
+          "          - run: npm install",
+          "          - uses: actions/upload-pages-artifact@abc",
+          "    deploy:",
+          "        runs-on: ubuntu-latest",
+          "        permissions:",
+          "          pages: write",
+          "          id-token: write",
+          "        steps:",
+          "          - uses: actions/deploy-pages@def",
+          "",
+        ].join("\n"),
+      );
+
+      const result = spawnSync(process.execPath, ["scripts/check-runtime-policy.mjs"], {
+        cwd: root,
+        env: { ...process.env, B2_MCP_RUNTIME_POLICY_ROOT: fixtureRoot },
+        encoding: "utf8",
+      });
+
+      expect(result.status).not.toBe(0);
+      expect(result.stderr).toContain(
+        ".github/workflows/docs.yml: Pages deploy job deploy must require github.ref == refs/heads/main",
+      );
+      expect(result.stderr).toContain(
+        ".github/workflows/docs.yml: Pages job build must declare timeout-minutes",
+      );
+      expect(result.stderr).toContain(
+        ".github/workflows/docs.yml: Pages job deploy must declare timeout-minutes",
+      );
+      expect(result.stderr).toContain(
+        ".github/workflows/docs.yml: Pages artifact job build has unexpected package command",
+      );
+      expect(result.stderr).toContain(
+        ".github/workflows/docs.yml: Pages artifact job build must run pnpm install with --ignore-scripts",
+      );
+      expect(result.stderr).toContain(
+        ".github/workflows/docs.yml: Pages artifact job build must run pnpm run docs",
+      );
+    });
+  });
+
   it("rejects Pages artifact jobs missing the expected package steps", () => {
     withRuntimePolicyFixture((fixtureRoot) => {
       writeFixtureFile(

--- a/tests/unit/runtime-policy.unit.test.ts
+++ b/tests/unit/runtime-policy.unit.test.ts
@@ -199,4 +199,58 @@ describe("runtime policy", () => {
       expect(result.stderr).toContain("^22.3.0 || ^24 || ^26");
     });
   });
+
+  it("rejects Pages workflows without deploy and package hardening", () => {
+    withRuntimePolicyFixture((fixtureRoot) => {
+      writeFixtureFile(
+        fixtureRoot,
+        ".github/workflows/docs.yml",
+        [
+          "on:",
+          "  workflow_dispatch:",
+          "jobs:",
+          "  build:",
+          "    runs-on: ubuntu-latest",
+          "    steps:",
+          "      - run: pnpm install --frozen-lockfile",
+          "      - run: pnpm run docs",
+          "      - uses: actions/upload-pages-artifact@abc",
+          "  deploy:",
+          "    runs-on: ubuntu-latest",
+          "    permissions:",
+          "      pages: write",
+          "      id-token: write",
+          "    steps:",
+          "      - uses: actions/deploy-pages@def",
+          "",
+        ].join("\n"),
+      );
+
+      const result = spawnSync(process.execPath, ["scripts/check-runtime-policy.mjs"], {
+        cwd: root,
+        env: { ...process.env, B2_MCP_RUNTIME_POLICY_ROOT: fixtureRoot },
+        encoding: "utf8",
+      });
+
+      expect(result.status).not.toBe(0);
+      expect(result.stderr).toContain(
+        ".github/workflows/docs.yml: Pages deploy job deploy must require github.ref == refs/heads/main",
+      );
+      expect(result.stderr).toContain(
+        ".github/workflows/docs.yml: Pages job build must declare timeout-minutes",
+      );
+      expect(result.stderr).toContain(
+        ".github/workflows/docs.yml: Pages job deploy must declare timeout-minutes",
+      );
+      expect(result.stderr).toContain(
+        ".github/workflows/docs.yml: Pages pnpm install step must use --ignore-scripts",
+      );
+      expect(result.stderr).toContain(
+        ".github/workflows/docs.yml: Pages pnpm install step must blank ACTIONS_RUNTIME_TOKEN",
+      );
+      expect(result.stderr).toContain(
+        ".github/workflows/docs.yml: Pages docs build step must blank ACTIONS_RUNTIME_TOKEN",
+      );
+    });
+  });
 });

--- a/tests/unit/runtime-policy.unit.test.ts
+++ b/tests/unit/runtime-policy.unit.test.ts
@@ -1258,4 +1258,55 @@ describe("runtime policy", () => {
       );
     });
   });
+
+  it("rejects aliases to anchors nested in flow collections", () => {
+    withRuntimePolicyFixture((fixtureRoot) => {
+      writeFixtureFile(
+        fixtureRoot,
+        ".github/workflows/docs.yml",
+        [
+          "on:",
+          "  workflow_dispatch:",
+          "jobs:",
+          "  build:",
+          "    runs-on: ubuntu-latest",
+          "    timeout-minutes: 15",
+          "    strategy:",
+          "      matrix:",
+          '        marker: [&pages "actions/deploy-\\u0070ages@sha"]',
+          "    steps:",
+          "      - run: pnpm install --frozen-lockfile --ignore-scripts",
+          "        env:",
+          '          ACTIONS_CACHE_URL: ""',
+          '          ACTIONS_RESULTS_URL: ""',
+          '          ACTIONS_RUNTIME_TOKEN: ""',
+          '          ACTIONS_RUNTIME_URL: ""',
+          "      - run: pnpm run docs",
+          "        env:",
+          '          ACTIONS_CACHE_URL: ""',
+          '          ACTIONS_RESULTS_URL: ""',
+          '          ACTIONS_RUNTIME_TOKEN: ""',
+          '          ACTIONS_RUNTIME_URL: ""',
+          "      - uses: actions/upload-pages-artifact@abc",
+          "  deploy:",
+          "    runs-on: ubuntu-latest",
+          "    timeout-minutes: 10",
+          "    steps:",
+          "      - uses: *pages",
+          "",
+        ].join("\n"),
+      );
+
+      const result = spawnSync(process.execPath, ["scripts/check-runtime-policy.mjs"], {
+        cwd: root,
+        env: { ...process.env, B2_MCP_RUNTIME_POLICY_ROOT: fixtureRoot },
+        encoding: "utf8",
+      });
+
+      expect(result.status).not.toBe(0);
+      expect(result.stderr).toContain(
+        ".github/workflows/docs.yml: alias *pages refers to an unresolved anchor",
+      );
+    });
+  });
 });

--- a/tests/unit/runtime-policy.unit.test.ts
+++ b/tests/unit/runtime-policy.unit.test.ts
@@ -520,7 +520,7 @@ describe("runtime policy", () => {
     });
   });
 
-  it("rejects Pages workflows using quoted keys and bare sequence steps", () => {
+  it("rejects Pages workflows using quoted keys and mixed-case bare sequence steps", () => {
     withRuntimePolicyFixture((fixtureRoot) => {
       writeFixtureFile(
         fixtureRoot,
@@ -536,7 +536,7 @@ describe("runtime policy", () => {
           "      -",
           "        run: npm install",
           "      -",
-          "        uses: actions/upload-pages-artifact@abc",
+          "        uses: Actions/Upload-Pages-Artifact@abc",
           "  'deploy':",
           "    runs-on: ubuntu-latest",
           "    permissions:",
@@ -544,7 +544,7 @@ describe("runtime policy", () => {
           "      id-token: write",
           "    steps:",
           "      -",
-          "        uses: actions/deploy-pages@def",
+          "        uses: Actions/Deploy-Pages@def",
           "",
         ].join("\n"),
       );
@@ -562,6 +562,115 @@ describe("runtime policy", () => {
       expect(result.stderr).toContain(
         ".github/workflows/docs.yml: Pages job deploy must declare timeout-minutes",
       );
+      expect(result.stderr).toContain(
+        ".github/workflows/docs.yml: Pages artifact job build has unexpected package command",
+      );
+    });
+  });
+
+  it("rejects Pages run aliases spoofed by block scalar text", () => {
+    withRuntimePolicyFixture((fixtureRoot) => {
+      writeFixtureFile(
+        fixtureRoot,
+        ".github/workflows/docs.yml",
+        [
+          "on:",
+          "  workflow_dispatch:",
+          "x-cmd: &cmd npm install",
+          "jobs:",
+          "  build:",
+          "    runs-on: ubuntu-latest",
+          "    timeout-minutes: 15",
+          "    steps:",
+          "      - run: *cmd",
+          "      - name: |",
+          "          ignored: &cmd pnpm install --frozen-lockfile --ignore-scripts",
+          "      - run: pnpm install --frozen-lockfile --ignore-scripts",
+          "        env:",
+          '          ACTIONS_CACHE_URL: ""',
+          '          ACTIONS_RESULTS_URL: ""',
+          '          ACTIONS_RUNTIME_TOKEN: ""',
+          '          ACTIONS_RUNTIME_URL: ""',
+          "      - run: pnpm run docs",
+          "        env:",
+          '          ACTIONS_CACHE_URL: ""',
+          '          ACTIONS_RESULTS_URL: ""',
+          '          ACTIONS_RUNTIME_TOKEN: ""',
+          '          ACTIONS_RUNTIME_URL: ""',
+          "      - uses: actions/upload-pages-artifact@abc",
+          "  deploy:",
+          "    if: github.ref == 'refs/heads/main'",
+          "    runs-on: ubuntu-latest",
+          "    timeout-minutes: 10",
+          "    permissions:",
+          "      pages: write",
+          "      id-token: write",
+          "    steps:",
+          "      - uses: actions/deploy-pages@def",
+          "",
+        ].join("\n"),
+      );
+
+      const result = spawnSync(process.execPath, ["scripts/check-runtime-policy.mjs"], {
+        cwd: root,
+        env: { ...process.env, B2_MCP_RUNTIME_POLICY_ROOT: fixtureRoot },
+        encoding: "utf8",
+      });
+
+      expect(result.status).not.toBe(0);
+      expect(result.stderr).toContain(
+        ".github/workflows/docs.yml: Pages artifact job build has unexpected package command",
+      );
+    });
+  });
+
+  it("rejects obfuscated Pages package commands", () => {
+    withRuntimePolicyFixture((fixtureRoot) => {
+      writeFixtureFile(
+        fixtureRoot,
+        ".github/workflows/docs.yml",
+        [
+          "on:",
+          "  workflow_dispatch:",
+          "jobs:",
+          "  build:",
+          "    runs-on: ubuntu-latest",
+          "    timeout-minutes: 15",
+          "    steps:",
+          "      - run: pnpm install --frozen-lockfile --ignore-scripts",
+          "        env:",
+          '          ACTIONS_CACHE_URL: ""',
+          '          ACTIONS_RESULTS_URL: ""',
+          '          ACTIONS_RUNTIME_TOKEN: ""',
+          '          ACTIONS_RUNTIME_URL: ""',
+          "      - run: pnpm run docs",
+          "        env:",
+          '          ACTIONS_CACHE_URL: ""',
+          '          ACTIONS_RESULTS_URL: ""',
+          '          ACTIONS_RUNTIME_TOKEN: ""',
+          '          ACTIONS_RUNTIME_URL: ""',
+          "      - run: n\\pm install",
+          "      - uses: actions/upload-pages-artifact@abc",
+          "  deploy:",
+          "    if: github.ref == 'refs/heads/main'",
+          "    runs-on: ubuntu-latest",
+          "    timeout-minutes: 10",
+          "    permissions:",
+          "      pages: write",
+          "      id-token: write",
+          "    steps:",
+          "      - uses: actions/deploy-pages@def",
+          "",
+        ].join("\n"),
+      );
+
+      const result = spawnSync(process.execPath, ["scripts/check-runtime-policy.mjs"], {
+        cwd: root,
+        env: { ...process.env, B2_MCP_RUNTIME_POLICY_ROOT: fixtureRoot },
+        encoding: "utf8",
+      });
+
+      expect(result.status).not.toBe(0);
       expect(result.stderr).toContain(
         ".github/workflows/docs.yml: Pages artifact job build has unexpected package command",
       );

--- a/tests/unit/runtime-policy.unit.test.ts
+++ b/tests/unit/runtime-policy.unit.test.ts
@@ -888,4 +888,102 @@ describe("runtime policy", () => {
       );
     });
   });
+
+  it("rejects Pages deploy jobs hidden in flow-style mappings", () => {
+    withRuntimePolicyFixture((fixtureRoot) => {
+      writeFixtureFile(
+        fixtureRoot,
+        ".github/workflows/docs.yml",
+        [
+          "on:",
+          "  workflow_dispatch:",
+          "jobs:",
+          "  build:",
+          "    runs-on: ubuntu-latest",
+          "    timeout-minutes: 15",
+          "    steps:",
+          "      - run: pnpm install --frozen-lockfile --ignore-scripts",
+          "        env:",
+          '          ACTIONS_CACHE_URL: ""',
+          '          ACTIONS_RESULTS_URL: ""',
+          '          ACTIONS_RUNTIME_TOKEN: ""',
+          '          ACTIONS_RUNTIME_URL: ""',
+          "      - run: pnpm run docs",
+          "        env:",
+          '          ACTIONS_CACHE_URL: ""',
+          '          ACTIONS_RESULTS_URL: ""',
+          '          ACTIONS_RUNTIME_TOKEN: ""',
+          '          ACTIONS_RUNTIME_URL: ""',
+          "      - uses: actions/upload-pages-artifact@abc",
+          '  deploy: { runs-on: ubuntu-latest, steps: [{ uses: "actions/deploy-\\u0070ages@def" }] }',
+          "",
+        ].join("\n"),
+      );
+
+      const result = spawnSync(process.execPath, ["scripts/check-runtime-policy.mjs"], {
+        cwd: root,
+        env: { ...process.env, B2_MCP_RUNTIME_POLICY_ROOT: fixtureRoot },
+        encoding: "utf8",
+      });
+
+      expect(result.status).not.toBe(0);
+      expect(result.stderr).toContain(
+        ".github/workflows/docs.yml: job deploy uses an unsupported inline mapping form",
+      );
+    });
+  });
+
+  it("rejects Pages run aliases resolving a redefined anchor", () => {
+    withRuntimePolicyFixture((fixtureRoot) => {
+      writeFixtureFile(
+        fixtureRoot,
+        ".github/workflows/docs.yml",
+        [
+          "on:",
+          "  workflow_dispatch:",
+          "x-approved: &cmd pnpm install --frozen-lockfile --ignore-scripts",
+          "x-later: &cmd npm install",
+          "jobs:",
+          "  build:",
+          "    runs-on: ubuntu-latest",
+          "    timeout-minutes: 15",
+          "    steps:",
+          "      - run: *cmd",
+          "        env:",
+          '          ACTIONS_CACHE_URL: ""',
+          '          ACTIONS_RESULTS_URL: ""',
+          '          ACTIONS_RUNTIME_TOKEN: ""',
+          '          ACTIONS_RUNTIME_URL: ""',
+          "      - run: pnpm run docs",
+          "        env:",
+          '          ACTIONS_CACHE_URL: ""',
+          '          ACTIONS_RESULTS_URL: ""',
+          '          ACTIONS_RUNTIME_TOKEN: ""',
+          '          ACTIONS_RUNTIME_URL: ""',
+          "      - uses: actions/upload-pages-artifact@abc",
+          "  deploy:",
+          "    if: github.ref == 'refs/heads/main'",
+          "    runs-on: ubuntu-latest",
+          "    timeout-minutes: 10",
+          "    permissions:",
+          "      pages: write",
+          "      id-token: write",
+          "    steps:",
+          "      - uses: actions/deploy-pages@def",
+          "",
+        ].join("\n"),
+      );
+
+      const result = spawnSync(process.execPath, ["scripts/check-runtime-policy.mjs"], {
+        cwd: root,
+        env: { ...process.env, B2_MCP_RUNTIME_POLICY_ROOT: fixtureRoot },
+        encoding: "utf8",
+      });
+
+      expect(result.status).not.toBe(0);
+      expect(result.stderr).toContain(
+        ".github/workflows/docs.yml: alias *cmd resolves a redefined anchor",
+      );
+    });
+  });
 });

--- a/tests/unit/runtime-policy.unit.test.ts
+++ b/tests/unit/runtime-policy.unit.test.ts
@@ -1156,4 +1156,106 @@ describe("runtime policy", () => {
       );
     });
   });
+
+  it("rejects a custom shell declared on a step dash line", () => {
+    withRuntimePolicyFixture((fixtureRoot) => {
+      writeFixtureFile(
+        fixtureRoot,
+        ".github/workflows/docs.yml",
+        [
+          "on:",
+          "  workflow_dispatch:",
+          "jobs:",
+          "  build:",
+          "    runs-on: ubuntu-latest",
+          "    timeout-minutes: 15",
+          "    steps:",
+          "      - shell: custom-wrapper {0}",
+          "        run: pnpm install --frozen-lockfile --ignore-scripts",
+          "        env:",
+          '          ACTIONS_CACHE_URL: ""',
+          '          ACTIONS_RESULTS_URL: ""',
+          '          ACTIONS_RUNTIME_TOKEN: ""',
+          '          ACTIONS_RUNTIME_URL: ""',
+          "      - run: pnpm run docs",
+          "        env:",
+          '          ACTIONS_CACHE_URL: ""',
+          '          ACTIONS_RESULTS_URL: ""',
+          '          ACTIONS_RUNTIME_TOKEN: ""',
+          '          ACTIONS_RUNTIME_URL: ""',
+          "      - uses: actions/upload-pages-artifact@abc",
+          "  deploy:",
+          "    if: github.ref == 'refs/heads/main'",
+          "    runs-on: ubuntu-latest",
+          "    timeout-minutes: 10",
+          "    permissions:",
+          "      pages: write",
+          "      id-token: write",
+          "    steps:",
+          "      - uses: actions/deploy-pages@def",
+          "",
+        ].join("\n"),
+      );
+
+      const result = spawnSync(process.execPath, ["scripts/check-runtime-policy.mjs"], {
+        cwd: root,
+        env: { ...process.env, B2_MCP_RUNTIME_POLICY_ROOT: fixtureRoot },
+        encoding: "utf8",
+      });
+
+      expect(result.status).not.toBe(0);
+      expect(result.stderr).toContain(
+        ".github/workflows/docs.yml: Pages workflow must use a trusted default shell",
+      );
+    });
+  });
+
+  it("rejects Pages deploy actions split across continued quoted scalars", () => {
+    withRuntimePolicyFixture((fixtureRoot) => {
+      writeFixtureFile(
+        fixtureRoot,
+        ".github/workflows/docs.yml",
+        [
+          "on:",
+          "  workflow_dispatch:",
+          "jobs:",
+          "  build:",
+          "    runs-on: ubuntu-latest",
+          "    timeout-minutes: 15",
+          "    steps:",
+          "      - run: pnpm install --frozen-lockfile --ignore-scripts",
+          "        env:",
+          '          ACTIONS_CACHE_URL: ""',
+          '          ACTIONS_RESULTS_URL: ""',
+          '          ACTIONS_RUNTIME_TOKEN: ""',
+          '          ACTIONS_RUNTIME_URL: ""',
+          "      - run: pnpm run docs",
+          "        env:",
+          '          ACTIONS_CACHE_URL: ""',
+          '          ACTIONS_RESULTS_URL: ""',
+          '          ACTIONS_RUNTIME_TOKEN: ""',
+          '          ACTIONS_RUNTIME_URL: ""',
+          "      - uses: actions/upload-pages-artifact@abc",
+          "  deploy:",
+          "    runs-on: ubuntu-latest",
+          "    timeout-minutes: 10",
+          "    steps:",
+          '      - uses: "actions/deploy-\\',
+          'pages@def"',
+          "",
+        ].join("\n"),
+      );
+
+      const result = spawnSync(process.execPath, ["scripts/check-runtime-policy.mjs"], {
+        cwd: root,
+        env: { ...process.env, B2_MCP_RUNTIME_POLICY_ROOT: fixtureRoot },
+        encoding: "utf8",
+      });
+
+      expect(result.status).not.toBe(0);
+      expect(result.stderr).toContain(
+        ".github/workflows/docs.yml: continued double-quoted scalar is not supported",
+      );
+    });
+  });
 });

--- a/tests/unit/runtime-policy.unit.test.ts
+++ b/tests/unit/runtime-policy.unit.test.ts
@@ -461,6 +461,65 @@ describe("runtime policy", () => {
     });
   });
 
+  it("rejects Pages workflows using escaped and aliased scalars", () => {
+    withRuntimePolicyFixture((fixtureRoot) => {
+      writeFixtureFile(
+        fixtureRoot,
+        ".github/workflows/docs.yml",
+        [
+          "on:",
+          "  workflow_dispatch:",
+          "x-upload: &upload actions/upload-pages-artifact@abc",
+          "x-unsafe: &unsafe npm install",
+          "jobs:",
+          "  build:",
+          "    runs-on: ubuntu-latest",
+          "    timeout-minutes: 15",
+          "    steps:",
+          "      - run: pnpm install --frozen-lockfile --ignore-scripts",
+          "        env:",
+          '          ACTIONS_CACHE_URL: ""',
+          '          ACTIONS_RESULTS_URL: ""',
+          '          ACTIONS_RUNTIME_TOKEN: ""',
+          '          ACTIONS_RUNTIME_URL: ""',
+          "      - run: pnpm run docs",
+          "        env:",
+          '          ACTIONS_CACHE_URL: ""',
+          '          ACTIONS_RESULTS_URL: ""',
+          '          ACTIONS_RUNTIME_TOKEN: ""',
+          '          ACTIONS_RUNTIME_URL: ""',
+          "      - run: *unsafe",
+          "      - uses: *upload",
+          "  deploy:",
+          "    runs-on: ubuntu-latest",
+          "    permissions:",
+          "      pages: write",
+          "      id-token: write",
+          "    steps:",
+          '      - uses: "actions/deploy-\\u0070ages@def"',
+          "",
+        ].join("\n"),
+      );
+
+      const result = spawnSync(process.execPath, ["scripts/check-runtime-policy.mjs"], {
+        cwd: root,
+        env: { ...process.env, B2_MCP_RUNTIME_POLICY_ROOT: fixtureRoot },
+        encoding: "utf8",
+      });
+
+      expect(result.status).not.toBe(0);
+      expect(result.stderr).toContain(
+        ".github/workflows/docs.yml: Pages deploy job deploy must require github.ref == refs/heads/main",
+      );
+      expect(result.stderr).toContain(
+        ".github/workflows/docs.yml: Pages job deploy must declare timeout-minutes",
+      );
+      expect(result.stderr).toContain(
+        ".github/workflows/docs.yml: Pages artifact job build has unexpected package command",
+      );
+    });
+  });
+
   it("rejects Pages artifact jobs missing the expected package steps", () => {
     withRuntimePolicyFixture((fixtureRoot) => {
       writeFixtureFile(

--- a/tests/unit/runtime-policy.unit.test.ts
+++ b/tests/unit/runtime-policy.unit.test.ts
@@ -986,4 +986,174 @@ describe("runtime policy", () => {
       );
     });
   });
+
+  it("rejects Pages deploy actions hidden in flow-style steps", () => {
+    withRuntimePolicyFixture((fixtureRoot) => {
+      writeFixtureFile(
+        fixtureRoot,
+        ".github/workflows/docs.yml",
+        [
+          "on:",
+          "  workflow_dispatch:",
+          "jobs:",
+          "  build:",
+          "    runs-on: ubuntu-latest",
+          "    timeout-minutes: 15",
+          "    steps:",
+          "      - run: pnpm install --frozen-lockfile --ignore-scripts",
+          "        env:",
+          '          ACTIONS_CACHE_URL: ""',
+          '          ACTIONS_RESULTS_URL: ""',
+          '          ACTIONS_RUNTIME_TOKEN: ""',
+          '          ACTIONS_RUNTIME_URL: ""',
+          "      - run: pnpm run docs",
+          "        env:",
+          '          ACTIONS_CACHE_URL: ""',
+          '          ACTIONS_RESULTS_URL: ""',
+          '          ACTIONS_RUNTIME_TOKEN: ""',
+          '          ACTIONS_RUNTIME_URL: ""',
+          "      - uses: actions/upload-pages-artifact@abc",
+          "  deploy:",
+          "    runs-on: ubuntu-latest",
+          "    timeout-minutes: 10",
+          '    steps: [{ uses: "actions/deploy-\\u0070ages@def" }]',
+          "",
+        ].join("\n"),
+      );
+
+      const result = spawnSync(process.execPath, ["scripts/check-runtime-policy.mjs"], {
+        cwd: root,
+        env: { ...process.env, B2_MCP_RUNTIME_POLICY_ROOT: fixtureRoot },
+        encoding: "utf8",
+      });
+
+      expect(result.status).not.toBe(0);
+      expect(result.stderr).toContain(
+        ".github/workflows/docs.yml: job deploy uses an unsupported inline steps form",
+      );
+    });
+  });
+
+  it("rejects individual Pages steps written in flow-mapping form", () => {
+    withRuntimePolicyFixture((fixtureRoot) => {
+      writeFixtureFile(
+        fixtureRoot,
+        ".github/workflows/docs.yml",
+        [
+          "on:",
+          "  workflow_dispatch:",
+          "jobs:",
+          "  build:",
+          "    runs-on: ubuntu-latest",
+          "    timeout-minutes: 15",
+          "    steps:",
+          '      - { uses: "actions/deploy-\\u0070ages@def" }',
+          "  deploy:",
+          "    if: github.ref == 'refs/heads/main'",
+          "    runs-on: ubuntu-latest",
+          "    timeout-minutes: 10",
+          "    steps:",
+          "      - uses: actions/deploy-pages@def",
+          "",
+        ].join("\n"),
+      );
+
+      const result = spawnSync(process.execPath, ["scripts/check-runtime-policy.mjs"], {
+        cwd: root,
+        env: { ...process.env, B2_MCP_RUNTIME_POLICY_ROOT: fixtureRoot },
+        encoding: "utf8",
+      });
+
+      expect(result.status).not.toBe(0);
+      expect(result.stderr).toContain(
+        ".github/workflows/docs.yml: job build uses an unsupported inline step form",
+      );
+    });
+  });
+
+  it("rejects Pages deploy actions written with escaped keys and values", () => {
+    withRuntimePolicyFixture((fixtureRoot) => {
+      writeFixtureFile(
+        fixtureRoot,
+        ".github/workflows/docs.yml",
+        [
+          "on:",
+          "  workflow_dispatch:",
+          "jobs:",
+          "  deploy:",
+          "    runs-on: ubuntu-latest",
+          "    steps:",
+          '      - "\\x75ses": "actions/deploy-\\x70ages@def"',
+          "",
+        ].join("\n"),
+      );
+
+      const result = spawnSync(process.execPath, ["scripts/check-runtime-policy.mjs"], {
+        cwd: root,
+        env: { ...process.env, B2_MCP_RUNTIME_POLICY_ROOT: fixtureRoot },
+        encoding: "utf8",
+      });
+
+      expect(result.status).not.toBe(0);
+      expect(result.stderr).toContain(
+        ".github/workflows/docs.yml: Pages deploy job deploy must require github.ref == refs/heads/main",
+      );
+      expect(result.stderr).toContain(
+        ".github/workflows/docs.yml: Pages job deploy must declare timeout-minutes",
+      );
+    });
+  });
+
+  it("rejects Pages steps that run under a custom shell wrapper", () => {
+    withRuntimePolicyFixture((fixtureRoot) => {
+      writeFixtureFile(
+        fixtureRoot,
+        ".github/workflows/docs.yml",
+        [
+          "on:",
+          "  workflow_dispatch:",
+          "jobs:",
+          "  build:",
+          "    runs-on: ubuntu-latest",
+          "    timeout-minutes: 15",
+          "    steps:",
+          "      - run: pnpm install --frozen-lockfile --ignore-scripts",
+          "        shell: custom-wrapper {0}",
+          "        env:",
+          '          ACTIONS_CACHE_URL: ""',
+          '          ACTIONS_RESULTS_URL: ""',
+          '          ACTIONS_RUNTIME_TOKEN: ""',
+          '          ACTIONS_RUNTIME_URL: ""',
+          "      - run: pnpm run docs",
+          "        env:",
+          '          ACTIONS_CACHE_URL: ""',
+          '          ACTIONS_RESULTS_URL: ""',
+          '          ACTIONS_RUNTIME_TOKEN: ""',
+          '          ACTIONS_RUNTIME_URL: ""',
+          "      - uses: actions/upload-pages-artifact@abc",
+          "  deploy:",
+          "    if: github.ref == 'refs/heads/main'",
+          "    runs-on: ubuntu-latest",
+          "    timeout-minutes: 10",
+          "    permissions:",
+          "      pages: write",
+          "      id-token: write",
+          "    steps:",
+          "      - uses: actions/deploy-pages@def",
+          "",
+        ].join("\n"),
+      );
+
+      const result = spawnSync(process.execPath, ["scripts/check-runtime-policy.mjs"], {
+        cwd: root,
+        env: { ...process.env, B2_MCP_RUNTIME_POLICY_ROOT: fixtureRoot },
+        encoding: "utf8",
+      });
+
+      expect(result.status).not.toBe(0);
+      expect(result.stderr).toContain(
+        ".github/workflows/docs.yml: Pages workflow must use a trusted default shell",
+      );
+    });
+  });
 });

--- a/tests/unit/runtime-policy.unit.test.ts
+++ b/tests/unit/runtime-policy.unit.test.ts
@@ -253,4 +253,108 @@ describe("runtime policy", () => {
       );
     });
   });
+
+  it("rejects Pages artifact jobs missing the expected package steps", () => {
+    withRuntimePolicyFixture((fixtureRoot) => {
+      writeFixtureFile(
+        fixtureRoot,
+        ".github/workflows/docs.yml",
+        [
+          "on:",
+          "  workflow_dispatch:",
+          "jobs:",
+          "  build:",
+          "    runs-on: ubuntu-latest",
+          "    timeout-minutes: 15",
+          "    steps:",
+          "      - run: npm install",
+          "      - uses: actions/upload-pages-artifact@abc",
+          "  deploy:",
+          "    if: github.ref == 'refs/heads/main'",
+          "    runs-on: ubuntu-latest",
+          "    timeout-minutes: 10",
+          "    permissions:",
+          "      pages: write",
+          "      id-token: write",
+          "    steps:",
+          "      - uses: actions/deploy-pages@def",
+          "",
+        ].join("\n"),
+      );
+
+      const result = spawnSync(process.execPath, ["scripts/check-runtime-policy.mjs"], {
+        cwd: root,
+        env: { ...process.env, B2_MCP_RUNTIME_POLICY_ROOT: fixtureRoot },
+        encoding: "utf8",
+      });
+
+      expect(result.status).not.toBe(0);
+      expect(result.stderr).toContain(
+        ".github/workflows/docs.yml: Pages artifact job build has unexpected package command",
+      );
+      expect(result.stderr).toContain(
+        ".github/workflows/docs.yml: Pages artifact job build must run pnpm install with --ignore-scripts",
+      );
+      expect(result.stderr).toContain(
+        ".github/workflows/docs.yml: Pages artifact job build must run pnpm run docs",
+      );
+    });
+  });
+
+  it("rejects Pages package steps with heredoc-spoofed env blanks", () => {
+    withRuntimePolicyFixture((fixtureRoot) => {
+      writeFixtureFile(
+        fixtureRoot,
+        ".github/workflows/docs.yml",
+        [
+          "on:",
+          "  workflow_dispatch:",
+          "jobs:",
+          "  build:",
+          "    runs-on: ubuntu-latest",
+          "    timeout-minutes: 15",
+          "    steps:",
+          "      - run: |",
+          "          pnpm install --frozen-lockfile --ignore-scripts",
+          "          cat <<'EOF'",
+          '          ACTIONS_CACHE_URL: ""',
+          '          ACTIONS_RESULTS_URL: ""',
+          '          ACTIONS_RUNTIME_TOKEN: ""',
+          '          ACTIONS_RUNTIME_URL: ""',
+          "          EOF",
+          "      - run: pnpm run docs",
+          "        env:",
+          '          ACTIONS_CACHE_URL: ""',
+          '          ACTIONS_RESULTS_URL: ""',
+          '          ACTIONS_RUNTIME_TOKEN: ""',
+          '          ACTIONS_RUNTIME_URL: ""',
+          "      - uses: actions/upload-pages-artifact@abc",
+          "  deploy:",
+          "    if: github.ref == 'refs/heads/main'",
+          "    runs-on: ubuntu-latest",
+          "    timeout-minutes: 10",
+          "    permissions:",
+          "      pages: write",
+          "      id-token: write",
+          "    steps:",
+          "      - uses: actions/deploy-pages@def",
+          "",
+        ].join("\n"),
+      );
+
+      const result = spawnSync(process.execPath, ["scripts/check-runtime-policy.mjs"], {
+        cwd: root,
+        env: { ...process.env, B2_MCP_RUNTIME_POLICY_ROOT: fixtureRoot },
+        encoding: "utf8",
+      });
+
+      expect(result.status).not.toBe(0);
+      expect(result.stderr).toContain(
+        ".github/workflows/docs.yml: Pages pnpm install step must blank ACTIONS_RUNTIME_TOKEN",
+      );
+      expect(result.stderr).not.toContain(
+        ".github/workflows/docs.yml: Pages docs build step must blank ACTIONS_RUNTIME_TOKEN",
+      );
+    });
+  });
 });

--- a/tests/unit/runtime-policy.unit.test.ts
+++ b/tests/unit/runtime-policy.unit.test.ts
@@ -307,6 +307,55 @@ describe("runtime policy", () => {
     });
   });
 
+  it("rejects commented Pages workflows without package hardening", () => {
+    withRuntimePolicyFixture((fixtureRoot) => {
+      writeFixtureFile(
+        fixtureRoot,
+        ".github/workflows/docs.yml",
+        [
+          "on:",
+          "  workflow_dispatch:",
+          "jobs:",
+          "# comment before build",
+          "  build:",
+          "    runs-on: ubuntu-latest",
+          "    timeout-minutes: 15",
+          "    steps:",
+          "      - run: npm install",
+          "      - uses: actions/upload-pages-artifact@abc",
+          "# comment before deploy",
+          "  deploy:",
+          "    if: github.ref == 'refs/heads/main'",
+          "    runs-on: ubuntu-latest",
+          "    timeout-minutes: 10",
+          "    permissions:",
+          "      pages: write",
+          "      id-token: write",
+          "    steps:",
+          "      - uses: actions/deploy-pages@def",
+          "",
+        ].join("\n"),
+      );
+
+      const result = spawnSync(process.execPath, ["scripts/check-runtime-policy.mjs"], {
+        cwd: root,
+        env: { ...process.env, B2_MCP_RUNTIME_POLICY_ROOT: fixtureRoot },
+        encoding: "utf8",
+      });
+
+      expect(result.status).not.toBe(0);
+      expect(result.stderr).toContain(
+        ".github/workflows/docs.yml: Pages artifact job build has unexpected package command",
+      );
+      expect(result.stderr).toContain(
+        ".github/workflows/docs.yml: Pages artifact job build must run pnpm install with --ignore-scripts",
+      );
+      expect(result.stderr).toContain(
+        ".github/workflows/docs.yml: Pages artifact job build must run pnpm run docs",
+      );
+    });
+  });
+
   it("rejects Pages artifact jobs missing the expected package steps", () => {
     withRuntimePolicyFixture((fixtureRoot) => {
       writeFixtureFile(

--- a/tests/unit/runtime-policy.unit.test.ts
+++ b/tests/unit/runtime-policy.unit.test.ts
@@ -1354,4 +1354,52 @@ describe("runtime policy", () => {
       );
     });
   });
+
+  it("rejects Pages deploy actions in indentationless step sequences", () => {
+    withRuntimePolicyFixture((fixtureRoot) => {
+      writeFixtureFile(
+        fixtureRoot,
+        ".github/workflows/docs.yml",
+        [
+          "on:",
+          "  workflow_dispatch:",
+          "jobs:",
+          "  build:",
+          "    runs-on: ubuntu-latest",
+          "    timeout-minutes: 15",
+          "    steps:",
+          "      - run: pnpm install --frozen-lockfile --ignore-scripts",
+          "        env:",
+          '          ACTIONS_CACHE_URL: ""',
+          '          ACTIONS_RESULTS_URL: ""',
+          '          ACTIONS_RUNTIME_TOKEN: ""',
+          '          ACTIONS_RUNTIME_URL: ""',
+          "      - run: pnpm run docs",
+          "        env:",
+          '          ACTIONS_CACHE_URL: ""',
+          '          ACTIONS_RESULTS_URL: ""',
+          '          ACTIONS_RUNTIME_TOKEN: ""',
+          '          ACTIONS_RUNTIME_URL: ""',
+          "      - uses: actions/upload-pages-artifact@abc",
+          "  deploy:",
+          "    runs-on: ubuntu-latest",
+          "    timeout-minutes: 10",
+          "    steps:",
+          '    - uses: "actions/deploy-\\u0070ages@def"',
+          "",
+        ].join("\n"),
+      );
+
+      const result = spawnSync(process.execPath, ["scripts/check-runtime-policy.mjs"], {
+        cwd: root,
+        env: { ...process.env, B2_MCP_RUNTIME_POLICY_ROOT: fixtureRoot },
+        encoding: "utf8",
+      });
+
+      expect(result.status).not.toBe(0);
+      expect(result.stderr).toContain(
+        ".github/workflows/docs.yml: job deploy uses an unsupported indentationless steps form",
+      );
+    });
+  });
 });

--- a/tests/unit/runtime-policy.unit.test.ts
+++ b/tests/unit/runtime-policy.unit.test.ts
@@ -1506,4 +1506,41 @@ describe("runtime policy", () => {
       );
     });
   });
+
+  it("rejects anchored flow-mapping Pages steps", () => {
+    withRuntimePolicyFixture((fixtureRoot) => {
+      writeFixtureFile(
+        fixtureRoot,
+        ".github/workflows/docs.yml",
+        [
+          "on:",
+          "  workflow_dispatch:",
+          "jobs:",
+          "  build:",
+          "    runs-on: ubuntu-latest",
+          "    timeout-minutes: 15",
+          "    steps:",
+          '      - &deploy { uses: "actions/deploy-\\u0070ages@sha" }',
+          "  deploy:",
+          "    if: github.ref == 'refs/heads/main'",
+          "    runs-on: ubuntu-latest",
+          "    timeout-minutes: 10",
+          "    steps:",
+          "      - uses: actions/deploy-pages@def",
+          "",
+        ].join("\n"),
+      );
+
+      const result = spawnSync(process.execPath, ["scripts/check-runtime-policy.mjs"], {
+        cwd: root,
+        env: { ...process.env, B2_MCP_RUNTIME_POLICY_ROOT: fixtureRoot },
+        encoding: "utf8",
+      });
+
+      expect(result.status).not.toBe(0);
+      expect(result.stderr).toContain(
+        ".github/workflows/docs.yml: job build uses an unsupported inline step form",
+      );
+    });
+  });
 });

--- a/tests/unit/runtime-policy.unit.test.ts
+++ b/tests/unit/runtime-policy.unit.test.ts
@@ -520,6 +520,54 @@ describe("runtime policy", () => {
     });
   });
 
+  it("rejects Pages workflows using quoted keys and bare sequence steps", () => {
+    withRuntimePolicyFixture((fixtureRoot) => {
+      writeFixtureFile(
+        fixtureRoot,
+        ".github/workflows/docs.yml",
+        [
+          "on:",
+          "  workflow_dispatch:",
+          '"jobs":',
+          '  "build":',
+          "    runs-on: ubuntu-latest",
+          "    timeout-minutes: 15",
+          '    "steps":',
+          "      -",
+          "        run: npm install",
+          "      -",
+          "        uses: actions/upload-pages-artifact@abc",
+          "  'deploy':",
+          "    runs-on: ubuntu-latest",
+          "    permissions:",
+          "      pages: write",
+          "      id-token: write",
+          "    steps:",
+          "      -",
+          "        uses: actions/deploy-pages@def",
+          "",
+        ].join("\n"),
+      );
+
+      const result = spawnSync(process.execPath, ["scripts/check-runtime-policy.mjs"], {
+        cwd: root,
+        env: { ...process.env, B2_MCP_RUNTIME_POLICY_ROOT: fixtureRoot },
+        encoding: "utf8",
+      });
+
+      expect(result.status).not.toBe(0);
+      expect(result.stderr).toContain(
+        ".github/workflows/docs.yml: Pages deploy job deploy must require github.ref == refs/heads/main",
+      );
+      expect(result.stderr).toContain(
+        ".github/workflows/docs.yml: Pages job deploy must declare timeout-minutes",
+      );
+      expect(result.stderr).toContain(
+        ".github/workflows/docs.yml: Pages artifact job build has unexpected package command",
+      );
+    });
+  });
+
   it("rejects Pages artifact jobs missing the expected package steps", () => {
     withRuntimePolicyFixture((fixtureRoot) => {
       writeFixtureFile(

--- a/tests/unit/workflow-yaml.unit.test.ts
+++ b/tests/unit/workflow-yaml.unit.test.ts
@@ -2,6 +2,7 @@ import { createRequire } from "module";
 
 const nodeRequire = createRequire(__filename);
 const {
+  decodeYamlDoubleQuoted,
   valuesEqual,
   workflowJobBlock,
   workflowJobBlocks,
@@ -9,6 +10,7 @@ const {
   yamlMappingForKey,
   yamlValuesForKey,
 } = nodeRequire("../../scripts/lib/workflow-yaml.cjs") as {
+  decodeYamlDoubleQuoted: (inner: string) => string;
   valuesEqual: (actual: string[], expected: string[]) => boolean;
   workflowJobBlock: (text: string, jobName: string) => string | null;
   workflowJobBlocks: (text: string) => Array<{ name: string; block: string }>;
@@ -116,6 +118,17 @@ describe("workflow YAML helper", () => {
     expect(workflowJobBlocks(quotedWorkflow).map((job) => job.name)).toEqual(["build", "deploy"]);
     expect(workflowJobBlock(quotedWorkflow, "deploy")).toContain("&pages-deploy");
     expect(workflowJobBlock(quotedWorkflow, "build")).not.toContain("deploy");
+  });
+
+  it("decodes YAML double-quoted escapes JSON rejects", () => {
+    expect(decodeYamlDoubleQuoted("actions/deploy-\\u0070ages@sha")).toBe(
+      "actions/deploy-pages@sha",
+    );
+    expect(decodeYamlDoubleQuoted("u\\x73es")).toBe("uses");
+    expect(decodeYamlDoubleQuoted("\\U00000041")).toBe("A");
+    expect(decodeYamlDoubleQuoted("plain/value@sha")).toBe("plain/value@sha");
+    // Malformed hex escapes stay undecoded so they cannot spell a token.
+    expect(decodeYamlDoubleQuoted("bad\\xZZ")).toBe("bad\\xZZ");
   });
 
   it("flags flow-style job mappings as unsupported forms", () => {

--- a/tests/unit/workflow-yaml.unit.test.ts
+++ b/tests/unit/workflow-yaml.unit.test.ts
@@ -1,14 +1,21 @@
 import { createRequire } from "module";
 
 const nodeRequire = createRequire(__filename);
-const { valuesEqual, workflowJobBlock, workflowJobBlocks, yamlMappingForKey, yamlValuesForKey } =
-  nodeRequire("../../scripts/lib/workflow-yaml.cjs") as {
-    valuesEqual: (actual: string[], expected: string[]) => boolean;
-    workflowJobBlock: (text: string, jobName: string) => string | null;
-    workflowJobBlocks: (text: string) => Array<{ name: string; block: string }>;
-    yamlMappingForKey: (text: string, key: string) => Record<string, string | string[]> | null;
-    yamlValuesForKey: (text: string, key: string) => Array<string | string[]>;
-  };
+const {
+  valuesEqual,
+  workflowJobBlock,
+  workflowJobBlocks,
+  unsupportedWorkflowJobForms,
+  yamlMappingForKey,
+  yamlValuesForKey,
+} = nodeRequire("../../scripts/lib/workflow-yaml.cjs") as {
+  valuesEqual: (actual: string[], expected: string[]) => boolean;
+  workflowJobBlock: (text: string, jobName: string) => string | null;
+  workflowJobBlocks: (text: string) => Array<{ name: string; block: string }>;
+  unsupportedWorkflowJobForms: (text: string) => string[];
+  yamlMappingForKey: (text: string, key: string) => Record<string, string | string[]> | null;
+  yamlValuesForKey: (text: string, key: string) => Array<string | string[]>;
+};
 
 describe("workflow YAML helper", () => {
   const workflow = [
@@ -109,6 +116,20 @@ describe("workflow YAML helper", () => {
     expect(workflowJobBlocks(quotedWorkflow).map((job) => job.name)).toEqual(["build", "deploy"]);
     expect(workflowJobBlock(quotedWorkflow, "deploy")).toContain("&pages-deploy");
     expect(workflowJobBlock(quotedWorkflow, "build")).not.toContain("deploy");
+  });
+
+  it("flags flow-style job mappings as unsupported forms", () => {
+    const flowWorkflow = [
+      "jobs:",
+      "  build:",
+      "    runs-on: ubuntu-latest",
+      '  deploy: { runs-on: ubuntu-latest, steps: [{ uses: "actions/deploy-\\u0070ages@sha" }] }',
+      "",
+    ].join("\n");
+
+    expect(workflowJobBlocks(flowWorkflow).map((job) => job.name)).toEqual(["build"]);
+    expect(unsupportedWorkflowJobForms(flowWorkflow)).toEqual(["deploy"]);
+    expect(unsupportedWorkflowJobForms(workflow)).toEqual([]);
   });
 
   it("extracts mapping values independent of key order", () => {

--- a/tests/unit/workflow-yaml.unit.test.ts
+++ b/tests/unit/workflow-yaml.unit.test.ts
@@ -96,6 +96,21 @@ describe("workflow YAML helper", () => {
     expect(workflowJobBlock(reusableWorkflow, "build")).not.toContain("workflow_call");
   });
 
+  it("extracts quoted jobs keys and quoted job ids", () => {
+    const quotedWorkflow = [
+      '"jobs": &all-jobs',
+      '  "build":',
+      "    runs-on: ubuntu-latest",
+      "  'deploy': &pages-deploy",
+      "    runs-on: ubuntu-latest",
+      "",
+    ].join("\n");
+
+    expect(workflowJobBlocks(quotedWorkflow).map((job) => job.name)).toEqual(["build", "deploy"]);
+    expect(workflowJobBlock(quotedWorkflow, "deploy")).toContain("&pages-deploy");
+    expect(workflowJobBlock(quotedWorkflow, "build")).not.toContain("deploy");
+  });
+
   it("extracts mapping values independent of key order", () => {
     expect(yamlMappingForKey(workflow, "permissions")).toEqual({
       actions: "read",

--- a/tests/unit/workflow-yaml.unit.test.ts
+++ b/tests/unit/workflow-yaml.unit.test.ts
@@ -61,10 +61,10 @@ describe("workflow YAML helper", () => {
     const commentedWorkflow = [
       "jobs:",
       "# before first job",
-      "  build:",
+      "  build: # build job",
       "    runs-on: ubuntu-latest",
       "# between jobs",
-      "  deploy:",
+      "  deploy: # deploy job",
       "    runs-on: ubuntu-latest",
       "",
     ].join("\n");

--- a/tests/unit/workflow-yaml.unit.test.ts
+++ b/tests/unit/workflow-yaml.unit.test.ts
@@ -40,6 +40,23 @@ describe("workflow YAML helper", () => {
     expect(workflowJobBlock(workflow, "missing")).toBeNull();
   });
 
+  it("extracts workflow job blocks with nonstandard indentation", () => {
+    const indentedWorkflow = [
+      "jobs:",
+      "    build:",
+      "        runs-on: ubuntu-latest",
+      "        steps:",
+      "          - run: pnpm test",
+      "    deploy:",
+      "        runs-on: ubuntu-latest",
+      "",
+    ].join("\n");
+
+    expect(workflowJobBlocks(indentedWorkflow).map((job) => job.name)).toEqual(["build", "deploy"]);
+    expect(workflowJobBlock(indentedWorkflow, "build")).toContain("pnpm test");
+    expect(workflowJobBlock(indentedWorkflow, "build")).not.toContain("deploy:");
+  });
+
   it("extracts mapping values independent of key order", () => {
     expect(yamlMappingForKey(workflow, "permissions")).toEqual({
       actions: "read",

--- a/tests/unit/workflow-yaml.unit.test.ts
+++ b/tests/unit/workflow-yaml.unit.test.ts
@@ -57,6 +57,25 @@ describe("workflow YAML helper", () => {
     expect(workflowJobBlock(indentedWorkflow, "build")).not.toContain("deploy:");
   });
 
+  it("extracts workflow job blocks across comment-only lines", () => {
+    const commentedWorkflow = [
+      "jobs:",
+      "# before first job",
+      "  build:",
+      "    runs-on: ubuntu-latest",
+      "# between jobs",
+      "  deploy:",
+      "    runs-on: ubuntu-latest",
+      "",
+    ].join("\n");
+
+    expect(workflowJobBlocks(commentedWorkflow).map((job) => job.name)).toEqual([
+      "build",
+      "deploy",
+    ]);
+    expect(workflowJobBlock(commentedWorkflow, "build")).not.toContain("deploy:");
+  });
+
   it("extracts mapping values independent of key order", () => {
     expect(yamlMappingForKey(workflow, "permissions")).toEqual({
       actions: "read",

--- a/tests/unit/workflow-yaml.unit.test.ts
+++ b/tests/unit/workflow-yaml.unit.test.ts
@@ -76,6 +76,26 @@ describe("workflow YAML helper", () => {
     expect(workflowJobBlock(commentedWorkflow, "build")).not.toContain("deploy:");
   });
 
+  it("extracts root workflow jobs when nested jobs metadata comes first", () => {
+    const reusableWorkflow = [
+      "on:",
+      "  workflow_call:",
+      "    inputs:",
+      "      jobs:",
+      "        type: string",
+      "jobs:",
+      "  build: &docs-build",
+      "    runs-on: ubuntu-latest",
+      "  deploy: &pages-deploy",
+      "    runs-on: ubuntu-latest",
+      "",
+    ].join("\n");
+
+    expect(workflowJobBlocks(reusableWorkflow).map((job) => job.name)).toEqual(["build", "deploy"]);
+    expect(workflowJobBlock(reusableWorkflow, "build")).toContain("&docs-build");
+    expect(workflowJobBlock(reusableWorkflow, "build")).not.toContain("workflow_call");
+  });
+
   it("extracts mapping values independent of key order", () => {
     expect(yamlMappingForKey(workflow, "permissions")).toEqual({
       actions: "read",


### PR DESCRIPTION
## Summary
- Add the Deploy API Docs GitHub Pages workflow for pushes to main and manual dispatch.
- Build TypeDoc output with Node 22.23.1 and pnpm, then upload api-docs as the Pages artifact.
- Harden the Pages deploy path with a main-ref guard, explicit timeouts, blanked Actions runtime/cache env vars for package execution, `--ignore-scripts`, and deployment URL metadata.
- Extend workflow policy coverage to include the docs workflow and add fail-closed Pages runtime-policy checks for expected package steps, unexpected package-manager commands, and actual step-level env mappings.

## Runtime-policy parser hardening (review follow-ups)
The Pages runtime-policy checker parses workflows with a dependency-free scanner (the `runtime-policy` CI job runs before `pnpm install`, so a real YAML library is not available at that trust boundary). Review iterations closed a series of fail-open bypasses so a hidden `actions/deploy-pages` action or extra package command cannot dodge the Pages guards. Each fix is fail-closed and ships a regression fixture:
- Reject flow-style workflow jobs, flow-style/aliased steps, individual flow-mapping or aliased step items, anchored flow-mapping steps, and indentationless step sequences.
- Reject aliases to redefined anchors and to anchors uncaptured by the prescan (e.g. nested in flow collections).
- Fully decode YAML double-quoted escapes (`\xXX`, `\U00XXXXXX`, letter escapes), and reject continued double-quoted keys and values.
- Parse block-scalar indentation indicators (`|2-`, `>-2`) consistently across scanners.
- Require a trusted default shell (bash/sh) for Pages steps, including dash-line shells and job/workflow defaults, and reject flow-style `defaults` mappings.
- Keep the checker dependency-free and handle nonstandard indentation, comments, quoted/anchored job keys, and the least-indented root `jobs:` mapping.

## Linked issue
Closes #305

## Tests run
- ACTIONS_CACHE_URL= ACTIONS_RESULTS_URL= ACTIONS_RUNTIME_TOKEN= ACTIONS_RUNTIME_URL= pnpm install --frozen-lockfile --ignore-scripts
- ACTIONS_CACHE_URL= ACTIONS_RESULTS_URL= ACTIONS_RUNTIME_TOKEN= ACTIONS_RUNTIME_URL= pnpm run docs
- pnpm run check:runtime-policy
- pnpm run format:check
- pnpm run typecheck
- pnpm exec vitest run --config vitest.config.mts --project=unit tests/unit/runtime-policy.unit.test.ts
- pnpm exec vitest run --config vitest.config.mts --project=unit tests/unit/workflow-yaml.unit.test.ts
- pnpm exec vitest run --config vitest.config.mts --project=unit tests/unit/supply-chain-policy.unit.test.ts
- pnpm exec vitest run --config vitest.config.mts --project=contract tests/contract/ci-workflow-policy.contract.test.ts

## Follow-up notes
- Repository Pages must be enabled with source: GitHub Actions before the first main-branch deployment can publish.
