### PR TITLE
Publish b2-mcp to the MCP Registry

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -440,13 +440,6 @@ jobs:
           tar -xzf mcp-publisher.tar.gz -C mcp-publisher-bin mcp-publisher
           printf '%s  mcp-publisher-bin/mcp-publisher\n' "${MCP_PUBLISHER_BINARY_SHA256}" | sha256sum -c -
           chmod +x mcp-publisher-bin/mcp-publisher
-      - name: Validate MCP registry manifest
-        env:
-          ACTIONS_CACHE_URL: ""
-          ACTIONS_RESULTS_URL: ""
-          ACTIONS_RUNTIME_TOKEN: ""
-          ACTIONS_RUNTIME_URL: ""
-        run: mcp-publisher-bin/mcp-publisher validate publish-package/server.json
       # actions/upload-artifact v7, reviewed 2026-08-25.
       - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
         with:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -22,6 +22,18 @@ concurrency:
   group: npm-publish-${{ github.repository }}
   cancel-in-progress: false
 
+env:
+  MCP_PUBLISHER_BINARY_SHA256: 5e39fe8b6fc3c8b01bed6f1de364b88e9dd10ccbef6d3d3b1a0caa46115bf869
+  MCP_PUBLISHER_CERTIFICATE_IDENTITY: https://github.com/modelcontextprotocol/registry/.github/workflows/release.yml@refs/tags/v1.8.1
+  MCP_PUBLISHER_GITHUB_REF: refs/tags/v1.8.1
+  MCP_PUBLISHER_GITHUB_REPOSITORY: modelcontextprotocol/registry
+  MCP_PUBLISHER_GITHUB_SHA: f52dc8525a441a3abf5fedc9912152d95af5aab1
+  MCP_PUBLISHER_GITHUB_WORKFLOW_NAME: Release
+  MCP_PUBLISHER_GITHUB_WORKFLOW_TRIGGER: release
+  MCP_PUBLISHER_OIDC_ISSUER: https://token.actions.githubusercontent.com
+  MCP_PUBLISHER_SHA256: a06c9096dcb9727c13555b6be26c7effa707b01f06a4c561ba7a3635443cf2cc
+  MCP_PUBLISHER_VERSION: v1.8.1
+
 jobs:
   prepare:
     if: github.repository == 'backblaze-labs/b2-mcp' && github.event.workflow_run.conclusion == 'success'
@@ -290,10 +302,15 @@ jobs:
           set -euo pipefail
           mkdir -p publish-package/release-tools/lib
           cp \
+            scripts/mcp-registry-publish.mjs \
             scripts/npm-publish-metadata.mjs \
+            scripts/verify-mcp-registry-manifest.mjs \
             scripts/verify-npm-registry-metadata.mjs \
             publish-package/release-tools/
-          cp scripts/lib/release-utils.mjs publish-package/release-tools/lib/
+          cp \
+            scripts/lib/mcp-registry-manifest.mjs \
+            scripts/lib/release-utils.mjs \
+            publish-package/release-tools/lib/
       - name: Stage MCP registry manifest
         env:
           ACTIONS_CACHE_URL: ""
@@ -332,8 +349,114 @@ jobs:
       LIVE_B2_MASTER_KEY_ID: ${{ secrets.LIVE_B2_MASTER_KEY_ID }}
       LIVE_B2_MASTER_KEY: ${{ secrets.LIVE_B2_MASTER_KEY }}
 
+  mcp-registry-preflight:
+    name: MCP registry preflight
+    needs: prepare
+    if: github.repository == 'backblaze-labs/b2-mcp'
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      actions: read
+      contents: read
+    steps:
+      # actions/download-artifact v8, reviewed 2026-08-25.
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c
+        with:
+          name: npm-package
+          path: publish-package
+      # Node 24.19.0 bundles the fetch/AbortController runtime used by release helpers.
+      # actions/setup-node v7, reviewed 2026-08-06.
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020
+        with:
+          node-version: 24.19.0
+          package-manager-cache: false
+      - name: Extract staged package for registry preflight
+        env:
+          ACTIONS_CACHE_URL: ""
+          ACTIONS_RESULTS_URL: ""
+          ACTIONS_RUNTIME_TOKEN: ""
+          ACTIONS_RUNTIME_URL: ""
+          EXPECTED_TARBALL_NAME: ${{ needs.prepare.outputs.tarball-name }}
+          EXPECTED_TARBALL_SHA256: ${{ needs.prepare.outputs.tarball-sha256 }}
+        run: |
+          set -euo pipefail
+          tarball="./publish-package/${EXPECTED_TARBALL_NAME}"
+          if [[ ! -f "$tarball" ]]; then
+            echo "::error::Expected publish tarball ${tarball} is missing"
+            exit 1
+          fi
+          actual_sha="$(sha256sum "$tarball" | awk '{print $1}')"
+          if [[ "$actual_sha" != "$EXPECTED_TARBALL_SHA256" ]]; then
+            echo "::error::Publish tarball SHA-256 mismatch"
+            exit 1
+          fi
+          rm -rf publish-package/staged
+          mkdir -p publish-package/staged
+          tar -xzf "$tarball" -C publish-package/staged
+      - name: Verify MCP registry manifest metadata
+        env:
+          ACTIONS_CACHE_URL: ""
+          ACTIONS_RESULTS_URL: ""
+          ACTIONS_RUNTIME_TOKEN: ""
+          ACTIONS_RUNTIME_URL: ""
+          PUBLISH_TAG: ${{ needs.prepare.outputs.publish-tag }}
+        run: |
+          set -euo pipefail
+          version="${PUBLISH_TAG#refs/tags/}"
+          version="${version#v}"
+          node publish-package/release-tools/verify-mcp-registry-manifest.mjs \
+            --server-json publish-package/server.json \
+            --package-json publish-package/staged/package/package.json \
+            --version "${version}"
+      # sigstore/cosign-installer v4.1.2, reviewed 2026-08-27.
+      - uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6
+      # mcp-publisher v1.8.1, reviewed 2026-08-31.
+      - name: Download and verify mcp-publisher
+        env:
+          ACTIONS_CACHE_URL: ""
+          ACTIONS_RESULTS_URL: ""
+          ACTIONS_RUNTIME_TOKEN: ""
+          ACTIONS_RUNTIME_URL: ""
+        run: |
+          set -euo pipefail
+          curl --retry 3 --retry-all-errors --retry-delay 5 --connect-timeout 10 --max-time 60 \
+            -fsSLo mcp-publisher.tar.gz \
+            "https://github.com/modelcontextprotocol/registry/releases/download/${MCP_PUBLISHER_VERSION}/mcp-publisher_linux_amd64.tar.gz"
+          curl --retry 3 --retry-all-errors --retry-delay 5 --connect-timeout 10 --max-time 60 \
+            -fsSLo mcp-publisher.tar.gz.sigstore.json \
+            "https://github.com/modelcontextprotocol/registry/releases/download/${MCP_PUBLISHER_VERSION}/mcp-publisher_linux_amd64.tar.gz.sigstore.json"
+          printf '%s  mcp-publisher.tar.gz\n' "${MCP_PUBLISHER_SHA256}" | sha256sum -c -
+          cosign verify-blob \
+            --bundle mcp-publisher.tar.gz.sigstore.json \
+            --certificate-identity "${MCP_PUBLISHER_CERTIFICATE_IDENTITY}" \
+            --certificate-oidc-issuer "${MCP_PUBLISHER_OIDC_ISSUER}" \
+            --certificate-github-workflow-repository "${MCP_PUBLISHER_GITHUB_REPOSITORY}" \
+            --certificate-github-workflow-ref "${MCP_PUBLISHER_GITHUB_REF}" \
+            --certificate-github-workflow-sha "${MCP_PUBLISHER_GITHUB_SHA}" \
+            --certificate-github-workflow-name "${MCP_PUBLISHER_GITHUB_WORKFLOW_NAME}" \
+            --certificate-github-workflow-trigger "${MCP_PUBLISHER_GITHUB_WORKFLOW_TRIGGER}" \
+            mcp-publisher.tar.gz
+          mkdir -p mcp-publisher-bin
+          tar -xzf mcp-publisher.tar.gz -C mcp-publisher-bin mcp-publisher
+          printf '%s  mcp-publisher-bin/mcp-publisher\n' "${MCP_PUBLISHER_BINARY_SHA256}" | sha256sum -c -
+          chmod +x mcp-publisher-bin/mcp-publisher
+      - name: Validate MCP registry manifest
+        env:
+          ACTIONS_CACHE_URL: ""
+          ACTIONS_RESULTS_URL: ""
+          ACTIONS_RUNTIME_TOKEN: ""
+          ACTIONS_RUNTIME_URL: ""
+        run: mcp-publisher-bin/mcp-publisher validate publish-package/server.json
+      # actions/upload-artifact v7, reviewed 2026-08-25.
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
+        with:
+          name: mcp-publisher
+          path: mcp-publisher-bin/mcp-publisher
+          if-no-files-found: error
+          retention-days: 7
+
   publish:
-    needs: [prepare, live-contract]
+    needs: [prepare, live-contract, mcp-registry-preflight]
     if: github.repository == 'backblaze-labs/b2-mcp'
     runs-on: ubuntu-latest
     timeout-minutes: 10
@@ -347,6 +470,11 @@ jobs:
         with:
           name: npm-package
           path: publish-package
+      # actions/download-artifact v8, reviewed 2026-08-25.
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c
+        with:
+          name: mcp-publisher
+          path: mcp-publisher-bin
       # Node 24.19.0 bundles npm >=11.5.1, required for npm trusted publishing.
       # actions/setup-node v7, reviewed 2026-08-06.
       - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020
@@ -483,7 +611,7 @@ jobs:
             --tag "$npm_tag"
           node publish-package/release-tools/verify-npm-registry-metadata.mjs \
             "${metadata_verify_args[@]}"
-      - name: Verify MCP registry manifest metadata
+      - name: Publish MCP registry entry
         env:
           ACTIONS_CACHE_URL: ""
           ACTIONS_RESULTS_URL: ""
@@ -492,100 +620,15 @@ jobs:
           PUBLISH_TAG: ${{ needs.prepare.outputs.publish-tag }}
         run: |
           set -euo pipefail
-          if [[ -z "${PUBLISH_TAG:-}" ]]; then
-            echo "::error::Missing release tag for MCP registry manifest"
-            exit 1
-          fi
+          printf '%s  mcp-publisher-bin/mcp-publisher\n' "${MCP_PUBLISHER_BINARY_SHA256}" | sha256sum -c -
+          chmod +x mcp-publisher-bin/mcp-publisher
           version="${PUBLISH_TAG#refs/tags/}"
           version="${version#v}"
-          if [[ -z "${version}" ]]; then
-            echo "::error::Could not resolve release version for MCP registry manifest"
-            exit 1
-          fi
-          PUBLISH_VERSION="${version}" node <<'NODE'
-          const fs = require("node:fs");
-          const manifestPath = "publish-package/server.json";
-          const version = process.env.PUBLISH_VERSION;
-          if (!version) {
-            throw new Error("PUBLISH_VERSION is required");
-          }
-          const manifest = JSON.parse(fs.readFileSync(manifestPath, "utf8"));
-          const packageJson = JSON.parse(
-            fs.readFileSync("publish-package/staged/package/package.json", "utf8"),
-          );
-          const manifestPackage = (manifest.packages ?? []).find(
-            (pkg) => pkg.registryType === "npm" && pkg.identifier === "@backblaze-labs/b2-mcp",
-          );
-          if (!manifestPackage) {
-            throw new Error("server.json is missing the @backblaze-labs/b2-mcp npm package");
-          }
-          if (packageJson.version !== version) {
-            throw new Error(`package.json version ${packageJson.version} does not match ${version}`);
-          }
-          if (packageJson.mcpName !== manifest.name) {
-            throw new Error(`package.json mcpName ${packageJson.mcpName} does not match ${manifest.name}`);
-          }
-          if (manifest.version !== version) {
-            throw new Error(`server.json version ${manifest.version} does not match ${version}`);
-          }
-          if (manifestPackage.version !== version) {
-            throw new Error(`server.json package version ${manifestPackage.version} does not match ${version}`);
-          }
-          NODE
-      # mcp-publisher v1.8.1, reviewed 2026-08-31.
-      - name: Install mcp-publisher
-        env:
-          ACTIONS_CACHE_URL: ""
-          ACTIONS_RESULTS_URL: ""
-          ACTIONS_RUNTIME_TOKEN: ""
-          ACTIONS_RUNTIME_URL: ""
-          MCP_PUBLISHER_SHA256: a06c9096dcb9727c13555b6be26c7effa707b01f06a4c561ba7a3635443cf2cc
-          MCP_PUBLISHER_VERSION: v1.8.1
-        run: |
-          set -euo pipefail
-          curl -fsSLo mcp-publisher.tar.gz \
-            "https://github.com/modelcontextprotocol/registry/releases/download/${MCP_PUBLISHER_VERSION}/mcp-publisher_linux_amd64.tar.gz"
-          printf '%s  mcp-publisher.tar.gz\n' "${MCP_PUBLISHER_SHA256}" | sha256sum -c -
-          tar -xzf mcp-publisher.tar.gz mcp-publisher
-      - name: Validate MCP registry manifest
-        env:
-          ACTIONS_CACHE_URL: ""
-          ACTIONS_RESULTS_URL: ""
-          ACTIONS_RUNTIME_TOKEN: ""
-          ACTIONS_RUNTIME_URL: ""
-        run: ./mcp-publisher validate publish-package/server.json
-      - name: Authenticate to MCP Registry
-        env:
-          ACTIONS_CACHE_URL: ""
-          ACTIONS_RESULTS_URL: ""
-          ACTIONS_RUNTIME_TOKEN: ""
-          ACTIONS_RUNTIME_URL: ""
-        run: ./mcp-publisher login github-oidc
-      - name: Publish MCP registry entry
-        env:
-          ACTIONS_CACHE_URL: ""
-          ACTIONS_RESULTS_URL: ""
-          ACTIONS_RUNTIME_TOKEN: ""
-          ACTIONS_RUNTIME_URL: ""
-        run: |
-          set -euo pipefail
-          manifest="publish-package/server.json"
-          server_name="$(node -e 'const fs = require("node:fs"); process.stdout.write(JSON.parse(fs.readFileSync(process.argv[1], "utf8")).name);' "$manifest")"
-          server_version="$(node -e 'const fs = require("node:fs"); process.stdout.write(JSON.parse(fs.readFileSync(process.argv[1], "utf8")).version);' "$manifest")"
-          encoded_name="$(node -e 'process.stdout.write(encodeURIComponent(process.argv[1]));' "$server_name")"
-          encoded_version="$(node -e 'process.stdout.write(encodeURIComponent(process.argv[1]));' "$server_version")"
-          lookup_url="https://registry.modelcontextprotocol.io/v0/servers/${encoded_name}/versions/${encoded_version}"
-          http_status="$(curl -sS -o /tmp/mcp-registry-version.json -w '%{http_code}' "$lookup_url" || true)"
-          if [[ "$http_status" == "200" ]]; then
-            echo "::notice::${server_name}@${server_version} already exists in the MCP Registry; treating as idempotent success"
-            exit 0
-          fi
-          if [[ "$http_status" != "404" ]]; then
-            echo "::error::Unexpected MCP Registry lookup status: ${http_status}"
-            cat /tmp/mcp-registry-version.json || true
-            exit 1
-          fi
-          ./mcp-publisher publish "$manifest"
+          node publish-package/release-tools/mcp-registry-publish.mjs \
+            --server-json publish-package/server.json \
+            --publisher ./mcp-publisher-bin/mcp-publisher \
+            --version "${version}" \
+            --skip-prerelease
 
   container-image:
     needs: [prepare, publish]

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -354,7 +354,7 @@ jobs:
     needs: prepare
     if: github.repository == 'backblaze-labs/b2-mcp'
     runs-on: ubuntu-latest
