### PR TITLE
docs: add tsdoc lint script

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -90,6 +90,7 @@ jobs:
           node-version: 22.23.1
           cache: pnpm
       - run: pnpm install --frozen-lockfile
+      - run: pnpm run lint:tsdoc
       - run: pnpm run lint:docs
       - run: pnpm run spell
       - run: pnpm run lint:links

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -90,7 +90,6 @@ jobs:
           node-version: 22.23.1
           cache: pnpm
       - run: pnpm install --frozen-lockfile
-      - run: pnpm run lint:tsdoc
       - run: pnpm run lint:docs
       - run: pnpm run spell
       - run: pnpm run lint:links

--- a/deploy/customer-hosted/pnpm-lock.yaml
+++ b/deploy/customer-hosted/pnpm-lock.yaml
@@ -65,6 +65,9 @@ importers:
       '@biomejs/biome':
         specifier: 2.5.10
         version: 2.5.10
+      '@microsoft/tsdoc-config':
+        specifier: 0.18.1
+        version: 0.18.1
       '@modelcontextprotocol/client':
         specifier: 2.0.0
         version: 2.0.0

--- a/docs/SUPPLY_CHAIN_SECURITY.md
+++ b/docs/SUPPLY_CHAIN_SECURITY.md
@@ -17,10 +17,15 @@ toolchain:
 - `keyv@4.5.4`
 
 Biome remains the owner for code linting and formatting. ESLint is present only
-for `pnpm run lint:docs`, where it validates TSDoc syntax and JSDoc hygiene for
-the exported TypeScript tool/handler surface that Biome cannot validate. The
-direct doc-lint packages are exact-pinned in `package.json`; the lockfile
-snapshot above remains unchanged after reintroducing that narrow ESLint path.
+for doc-comment scripts: `pnpm run lint:docs` validates TSDoc syntax and JSDoc
+hygiene for the exported TypeScript tool/handler surface that Biome cannot
+validate, while `pnpm run lint:tsdoc` is a TSDoc-only local diagnostic through
+the same wrapper. The CI and `verify` gates stay on `lint:docs` so there is one
+canonical doc-comment lint path. The direct doc-lint packages are exact-pinned
+in `package.json`; `@microsoft/tsdoc-config` is pinned directly to make the
+configuration reader version explicit, even though `eslint-plugin-tsdoc`
+already depends on the same version transitively. The lockfile snapshot above
+remains unchanged after reintroducing that narrow ESLint path.
 Reviewer-owned dependency overrides live only in
 [`../pnpm-workspace.yaml`](../pnpm-workspace.yaml), where the current entries
 pin reviewed transitive fixes for packages including `@hono/node-server`,