-    timeout-minutes: 10
+    timeout-minutes: 20
     permissions:
       actions: read
       contents: read

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -294,6 +294,15 @@ jobs:
             scripts/verify-npm-registry-metadata.mjs \
             publish-package/release-tools/
           cp scripts/lib/release-utils.mjs publish-package/release-tools/lib/
+      - name: Stage MCP registry manifest
+        env:
+          ACTIONS_CACHE_URL: ""
+          ACTIONS_RESULTS_URL: ""
+          ACTIONS_RUNTIME_TOKEN: ""
+          ACTIONS_RUNTIME_URL: ""
+        run: |
+          set -euo pipefail
+          cp server.json publish-package/server.json
       # actions/upload-artifact v7, reviewed 2026-08-25.
       - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
         with:
@@ -304,6 +313,7 @@ jobs:
             publish-package/SHA256SUMS
             publish-package/release-notes.md
             publish-package/npm-pack.json
+            publish-package/server.json
             publish-package/release-tools/*.mjs
             publish-package/release-tools/lib/*.mjs
           if-no-files-found: error
@@ -326,7 +336,7 @@ jobs:
     needs: [prepare, live-contract]
     if: github.repository == 'backblaze-labs/b2-mcp'
     runs-on: ubuntu-latest
-    timeout-minutes: 5
+    timeout-minutes: 10
     permissions:
       actions: read
       contents: read
@@ -473,6 +483,109 @@ jobs:
             --tag "$npm_tag"
           node publish-package/release-tools/verify-npm-registry-metadata.mjs \
             "${metadata_verify_args[@]}"
+      - name: Verify MCP registry manifest metadata
+        env:
+          ACTIONS_CACHE_URL: ""
+          ACTIONS_RESULTS_URL: ""
+          ACTIONS_RUNTIME_TOKEN: ""
+          ACTIONS_RUNTIME_URL: ""
+          PUBLISH_TAG: ${{ needs.prepare.outputs.publish-tag }}
+        run: |
+          set -euo pipefail
+          if [[ -z "${PUBLISH_TAG:-}" ]]; then
+            echo "::error::Missing release tag for MCP registry manifest"
+            exit 1
+          fi
+          version="${PUBLISH_TAG#refs/tags/}"
+          version="${version#v}"
+          if [[ -z "${version}" ]]; then
+            echo "::error::Could not resolve release version for MCP registry manifest"
+            exit 1
+          fi
+          PUBLISH_VERSION="${version}" node <<'NODE'
+          const fs = require("node:fs");
+          const manifestPath = "publish-package/server.json";
+          const version = process.env.PUBLISH_VERSION;
+          if (!version) {
+            throw new Error("PUBLISH_VERSION is required");
+          }
+          const manifest = JSON.parse(fs.readFileSync(manifestPath, "utf8"));
+          const packageJson = JSON.parse(
+            fs.readFileSync("publish-package/staged/package/package.json", "utf8"),
+          );
+          const manifestPackage = (manifest.packages ?? []).find(
+            (pkg) => pkg.registryType === "npm" && pkg.identifier === "@backblaze-labs/b2-mcp",
+          );
+          if (!manifestPackage) {
+            throw new Error("server.json is missing the @backblaze-labs/b2-mcp npm package");
+          }
+          if (packageJson.version !== version) {
+            throw new Error(`package.json version ${packageJson.version} does not match ${version}`);
+          }
+          if (packageJson.mcpName !== manifest.name) {
+            throw new Error(`package.json mcpName ${packageJson.mcpName} does not match ${manifest.name}`);
+          }
+          if (manifest.version !== version) {
+            throw new Error(`server.json version ${manifest.version} does not match ${version}`);
+          }
+          if (manifestPackage.version !== version) {
+            throw new Error(`server.json package version ${manifestPackage.version} does not match ${version}`);
+          }
+          NODE
+      # mcp-publisher v1.8.1, reviewed 2026-08-31.
+      - name: Install mcp-publisher
+        env:
+          ACTIONS_CACHE_URL: ""
+          ACTIONS_RESULTS_URL: ""
+          ACTIONS_RUNTIME_TOKEN: ""
+          ACTIONS_RUNTIME_URL: ""
+          MCP_PUBLISHER_SHA256: a06c9096dcb9727c13555b6be26c7effa707b01f06a4c561ba7a3635443cf2cc
+          MCP_PUBLISHER_VERSION: v1.8.1
+        run: |
+          set -euo pipefail
+          curl -fsSLo mcp-publisher.tar.gz \
+            "https://github.com/modelcontextprotocol/registry/releases/download/${MCP_PUBLISHER_VERSION}/mcp-publisher_linux_amd64.tar.gz"
+          printf '%s  mcp-publisher.tar.gz\n' "${MCP_PUBLISHER_SHA256}" | sha256sum -c -
+          tar -xzf mcp-publisher.tar.gz mcp-publisher
+      - name: Validate MCP registry manifest
+        env:
+          ACTIONS_CACHE_URL: ""
+          ACTIONS_RESULTS_URL: ""
+          ACTIONS_RUNTIME_TOKEN: ""
+          ACTIONS_RUNTIME_URL: ""
+        run: ./mcp-publisher validate publish-package/server.json
+      - name: Authenticate to MCP Registry
+        env:
+          ACTIONS_CACHE_URL: ""
+          ACTIONS_RESULTS_URL: ""
+          ACTIONS_RUNTIME_TOKEN: ""
+          ACTIONS_RUNTIME_URL: ""
+        run: ./mcp-publisher login github-oidc
+      - name: Publish MCP registry entry
+        env:
+          ACTIONS_CACHE_URL: ""
+          ACTIONS_RESULTS_URL: ""
+          ACTIONS_RUNTIME_TOKEN: ""
+          ACTIONS_RUNTIME_URL: ""
+        run: |
+          set -euo pipefail
+          manifest="publish-package/server.json"
+          server_name="$(node -e 'const fs = require("node:fs"); process.stdout.write(JSON.parse(fs.readFileSync(process.argv[1], "utf8")).name);' "$manifest")"
+          server_version="$(node -e 'const fs = require("node:fs"); process.stdout.write(JSON.parse(fs.readFileSync(process.argv[1], "utf8")).version);' "$manifest")"
+          encoded_name="$(node -e 'process.stdout.write(encodeURIComponent(process.argv[1]));' "$server_name")"
+          encoded_version="$(node -e 'process.stdout.write(encodeURIComponent(process.argv[1]));' "$server_version")"
+          lookup_url="https://registry.modelcontextprotocol.io/v0/servers/${encoded_name}/versions/${encoded_version}"
+          http_status="$(curl -sS -o /tmp/mcp-registry-version.json -w '%{http_code}' "$lookup_url" || true)"
+          if [[ "$http_status" == "200" ]]; then
+            echo "::notice::${server_name}@${server_version} already exists in the MCP Registry; treating as idempotent success"
+            exit 0
+          fi
+          if [[ "$http_status" != "404" ]]; then
+            echo "::error::Unexpected MCP Registry lookup status: ${http_status}"
+            cat /tmp/mcp-registry-version.json || true
+            exit 1
+          fi
+          ./mcp-publisher publish "$manifest"
 
   container-image:
     needs: [prepare, publish]

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -459,7 +459,7 @@ jobs:
     needs: [prepare, live-contract, mcp-registry-preflight]
     if: github.repository == 'backblaze-labs/b2-mcp'
     runs-on: ubuntu-latest
-    timeout-minutes: 10
+    timeout-minutes: 30
     permissions:
       actions: read
       contents: read

--- a/package.json
+++ b/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@backblaze-labs/b2-mcp",
   "version": "0.1.2",
+  "mcpName": "io.github.backblaze-labs/b2-mcp",
   "description": "MCP server for Backblaze B2 with frozen Phase 1 B2 and S3-compatible tool profiles",
   "packageManager": "pnpm@11.20.0+sha256.34e198cb1e43237517ecedfd31f9ae26a6c0a3e5366ce58a2d05f4b21fb5f19a",
   "main": "dist/index.js",
@@ -82,7 +83,7 @@
     "release:notes": "node scripts/extract-release-notes.mjs",
     "release:stamp": "node scripts/write-release-version.mjs",
     "release:sbom": "node scripts/production-security-gate.mjs --sbom publish-package/b2-mcp-production.cdx.json",
-    "version": "node scripts/cut-changelog.mjs && git add CHANGELOG.md",
+    "version": "node scripts/cut-changelog.mjs && node scripts/update-server-json-version.mjs && git add CHANGELOG.md server.json",
     "prepublishOnly": "pnpm run build && node scripts/verify-release-input.mjs --tag \"v$(node -p 'require(\"./package.json\").version')\" && pnpm run release:stamp",
     "postpack": "node -e \"require('node:fs').rmSync('dist/release-version.json',{force:true})\"",
     "probe:500": "pnpm run build && node scripts/probe-b2-500s.mjs",

--- a/scripts/lib/mcp-registry-manifest.mjs
+++ b/scripts/lib/mcp-registry-manifest.mjs
@@ -1,0 +1,302 @@
+import { readFileSync } from "node:fs";
+import {
+  assert,
+  canonicalHomepage,
+  canonicalMcpName,
+  canonicalPackageName,
+  canonicalRepositoryId,
+  canonicalRepositorySource,
+  canonicalRepositoryUrl,
+} from "./release-utils.mjs";
+
+export const mcpRegistryApiBaseUrl = "https://registry.modelcontextprotocol.io/v0";
+export const mcpRegistrySchemaUrl =
+  "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json";
+export const mcpRegistryTitle = "Backblaze B2 MCP Server";
+export const mcpRegistryDescription =
+  "Operate Backblaze B2 buckets, files, keys, Object Lock, and S3-compatible storage.";
+
+export const expectedMcpRegistryEnvironmentVariables = Object.freeze([
+  Object.freeze({
+    description: "Backblaze B2 application key ID for native B2 and S3-compatible tools.",
+    format: "string",
+    isRequired: true,
+    isSecret: true,
+    name: "B2_APPLICATION_KEY_ID",
+  }),
+  Object.freeze({
+    description: "Backblaze B2 application key secret.",
+    format: "string",
+    isRequired: true,
+    isSecret: true,
+    name: "B2_APPLICATION_KEY",
+  }),
+  Object.freeze({
+    description: "Optional fallback S3-compatible region used before authorization.",
+    format: "string",
+    isRequired: false,
+    isSecret: false,
+    name: "B2_REGION",
+    placeholder: "us-east-005",
+  }),
+  Object.freeze({
+    description: "Optional master key ID for Partner/Groups API tools.",
+    format: "string",
+    isRequired: false,
+    isSecret: true,
+    name: "B2_MASTER_KEY_ID",
+  }),
+  Object.freeze({
+    description: "Optional master key secret for Partner/Groups API tools.",
+    format: "string",
+    isRequired: false,
+    isSecret: true,
+    name: "B2_MASTER_KEY",
+  }),
+]);
+
+const allowedManifestKeys = new Set([
+  "$schema",
+  "description",
+  "name",
+  "packages",
+  "repository",
+  "title",
+  "version",
+  "websiteUrl",
+]);
+const allowedRepositoryKeys = new Set(["id", "source", "url"]);
+const allowedPackageKeys = new Set([
+  "environmentVariables",
+  "identifier",
+  "registryType",
+  "transport",
+  "version",
+]);
+const allowedTransportKeys = new Set(["type"]);
+
+function readJsonFile(filePath) {
+  return JSON.parse(readFileSync(filePath, "utf8"));
+}
+
+function isRecord(value) {
+  return !!value && typeof value === "object" && !Array.isArray(value);
+}
+
+function assertRecord(value, label) {
+  assert(isRecord(value), `${label} must be an object`);
+}
+
+function assertOnlyKeys(value, allowedKeys, label) {
+  const unexpected = Object.keys(value).filter((key) => !allowedKeys.has(key));
+  assert(unexpected.length === 0, `${label} has unexpected keys: ${unexpected.join(", ")}`);
+}
+
+function secretLikeB2EnvironmentVariable(name) {
+  return name.startsWith("B2_") && /(CREDENTIAL|KEY|PASSWORD|SECRET|TOKEN)/.test(name);
+}
+
+function assertEnvironmentVariableContract(environmentVariables) {
+  assert(Array.isArray(environmentVariables), "server.json environmentVariables must be an array");
+
+  const byName = new Map();
+  const expectedByName = new Map(
+    expectedMcpRegistryEnvironmentVariables.map((variable) => [variable.name, variable]),
+  );
+  for (const variable of environmentVariables) {
+    assertRecord(variable, "server.json environment variable");
+    const name = variable.name;
+    assert(
+      typeof name === "string" && name.length > 0,
+      "server.json environment variable needs a name",
+    );
+    if (secretLikeB2EnvironmentVariable(name)) {
+      assert(variable.isSecret === true, `server.json environment variable ${name} must be secret`);
+    }
+    assert(!byName.has(name), `server.json environment variable ${name} is duplicated`);
+    byName.set(name, variable);
+    assert(
+      expectedByName.has(name),
+      `server.json environment variable ${name} is not in the approved allowlist`,
+    );
+  }
+  assert(
+    environmentVariables.length === expectedMcpRegistryEnvironmentVariables.length,
+    `server.json environmentVariables must contain exactly ${expectedMcpRegistryEnvironmentVariables.length} entries`,
+  );
+
+  for (const expected of expectedMcpRegistryEnvironmentVariables) {
+    const actual = byName.get(expected.name);
+    assert(!!actual, `server.json environment variable ${expected.name} is missing`);
+    assertOnlyKeys(
+      actual,
+      new Set(Object.keys(expected)),
+      `server.json environment variable ${expected.name}`,
+    );
+    for (const [field, expectedValue] of Object.entries(expected)) {
+      assert(
+        actual[field] === expectedValue,
+        `server.json environment variable ${expected.name}.${field} must be ${JSON.stringify(expectedValue)}`,
+      );
+    }
+  }
+}
+
+export function assertMcpRegistryManifestContract(manifest, options = {}) {
+  const expectedVersion = options.expectedVersion ?? manifest?.version;
+
+  assertRecord(manifest, "server.json");
+  assertOnlyKeys(manifest, allowedManifestKeys, "server.json");
+  assert(manifest.$schema === mcpRegistrySchemaUrl, "server.json schema URL is not canonical");
+  assert(manifest.name === canonicalMcpName, "server.json name is not canonical");
+  assert(manifest.title === mcpRegistryTitle, "server.json title is not canonical");
+  assert(
+    manifest.description === mcpRegistryDescription,
+    "server.json description is not canonical",
+  );
+  assert(manifest.websiteUrl === canonicalHomepage, "server.json website URL is not canonical");
+  assert(
+    manifest.version === expectedVersion,
+    `server.json version ${manifest.version} does not match ${expectedVersion}`,
+  );
+
+  assertRecord(manifest.repository, "server.json repository");
+  assertOnlyKeys(manifest.repository, allowedRepositoryKeys, "server.json repository");
+  assert(
+    manifest.repository.url === canonicalRepositoryUrl,
+    "server.json repository URL is not canonical",
+  );
+  assert(
+    manifest.repository.source === canonicalRepositorySource,
+    "server.json repository source is not canonical",
+  );
+  assert(
+    manifest.repository.id === canonicalRepositoryId,
+    "server.json repository id is not canonical",
+  );
+
+  assert(Array.isArray(manifest.packages), "server.json packages must be an array");
+  assert(manifest.packages.length === 1, "server.json packages must contain exactly one entry");
+  const packageEntry = manifest.packages[0];
+  assertRecord(packageEntry, "server.json npm package");
+  assertOnlyKeys(packageEntry, allowedPackageKeys, "server.json npm package");
+  assert(packageEntry.registryType === "npm", "server.json package registryType must be npm");
+  assert(
+    packageEntry.identifier === canonicalPackageName,
+    `server.json package identifier must be ${canonicalPackageName}`,
+  );
+  assert(
+    packageEntry.version === expectedVersion,
+    `server.json package version ${packageEntry.version} does not match ${expectedVersion}`,
+  );
+  assertRecord(packageEntry.transport, "server.json package transport");
+  assertOnlyKeys(packageEntry.transport, allowedTransportKeys, "server.json package transport");
+  assert(packageEntry.transport.type === "stdio", "server.json package transport must be stdio");
+  assertEnvironmentVariableContract(packageEntry.environmentVariables);
+
+  return normalizedMcpRegistryManifest(manifest);
+}
+
+export function assertMcpRegistryPackageJsonContract(packageJson, options = {}) {
+  const expectedVersion = options.expectedVersion ?? packageJson?.version;
+
+  assertRecord(packageJson, "package.json");
+  assert(packageJson.name === canonicalPackageName, `unexpected package name ${packageJson.name}`);
+  assert(packageJson.mcpName === canonicalMcpName, "package mcpName is not canonical");
+  assert(
+    packageJson.version === expectedVersion,
+    `package.json version ${packageJson.version} does not match ${expectedVersion}`,
+  );
+}
+
+export function verifyMcpRegistryManifestFiles({
+  serverJsonPath,
+  packageJsonPath,
+  expectedVersion,
+}) {
+  const manifest = readJsonFile(serverJsonPath);
+  const packageJson = readJsonFile(packageJsonPath);
+  assertMcpRegistryPackageJsonContract(packageJson, { expectedVersion });
+  const normalized = assertMcpRegistryManifestContract(manifest, { expectedVersion });
+  assert(
+    packageJson.mcpName === manifest.name,
+    "package.json mcpName does not match server.json name",
+  );
+  return { manifest, normalized, packageJson };
+}
+
+export function normalizedMcpRegistryManifest(manifest) {
+  const packageEntry = manifest.packages[0];
+  return {
+    $schema: manifest.$schema,
+    name: manifest.name,
+    title: manifest.title,
+    description: manifest.description,
+    websiteUrl: manifest.websiteUrl,
+    repository: {
+      url: manifest.repository.url,
+      source: manifest.repository.source,
+      id: manifest.repository.id,
+    },
+    version: manifest.version,
+    packages: [
+      {
+        registryType: packageEntry.registryType,
+        identifier: packageEntry.identifier,
+        version: packageEntry.version,
+        transport: { type: packageEntry.transport.type },
+        environmentVariables: expectedMcpRegistryEnvironmentVariables.map((expected) => {
+          const actual = packageEntry.environmentVariables.find(
+            (variable) => variable.name === expected.name,
+          );
+          return Object.fromEntries(Object.keys(expected).map((key) => [key, actual[key]]));
+        }),
+      },
+    ],
+  };
+}
+
+export function registryServerFromResponse(responseJson) {
+  return responseJson?.server ?? responseJson;
+}
+
+export function assertRegistryResponseMatchesManifest(responseJson, manifest) {
+  const expected = assertMcpRegistryManifestContract(manifest);
+  const fetchedServer = registryServerFromResponse(responseJson);
+  let actual;
+  try {
+    actual = assertMcpRegistryManifestContract(fetchedServer, {
+      expectedVersion: manifest.version,
+    });
+  } catch (error) {
+    throw new Error(
+      `MCP Registry version does not match local server.json: ${
+        error instanceof Error ? error.message : String(error)
+      }\nfetched=${JSON.stringify(fetchedServer)}`,
+    );
+  }
+  const expectedJson = JSON.stringify(expected);
+  const actualJson = JSON.stringify(actual);
+  assert(
+    actualJson === expectedJson,
+    `MCP Registry version does not match local server.json\nexpected=${expectedJson}\nactual=${actualJson}`,
+  );
+}
+
+export function mcpRegistryVersionUrl(manifest, baseUrl = mcpRegistryApiBaseUrl) {
+  assertRecord(manifest, "server.json");
+  assert(
+    typeof manifest.name === "string" && manifest.name.length > 0,
+    "server.json name is required",
+  );
+  assert(
+    typeof manifest.version === "string" && manifest.version.length > 0,
+    "server.json version is required",
+  );
+  const root = baseUrl.replace(/\/+$/, "");
+  return `${root}/servers/${encodeURIComponent(manifest.name)}/versions/${encodeURIComponent(manifest.version)}`;
+}
+
+export function isPrereleaseVersion(version) {
+  return String(version).includes("-");
+}

--- a/scripts/lib/mcp-registry-manifest.mjs
+++ b/scripts/lib/mcp-registry-manifest.mjs
@@ -96,7 +96,18 @@ function secretLikeB2EnvironmentVariable(name) {
   return name.startsWith("B2_") && /(CREDENTIAL|KEY|PASSWORD|SECRET|TOKEN)/.test(name);
 }
 
-function assertEnvironmentVariableContract(environmentVariables) {
+function normalizedEnvironmentVariableField(actual, field, expectedValue, options) {
+  if (
+    options.omittedFalseBooleansAsFalse &&
+    expectedValue === false &&
+    actual[field] === undefined
+  ) {
+    return false;
+  }
+  return actual[field];
+}
+
+function assertEnvironmentVariableContract(environmentVariables, options = {}) {
   assert(Array.isArray(environmentVariables), "server.json environmentVariables must be an array");
 
   const byName = new Map();
@@ -134,8 +145,9 @@ function assertEnvironmentVariableContract(environmentVariables) {
       `server.json environment variable ${expected.name}`,
     );
     for (const [field, expectedValue] of Object.entries(expected)) {
+      const actualValue = normalizedEnvironmentVariableField(actual, field, expectedValue, options);
       assert(
-        actual[field] === expectedValue,
+        actualValue === expectedValue,
         `server.json environment variable ${expected.name}.${field} must be ${JSON.stringify(expectedValue)}`,
       );
     }
@@ -192,9 +204,9 @@ export function assertMcpRegistryManifestContract(manifest, options = {}) {
   assertRecord(packageEntry.transport, "server.json package transport");
   assertOnlyKeys(packageEntry.transport, allowedTransportKeys, "server.json package transport");
   assert(packageEntry.transport.type === "stdio", "server.json package transport must be stdio");
-  assertEnvironmentVariableContract(packageEntry.environmentVariables);
+  assertEnvironmentVariableContract(packageEntry.environmentVariables, options);
 
-  return normalizedMcpRegistryManifest(manifest);
+  return normalizedMcpRegistryManifest(manifest, options);
 }
 
 export function assertMcpRegistryPackageJsonContract(packageJson, options = {}) {
@@ -225,7 +237,7 @@ export function verifyMcpRegistryManifestFiles({
   return { manifest, normalized, packageJson };
 }
 
-export function normalizedMcpRegistryManifest(manifest) {
+export function normalizedMcpRegistryManifest(manifest, options = {}) {
   const packageEntry = manifest.packages[0];
   return {
     $schema: manifest.$schema,
@@ -249,7 +261,12 @@ export function normalizedMcpRegistryManifest(manifest) {
           const actual = packageEntry.environmentVariables.find(
             (variable) => variable.name === expected.name,
           );
-          return Object.fromEntries(Object.keys(expected).map((key) => [key, actual[key]]));
+          return Object.fromEntries(
+            Object.entries(expected).map(([key, expectedValue]) => [
+              key,
+              normalizedEnvironmentVariableField(actual, key, expectedValue, options),
+            ]),
+          );
         }),
       },
     ],
@@ -266,6 +283,7 @@ export function assertRegistryResponseMatchesManifest(responseJson, manifest) {
   let actual;
   try {
     actual = assertMcpRegistryManifestContract(fetchedServer, {
+      omittedFalseBooleansAsFalse: true,
       expectedVersion: manifest.version,
     });
   } catch (error) {

--- a/scripts/lib/release-utils.mjs
+++ b/scripts/lib/release-utils.mjs
@@ -1,6 +1,14 @@
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 
+export const canonicalMcpName = "io.github.backblaze-labs/b2-mcp";
+export const canonicalPackageName = "@backblaze-labs/b2-mcp";
+export const canonicalPackageRepository = "git+https://github.com/backblaze-labs/b2-mcp.git";
+export const canonicalRepositoryId = "1241092911";
+export const canonicalRepositorySource = "github";
+export const canonicalRepositoryUrl = "https://github.com/backblaze-labs/b2-mcp";
+export const canonicalHomepage = "https://github.com/backblaze-labs/b2-mcp#readme";
+export const canonicalIssues = "https://github.com/backblaze-labs/b2-mcp/issues";
 export const defaultRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "../..");
 
 export function assert(condition, message) {

--- a/scripts/mcp-registry-publish.mjs
+++ b/scripts/mcp-registry-publish.mjs
@@ -139,6 +139,11 @@ function shouldRequeryAfterPublishFailure(result) {
   return isTransientMcpPublisherFailure(result) || isDuplicateVersionFailure(result);
 }
 
+function registryPublisherRootUrl(registryBaseUrl) {
+  const root = String(registryBaseUrl).replace(/\/+$/, "");
+  return root.endsWith("/v0") ? root.slice(0, -"/v0".length) : root;
+}
+
 async function defaultFetchText(url, { timeoutMs }) {
   const controller = new AbortController();
   const timer = setTimeout(
@@ -333,7 +338,16 @@ export async function publishMcpRegistry(options) {
     throw new Error(`MCP Registry lookup returned ${lookup.status}: ${lookup.body}`);
   }
 
-  await runPublisherWithRetry("login github-oidc", ["login", "github-oidc"], runtimeOptions);
+  await runPublisherWithRetry(
+    "login github-oidc",
+    [
+      "login",
+      "github-oidc",
+      "--registry",
+      registryPublisherRootUrl(runtimeOptions.registryBaseUrl),
+    ],
+    runtimeOptions,
+  );
   return publishWithRegistryRecheck(manifest, lookupUrl, runtimeOptions);
 }
 

--- a/scripts/mcp-registry-publish.mjs
+++ b/scripts/mcp-registry-publish.mjs
@@ -18,8 +18,11 @@ function usage() {
 }
 
 function parsePositiveInt(raw, name) {
-  const value = Number.parseInt(raw, 10);
-  if (!Number.isFinite(value) || value <= 0) throw new Error(`${name} must be a positive integer`);
+  if (!/^[1-9]\d*$/.test(String(raw ?? ""))) {
+    throw new Error(`${name} must be a positive integer`);
+  }
+  const value = Number(raw);
+  if (!Number.isSafeInteger(value)) throw new Error(`${name} must be a positive integer`);
   return value;
 }
 
@@ -120,6 +123,20 @@ function transientPublisherText(text) {
 export function isTransientMcpPublisherFailure(result) {
   if (result.timedOut || result.signal) return true;
   return transientPublisherText(`${result.stderr ?? ""}\n${result.stdout ?? ""}`);
+}
+
+function publisherOutput(result) {
+  return `${result.stderr ?? ""}\n${result.stdout ?? ""}`;
+}
+
+function isDuplicateVersionFailure(result) {
+  return /already exists|cannot publish duplicate version|duplicate version|version already exists/i.test(
+    publisherOutput(result),
+  );
+}
+
+function shouldRequeryAfterPublishFailure(result) {
+  return isTransientMcpPublisherFailure(result) || isDuplicateVersionFailure(result);
 }
 
 async function defaultFetchText(url, { timeoutMs }) {
@@ -230,6 +247,54 @@ async function runPublisherWithRetry(label, args, options) {
   );
 }
 
+async function registryVersionMatches(lookupUrl, manifest, options, context) {
+  const lookup = await lookupRegistryVersion(lookupUrl, options);
+  if (lookup.status === 200) {
+    const responseJson = JSON.parse(lookup.body);
+    assertRegistryResponseMatchesManifest(responseJson, manifest);
+    options.log.log(
+      `mcp-registry: ${manifest.name}@${manifest.version} exists and matches server.json after ${context}`,
+    );
+    return true;
+  }
+  if (lookup.status === 404) return false;
+  throw new Error(`MCP Registry lookup returned ${lookup.status}: ${lookup.body}`);
+}
+
+async function publishWithRegistryRecheck(manifest, lookupUrl, options) {
+  let lastResult = null;
+  for (let attempt = 1; attempt <= options.attempts; attempt += 1) {
+    const result = await options.runPublisher(["publish", options.serverJsonPath], {
+      publisherPath: options.publisherPath,
+      timeoutMs: options.publisherTimeoutMs,
+    });
+    lastResult = result;
+    if (result.stdout) process.stdout.write(result.stdout);
+    if (result.stderr) process.stderr.write(result.stderr);
+    if (result.code === 0) return { status: "published" };
+
+    if (shouldRequeryAfterPublishFailure(result)) {
+      const matched = await registryVersionMatches(
+        lookupUrl,
+        manifest,
+        options,
+        "ambiguous publish failure",
+      );
+      if (matched) return { status: "already-published" };
+    }
+
+    if (!isTransientMcpPublisherFailure(result) || attempt >= options.attempts) break;
+    options.log.warn(
+      `mcp-registry: publish failed transiently; retrying in ${options.initialDelayMs * attempt}ms`,
+    );
+    await options.sleep(options.initialDelayMs * attempt);
+  }
+
+  throw new Error(
+    `mcp-publisher publish failed after ${options.attempts} attempts with exit ${lastResult?.code ?? "unknown"}`,
+  );
+}
+
 export async function publishMcpRegistry(options) {
   const runtimeOptions = {
     attempts: 3,
@@ -269,12 +334,7 @@ export async function publishMcpRegistry(options) {
   }
 
   await runPublisherWithRetry("login github-oidc", ["login", "github-oidc"], runtimeOptions);
-  await runPublisherWithRetry(
-    "publish",
-    ["publish", runtimeOptions.serverJsonPath],
-    runtimeOptions,
-  );
-  return { status: "published" };
+  return publishWithRegistryRecheck(manifest, lookupUrl, runtimeOptions);
 }
 
 async function main() {

--- a/scripts/mcp-registry-publish.mjs
+++ b/scripts/mcp-registry-publish.mjs
@@ -114,9 +114,19 @@ function isTransientHttpStatus(status) {
   return status === 408 || status === 409 || status === 425 || status === 429 || status >= 500;
 }
 
+function isRegistryNpmPropagationDelay(text) {
+  return (
+    /\b404\b/.test(text) &&
+    /newly published release can take a moment to appear\.\s*wait and retry/i.test(text)
+  );
+}
+
 function transientPublisherText(text) {
-  return /\b(408|409|425|429|5\d\d)\b|bad gateway|connection reset|dns|econnreset|econnrefused|etimedout|gateway timeout|i\/o timeout|network|no such host|service unavailable|temporary|timeout|too many requests/i.test(
-    text,
+  return (
+    isRegistryNpmPropagationDelay(text) ||
+    /\b(408|409|425|429|5\d\d)\b|bad gateway|connection reset|dns|econnreset|econnrefused|etimedout|gateway timeout|i\/o timeout|network|no such host|service unavailable|temporary|timeout|too many requests/i.test(
+      text,
+    )
   );
 }
 

--- a/scripts/mcp-registry-publish.mjs
+++ b/scripts/mcp-registry-publish.mjs
@@ -1,0 +1,308 @@
+#!/usr/bin/env node
+import { readFileSync } from "node:fs";
+import { spawn } from "node:child_process";
+import { pathToFileURL } from "node:url";
+import {
+  assertMcpRegistryManifestContract,
+  assertRegistryResponseMatchesManifest,
+  isPrereleaseVersion,
+  mcpRegistryApiBaseUrl,
+  mcpRegistryVersionUrl,
+} from "./lib/mcp-registry-manifest.mjs";
+
+function usage() {
+  return [
+    "Usage: node scripts/mcp-registry-publish.mjs",
+    "--server-json <path> --publisher <path> --version <version> [--skip-prerelease]",
+  ].join(" ");
+}
+
+function parsePositiveInt(raw, name) {
+  const value = Number.parseInt(raw, 10);
+  if (!Number.isFinite(value) || value <= 0) throw new Error(`${name} must be a positive integer`);
+  return value;
+}
+
+function parseArgs(argv) {
+  const options = {
+    attempts: 3,
+    initialDelayMs: 5000,
+    lookupTimeoutMs: 30000,
+    publisherPath: "",
+    publisherTimeoutMs: 120000,
+    registryBaseUrl: mcpRegistryApiBaseUrl,
+    serverJsonPath: "",
+    skipPrerelease: false,
+    version: "",
+  };
+
+  for (let index = 0; index < argv.length; index += 1) {
+    const arg = argv[index];
+    if (arg === "--help") {
+      console.log(usage());
+      process.exit(0);
+    }
+    if (arg === "--server-json") {
+      const value = argv[index + 1];
+      if (!value) throw new Error("--server-json requires a value");
+      options.serverJsonPath = value;
+      index += 1;
+      continue;
+    }
+    if (arg === "--publisher") {
+      const value = argv[index + 1];
+      if (!value) throw new Error("--publisher requires a value");
+      options.publisherPath = value;
+      index += 1;
+      continue;
+    }
+    if (arg === "--version") {
+      const value = argv[index + 1];
+      if (!value) throw new Error("--version requires a value");
+      options.version = value;
+      index += 1;
+      continue;
+    }
+    if (arg === "--registry-base-url") {
+      const value = argv[index + 1];
+      if (!value) throw new Error("--registry-base-url requires a value");
+      options.registryBaseUrl = value;
+      index += 1;
+      continue;
+    }
+    if (arg === "--attempts") {
+      options.attempts = parsePositiveInt(argv[index + 1], "--attempts");
+      index += 1;
+      continue;
+    }
+    if (arg === "--initial-delay-ms") {
+      options.initialDelayMs = parsePositiveInt(argv[index + 1], "--initial-delay-ms");
+      index += 1;
+      continue;
+    }
+    if (arg === "--lookup-timeout-ms") {
+      options.lookupTimeoutMs = parsePositiveInt(argv[index + 1], "--lookup-timeout-ms");
+      index += 1;
+      continue;
+    }
+    if (arg === "--publisher-timeout-ms") {
+      options.publisherTimeoutMs = parsePositiveInt(argv[index + 1], "--publisher-timeout-ms");
+      index += 1;
+      continue;
+    }
+    if (arg === "--skip-prerelease") {
+      options.skipPrerelease = true;
+      continue;
+    }
+    throw new Error(`unknown argument ${arg}`);
+  }
+
+  if (!options.serverJsonPath) throw new Error("--server-json is required");
+  if (!options.publisherPath) throw new Error("--publisher is required");
+  if (!options.version) throw new Error("--version is required");
+  return options;
+}
+
+function sleep(ms) {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+function isTransientHttpStatus(status) {
+  return status === 408 || status === 409 || status === 425 || status === 429 || status >= 500;
+}
+
+function transientPublisherText(text) {
+  return /\b(408|409|425|429|5\d\d)\b|bad gateway|connection reset|dns|econnreset|econnrefused|etimedout|gateway timeout|i\/o timeout|network|no such host|service unavailable|temporary|timeout|too many requests/i.test(
+    text,
+  );
+}
+
+export function isTransientMcpPublisherFailure(result) {
+  if (result.timedOut || result.signal) return true;
+  return transientPublisherText(`${result.stderr ?? ""}\n${result.stdout ?? ""}`);
+}
+
+async function defaultFetchText(url, { timeoutMs }) {
+  const controller = new AbortController();
+  const timer = setTimeout(
+    () => controller.abort(new Error(`timed out after ${timeoutMs}ms`)),
+    timeoutMs,
+  );
+  try {
+    const response = await fetch(url, { signal: controller.signal });
+    return { body: await response.text(), status: response.status };
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+async function lookupRegistryVersion(url, options) {
+  let lastError = null;
+  for (let attempt = 1; attempt <= options.attempts; attempt += 1) {
+    try {
+      const response = await options.fetchText(url, { timeoutMs: options.lookupTimeoutMs });
+      if (isTransientHttpStatus(response.status) && attempt < options.attempts) {
+        options.log.warn(
+          `mcp-registry: lookup returned ${response.status}; retrying in ${options.initialDelayMs * attempt}ms`,
+        );
+        await options.sleep(options.initialDelayMs * attempt);
+        continue;
+      }
+      return response;
+    } catch (error) {
+      lastError = error;
+      if (attempt >= options.attempts) break;
+      options.log.warn(
+        `mcp-registry: lookup failed (${error instanceof Error ? error.message : String(error)}); retrying in ${
+          options.initialDelayMs * attempt
+        }ms`,
+      );
+      await options.sleep(options.initialDelayMs * attempt);
+    }
+  }
+  throw new Error(
+    `MCP Registry lookup failed after ${options.attempts} attempts: ${
+      lastError instanceof Error ? lastError.message : String(lastError)
+    }`,
+  );
+}
+
+async function defaultRunPublisher(args, { publisherPath, timeoutMs }) {
+  return new Promise((resolve) => {
+    const child = spawn(publisherPath, args, { stdio: ["ignore", "pipe", "pipe"] });
+    let stdout = "";
+    let stderr = "";
+    let timedOut = false;
+    let forceKillTimer = null;
+    const timer = setTimeout(() => {
+      timedOut = true;
+      child.kill("SIGTERM");
+      forceKillTimer = setTimeout(() => {
+        child.kill("SIGKILL");
+      }, 5000);
+    }, timeoutMs);
+
+    const clearTimers = () => {
+      clearTimeout(timer);
+      if (forceKillTimer) clearTimeout(forceKillTimer);
+    };
+
+    child.stdout.setEncoding("utf8");
+    child.stderr.setEncoding("utf8");
+    child.stdout.on("data", (chunk) => {
+      stdout += chunk;
+    });
+    child.stderr.on("data", (chunk) => {
+      stderr += chunk;
+    });
+    child.on("error", (error) => {
+      clearTimers();
+      resolve({ code: 1, stderr: error.message, stdout, timedOut });
+    });
+    child.on("close", (code, signal) => {
+      clearTimers();
+      resolve({ code, signal, stderr, stdout, timedOut });
+    });
+  });
+}
+
+async function runPublisherWithRetry(label, args, options) {
+  let lastResult = null;
+  for (let attempt = 1; attempt <= options.attempts; attempt += 1) {
+    const result = await options.runPublisher(args, {
+      publisherPath: options.publisherPath,
+      timeoutMs: options.publisherTimeoutMs,
+    });
+    lastResult = result;
+    if (result.stdout) process.stdout.write(result.stdout);
+    if (result.stderr) process.stderr.write(result.stderr);
+    if (result.code === 0) return result;
+
+    if (!isTransientMcpPublisherFailure(result) || attempt >= options.attempts) break;
+    options.log.warn(
+      `mcp-registry: ${label} failed transiently; retrying in ${options.initialDelayMs * attempt}ms`,
+    );
+    await options.sleep(options.initialDelayMs * attempt);
+  }
+
+  throw new Error(
+    `mcp-publisher ${label} failed after ${options.attempts} attempts with exit ${lastResult?.code ?? "unknown"}`,
+  );
+}
+
+export async function publishMcpRegistry(options) {
+  const runtimeOptions = {
+    attempts: 3,
+    fetchText: defaultFetchText,
+    initialDelayMs: 5000,
+    log: console,
+    lookupTimeoutMs: 30000,
+    publisherTimeoutMs: 120000,
+    registryBaseUrl: mcpRegistryApiBaseUrl,
+    runPublisher: defaultRunPublisher,
+    skipPrerelease: false,
+    sleep,
+    ...options,
+  };
+  const manifest = JSON.parse(readFileSync(runtimeOptions.serverJsonPath, "utf8"));
+  assertMcpRegistryManifestContract(manifest, { expectedVersion: runtimeOptions.version });
+
+  if (runtimeOptions.skipPrerelease && isPrereleaseVersion(runtimeOptions.version)) {
+    runtimeOptions.log.log(
+      `mcp-registry: skipping prerelease ${manifest.name}@${runtimeOptions.version}`,
+    );
+    return { status: "skipped-prerelease" };
+  }
+
+  const lookupUrl = mcpRegistryVersionUrl(manifest, runtimeOptions.registryBaseUrl);
+  const lookup = await lookupRegistryVersion(lookupUrl, runtimeOptions);
+  if (lookup.status === 200) {
+    const responseJson = JSON.parse(lookup.body);
+    assertRegistryResponseMatchesManifest(responseJson, manifest);
+    runtimeOptions.log.log(
+      `mcp-registry: ${manifest.name}@${manifest.version} already exists and matches server.json`,
+    );
+    return { status: "already-published" };
+  }
+  if (lookup.status !== 404) {
+    throw new Error(`MCP Registry lookup returned ${lookup.status}: ${lookup.body}`);
+  }
+
+  await runPublisherWithRetry("login github-oidc", ["login", "github-oidc"], runtimeOptions);
+  await runPublisherWithRetry(
+    "publish",
+    ["publish", runtimeOptions.serverJsonPath],
+    runtimeOptions,
+  );
+  return { status: "published" };
+}
+
+async function main() {
+  const args = parseArgs(process.argv.slice(2));
+  const result = await publishMcpRegistry({
+    attempts: args.attempts,
+    fetchText: defaultFetchText,
+    initialDelayMs: args.initialDelayMs,
+    log: console,
+    lookupTimeoutMs: args.lookupTimeoutMs,
+    publisherPath: args.publisherPath,
+    publisherTimeoutMs: args.publisherTimeoutMs,
+    registryBaseUrl: args.registryBaseUrl,
+    runPublisher: defaultRunPublisher,
+    serverJsonPath: args.serverJsonPath,
+    skipPrerelease: args.skipPrerelease,
+    sleep,
+    version: args.version,
+  });
+  console.log(`mcp-registry: ${result.status}`);
+}
+
+if (import.meta.url === pathToFileURL(process.argv[1]).href) {
+  try {
+    await main();
+  } catch (error) {
+    console.error(`mcp-registry: ${error instanceof Error ? error.message : String(error)}`);
+    console.error(usage());
+    process.exit(2);
+  }
+}

--- a/scripts/mcp-registry-publish.mjs
+++ b/scripts/mcp-registry-publish.mjs
@@ -117,7 +117,9 @@ function isTransientHttpStatus(status) {
 function isRegistryNpmPropagationDelay(text) {
   return (
     /\b404\b/.test(text) &&
-    /newly published release can take a moment to appear\.\s*wait and retry/i.test(text)
+    /newly published release can take a moment to appear on the registry\.\s*wait and retry/i.test(
+      text,
+    )
   );
 }
 

--- a/scripts/mcp-registry-publish.mjs
+++ b/scripts/mcp-registry-publish.mjs
@@ -129,6 +129,10 @@ function publisherOutput(result) {
   return `${result.stderr ?? ""}\n${result.stdout ?? ""}`;
 }
 
+function attemptCountText(count) {
+  return `${count} attempt${count === 1 ? "" : "s"}`;
+}
+
 function isDuplicateVersionFailure(result) {
   return /already exists|cannot publish duplicate version|duplicate version|version already exists/i.test(
     publisherOutput(result),
@@ -230,7 +234,9 @@ async function defaultRunPublisher(args, { publisherPath, timeoutMs }) {
 
 async function runPublisherWithRetry(label, args, options) {
   let lastResult = null;
+  let attemptsRun = 0;
   for (let attempt = 1; attempt <= options.attempts; attempt += 1) {
+    attemptsRun = attempt;
     const result = await options.runPublisher(args, {
       publisherPath: options.publisherPath,
       timeoutMs: options.publisherTimeoutMs,
@@ -248,7 +254,7 @@ async function runPublisherWithRetry(label, args, options) {
   }
 
   throw new Error(
-    `mcp-publisher ${label} failed after ${options.attempts} attempts with exit ${lastResult?.code ?? "unknown"}`,
+    `mcp-publisher ${label} failed after ${attemptCountText(attemptsRun)} with exit ${lastResult?.code ?? "unknown"}`,
   );
 }
 
@@ -268,7 +274,9 @@ async function registryVersionMatches(lookupUrl, manifest, options, context) {
 
 async function publishWithRegistryRecheck(manifest, lookupUrl, options) {
   let lastResult = null;
+  let attemptsRun = 0;
   for (let attempt = 1; attempt <= options.attempts; attempt += 1) {
+    attemptsRun = attempt;
     const result = await options.runPublisher(["publish", options.serverJsonPath], {
       publisherPath: options.publisherPath,
       timeoutMs: options.publisherTimeoutMs,
@@ -296,7 +304,7 @@ async function publishWithRegistryRecheck(manifest, lookupUrl, options) {
   }
 
   throw new Error(
-    `mcp-publisher publish failed after ${options.attempts} attempts with exit ${lastResult?.code ?? "unknown"}`,
+    `mcp-publisher publish failed after ${attemptCountText(attemptsRun)} with exit ${lastResult?.code ?? "unknown"}`,
   );
 }
 

--- a/scripts/update-server-json-version.mjs
+++ b/scripts/update-server-json-version.mjs
@@ -2,9 +2,13 @@
 import { readFileSync, writeFileSync } from "node:fs";
 import path from "node:path";
 import { pathToFileURL } from "node:url";
-import { assert, releaseRoot } from "./lib/release-utils.mjs";
-
-const canonicalServerName = "io.github.backblaze-labs/b2-mcp";
+import { assertMcpRegistryManifestContract } from "./lib/mcp-registry-manifest.mjs";
+import {
+  assert,
+  canonicalMcpName,
+  canonicalPackageName,
+  releaseRoot,
+} from "./lib/release-utils.mjs";
 
 function readJson(root, relativePath) {
   return JSON.parse(readFileSync(path.join(root, relativePath), "utf8"));
@@ -15,12 +19,9 @@ export function updateServerJsonVersion(root) {
   const serverJsonPath = path.join(root, "server.json");
   const serverJson = readJson(root, "server.json");
 
-  assert(
-    packageJson.name === "@backblaze-labs/b2-mcp",
-    `unexpected package name ${packageJson.name}`,
-  );
-  assert(packageJson.mcpName === canonicalServerName, "package.json mcpName is not canonical");
-  assert(serverJson.name === canonicalServerName, "server.json name is not canonical");
+  assert(packageJson.name === canonicalPackageName, `unexpected package name ${packageJson.name}`);
+  assert(packageJson.mcpName === canonicalMcpName, "package.json mcpName is not canonical");
+  assert(serverJson.name === canonicalMcpName, "server.json name is not canonical");
 
   serverJson.version = packageJson.version;
   let packageUpdated = false;
@@ -31,6 +32,7 @@ export function updateServerJsonVersion(root) {
     }
   }
   assert(packageUpdated, `server.json is missing npm package ${packageJson.name}`);
+  assertMcpRegistryManifestContract(serverJson, { expectedVersion: packageJson.version });
 
   writeFileSync(serverJsonPath, `${JSON.stringify(serverJson, null, 2)}\n`);
   return { name: serverJson.name, version: serverJson.version };

--- a/scripts/update-server-json-version.mjs
+++ b/scripts/update-server-json-version.mjs
@@ -1,0 +1,51 @@
+#!/usr/bin/env node
+import { readFileSync, writeFileSync } from "node:fs";
+import path from "node:path";
+import { pathToFileURL } from "node:url";
+import { assert, releaseRoot } from "./lib/release-utils.mjs";
+
+const canonicalServerName = "io.github.backblaze-labs/b2-mcp";
+
+function readJson(root, relativePath) {
+  return JSON.parse(readFileSync(path.join(root, relativePath), "utf8"));
+}
+
+export function updateServerJsonVersion(root) {
+  const packageJson = readJson(root, "package.json");
+  const serverJsonPath = path.join(root, "server.json");
+  const serverJson = readJson(root, "server.json");
+
+  assert(
+    packageJson.name === "@backblaze-labs/b2-mcp",
+    `unexpected package name ${packageJson.name}`,
+  );
+  assert(packageJson.mcpName === canonicalServerName, "package.json mcpName is not canonical");
+  assert(serverJson.name === canonicalServerName, "server.json name is not canonical");
+
+  serverJson.version = packageJson.version;
+  let packageUpdated = false;
+  for (const pkg of serverJson.packages ?? []) {
+    if (pkg.registryType === "npm" && pkg.identifier === packageJson.name) {
+      pkg.version = packageJson.version;
+      packageUpdated = true;
+    }
+  }
+  assert(packageUpdated, `server.json is missing npm package ${packageJson.name}`);
+
+  writeFileSync(serverJsonPath, `${JSON.stringify(serverJson, null, 2)}\n`);
+  return { name: serverJson.name, version: serverJson.version };
+}
+
+function main() {
+  const result = updateServerJsonVersion(releaseRoot());
+  console.log(`server-json-version: updated ${result.name}@${result.version}`);
+}
+
+if (import.meta.url === pathToFileURL(process.argv[1]).href) {
+  try {
+    main();
+  } catch (error) {
+    console.error(`server-json-version: ${error instanceof Error ? error.message : String(error)}`);
+    process.exit(2);
+  }
+}

--- a/scripts/verify-mcp-registry-manifest.mjs
+++ b/scripts/verify-mcp-registry-manifest.mjs
@@ -1,0 +1,83 @@
+#!/usr/bin/env node
+import { pathToFileURL } from "node:url";
+import { verifyMcpRegistryManifestFiles } from "./lib/mcp-registry-manifest.mjs";
+
+function usage() {
+  return [
+    "Usage: node scripts/verify-mcp-registry-manifest.mjs",
+    "--server-json <path> --package-json <path> --version <version>",
+  ].join(" ");
+}
+
+function parseArgs(argv) {
+  const options = { packageJsonPath: "", serverJsonPath: "", version: "" };
+
+  for (let index = 0; index < argv.length; index += 1) {
+    const arg = argv[index];
+    if (arg === "--help") {
+      console.log(usage());
+      process.exit(0);
+    }
+    if (arg === "--package-json") {
+      const value = argv[index + 1];
+      if (!value) throw new Error("--package-json requires a value");
+      options.packageJsonPath = value;
+      index += 1;
+      continue;
+    }
+    if (arg.startsWith("--package-json=")) {
+      options.packageJsonPath = arg.slice("--package-json=".length);
+      continue;
+    }
+    if (arg === "--server-json") {
+      const value = argv[index + 1];
+      if (!value) throw new Error("--server-json requires a value");
+      options.serverJsonPath = value;
+      index += 1;
+      continue;
+    }
+    if (arg.startsWith("--server-json=")) {
+      options.serverJsonPath = arg.slice("--server-json=".length);
+      continue;
+    }
+    if (arg === "--version") {
+      const value = argv[index + 1];
+      if (!value) throw new Error("--version requires a value");
+      options.version = value;
+      index += 1;
+      continue;
+    }
+    if (arg.startsWith("--version=")) {
+      options.version = arg.slice("--version=".length);
+      continue;
+    }
+    throw new Error(`unknown argument ${arg}`);
+  }
+
+  if (!options.packageJsonPath) throw new Error("--package-json is required");
+  if (!options.serverJsonPath) throw new Error("--server-json is required");
+  if (!options.version) throw new Error("--version is required");
+  return options;
+}
+
+function main() {
+  const options = parseArgs(process.argv.slice(2));
+  const { manifest } = verifyMcpRegistryManifestFiles({
+    serverJsonPath: options.serverJsonPath,
+    packageJsonPath: options.packageJsonPath,
+    expectedVersion: options.version,
+  });
+  console.log(`mcp-registry-manifest: verified ${manifest.name}@${manifest.version}`);
+}
+
+if (import.meta.url === pathToFileURL(process.argv[1]).href) {
+  try {
+    main();
+  } catch (error) {
+    console.error(
+      `mcp-registry-manifest: ${error instanceof Error ? error.message : String(error)}`,
+    );
+    console.error(usage());
+    process.exit(2);
+  }
+}

--- a/scripts/verify-release-input.mjs
+++ b/scripts/verify-release-input.mjs
@@ -3,13 +3,16 @@ import { readFileSync } from "node:fs";
 import path from "node:path";
 import { pathToFileURL } from "node:url";
 import { extractReleaseNotesFromRoot } from "./extract-release-notes.mjs";
-import { assert, releaseRoot } from "./lib/release-utils.mjs";
+import { verifyMcpRegistryManifestFiles } from "./lib/mcp-registry-manifest.mjs";
+import {
+  assert,
+  canonicalHomepage,
+  canonicalIssues,
+  canonicalPackageName,
+  canonicalPackageRepository,
+  releaseRoot,
+} from "./lib/release-utils.mjs";
 
-const canonicalRepository = "git+https://github.com/backblaze-labs/b2-mcp.git";
-const canonicalIssues = "https://github.com/backblaze-labs/b2-mcp/issues";
-const canonicalHomepage = "https://github.com/backblaze-labs/b2-mcp#readme";
-const canonicalMcpName = "io.github.backblaze-labs/b2-mcp";
-const canonicalPackageName = "@backblaze-labs/b2-mcp";
 const forbiddenDependencies = new Set(["axios", "@modelcontextprotocol/sdk"]);
 const requiredFiles = new Set([
   "dist/**/*",
@@ -58,33 +61,24 @@ function readJson(root, relativePath) {
 
 export function verifyReleaseInput(root, tag) {
   const pkg = readJson(root, "package.json");
-  const serverJson = readJson(root, "server.json");
   const runtimePolicy = readJson(root, "runtime-policy.json");
   const expectedTag = `v${pkg.version}`;
 
   assert(tag === expectedTag, `release tag ${tag} does not match package version ${pkg.version}`);
   extractReleaseNotesFromRoot(root, pkg.version);
   assert(pkg.name === canonicalPackageName, `unexpected package name ${pkg.name}`);
-  assert(pkg.mcpName === canonicalMcpName, "package mcpName is not canonical");
   assert(pkg.license === "MIT", "package license must be MIT");
-  assert(pkg.repository?.url === canonicalRepository, "package repository URL is not canonical");
+  assert(
+    pkg.repository?.url === canonicalPackageRepository,
+    "package repository URL is not canonical",
+  );
   assert(pkg.bugs?.url === canonicalIssues, "package bugs URL is not canonical");
   assert(pkg.homepage === canonicalHomepage, "package homepage is not canonical");
-  assert(serverJson.name === canonicalMcpName, "server.json name is not canonical");
-  assert(
-    serverJson.version === pkg.version,
-    `server.json version ${serverJson.version} does not match package version ${pkg.version}`,
-  );
-  const serverJsonPackage = (serverJson.packages ?? []).find(
-    (registryPackage) =>
-      registryPackage?.registryType === "npm" &&
-      registryPackage?.identifier === canonicalPackageName,
-  );
-  assert(!!serverJsonPackage, `server.json is missing npm package ${canonicalPackageName}`);
-  assert(
-    serverJsonPackage.version === pkg.version,
-    `server.json npm package version ${serverJsonPackage.version} does not match package version ${pkg.version}`,
-  );
+  verifyMcpRegistryManifestFiles({
+    serverJsonPath: path.join(root, "server.json"),
+    packageJsonPath: path.join(root, "package.json"),
+    expectedVersion: pkg.version,
+  });
   assert(
     pkg.engines?.node === runtimePolicy.engineRange,
     `package engine range must be ${runtimePolicy.engineRange}`,

--- a/scripts/verify-release-input.mjs
+++ b/scripts/verify-release-input.mjs
@@ -8,6 +8,8 @@ import { assert, releaseRoot } from "./lib/release-utils.mjs";
 const canonicalRepository = "git+https://github.com/backblaze-labs/b2-mcp.git";
 const canonicalIssues = "https://github.com/backblaze-labs/b2-mcp/issues";
 const canonicalHomepage = "https://github.com/backblaze-labs/b2-mcp#readme";
+const canonicalMcpName = "io.github.backblaze-labs/b2-mcp";
+const canonicalPackageName = "@backblaze-labs/b2-mcp";
 const forbiddenDependencies = new Set(["axios", "@modelcontextprotocol/sdk"]);
 const requiredFiles = new Set([
   "dist/**/*",
@@ -56,16 +58,33 @@ function readJson(root, relativePath) {
 
 export function verifyReleaseInput(root, tag) {
   const pkg = readJson(root, "package.json");
+  const serverJson = readJson(root, "server.json");
   const runtimePolicy = readJson(root, "runtime-policy.json");
   const expectedTag = `v${pkg.version}`;
 
   assert(tag === expectedTag, `release tag ${tag} does not match package version ${pkg.version}`);
   extractReleaseNotesFromRoot(root, pkg.version);
-  assert(pkg.name === "@backblaze-labs/b2-mcp", `unexpected package name ${pkg.name}`);
+  assert(pkg.name === canonicalPackageName, `unexpected package name ${pkg.name}`);
+  assert(pkg.mcpName === canonicalMcpName, "package mcpName is not canonical");
   assert(pkg.license === "MIT", "package license must be MIT");
   assert(pkg.repository?.url === canonicalRepository, "package repository URL is not canonical");
   assert(pkg.bugs?.url === canonicalIssues, "package bugs URL is not canonical");
   assert(pkg.homepage === canonicalHomepage, "package homepage is not canonical");
+  assert(serverJson.name === canonicalMcpName, "server.json name is not canonical");
+  assert(
+    serverJson.version === pkg.version,
+    `server.json version ${serverJson.version} does not match package version ${pkg.version}`,
+  );
+  const serverJsonPackage = (serverJson.packages ?? []).find(
+    (registryPackage) =>
+      registryPackage?.registryType === "npm" &&
+      registryPackage?.identifier === canonicalPackageName,
+  );
+  assert(!!serverJsonPackage, `server.json is missing npm package ${canonicalPackageName}`);
+  assert(
+    serverJsonPackage.version === pkg.version,
+    `server.json npm package version ${serverJsonPackage.version} does not match package version ${pkg.version}`,
+  );
   assert(
     pkg.engines?.node === runtimePolicy.engineRange,
     `package engine range must be ${runtimePolicy.engineRange}`,

--- a/server.json
+++ b/server.json
@@ -1,0 +1,61 @@
+{
+  "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
+  "name": "io.github.backblaze-labs/b2-mcp",
+  "title": "Backblaze B2 MCP Server",
+  "description": "Operate Backblaze B2 buckets, files, keys, Object Lock, and S3-compatible storage.",
+  "websiteUrl": "https://github.com/backblaze-labs/b2-mcp#readme",
+  "repository": {
+    "url": "https://github.com/backblaze-labs/b2-mcp",
+    "source": "github",
+    "id": "1241092911"
+  },
+  "version": "0.1.2",
+  "packages": [
+    {
+      "registryType": "npm",
+      "identifier": "@backblaze-labs/b2-mcp",
+      "version": "0.1.2",
+      "transport": {
+        "type": "stdio"
+      },
+      "environmentVariables": [
+        {
+          "description": "Backblaze B2 application key ID for native B2 and S3-compatible tools.",
+          "isRequired": true,
+          "format": "string",
+          "isSecret": true,
+          "name": "B2_APPLICATION_KEY_ID"
+        },
+        {
+          "description": "Backblaze B2 application key secret.",
+          "isRequired": true,
+          "format": "string",
+          "isSecret": true,
+          "name": "B2_APPLICATION_KEY"
+        },
+        {
+          "description": "Optional fallback S3-compatible region used before authorization.",
+          "isRequired": false,
+          "format": "string",
+          "isSecret": false,
+          "placeholder": "us-east-005",
+          "name": "B2_REGION"
+        },
+        {
+          "description": "Optional master key ID for Partner/Groups API tools.",
+          "isRequired": false,
+          "format": "string",
+          "isSecret": true,
+          "name": "B2_MASTER_KEY_ID"
+        },
+        {
+          "description": "Optional master key secret for Partner/Groups API tools.",
+          "isRequired": false,
+          "format": "string",
+          "isSecret": true,
+          "name": "B2_MASTER_KEY"
+        }
+      ]
+    }
+  ]
+}

--- a/tests/contract/ci-workflow-policy.contract.test.ts
+++ b/tests/contract/ci-workflow-policy.contract.test.ts
@@ -487,11 +487,12 @@ describe("CI workflow policy", () => {
 
   it("blocks publishing until the live contract suite passes for the publish ref", () => {
     const liveContract = workflowJobBlock(publish, "live-contract") ?? "";
+    const mcpRegistryPreflight = workflowJobBlock(publish, "mcp-registry-preflight") ?? "";
     const githubReleaseJob = workflowJobBlock(publish, "github-release") ?? "";
     const containerImageJob = workflowJobBlock(publish, "container-image") ?? "";
     const publishJob = workflowJobBlock(publish, "publish") ?? "";
 
-    expect(publishJob).toContain("needs: [prepare, live-contract]");
+    expect(publishJob).toContain("needs: [prepare, live-contract, mcp-registry-preflight]");
     expect(containerImageJob).toContain("needs: [prepare, publish]");
     expect(containerImageJob).not.toContain("environment: ghcr-publish");
     expect(containerImageJob).toContain("ghcr.io/${{ github.repository }}");
@@ -512,6 +513,7 @@ describe("CI workflow policy", () => {
     expect(liveContract).not.toContain("secrets: inherit");
     expect(liveContract).not.toContain("for attempt in 1 2 3");
     expect(liveContract).not.toContain("retrying");
+    expect(mcpRegistryPreflight).toContain("needs: prepare");
     expect(publish).toContain("github-release:");
   });
 });

--- a/tests/unit/release-scripts.unit.test.ts
+++ b/tests/unit/release-scripts.unit.test.ts
@@ -531,7 +531,7 @@ describe("release scripts", () => {
   it("retries only explicit MCP Registry npm propagation 404s", async () => {
     const { isTransientMcpPublisherFailure, publishMcpRegistry } = await mcpRegistryPublishModule();
     const propagationMessage =
-      "404: A newly published release can take a moment to appear. Wait and retry.";
+      "404: A newly published release can take a moment to appear on the registry. Wait and retry...";
 
     expect(isTransientMcpPublisherFailure({ stderr: propagationMessage, stdout: "" })).toBe(true);
     expect(isTransientMcpPublisherFailure({ stderr: "404: package not found", stdout: "" })).toBe(

--- a/tests/unit/release-scripts.unit.test.ts
+++ b/tests/unit/release-scripts.unit.test.ts
@@ -16,10 +16,27 @@ type RegistryMetadataModule = {
   leakedRegistryMetadataKeys: (metadata: unknown) => string[];
 };
 
+type McpRegistryPublishModule = {
+  publishMcpRegistry: (options: Record<string, unknown>) => Promise<Record<string, unknown>>;
+};
+
+type McpRegistryManifest = Record<string, any>;
+type McpPublisherRun = {
+  args: string[];
+  publisherPath?: string;
+  timeoutMs?: number;
+};
+
 async function registryMetadataModule(): Promise<RegistryMetadataModule> {
   return (await import(
     "../../scripts/verify-npm-registry-metadata.mjs"
   )) as unknown as RegistryMetadataModule;
+}
+
+async function mcpRegistryPublishModule(): Promise<McpRegistryPublishModule> {
+  return (await import(
+    "../../scripts/mcp-registry-publish.mjs"
+  )) as unknown as McpRegistryPublishModule;
 }
 
 function runGit(cwd: string, args: string[]): string {
@@ -72,7 +89,15 @@ function withFixture(run: (fixtureRoot: string) => void): void {
         {
           $schema: "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
           name: "io.github.backblaze-labs/b2-mcp",
-          description: "Operate Backblaze B2 buckets and S3-compatible storage.",
+          title: "Backblaze B2 MCP Server",
+          description:
+            "Operate Backblaze B2 buckets, files, keys, Object Lock, and S3-compatible storage.",
+          websiteUrl: "https://github.com/backblaze-labs/b2-mcp#readme",
+          repository: {
+            url: "https://github.com/backblaze-labs/b2-mcp",
+            source: "github",
+            id: "1241092911",
+          },
           version: "0.1.0",
           packages: [
             {
@@ -80,6 +105,45 @@ function withFixture(run: (fixtureRoot: string) => void): void {
               identifier: "@backblaze-labs/b2-mcp",
               version: "0.1.0",
               transport: { type: "stdio" },
+              environmentVariables: [
+                {
+                  description:
+                    "Backblaze B2 application key ID for native B2 and S3-compatible tools.",
+                  isRequired: true,
+                  format: "string",
+                  isSecret: true,
+                  name: "B2_APPLICATION_KEY_ID",
+                },
+                {
+                  description: "Backblaze B2 application key secret.",
+                  isRequired: true,
+                  format: "string",
+                  isSecret: true,
+                  name: "B2_APPLICATION_KEY",
+                },
+                {
+                  description: "Optional fallback S3-compatible region used before authorization.",
+                  isRequired: false,
+                  format: "string",
+                  isSecret: false,
+                  placeholder: "us-east-005",
+                  name: "B2_REGION",
+                },
+                {
+                  description: "Optional master key ID for Partner/Groups API tools.",
+                  isRequired: false,
+                  format: "string",
+                  isSecret: true,
+                  name: "B2_MASTER_KEY_ID",
+                },
+                {
+                  description: "Optional master key secret for Partner/Groups API tools.",
+                  isRequired: false,
+                  format: "string",
+                  isSecret: true,
+                  name: "B2_MASTER_KEY",
+                },
+              ],
             },
           ],
         },
@@ -116,6 +180,34 @@ function withFixture(run: (fixtureRoot: string) => void): void {
 
 function scriptEnv(fixtureRoot: string): NodeJS.ProcessEnv {
   return { ...process.env, NODE_ENV: "test", B2_MCP_RELEASE_ROOT: fixtureRoot };
+}
+
+function readFixtureServerJson(fixtureRoot: string): Record<string, any> {
+  return JSON.parse(readFileSync(join(fixtureRoot, "server.json"), "utf8"));
+}
+
+function writeFixtureServerJson(fixtureRoot: string, manifest: Record<string, any>): void {
+  writeFileSync(join(fixtureRoot, "server.json"), JSON.stringify(manifest, null, 2));
+}
+
+async function withTempManifest(
+  mutate: (manifest: McpRegistryManifest) => void,
+  run: (manifestPath: string, manifest: McpRegistryManifest) => Promise<void>,
+): Promise<void> {
+  const fixtureRoot = mkdtempSync(join(tmpdir(), "b2-mcp-mcp-registry-"));
+  try {
+    const manifest = JSON.parse(readFileSync(join(root, "server.json"), "utf8"));
+    mutate(manifest);
+    const manifestPath = join(fixtureRoot, "server.json");
+    writeFileSync(manifestPath, JSON.stringify(manifest, null, 2));
+    await run(manifestPath, manifest);
+  } finally {
+    rmSync(fixtureRoot, { recursive: true, force: true });
+  }
+}
+
+function quietLog() {
+  return { log: () => undefined, warn: () => undefined };
 }
 
 describe("release scripts", () => {
@@ -181,6 +273,315 @@ describe("release scripts", () => {
       expect(serverJson.version).toBe("0.2.0");
       expect(serverJson.packages[0].version).toBe("0.2.0");
     });
+  });
+
+  it("validates the checked-in MCP Registry manifest contract", () => {
+    const packageJson = JSON.parse(readFileSync(join(root, "package.json"), "utf8"));
+    const result = spawnSync(
+      process.execPath,
+      [
+        "scripts/verify-mcp-registry-manifest.mjs",
+        "--server-json",
+        "server.json",
+        "--package-json",
+        "package.json",
+        "--version",
+        packageJson.version,
+      ],
+      { cwd: root, encoding: "utf8" },
+    );
+
+    expect(result.status).toBe(0);
+    expect(result.stdout).toContain(
+      `mcp-registry-manifest: verified io.github.backblaze-labs/b2-mcp@${packageJson.version}`,
+    );
+  });
+
+  for (const testCase of [
+    {
+      name: "extra packages",
+      message: "server.json packages must contain exactly one entry",
+      mutate: (manifest: Record<string, any>) => {
+        manifest.packages.push({
+          registryType: "npm",
+          identifier: "@attacker/b2-mcp",
+          version: manifest.version,
+          transport: { type: "stdio" },
+        });
+      },
+    },
+    {
+      name: "non-canonical repository URLs",
+      message: "server.json repository URL is not canonical",
+      mutate: (manifest: Record<string, any>) => {
+        manifest.repository.url = "https://example.com/backblaze-labs/b2-mcp";
+      },
+    },
+    {
+      name: "non-stdio transports",
+      message: "server.json package transport must be stdio",
+      mutate: (manifest: Record<string, any>) => {
+        manifest.packages[0].transport = { type: "streamable-http" };
+      },
+    },
+    {
+      name: "unexpected environment variables",
+      message: "server.json environment variable B2_LOG_FILE is not in the approved allowlist",
+      mutate: (manifest: Record<string, any>) => {
+        manifest.packages[0].environmentVariables.push({
+          description: "Log file path.",
+          format: "string",
+          isRequired: false,
+          isSecret: false,
+          name: "B2_LOG_FILE",
+        });
+      },
+    },
+    {
+      name: "secret-like B2 variables marked non-secret",
+      message: "server.json environment variable B2_APPLICATION_KEY must be secret",
+      mutate: (manifest: Record<string, any>) => {
+        const variable = manifest.packages[0].environmentVariables.find(
+          (candidate: Record<string, any>) => candidate.name === "B2_APPLICATION_KEY",
+        );
+        variable.isSecret = false;
+      },
+    },
+    {
+      name: "server version drift",
+      message: "server.json version 0.9.9 does not match 0.1.0",
+      mutate: (manifest: Record<string, any>) => {
+        manifest.version = "0.9.9";
+      },
+    },
+  ]) {
+    it(`rejects ${testCase.name} in server.json`, () => {
+      withFixture((fixtureRoot) => {
+        const manifest = readFixtureServerJson(fixtureRoot);
+        testCase.mutate(manifest);
+        writeFixtureServerJson(fixtureRoot, manifest);
+
+        const result = spawnSync(
+          process.execPath,
+          ["scripts/verify-release-input.mjs", "--tag", "v0.1.0"],
+          { cwd: root, env: scriptEnv(fixtureRoot), encoding: "utf8" },
+        );
+
+        expect(result.status).not.toBe(0);
+        expect(result.stderr).toContain(testCase.message);
+      });
+    });
+  }
+
+  it("publishes stable MCP Registry versions after a missing-version lookup", async () => {
+    const { publishMcpRegistry } = await mcpRegistryPublishModule();
+    const calls: McpPublisherRun[] = [];
+
+    await withTempManifest(
+      () => undefined,
+      async (manifestPath, manifest) => {
+        const result = await publishMcpRegistry({
+          attempts: 2,
+          fetchText: async (url: string) => {
+            expect(url).toBe(
+              `https://registry.modelcontextprotocol.io/v0/servers/${encodeURIComponent(
+                manifest.name,
+              )}/versions/${manifest.version}`,
+            );
+            return { body: "not found", status: 404 };
+          },
+          initialDelayMs: 1,
+          log: quietLog(),
+          publisherPath: "/tmp/mcp-publisher",
+          runPublisher: async (args: string[], options: Record<string, unknown>) => {
+            calls.push({
+              args,
+              publisherPath: String(options.publisherPath),
+              timeoutMs: Number(options.timeoutMs),
+            });
+            return { code: 0, stderr: "", stdout: "" };
+          },
+          serverJsonPath: manifestPath,
+          sleep: async () => undefined,
+          version: manifest.version,
+        });
+
+        expect(result).toMatchObject({ status: "published" });
+        expect(calls).toEqual([
+          {
+            args: ["login", "github-oidc"],
+            publisherPath: "/tmp/mcp-publisher",
+            timeoutMs: 120000,
+          },
+          {
+            args: ["publish", manifestPath],
+            publisherPath: "/tmp/mcp-publisher",
+            timeoutMs: 120000,
+          },
+        ]);
+      },
+    );
+  });
+
+  it("skips prerelease MCP Registry publishing before lookup or OIDC login", async () => {
+    const { publishMcpRegistry } = await mcpRegistryPublishModule();
+
+    await withTempManifest(
+      (manifest) => {
+        manifest.version = "0.2.0-rc.1";
+        manifest.packages[0].version = "0.2.0-rc.1";
+      },
+      async (manifestPath, manifest) => {
+        const result = await publishMcpRegistry({
+          fetchText: async () => {
+            throw new Error("lookup should not run for prereleases");
+          },
+          log: quietLog(),
+          publisherPath: "/tmp/mcp-publisher",
+          runPublisher: async () => {
+            throw new Error("mcp-publisher should not run for prereleases");
+          },
+          serverJsonPath: manifestPath,
+          skipPrerelease: true,
+          sleep: async () => undefined,
+          version: manifest.version,
+        });
+
+        expect(result).toMatchObject({ status: "skipped-prerelease" });
+      },
+    );
+  });
+
+  it("fails closed when an existing MCP Registry version mismatches server.json", async () => {
+    const { publishMcpRegistry } = await mcpRegistryPublishModule();
+
+    await withTempManifest(
+      () => undefined,
+      async (manifestPath, manifest) => {
+        const registeredManifest = JSON.parse(JSON.stringify(manifest));
+        registeredManifest.packages[0].identifier = "@attacker/b2-mcp";
+
+        await expect(
+          publishMcpRegistry({
+            fetchText: async () => ({
+              body: JSON.stringify({ server: registeredManifest }),
+              status: 200,
+            }),
+            log: quietLog(),
+            publisherPath: "/tmp/mcp-publisher",
+            runPublisher: async () => {
+              throw new Error("mcp-publisher should not run after a mismatch");
+            },
+            serverJsonPath: manifestPath,
+            sleep: async () => undefined,
+            version: manifest.version,
+          }),
+        ).rejects.toThrow("server.json package identifier must be @backblaze-labs/b2-mcp");
+      },
+    );
+  });
+
+  it("accepts an existing MCP Registry version only when it matches server.json", async () => {
+    const { publishMcpRegistry } = await mcpRegistryPublishModule();
+
+    await withTempManifest(
+      () => undefined,
+      async (manifestPath, manifest) => {
+        const result = await publishMcpRegistry({
+          fetchText: async () => ({
+            body: JSON.stringify({ server: manifest }),
+            status: 200,
+          }),
+          log: quietLog(),
+          publisherPath: "/tmp/mcp-publisher",
+          runPublisher: async () => {
+            throw new Error("mcp-publisher should not run for matching existing versions");
+          },
+          serverJsonPath: manifestPath,
+          sleep: async () => undefined,
+          version: manifest.version,
+        });
+
+        expect(result).toMatchObject({ status: "already-published" });
+      },
+    );
+  });
+
+  it("retries transient MCP Registry lookup failures", async () => {
+    const { publishMcpRegistry } = await mcpRegistryPublishModule();
+    const statuses: number[] = [];
+    const sleeps: number[] = [];
+    let lookupAttempts = 0;
+
+    await withTempManifest(
+      () => undefined,
+      async (manifestPath, manifest) => {
+        const result = await publishMcpRegistry({
+          attempts: 3,
+          fetchText: async () => {
+            lookupAttempts += 1;
+            const status = lookupAttempts === 1 ? 503 : 404;
+            statuses.push(status);
+            return { body: "", status };
+          },
+          initialDelayMs: 7,
+          log: quietLog(),
+          publisherPath: "/tmp/mcp-publisher",
+          runPublisher: async () => ({ code: 0, stderr: "", stdout: "" }),
+          serverJsonPath: manifestPath,
+          sleep: async (delayMs: number) => {
+            sleeps.push(delayMs);
+          },
+          version: manifest.version,
+        });
+
+        expect(result).toMatchObject({ status: "published" });
+        expect(statuses).toEqual([503, 404]);
+        expect(sleeps).toEqual([7]);
+      },
+    );
+  });
+
+  it("retries transient mcp-publisher publish failures", async () => {
+    const { publishMcpRegistry } = await mcpRegistryPublishModule();
+    const publisherCalls: string[][] = [];
+    const sleeps: number[] = [];
+
+    await withTempManifest(
+      () => undefined,
+      async (manifestPath, manifest) => {
+        const result = await publishMcpRegistry({
+          attempts: 3,
+          fetchText: async () => ({ body: "", status: 404 }),
+          initialDelayMs: 11,
+          log: quietLog(),
+          publisherPath: "/tmp/mcp-publisher",
+          runPublisher: async (args: string[]) => {
+            publisherCalls.push(args);
+            if (
+              args[0] === "publish" &&
+              publisherCalls.filter(([command]) => command === "publish").length === 1
+            ) {
+              return { code: 1, stderr: "", stdout: "", timedOut: true };
+            }
+            return { code: 0, stderr: "", stdout: "" };
+          },
+          serverJsonPath: manifestPath,
+          sleep: async (delayMs: number) => {
+            sleeps.push(delayMs);
+          },
+          version: manifest.version,
+        });
+
+        expect(result).toMatchObject({ status: "published" });
+        expect(publisherCalls).toEqual([
+          ["login", "github-oidc"],
+          ["publish", manifestPath],
+          ["publish", manifestPath],
+        ]);
+        expect(sleeps).toEqual([11]);
+      },
+    );
   });
 
   it("runs the pnpm version changelog lifecycle with install scripts disabled", () => {

--- a/tests/unit/release-scripts.unit.test.ts
+++ b/tests/unit/release-scripts.unit.test.ts
@@ -18,6 +18,12 @@ type RegistryMetadataModule = {
 
 type McpRegistryPublishModule = {
   publishMcpRegistry: (options: Record<string, unknown>) => Promise<Record<string, unknown>>;
+  isTransientMcpPublisherFailure: (result: {
+    signal?: string | null;
+    stderr?: string;
+    stdout?: string;
+    timedOut?: boolean;
+  }) => boolean;
 };
 
 type McpRegistryManifest = Record<string, any>;
@@ -520,6 +526,55 @@ describe("release scripts", () => {
 
     expect(result.status).toBe(2);
     expect(result.stderr).toContain("--attempts must be a positive integer");
+  });
+
+  it("retries only explicit MCP Registry npm propagation 404s", async () => {
+    const { isTransientMcpPublisherFailure, publishMcpRegistry } = await mcpRegistryPublishModule();
+    const propagationMessage =
+      "404: A newly published release can take a moment to appear. Wait and retry.";
+
+    expect(isTransientMcpPublisherFailure({ stderr: propagationMessage, stdout: "" })).toBe(true);
+    expect(isTransientMcpPublisherFailure({ stderr: "404: package not found", stdout: "" })).toBe(
+      false,
+    );
+
+    await withTempManifest(
+      () => undefined,
+      async (manifestPath, manifest) => {
+        const publisherCalls: string[][] = [];
+        const sleeps: number[] = [];
+        const result = await publishMcpRegistry({
+          attempts: 3,
+          fetchText: async () => ({ body: "", status: 404 }),
+          initialDelayMs: 17,
+          log: quietLog(),
+          publisherPath: "/tmp/mcp-publisher",
+          runPublisher: async (args: string[]) => {
+            publisherCalls.push(args);
+            if (args[0] === "login") return { code: 0, stderr: "", stdout: "" };
+            const publishAttempts = publisherCalls.filter(
+              ([command]) => command === "publish",
+            ).length;
+            return publishAttempts === 1
+              ? { code: 1, stderr: propagationMessage, stdout: "" }
+              : { code: 0, stderr: "", stdout: "" };
+          },
+          serverJsonPath: manifestPath,
+          sleep: async (delayMs: number) => {
+            sleeps.push(delayMs);
+          },
+          version: manifest.version,
+        });
+
+        expect(result).toMatchObject({ status: "published" });
+        expect(publisherCalls).toEqual([
+          ["login", "github-oidc", "--registry", "https://registry.modelcontextprotocol.io"],
+          ["publish", manifestPath],
+          ["publish", manifestPath],
+        ]);
+        expect(sleeps).toEqual([17]);
+      },
+    );
   });
 
   it("reports actual attempts for permanent MCP Registry publisher failures", async () => {

--- a/tests/unit/release-scripts.unit.test.ts
+++ b/tests/unit/release-scripts.unit.test.ts
@@ -522,6 +522,63 @@ describe("release scripts", () => {
     expect(result.stderr).toContain("--attempts must be a positive integer");
   });
 
+  it("reports actual attempts for permanent MCP Registry publisher failures", async () => {
+    const { publishMcpRegistry } = await mcpRegistryPublishModule();
+
+    await withTempManifest(
+      () => undefined,
+      async (manifestPath, manifest) => {
+        const loginCalls: string[][] = [];
+        await expect(
+          publishMcpRegistry({
+            attempts: 3,
+            fetchText: async () => ({ body: "", status: 404 }),
+            log: quietLog(),
+            publisherPath: "/tmp/mcp-publisher",
+            runPublisher: async (args: string[]) => {
+              loginCalls.push(args);
+              return { code: 1, stderr: "", stdout: "" };
+            },
+            serverJsonPath: manifestPath,
+            sleep: async () => undefined,
+            version: manifest.version,
+          }),
+        ).rejects.toThrow("mcp-publisher login github-oidc failed after 1 attempt with exit 1");
+        expect(loginCalls).toEqual([
+          ["login", "github-oidc", "--registry", "https://registry.modelcontextprotocol.io"],
+        ]);
+      },
+    );
+
+    await withTempManifest(
+      () => undefined,
+      async (manifestPath, manifest) => {
+        const publishCalls: string[][] = [];
+        await expect(
+          publishMcpRegistry({
+            attempts: 3,
+            fetchText: async () => ({ body: "", status: 404 }),
+            log: quietLog(),
+            publisherPath: "/tmp/mcp-publisher",
+            runPublisher: async (args: string[]) => {
+              publishCalls.push(args);
+              return args[0] === "login"
+                ? { code: 0, stderr: "", stdout: "" }
+                : { code: 1, stderr: "", stdout: "" };
+            },
+            serverJsonPath: manifestPath,
+            sleep: async () => undefined,
+            version: manifest.version,
+          }),
+        ).rejects.toThrow("mcp-publisher publish failed after 1 attempt with exit 1");
+        expect(publishCalls).toEqual([
+          ["login", "github-oidc", "--registry", "https://registry.modelcontextprotocol.io"],
+          ["publish", manifestPath],
+        ]);
+      },
+    );
+  });
+
   it("fails closed when an existing MCP Registry version mismatches server.json", async () => {
     const { publishMcpRegistry } = await mcpRegistryPublishModule();
 

--- a/tests/unit/release-scripts.unit.test.ts
+++ b/tests/unit/release-scripts.unit.test.ts
@@ -452,6 +452,17 @@ describe("release scripts", () => {
     );
   });
 
+  it("rejects malformed MCP Registry retry integers", () => {
+    const result = spawnSync(
+      process.execPath,
+      ["scripts/mcp-registry-publish.mjs", "--attempts", "3seconds"],
+      { cwd: root, encoding: "utf8" },
+    );
+
+    expect(result.status).toBe(2);
+    expect(result.stderr).toContain("--attempts must be a positive integer");
+  });
+
   it("fails closed when an existing MCP Registry version mismatches server.json", async () => {
     const { publishMcpRegistry } = await mcpRegistryPublishModule();
 
@@ -503,6 +514,64 @@ describe("release scripts", () => {
         });
 
         expect(result).toMatchObject({ status: "already-published" });
+      },
+    );
+  });
+
+  it("rechecks the registry after ambiguous mcp-publisher publish failures", async () => {
+    const { publishMcpRegistry } = await mcpRegistryPublishModule();
+    const publisherCalls: string[][] = [];
+    const registryStatuses: number[] = [];
+    const sleeps: number[] = [];
+
+    await withTempManifest(
+      () => undefined,
+      async (manifestPath, manifest) => {
+        const registryResponses = [
+          { body: "", status: 404 },
+          { body: "", status: 404 },
+          { body: JSON.stringify({ server: manifest }), status: 200 },
+        ];
+        const result = await publishMcpRegistry({
+          attempts: 3,
+          fetchText: async () => {
+            const response = registryResponses.shift();
+            if (!response) throw new Error("unexpected registry lookup");
+            registryStatuses.push(response.status);
+            return response;
+          },
+          initialDelayMs: 13,
+          log: quietLog(),
+          publisherPath: "/tmp/mcp-publisher",
+          runPublisher: async (args: string[]) => {
+            publisherCalls.push(args);
+            if (args[0] === "login") return { code: 0, stderr: "", stdout: "" };
+            const publishAttempts = publisherCalls.filter(
+              ([command]) => command === "publish",
+            ).length;
+            return publishAttempts === 1
+              ? { code: 1, stderr: "", stdout: "", timedOut: true }
+              : {
+                  code: 1,
+                  stderr: "cannot publish duplicate version",
+                  stdout: "",
+                };
+          },
+          serverJsonPath: manifestPath,
+          sleep: async (delayMs: number) => {
+            sleeps.push(delayMs);
+          },
+          version: manifest.version,
+        });
+
+        expect(result).toMatchObject({ status: "already-published" });
+        expect(registryStatuses).toEqual([404, 404, 200]);
+        expect(publisherCalls).toEqual([
+          ["login", "github-oidc"],
+          ["publish", manifestPath],
+          ["publish", manifestPath],
+        ]);
+        expect(sleeps).toEqual([13]);
       },
     );
   });

--- a/tests/unit/release-scripts.unit.test.ts
+++ b/tests/unit/release-scripts.unit.test.ts
@@ -38,6 +38,7 @@ function withFixture(run: (fixtureRoot: string) => void): void {
         {
           name: "@backblaze-labs/b2-mcp",
           version: "0.1.0",
+          mcpName: "io.github.backblaze-labs/b2-mcp",
           license: "MIT",
           repository: {
             type: "git",
@@ -60,6 +61,27 @@ function withFixture(run: (fixtureRoot: string) => void): void {
             "LICENSE",
           ],
           dependencies: { "@backblaze-labs/b2-sdk": "0.2.0" },
+        },
+        null,
+        2,
+      ),
+    );
+    writeFileSync(
+      join(fixtureRoot, "server.json"),
+      JSON.stringify(
+        {
+          $schema: "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
+          name: "io.github.backblaze-labs/b2-mcp",
+          description: "Operate Backblaze B2 buckets and S3-compatible storage.",
+          version: "0.1.0",
+          packages: [
+            {
+              registryType: "npm",
+              identifier: "@backblaze-labs/b2-mcp",
+              version: "0.1.0",
+              transport: { type: "stdio" },
+            },
+          ],
         },
         null,
         2,
@@ -139,6 +161,28 @@ describe("release scripts", () => {
     });
   });
 
+  it("syncs server.json versions from package metadata", () => {
+    withFixture((fixtureRoot) => {
+      const packagePath = join(fixtureRoot, "package.json");
+      const pkg = JSON.parse(readFileSync(packagePath, "utf8"));
+      writeFileSync(packagePath, JSON.stringify({ ...pkg, version: "0.2.0" }, null, 2));
+
+      const result = spawnSync(process.execPath, ["scripts/update-server-json-version.mjs"], {
+        cwd: root,
+        env: scriptEnv(fixtureRoot),
+        encoding: "utf8",
+      });
+
+      const serverJson = JSON.parse(readFileSync(join(fixtureRoot, "server.json"), "utf8"));
+      expect(result.status).toBe(0);
+      expect(result.stdout).toContain(
+        "server-json-version: updated io.github.backblaze-labs/b2-mcp@0.2.0",
+      );
+      expect(serverJson.version).toBe("0.2.0");
+      expect(serverJson.packages[0].version).toBe("0.2.0");
+    });
+  });
+
   it("runs the pnpm version changelog lifecycle with install scripts disabled", () => {
     withFixture((fixtureRoot) => {
       const packagePath = join(fixtureRoot, "package.json");
@@ -149,7 +193,11 @@ describe("release scripts", () => {
           {
             ...pkg,
             scripts: {
-              version: `node ${join(root, "scripts/cut-changelog.mjs")} && git add CHANGELOG.md`,
+              version: [
+                `node ${join(root, "scripts/cut-changelog.mjs")}`,
+                `node ${join(root, "scripts/update-server-json-version.mjs")}`,
+                "git add CHANGELOG.md server.json",
+              ].join(" && "),
             },
           },
           null,
@@ -170,13 +218,17 @@ describe("release scripts", () => {
       );
       const changelog = readFileSync(join(fixtureRoot, "CHANGELOG.md"), "utf8");
       const bumpedPackage = JSON.parse(readFileSync(packagePath, "utf8"));
+      const bumpedServerJson = JSON.parse(readFileSync(join(fixtureRoot, "server.json"), "utf8"));
       const stagedFiles = runGit(fixtureRoot, ["diff", "--cached", "--name-only"]);
 
       expect(result.status).toBe(0);
       expect(result.stdout).toContain("cut-changelog: promoted [Unreleased] to [0.1.1]");
       expect(bumpedPackage.version).toBe("0.1.1");
+      expect(bumpedServerJson.version).toBe("0.1.1");
+      expect(bumpedServerJson.packages[0].version).toBe("0.1.1");
       expect(changelog).toMatch(/^## \[Unreleased\]\n\n## \[0\.1\.1\] - \d{4}-\d{2}-\d{2}/m);
       expect(stagedFiles.split(/\r?\n/)).toContain("CHANGELOG.md");
+      expect(stagedFiles.split(/\r?\n/)).toContain("server.json");
     });
   });
 

--- a/tests/unit/release-scripts.unit.test.ts
+++ b/tests/unit/release-scripts.unit.test.ts
@@ -338,6 +338,16 @@ describe("release scripts", () => {
       },
     },
     {
+      name: "omitted false environment variable flags",
+      message: "server.json environment variable B2_REGION.isRequired must be false",
+      mutate: (manifest: Record<string, any>) => {
+        const variable = manifest.packages[0].environmentVariables.find(
+          (candidate: Record<string, any>) => candidate.name === "B2_REGION",
+        );
+        delete variable.isRequired;
+      },
+    },
+    {
       name: "secret-like B2 variables marked non-secret",
       message: "server.json environment variable B2_APPLICATION_KEY must be secret",
       mutate: (manifest: Record<string, any>) => {
@@ -409,7 +419,12 @@ describe("release scripts", () => {
         expect(result).toMatchObject({ status: "published" });
         expect(calls).toEqual([
           {
-            args: ["login", "github-oidc"],
+            args: [
+              "login",
+              "github-oidc",
+              "--registry",
+              "https://registry.modelcontextprotocol.io",
+            ],
             publisherPath: "/tmp/mcp-publisher",
             timeoutMs: 120000,
           },
@@ -419,6 +434,50 @@ describe("release scripts", () => {
             timeoutMs: 120000,
           },
         ]);
+      },
+    );
+  });
+
+  it("passes custom MCP Registry roots to mcp-publisher login", async () => {
+    const { publishMcpRegistry } = await mcpRegistryPublishModule();
+    const calls: McpPublisherRun[] = [];
+    const lookupUrls: string[] = [];
+
+    await withTempManifest(
+      () => undefined,
+      async (manifestPath, manifest) => {
+        const result = await publishMcpRegistry({
+          fetchText: async (url: string) => {
+            lookupUrls.push(url);
+            return { body: "not found", status: 404 };
+          },
+          log: quietLog(),
+          publisherPath: "/tmp/mcp-publisher",
+          registryBaseUrl: "https://registry.example.test/custom/v0",
+          runPublisher: async (args: string[], options: Record<string, unknown>) => {
+            calls.push({
+              args,
+              publisherPath: String(options.publisherPath),
+              timeoutMs: Number(options.timeoutMs),
+            });
+            return { code: 0, stderr: "", stdout: "" };
+          },
+          serverJsonPath: manifestPath,
+          sleep: async () => undefined,
+          version: manifest.version,
+        });
+
+        expect(result).toMatchObject({ status: "published" });
+        expect(lookupUrls).toEqual([
+          `https://registry.example.test/custom/v0/servers/${encodeURIComponent(
+            manifest.name,
+          )}/versions/${manifest.version}`,
+        ]);
+        expect(calls[0]).toEqual({
+          args: ["login", "github-oidc", "--registry", "https://registry.example.test/custom"],
+          publisherPath: "/tmp/mcp-publisher",
+          timeoutMs: 120000,
+        });
       },
     );
   });
@@ -518,6 +577,46 @@ describe("release scripts", () => {
     );
   });
 
+  it("accepts registry response manifests that omit explicit false booleans", async () => {
+    const { publishMcpRegistry } = await mcpRegistryPublishModule();
+
+    await withTempManifest(
+      () => undefined,
+      async (manifestPath, manifest) => {
+        const registeredManifest = JSON.parse(JSON.stringify(manifest));
+        for (const variable of registeredManifest.packages[0].environmentVariables) {
+          if (variable.isRequired === false) delete variable.isRequired;
+          if (variable.isSecret === false) delete variable.isSecret;
+        }
+
+        const result = await publishMcpRegistry({
+          fetchText: async () => ({
+            body: JSON.stringify({
+              _meta: {
+                "io.modelcontextprotocol.registry/official": {
+                  isLatest: true,
+                  status: "active",
+                },
+              },
+              server: registeredManifest,
+            }),
+            status: 200,
+          }),
+          log: quietLog(),
+          publisherPath: "/tmp/mcp-publisher",
+          runPublisher: async () => {
+            throw new Error("mcp-publisher should not run for matching existing versions");
+          },
+          serverJsonPath: manifestPath,
+          sleep: async () => undefined,
+          version: manifest.version,
+        });
+
+        expect(result).toMatchObject({ status: "already-published" });
+      },
+    );
+  });
+
   it("rechecks the registry after ambiguous mcp-publisher publish failures", async () => {
     const { publishMcpRegistry } = await mcpRegistryPublishModule();
     const publisherCalls: string[][] = [];
@@ -567,7 +666,7 @@ describe("release scripts", () => {
         expect(result).toMatchObject({ status: "already-published" });
         expect(registryStatuses).toEqual([404, 404, 200]);
         expect(publisherCalls).toEqual([
-          ["login", "github-oidc"],
+          ["login", "github-oidc", "--registry", "https://registry.modelcontextprotocol.io"],
           ["publish", manifestPath],
           ["publish", manifestPath],
         ]);
@@ -644,7 +743,7 @@ describe("release scripts", () => {
 
         expect(result).toMatchObject({ status: "published" });
         expect(publisherCalls).toEqual([
-          ["login", "github-oidc"],
+          ["login", "github-oidc", "--registry", "https://registry.modelcontextprotocol.io"],
           ["publish", manifestPath],
           ["publish", manifestPath],
         ]);

--- a/tests/unit/supply-chain-policy.unit.test.ts
+++ b/tests/unit/supply-chain-policy.unit.test.ts
@@ -725,6 +725,7 @@ describe("supply-chain audit policy", () => {
       mcpPublisherInstallStep.indexOf("tar -xzf mcp-publisher.tar.gz"),
     );
     expect(publishJob).toContain("needs: [prepare, live-contract, mcp-registry-preflight]");
+    expect(publishJob).toContain("timeout-minutes: 30");
     expect(publishJob).toContain("actions: read");
     expect(publishJob).toContain("contents: read");
     expect(publishJob).toContain("id-token: write");

--- a/tests/unit/supply-chain-policy.unit.test.ts
+++ b/tests/unit/supply-chain-policy.unit.test.ts
@@ -76,6 +76,7 @@ describe("supply-chain audit policy", () => {
   const packageJson = JSON.parse(readFileSync(join(root, "package.json"), "utf8")) as {
     dependencies: Record<string, string>;
     devDependencies: Record<string, string>;
+    mcpName?: string;
     scripts: Record<string, string>;
   };
   const auditPolicy = JSON.parse(readFileSync(join(root, "audit-policy.json"), "utf8")) as {
@@ -621,8 +622,9 @@ describe("supply-chain audit policy", () => {
     );
     expect(packageJson.scripts["release:stamp"]).toBe("node scripts/write-release-version.mjs");
     expect(packageJson.scripts.version).toBe(
-      "node scripts/cut-changelog.mjs && git add CHANGELOG.md",
+      "node scripts/cut-changelog.mjs && node scripts/update-server-json-version.mjs && git add CHANGELOG.md server.json",
     );
+    expect(packageJson.mcpName).toBe("io.github.backblaze-labs/b2-mcp");
     expect(packageJson.scripts.prepublishOnly).toContain("pnpm run build");
     expect(packageJson.scripts.prepublishOnly).toContain("scripts/verify-release-input.mjs");
     expect(packageJson.scripts.prepublishOnly).toContain("pnpm run release:stamp");
@@ -657,6 +659,10 @@ describe("supply-chain audit policy", () => {
     expect(publishWorkflow).toContain("Stage publish helper scripts");
     expect(publishWorkflow).toContain("scripts/npm-publish-metadata.mjs");
     expect(publishWorkflow).toContain("scripts/verify-npm-registry-metadata.mjs");
+    expect(publishWorkflow).toContain("Stage MCP registry manifest");
+    expect(publishWorkflow).toContain("publish-package/server.json");
+    expect(publishWorkflow).toContain("mcp-publisher login github-oidc");
+    expect(publishWorkflow).toContain('mcp-publisher publish "$manifest"');
     expect(publishWorkflow).toContain("publish-package/release-tools/*.mjs");
     expect(publishWorkflow).toContain("Create GitHub release from verified artifact");
     expect(publishWorkflow).toContain("gh release upload");

--- a/tests/unit/supply-chain-policy.unit.test.ts
+++ b/tests/unit/supply-chain-policy.unit.test.ts
@@ -606,6 +606,12 @@ describe("supply-chain audit policy", () => {
     const githubReleaseJob = publishJobBlock("github-release");
     const containerImageJob = publishJobBlock("container-image");
     const publishJob = publishJobBlock("publish");
+    const mcpRegistryPreflightJob = publishJobBlock("mcp-registry-preflight");
+    const mcpPublisherInstallStep = workflowStepBlock(
+      mcpRegistryPreflightJob,
+      "Download and verify mcp-publisher",
+    );
+    const mcpRegistryPublishStep = workflowStepBlock(publishJob, "Publish MCP registry entry");
 
     expect(npmrc).toMatch(/^ignore-scripts=true$/m);
     expect(packageJson.scripts["audit:supply-chain"]).toContain(
@@ -661,8 +667,9 @@ describe("supply-chain audit policy", () => {
     expect(publishWorkflow).toContain("scripts/verify-npm-registry-metadata.mjs");
     expect(publishWorkflow).toContain("Stage MCP registry manifest");
     expect(publishWorkflow).toContain("publish-package/server.json");
-    expect(publishWorkflow).toContain("mcp-publisher login github-oidc");
-    expect(publishWorkflow).toContain('mcp-publisher publish "$manifest"');
+    expect(publishWorkflow).toContain("scripts/mcp-registry-publish.mjs");
+    expect(publishWorkflow).toContain("scripts/verify-mcp-registry-manifest.mjs");
+    expect(publishWorkflow).toContain("scripts/lib/mcp-registry-manifest.mjs");
     expect(publishWorkflow).toContain("publish-package/release-tools/*.mjs");
     expect(publishWorkflow).toContain("Create GitHub release from verified artifact");
     expect(publishWorkflow).toContain("gh release upload");
@@ -687,9 +694,40 @@ describe("supply-chain audit policy", () => {
     expect(containerImageJob).toContain("sigstore/cosign-installer");
     expect(containerImageJob).toContain("node scripts/smoke-container-image.mjs");
     expect(containerImageJob).toContain("node scripts/publish-container-image.mjs");
-    expect(publishJob).toContain("needs: [prepare, live-contract]");
+    expect(mcpRegistryPreflightJob).toContain("needs: prepare");
+    expect(mcpRegistryPreflightJob).toContain("actions: read");
+    expect(mcpRegistryPreflightJob).toContain("contents: read");
+    expect(mcpRegistryPreflightJob).not.toContain("id-token: write");
+    expect(mcpRegistryPreflightJob).toContain("Verify MCP registry manifest metadata");
+    expect(mcpRegistryPreflightJob).toContain("mcp-publisher-bin/mcp-publisher validate");
+    expect(mcpRegistryPreflightJob).toContain("sigstore/cosign-installer");
+    expect(mcpRegistryPreflightJob).toContain("cosign verify-blob");
+    expect(mcpRegistryPreflightJob).toContain("--certificate-identity");
+    expect(mcpRegistryPreflightJob).toContain("--certificate-oidc-issuer");
+    expect(mcpRegistryPreflightJob).toContain("--certificate-github-workflow-repository");
+    expect(mcpRegistryPreflightJob).toContain("--certificate-github-workflow-ref");
+    expect(mcpRegistryPreflightJob).toContain("--certificate-github-workflow-sha");
+    expect(mcpRegistryPreflightJob).toContain("--certificate-github-workflow-name");
+    expect(mcpRegistryPreflightJob).toContain("--certificate-github-workflow-trigger");
+    expect(mcpRegistryPreflightJob).toContain("name: mcp-publisher");
+    expect(mcpRegistryPreflightJob).toContain("path: mcp-publisher-bin/mcp-publisher");
+    expect(publishWorkflow).toContain("MCP_PUBLISHER_SHA256:");
+    expect(publishWorkflow).toContain("MCP_PUBLISHER_BINARY_SHA256:");
+    expect(mcpPublisherInstallStep).toContain(
+      "printf '%s  mcp-publisher.tar.gz\\n' \"${MCP_PUBLISHER_SHA256}\" | sha256sum -c -",
+    );
+    expect(mcpPublisherInstallStep).toContain("curl --retry 3 --retry-all-errors");
+    expect(mcpPublisherInstallStep).toContain("--connect-timeout 10 --max-time 60");
+    expect(mcpPublisherInstallStep.indexOf("sha256sum -c -")).toBeLessThan(
+      mcpPublisherInstallStep.indexOf("tar -xzf mcp-publisher.tar.gz"),
+    );
+    expect(mcpPublisherInstallStep.indexOf("cosign verify-blob")).toBeLessThan(
+      mcpPublisherInstallStep.indexOf("tar -xzf mcp-publisher.tar.gz"),
+    );
+    expect(publishJob).toContain("needs: [prepare, live-contract, mcp-registry-preflight]");
     expect(publishJob).toContain("actions: read");
     expect(publishJob).toContain("contents: read");
+    expect(publishJob).toContain("id-token: write");
     expect(publishJob).not.toContain("contents: write");
     expect(publishJob).toContain("node-version: 24.19.0");
     expect(publishJob).toContain("bundles npm >=11.5.1");
@@ -702,6 +740,13 @@ describe("supply-chain audit policy", () => {
     expect(publishWorkflow).toContain('--tag "$npm_tag"');
     expect(publishWorkflow).not.toContain("--ignore-scripts=false");
     expect(publishWorkflow).toContain('tar -xzf "$tarball" -C publish-package/staged');
+    expect(mcpRegistryPublishStep).toContain("mcp-registry-publish.mjs");
+    expect(mcpRegistryPublishStep).toContain("--skip-prerelease");
+    expect(mcpRegistryPublishStep).toContain("MCP_PUBLISHER_BINARY_SHA256");
+    expect(mcpRegistryPublishStep).not.toContain("curl");
+    expect(mcpRegistryPublishStep).not.toContain("mcp-publisher validate");
+    expect(mcpRegistryPublishStep).not.toContain("node -e");
+    expect(mcpRegistryPublishStep).not.toContain("encodeURIComponent");
   });
 
   it("keeps tsx dev-only and denies esbuild install builds", () => {

--- a/tests/unit/supply-chain-policy.unit.test.ts
+++ b/tests/unit/supply-chain-policy.unit.test.ts
@@ -700,7 +700,7 @@ describe("supply-chain audit policy", () => {
     expect(mcpRegistryPreflightJob).toContain("contents: read");
     expect(mcpRegistryPreflightJob).not.toContain("id-token: write");
     expect(mcpRegistryPreflightJob).toContain("Verify MCP registry manifest metadata");
-    expect(mcpRegistryPreflightJob).toContain("mcp-publisher-bin/mcp-publisher validate");
+    expect(mcpRegistryPreflightJob).not.toContain("mcp-publisher validate");
     expect(mcpRegistryPreflightJob).toContain("sigstore/cosign-installer");
     expect(mcpRegistryPreflightJob).toContain("cosign verify-blob");
     expect(mcpRegistryPreflightJob).toContain("--certificate-identity");
@@ -732,6 +732,9 @@ describe("supply-chain audit policy", () => {
     expect(publishJob).toContain("id-token: write");
     expect(publishJob).not.toContain("contents: write");
     expect(publishJob).toContain("node-version: 24.19.0");
+    expect(
+      publishJob.indexOf("Publish staged package directory with trusted provenance"),
+    ).toBeLessThan(publishJob.indexOf("Publish MCP registry entry"));
     expect(publishJob).toContain("bundles npm >=11.5.1");
     expect(publishJob).toContain("npm view");
     expect(publishJob).toContain("already exists on npm with matching integrity");

--- a/tests/unit/supply-chain-policy.unit.test.ts
+++ b/tests/unit/supply-chain-policy.unit.test.ts
@@ -695,6 +695,7 @@ describe("supply-chain audit policy", () => {
     expect(containerImageJob).toContain("node scripts/smoke-container-image.mjs");
     expect(containerImageJob).toContain("node scripts/publish-container-image.mjs");
     expect(mcpRegistryPreflightJob).toContain("needs: prepare");
+    expect(mcpRegistryPreflightJob).toContain("timeout-minutes: 20");
     expect(mcpRegistryPreflightJob).toContain("actions: read");
     expect(mcpRegistryPreflightJob).toContain("contents: read");
     expect(mcpRegistryPreflightJob).not.toContain("id-token: write");


### PR DESCRIPTION
## Summary
- Add Official MCP Registry `server.json` for `io.github.backblaze-labs/b2-mcp` with npm package metadata and B2 environment variables.
- Add the npm `mcpName` ownership marker and centralized release guardrails so `server.json`, package metadata, and release versions stay aligned.
- Add exact MCP Registry manifest allowlists for the canonical npm package, repository/source identity, stdio transport, website URL, and B2 environment variable secret flags.
- Harden registry publishing with provenance-verified publisher download, SHA pins, OIDC only in the publish job, prerelease skip, bounded retries, exact npm propagation retry matching, actual-attempt error reporting, and existing-version mismatch checks.
- Keep remote registry publishing after npm publish so first-time release versions exist on npm, while local manifest and publisher provenance checks still gate the release first.

## Linked Issue
Closes #298

## Tests
- `/tmp/mcp-publisher-issue298/mcp-publisher validate server.json`
- `pnpm exec vitest run --config vitest.config.mts --project=unit tests/unit/release-scripts.unit.test.ts tests/unit/supply-chain-policy.unit.test.ts`
- `pnpm run test:contract`
- `pnpm run test:coverage`
- `pnpm run typecheck`
- `pnpm run lint`
- `pnpm run format:check`
- `pnpm test`
- `pnpm run build`
- `pnpm run check:package-budget`
- `node scripts/verify-release-input.mjs --tag v0.1.2`
- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/publish.yml"); puts "ok"'`
- `gh pr checks 336 --watch --fail-fast`

## Follow-up Notes
- The current registry query `https://registry.modelcontextprotocol.io/v0/servers?search=backblaze` still returns `count: 0`; a first real registry publish still has to happen from a release/manual publish context with GitHub namespace auth.
- The already-published npm `0.1.2` metadata does not contain `mcpName`, so the first successful registry publish should use the next npm release that contains this PR's package metadata.