@@ -37,7 +42,7 @@ The current lockfile and publish packlist are checked by:
 pnpm run audit:supply-chain:denylist --packlist
 ```
 
-`pnpm run lint:docs` uses the repository-owned
+`pnpm run lint:docs` and `pnpm run lint:tsdoc` use the repository-owned
 [`../scripts/run-doc-lint.mjs`](../scripts/run-doc-lint.mjs) wrapper rather than
 executing the ESLint binary directly. The wrapper strips secret-like environment
 variables, refuses local checkout credentials such as persisted GitHub

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -31,6 +31,7 @@ The individual deterministic layers are:
 | `pnpm test`              | Typecheck, then `pnpm run test:unit`.                                                |
 | `pnpm run lint`          | Biome lint for source, test, and script code.                                        |
 | `pnpm run lint:docs`     | TSDoc/JSDoc doc-comment syntax and hygiene gate for non-test `src/**/*.ts` files.    |
+| `pnpm run lint:tsdoc`    | TSDoc-only syntax diagnostic through the same locked-down wrapper as `lint:docs`.     |
 | `pnpm run lint:links`    | Deterministic local Markdown link validation for repository docs.                    |
 | `pnpm run test:unit`     | Fast source unit tests.                                                              |
 | `pnpm run test:contract` | Deterministic MCP/package/schema/document/workflow contracts.                        |

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -2,6 +2,49 @@ const jsdoc = require("eslint-plugin-jsdoc");
 const tsdoc = require("eslint-plugin-tsdoc");
 const tseslint = require("typescript-eslint");
 
+const tsdocRules = {
+  "tsdoc/syntax": "error",
+};
+const jsdocRules = {
+  "jsdoc/no-bad-blocks": "error",
+  "jsdoc/no-blank-blocks": "error",
+  "jsdoc/multiline-blocks": "error",
+  "jsdoc/empty-tags": "error",
+  "jsdoc/check-tag-names": [
+    "error",
+    {
+      definedTags: ["internal", "inheritDoc", "typeParam", "packageDocumentation", "remarks"],
+    },
+  ],
+  "jsdoc/require-param-description": "error",
+  "jsdoc/require-hyphen-before-param-description": ["error", "always"],
+  // Keep public return docs intentional even when small wrappers need a
+  // short @returns line; the docs gate covers exported API surfaces.
+  "jsdoc/require-returns": ["error", { publicOnly: true }],
+  "jsdoc/require-returns-check": "error",
+  "jsdoc/require-throws": "error",
+  "jsdoc/no-types": "error",
+  "jsdoc/sort-tags": [
+    "error",
+    {
+      tagSequence: [
+        { tags: ["module", "packageDocumentation"] },
+        { tags: ["remarks"] },
+        { tags: ["typeParam", "template"] },
+        { tags: ["param"] },
+        { tags: ["returns"] },
+        { tags: ["throws"] },
+        { tags: ["example"] },
+        { tags: ["see"] },
+        { tags: ["deprecated"] },
+        { tags: ["internal"] },
+      ],
+    },
+  ],
+};
+const docCommentRules =
+  process.env.DOC_LINT_TSDOC_ONLY === "1" ? tsdocRules : { ...tsdocRules, ...jsdocRules };
+
 // ESLint is parser-only for TypeScript here; Biome owns code linting.
 // Do not register @typescript-eslint as a plugin unless doc lint starts using
 // one of its rules explicitly.
@@ -28,43 +71,6 @@ module.exports = [
         },
       },
     },
-    rules: {
-      "tsdoc/syntax": "error",
-      "jsdoc/no-bad-blocks": "error",
-      "jsdoc/no-blank-blocks": "error",
-      "jsdoc/multiline-blocks": "error",
-      "jsdoc/empty-tags": "error",
-      "jsdoc/check-tag-names": [
-        "error",
-        {
-          definedTags: ["internal", "inheritDoc", "typeParam", "packageDocumentation", "remarks"],
-        },
-      ],
-      "jsdoc/require-param-description": "error",
-      "jsdoc/require-hyphen-before-param-description": ["error", "always"],
-      // Keep public return docs intentional even when small wrappers need a
-      // short @returns line; the docs gate covers exported API surfaces.
-      "jsdoc/require-returns": ["error", { publicOnly: true }],
-      "jsdoc/require-returns-check": "error",
-      "jsdoc/require-throws": "error",
-      "jsdoc/no-types": "error",
-      "jsdoc/sort-tags": [
-        "error",
-        {
-          tagSequence: [
-            { tags: ["module", "packageDocumentation"] },
-            { tags: ["remarks"] },
-            { tags: ["typeParam", "template"] },
-            { tags: ["param"] },
-            { tags: ["returns"] },
-            { tags: ["throws"] },
-            { tags: ["example"] },
-            { tags: ["see"] },
-            { tags: ["deprecated"] },
-            { tags: ["internal"] },
-          ],
-        },
-      ],
-    },
+    rules: docCommentRules,
   },
 ];

--- a/package.json
+++ b/package.json
@@ -88,6 +88,7 @@
     "probe:500": "pnpm run build && node scripts/probe-b2-500s.mjs",
     "lint": "node scripts/run-biome.mjs lint src tests scripts evals test-support",
     "lint:fix": "node scripts/run-biome.mjs lint src tests scripts evals test-support --write",
+    "lint:tsdoc": "eslint \"src/**/*.ts\"",
     "lint:docs": "node scripts/run-doc-lint.mjs",
     "lint:docs:fix": "node scripts/run-doc-lint.mjs --fix",
     "lint:links": "node scripts/check-doc-links.mjs",
@@ -119,6 +120,7 @@
   },
   "devDependencies": {
     "@biomejs/biome": "2.5.10",
+    "@microsoft/tsdoc-config": "0.18.1",
     "@modelcontextprotocol/client": "2.0.0",
     "@modelcontextprotocol/inspector": "2.4.0",
     "@modelcontextprotocol/node": "2.0.0",

--- a/package.json
+++ b/package.json
@@ -88,7 +88,7 @@
     "probe:500": "pnpm run build && node scripts/probe-b2-500s.mjs",
     "lint": "node scripts/run-biome.mjs lint src tests scripts evals test-support",
     "lint:fix": "node scripts/run-biome.mjs lint src tests scripts evals test-support --write",
-    "lint:tsdoc": "eslint \"src/**/*.ts\"",
+    "lint:tsdoc": "node scripts/run-doc-lint.mjs --tsdoc-only",
     "lint:docs": "node scripts/run-doc-lint.mjs",
     "lint:docs:fix": "node scripts/run-doc-lint.mjs --fix",
     "lint:links": "node scripts/check-doc-links.mjs",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -65,6 +65,9 @@ importers:
       '@biomejs/biome':
         specifier: 2.5.10
         version: 2.5.10
+      '@microsoft/tsdoc-config':
+        specifier: 0.18.1
+        version: 0.18.1
       '@modelcontextprotocol/client':
         specifier: 2.0.0
         version: 2.0.0

--- a/scripts/run-doc-lint.mjs
+++ b/scripts/run-doc-lint.mjs
@@ -11,6 +11,9 @@ const { buildDocLintEnv, checkoutCredentialFindings } = require("./lib/doc-lint-
 const root = resolve(dirname(fileURLToPath(import.meta.url)), "..");
 const eslintEntrypoint = join(root, "node_modules", "eslint", "bin", "eslint.js");
 const lockdownEntrypoint = join(root, "scripts", "doc-lint-lockdown.mjs");
+const requestedArgs = process.argv.slice(2);
+const tsdocOnly = requestedArgs.includes("--tsdoc-only");
+const forwardedArgs = requestedArgs.filter((arg) => arg !== "--tsdoc-only");
 
 if (!existsSync(eslintEntrypoint)) {
   console.error(
@@ -26,13 +29,16 @@ if (checkoutFindings.length) {
   process.exit(1);
 }
 
+const docLintEnv = buildDocLintEnv({ lockdownPath: lockdownEntrypoint });
+if (tsdocOnly) docLintEnv.DOC_LINT_TSDOC_ONLY = "1";
+
 const result = spawnSync(
   process.execPath,
-  [eslintEntrypoint, "src", "--no-warn-ignored", ...process.argv.slice(2)],
+  [eslintEntrypoint, "src", "--no-warn-ignored", ...forwardedArgs],
   {
     cwd: root,
     stdio: "inherit",
-    env: buildDocLintEnv({ lockdownPath: lockdownEntrypoint }),
+    env: docLintEnv,
   },
 );
 

--- a/tests/contract/ci-workflow-policy.contract.test.ts
+++ b/tests/contract/ci-workflow-policy.contract.test.ts
@@ -220,6 +220,7 @@ describe("CI workflow policy", () => {
     const crossPlatformAggregateJob = workflowJob("cross-platform-minimum");
 
     expect(docsJob).toContain("pnpm run lint:docs");
+    expect(docsJob).not.toContain("pnpm run lint:tsdoc");
     expect(docsJob).toContain("pnpm run spell");
     expect(docsJob).toContain("pnpm run lint:links");
     expect(coverageJob).toContain("node-version: [22.23.1, 24, 26]");

--- a/tests/unit/doc-lint-runner.unit.test.ts
+++ b/tests/unit/doc-lint-runner.unit.test.ts
@@ -164,6 +164,7 @@ describe("doc lint runner", () => {
 
     expect(pkg.scripts["lint:docs"]).toBe("node scripts/run-doc-lint.mjs");
     expect(pkg.scripts["lint:docs:fix"]).toBe("node scripts/run-doc-lint.mjs --fix");
+    expect(pkg.scripts["lint:tsdoc"]).toBe("node scripts/run-doc-lint.mjs --tsdoc-only");
     expect(pkg.scripts["lint:links"]).toBe("node scripts/check-doc-links.mjs");
   });
 
@@ -181,10 +182,32 @@ describe("doc lint runner", () => {
     expect(docConfig).toBeDefined();
     expect(docConfig?.languageOptions?.parser).toBe(tseslint.parser);
     expect(Object.keys(docConfig?.plugins ?? {}).sort()).toEqual(["jsdoc", "tsdoc"]);
+    expect(docConfig?.rules?.["tsdoc/syntax"]).toBe("error");
     expect(
       Object.keys(docConfig?.rules ?? {}).some((ruleName) =>
         ruleName.startsWith("@typescript-eslint/"),
       ),
     ).toBe(false);
+  });
+
+  it("supports a TSDoc-only mode for the focused local script", () => {
+    const configPath = join(root, "eslint.config.js");
+    const previous = process.env.DOC_LINT_TSDOC_ONLY;
+    process.env.DOC_LINT_TSDOC_ONLY = "1";
+    delete nodeRequire.cache[nodeRequire.resolve(configPath)];
+
+    try {
+      const config = nodeRequire(configPath) as Array<{
+        files?: string[];
+        rules?: Record<string, unknown>;
+      }>;
+      const docConfig = config.find((entry) => entry.files?.includes("src/**/*.ts"));
+
+      expect(docConfig?.rules).toEqual({ "tsdoc/syntax": "error" });
+    } finally {
+      if (previous === undefined) delete process.env.DOC_LINT_TSDOC_ONLY;
+      else process.env.DOC_LINT_TSDOC_ONLY = previous;
+      delete nodeRequire.cache[nodeRequire.resolve(configPath)];
+    }
   });
 });

--- a/tests/unit/supply-chain-policy.unit.test.ts
+++ b/tests/unit/supply-chain-policy.unit.test.ts
@@ -759,8 +759,9 @@ describe("supply-chain audit policy", () => {
     expect(publishJob).toContain('--tag "$npm_tag"');
   });
 
-  it("exact-pins executable doc lint tooling", () => {
+  it("exact-pins doc lint tooling", () => {
     for (const name of [
+      "@microsoft/tsdoc-config",
       "eslint",
       "eslint-plugin-jsdoc",
       "eslint-plugin-tsdoc",


### PR DESCRIPTION
## Summary
- Add a dedicated `lint:tsdoc` script that runs a TSDoc-only syntax pass through the existing locked-down doc-lint wrapper.
- Keep `lint:docs` as the canonical CI and `verify` doc-comment gate, avoiding duplicate back-to-back ESLint runs.
- Add exact-pinned `@microsoft/tsdoc-config` as an explicit config-reader pin and document that it mirrors the transitive `eslint-plugin-tsdoc` dependency for reproducibility.
- Mirror the root lockfile update into the packaged customer-hosted deployment lockfile.

## Linked Issue
Closes #307

## Tests
- `pnpm install --frozen-lockfile`
- `pnpm run lint:tsdoc`
- malformed TSDoc probe confirmed `lint:tsdoc` fails on `tsdoc/syntax` only
- `pnpm run lint:docs`
- `pnpm run lint`
- `pnpm run typecheck`
- `pnpm run format:check`
- `pnpm exec vitest run --config vitest.config.mts --project=unit tests/unit/doc-lint-runner.unit.test.ts tests/unit/supply-chain-policy.unit.test.ts`
- `pnpm exec vitest run --config vitest.config.mts --project=unit tests/unit/package-surface-policy.unit.test.ts`
- `pnpm exec vitest run --config vitest.config.mts --project=unit tests/unit/release-scripts.unit.test.ts --testNamePattern "runs the pnpm version changelog lifecycle"`
- `pnpm exec vitest run --config vitest.config.mts --project=contract tests/contract/ci-workflow-policy.contract.test.ts tests/contract/spelling-policy.contract.test.ts`
- `pnpm run test:coverage`

## Follow-up Notes
- Biome lint remains unchanged.
- The docs/spelling/links workflow continues to run `lint:docs` as the single CI doc-comment lint path.