### PR TITLE
Fix empty egress report snapshot response

### DIFF
--- a/package-budget.json
+++ b/package-budget.json
@@ -8,22 +8,22 @@
     "date": "2026-08-31",
     "nodeVersions": ["22.3.0", "24", "26"],
     "primaryB2Transport": "@backblaze-labs/b2-sdk@0.3.0",
-    "sizeBudgetRationale": "Issues #306 and #308 intentionally add TSDoc to the published TypeScript source tree, increasing package source bytes without changing runtime dependencies.",
+    "sizeBudgetRationale": "Issues #306 and #308 intentionally add TSDoc to the published TypeScript source tree, increasing package source bytes without changing runtime dependencies. Issue #319 adds horizon-qualified empty-snapshot discovery to insights, growing compiled JS/d.ts source bytes with no new runtime dependencies.",
     "directProductionDependencyCount": 9,
     "totalProductionPackageCount": 48,
     "transitiveProductionPackageCount": 38,
-    "packedTarballBytes": 564424,
-    "unpackedPackageBytes": 2562614,
+    "packedTarballBytes": 569150,
+    "unpackedPackageBytes": 2582179,
     "packedEntryCount": 250,
-    "cleanConsumerInstallFootprintBytes": 31243303
+    "cleanConsumerInstallFootprintBytes": 31310721
   },
   "limits": {
     "directProductionDependencyCount": 9,
     "totalProductionPackageCount": 48,
-    "packedTarballBytes": 570000,
-    "unpackedPackageBytes": 2580000,
+    "packedTarballBytes": 575000,
+    "unpackedPackageBytes": 2600000,
     "packedEntryCount": 251,
-    "cleanConsumerInstallFootprintBytes": 31350000
+    "cleanConsumerInstallFootprintBytes": 31360000
   },
   "directProductionDependencies": {
     "@aws-sdk/client-s3": {

--- a/src/b2/insights.ts
+++ b/src/b2/insights.ts
@@ -278,6 +278,10 @@ const NO_USAGE_REPORT_SNAPSHOTS_NOTE = "No usage-report snapshots found yet.";
 const SNAPSHOT_LOOKBACK_DAYS = [10, 45, 180] as const;
 const SNAPSHOT_DISCOVERY_HORIZON_DAYS = SNAPSHOT_LOOKBACK_DAYS[SNAPSHOT_LOOKBACK_DAYS.length - 1];
 
+// A usage-report snapshot key: date-prefixed CSV. Non-report objects a bucket may
+// also hold (e.g. YYYY-MM-DD/notes.txt) are not snapshots.
+const REPORT_DAY_CSV_RE = /^\d{4}-\d{2}-\d{2}\/.+\.csv$/;
+
 const REPORT_SCAN_LIMITS = {
   maxPages: 100,
   maxCandidateKeys: 5_000,
@@ -517,7 +521,6 @@ async function loadReportRows(
   sinceDate: string,
   budget: ReportScanBudget = createReportScanBudget(),
 ): Promise<ReportRowsResult | null> {
-  const keyRe = /^\d{4}-\d{2}-\d{2}\/.+\.csv$/;
   const keys: string[] = [];
   let token: string | undefined;
   const { stats } = budget;
@@ -536,7 +539,7 @@ async function loadReportRows(
       stats.pages++;
       stats.listed_keys += page.keys.length;
       for (const k of page.keys) {
-        if (!keyRe.test(k) || k.slice(0, 10) < sinceDate) continue;
+        if (!REPORT_DAY_CSV_RE.test(k) || k.slice(0, 10) < sinceDate) continue;
         if (keys.length >= REPORT_SCAN_LIMITS.maxCandidateKeys) {
           stopReportScan(stats, "max_candidate_keys");
           break;
@@ -736,7 +739,7 @@ export async function latestSnapshotDate(
   for (const lookback of SNAPSHOT_LOOKBACK_DAYS) {
     const after = new Date(today.getTime() - lookback * 86400_000).toISOString().slice(0, 10);
     let token: string | undefined;
-    let max: string | null = null;
+    const candidates: string[] = [];
     try {
       do {
         if (!ensureReportPageBudget(budget)) break;
@@ -748,16 +751,20 @@ export async function latestSnapshotDate(
         });
         budget.stats.pages++;
         budget.stats.listed_keys += page.keys.length;
-        for (const key of page.keys) {
-          const d = snapshotDateOf(key);
-          if (d && (max === null || d > max)) max = d;
-        }
+        for (const key of page.keys) if (REPORT_DAY_CSV_RE.test(key)) candidates.push(key);
         token = page.isTruncated ? page.nextContinuationToken : undefined;
         if (budget.stats.stop_reason) break;
       } while (token);
     } catch (e) {
       if (is404(e)) return { date: null, bucketMissing: true };
       throw e;
+    }
+    // Apply the row loader's usage-data selection so a bucket holding only
+    // non-usage date-prefixed objects is not mistaken for a snapshot.
+    let max: string | null = null;
+    for (const key of selectUsageKeys(candidates)) {
+      const d = snapshotDateOf(key);
+      if (d && (max === null || d > max)) max = d;
     }
     if (max) return { date: max, bucketMissing: false };
     if (budget.stats.stop_reason) break;

--- a/src/b2/insights.ts
+++ b/src/b2/insights.ts
@@ -389,10 +389,59 @@ function reportScanMetadata(...loads: ReportRowsResult[]): Record<string, unknow
   return reportScanMetadataFromStats(totals);
 }
 
+function hasUsageReportSnapshots<T extends { date: string | null }>(
+  value: T,
+): value is T & { date: string };
+function hasUsageReportSnapshots(value: ReportRowsResult): boolean;
+function hasUsageReportSnapshots(value: { date: string | null } | ReportRowsResult): boolean {
+  if ("date" in value) return value.date !== null;
+  // A selected usage CSV key is the egress path's proof that a report snapshot
+  // was loadable in the requested scan window.
+  return value.stats.selected_keys > 0;
+}
+
+function hasUsageReportRows(load: ReportRowsResult): boolean {
+  return load.rows.length > 0;
+}
+
 function noUsageReportSnapshots(stats: ReportLoadStats): Record<string, unknown> {
   return {
     reports_enabled: true,
-    note: NO_USAGE_REPORT_SNAPSHOTS_NOTE,
+    note: stats.stop_reason
+      ? "No usage-report snapshots were loaded before the scan budget was exhausted; " +
+        "results are inconclusive (see report_scan.stop_reasons)."
+      : NO_USAGE_REPORT_SNAPSHOTS_NOTE,
+    ...reportScanMetadataFromStats(stats),
+  };
+}
+
+function noUsageReportSnapshotsInPeriod(
+  stats: ReportLoadStats,
+  sinceDate: string,
+  latestSnapshot: string,
+): Record<string, unknown> {
+  return {
+    reports_enabled: true,
+    note: stats.stop_reason
+      ? "No usage-report snapshots were loaded in the requested period before the scan budget " +
+        "was exhausted; results are inconclusive (see report_scan.stop_reasons)."
+      : latestSnapshot >= sinceDate
+        ? `Report snapshots exist (latest snapshot is ${latestSnapshot}), but no usage-report ` +
+          "data files were found in the requested period."
+        : `No usage-report snapshots found in the requested period. Latest available snapshot ` +
+          `is ${latestSnapshot}.`,
+    latest_snapshot: latestSnapshot,
+    ...reportScanMetadataFromStats(stats),
+  };
+}
+
+function noUsageReportRows(stats: ReportLoadStats): Record<string, unknown> {
+  return {
+    reports_enabled: true,
+    note: stats.stop_reason
+      ? "Usage-report snapshots were found, but no parseable usage rows were loaded before " +
+        "the scan budget was exhausted; results are inconclusive (see report_scan.stop_reasons)."
+      : "Usage-report snapshots were found, but no parseable usage rows were loaded.",
     ...reportScanMetadataFromStats(stats),
   };
 }
@@ -1042,7 +1091,8 @@ export function registerInsightTools(
 
         const latest = await latestSnapshotDate(reportClient, bucket, today, reportBudget);
         if (latest.bucketMissing) return toolJson(NOT_ENABLED);
-        if (!latest.date) return toolJson(noUsageReportSnapshots(reportBudget.stats));
+        if (!hasUsageReportSnapshots(latest))
+          return toolJson(noUsageReportSnapshots(reportBudget.stats));
 
         const then = await nearestSnapshotDate(reportClient, bucket, targetThen, reportBudget);
         if (then.bucketMissing) return toolJson(NOT_ENABLED);
@@ -1111,14 +1161,32 @@ export function registerInsightTools(
     async (args) => {
       try {
         const since = args.days != null ? daysAgo(args.days) : startOfMonthUTC();
-        const loaded = await loadReportRows(reportClient, await reportsBucketName(auth), since);
+        const bucket = await reportsBucketName(auth);
+        const reportBudget = createReportScanBudget();
+        const loaded = await loadReportRows(reportClient, bucket, since, reportBudget);
         if (loaded === null) return toolJson(NOT_ENABLED);
         const period = args.days != null ? `last ${args.days} days` : "current month to date";
-        if (loaded.stats.selected_keys === 0) {
+        if (!hasUsageReportSnapshots(loaded)) {
+          let emptySnapshotMetadata = noUsageReportSnapshots(loaded.stats);
+          if (!loaded.stats.stop_reason) {
+            const latest = await latestSnapshotDate(reportClient, bucket, new Date(), reportBudget);
+            if (latest.bucketMissing) return toolJson(NOT_ENABLED);
+            emptySnapshotMetadata = hasUsageReportSnapshots(latest)
+              ? noUsageReportSnapshotsInPeriod(loaded.stats, since, latest.date)
+              : noUsageReportSnapshots(loaded.stats);
+          }
           return toolJson({
             period,
             rank_by: args.by,
-            ...noUsageReportSnapshots(loaded.stats),
+            ...emptySnapshotMetadata,
+            leaders: [],
+          });
+        }
+        if (!hasUsageReportRows(loaded)) {
+          return toolJson({
+            period,
+            rank_by: args.by,
+            ...noUsageReportRows(loaded.stats),
             leaders: [],
           });
         }

--- a/src/b2/insights.ts
+++ b/src/b2/insights.ts
@@ -759,6 +759,10 @@ export async function latestSnapshotDate(
       if (is404(e)) return { date: null, bucketMissing: true };
       throw e;
     }
+    // A truncated window collected only the older (lexically earlier) keys, so its
+    // max is not the true latest; fall through to the inconclusive path instead of
+    // publishing a stale date.
+    if (budget.stats.stop_reason) break;
     // Apply the row loader's usage-data selection so a bucket holding only
     // non-usage date-prefixed objects is not mistaken for a snapshot.
     let max: string | null = null;
@@ -767,7 +771,6 @@ export async function latestSnapshotDate(
       if (d && (max === null || d > max)) max = d;
     }
     if (max) return { date: max, bucketMissing: false };
-    if (budget.stats.stop_reason) break;
   }
   // Bounded probe finished with no snapshot and budget intact: report the horizon
   // searched so callers do not assert snapshots never existed.

--- a/src/b2/insights.ts
+++ b/src/b2/insights.ts
@@ -272,12 +272,11 @@ const NOT_ENABLED = {
 };
 const NO_USAGE_REPORT_SNAPSHOTS_NOTE = "No usage-report snapshots found yet.";
 
-// Widening lookback windows (in days) for latest-snapshot discovery. The last
-// entry is the bounded discovery horizon: finding nothing within it does not
-// prove snapshots never existed, only that none fall inside the searched window.
+// Widening lookback windows (days) for latest-snapshot discovery. The last entry
+// is the bounded horizon: finding nothing within it means none in that window,
+// not none ever.
 const SNAPSHOT_LOOKBACK_DAYS = [10, 45, 180] as const;
-const SNAPSHOT_DISCOVERY_HORIZON_DAYS =
-  SNAPSHOT_LOOKBACK_DAYS[SNAPSHOT_LOOKBACK_DAYS.length - 1];
+const SNAPSHOT_DISCOVERY_HORIZON_DAYS = SNAPSHOT_LOOKBACK_DAYS[SNAPSHOT_LOOKBACK_DAYS.length - 1];
 
 const REPORT_SCAN_LIMITS = {
   maxPages: 100,
@@ -722,11 +721,9 @@ async function nearestSnapshotDate(
  * @param budget - Optional scan budget for tests and bounded runtime.
  *
  * @returns The latest snapshot date, whether the reports bucket is missing, and
- *   `searchedSince` — the oldest date probed when the bounded discovery finished
- *   without finding a snapshot. It is only set when the search completed the full
- *   {@link SNAPSHOT_DISCOVERY_HORIZON_DAYS} horizon without hitting the scan
- *   budget, so a null `date` with a `searchedSince` means "none in that window",
- *   not "none ever".
+ *   `searchedSince` (the oldest date probed) when the bounded horizon completed
+ *   without a snapshot and without exhausting the budget. A null `date` with a
+ *   `searchedSince` means "none in that window", not "none ever".
  *
  * @internal
  */
@@ -765,9 +762,8 @@ export async function latestSnapshotDate(
     if (max) return { date: max, bucketMissing: false };
     if (budget.stats.stop_reason) break;
   }
-  // Completed the bounded probe without a snapshot and without exhausting the
-  // budget: report the horizon we actually searched so callers do not assert
-  // that snapshots never existed when reporting simply stopped long ago.
+  // Bounded probe finished with no snapshot and budget intact: report the horizon
+  // searched so callers do not assert snapshots never existed.
   const searchedSince = budget.stats.stop_reason
     ? undefined
     : new Date(today.getTime() - SNAPSHOT_DISCOVERY_HORIZON_DAYS * 86400_000)

--- a/src/b2/insights.ts
+++ b/src/b2/insights.ts
@@ -751,7 +751,17 @@ export async function latestSnapshotDate(
         });
         budget.stats.pages++;
         budget.stats.listed_keys += page.keys.length;
-        for (const key of page.keys) if (REPORT_DAY_CSV_RE.test(key)) candidates.push(key);
+        for (const key of page.keys) {
+          if (!REPORT_DAY_CSV_RE.test(key)) continue;
+          // Bound transient memory: an audit-heavy bucket could otherwise buffer
+          // up to maxPages * maxKeysPerPage keys. Cap it and fall through to the
+          // inconclusive path rather than holding the whole namespace in memory.
+          if (candidates.length >= REPORT_SCAN_LIMITS.maxCandidateKeys) {
+            stopReportScan(budget.stats, "max_candidate_keys");
+            break;
+          }
+          candidates.push(key);
+        }
         token = page.isTruncated ? page.nextContinuationToken : undefined;
         if (budget.stats.stop_reason) break;
       } while (token);

--- a/src/b2/insights.ts
+++ b/src/b2/insights.ts
@@ -272,6 +272,13 @@ const NOT_ENABLED = {
 };
 const NO_USAGE_REPORT_SNAPSHOTS_NOTE = "No usage-report snapshots found yet.";
 
+// Widening lookback windows (in days) for latest-snapshot discovery. The last
+// entry is the bounded discovery horizon: finding nothing within it does not
+// prove snapshots never existed, only that none fall inside the searched window.
+const SNAPSHOT_LOOKBACK_DAYS = [10, 45, 180] as const;
+const SNAPSHOT_DISCOVERY_HORIZON_DAYS =
+  SNAPSHOT_LOOKBACK_DAYS[SNAPSHOT_LOOKBACK_DAYS.length - 1];
+
 const REPORT_SCAN_LIMITS = {
   maxPages: 100,
   maxCandidateKeys: 5_000,
@@ -411,6 +418,21 @@ function noUsageReportSnapshots(stats: ReportLoadStats): Record<string, unknown>
       ? "No usage-report snapshots were loaded before the scan budget was exhausted; " +
         "results are inconclusive (see report_scan.stop_reasons)."
       : NO_USAGE_REPORT_SNAPSHOTS_NOTE,
+    ...reportScanMetadataFromStats(stats),
+  };
+}
+
+function noUsageReportSnapshotsWithinHorizon(
+  stats: ReportLoadStats,
+  searchedSince: string,
+): Record<string, unknown> {
+  return {
+    reports_enabled: true,
+    note:
+      `No usage-report snapshots found in the last ${SNAPSHOT_DISCOVERY_HORIZON_DAYS} days ` +
+      `(searched back to ${searchedSince}). Older snapshots, if reporting stopped earlier, are ` +
+      "outside this bounded discovery window and were not confirmed absent.",
+    searched_since: searchedSince,
     ...reportScanMetadataFromStats(stats),
   };
 }
@@ -699,7 +721,12 @@ async function nearestSnapshotDate(
  * @param today - Date used as the current-day search anchor.
  * @param budget - Optional scan budget for tests and bounded runtime.
  *
- * @returns The latest snapshot date and whether the reports bucket is missing.
+ * @returns The latest snapshot date, whether the reports bucket is missing, and
+ *   `searchedSince` — the oldest date probed when the bounded discovery finished
+ *   without finding a snapshot. It is only set when the search completed the full
+ *   {@link SNAPSHOT_DISCOVERY_HORIZON_DAYS} horizon without hitting the scan
+ *   budget, so a null `date` with a `searchedSince` means "none in that window",
+ *   not "none ever".
  *
  * @internal
  */
@@ -708,8 +735,8 @@ export async function latestSnapshotDate(
   bucketName: string,
   today: Date,
   budget: ReportScanBudget = createReportScanBudget(),
-): Promise<{ date: string | null; bucketMissing: boolean }> {
-  for (const lookback of [10, 45, 180]) {
+): Promise<{ date: string | null; bucketMissing: boolean; searchedSince?: string }> {
+  for (const lookback of SNAPSHOT_LOOKBACK_DAYS) {
     const after = new Date(today.getTime() - lookback * 86400_000).toISOString().slice(0, 10);
     let token: string | undefined;
     let max: string | null = null;
@@ -738,7 +765,15 @@ export async function latestSnapshotDate(
     if (max) return { date: max, bucketMissing: false };
     if (budget.stats.stop_reason) break;
   }
-  return { date: null, bucketMissing: false };
+  // Completed the bounded probe without a snapshot and without exhausting the
+  // budget: report the horizon we actually searched so callers do not assert
+  // that snapshots never existed when reporting simply stopped long ago.
+  const searchedSince = budget.stats.stop_reason
+    ? undefined
+    : new Date(today.getTime() - SNAPSHOT_DISCOVERY_HORIZON_DAYS * 86400_000)
+        .toISOString()
+        .slice(0, 10);
+  return { date: null, bucketMissing: false, searchedSince };
 }
 
 /**
@@ -1092,7 +1127,11 @@ export function registerInsightTools(
         const latest = await latestSnapshotDate(reportClient, bucket, today, reportBudget);
         if (latest.bucketMissing) return toolJson(NOT_ENABLED);
         if (!hasUsageReportSnapshots(latest))
-          return toolJson(noUsageReportSnapshots(reportBudget.stats));
+          return toolJson(
+            latest.searchedSince
+              ? noUsageReportSnapshotsWithinHorizon(reportBudget.stats, latest.searchedSince)
+              : noUsageReportSnapshots(reportBudget.stats),
+          );
 
         const then = await nearestSnapshotDate(reportClient, bucket, targetThen, reportBudget);
         if (then.bucketMissing) return toolJson(NOT_ENABLED);
@@ -1173,7 +1212,9 @@ export function registerInsightTools(
             if (latest.bucketMissing) return toolJson(NOT_ENABLED);
             emptySnapshotMetadata = hasUsageReportSnapshots(latest)
               ? noUsageReportSnapshotsInPeriod(loaded.stats, since, latest.date)
-              : noUsageReportSnapshots(loaded.stats);
+              : latest.searchedSince
+                ? noUsageReportSnapshotsWithinHorizon(loaded.stats, latest.searchedSince)
+                : noUsageReportSnapshots(loaded.stats);
           }
           return toolJson({
             period,

--- a/src/b2/insights.ts
+++ b/src/b2/insights.ts
@@ -430,7 +430,7 @@ function noUsageReportSnapshotsInPeriod(
           "data files were found in the requested period."
         : `No usage-report snapshots found in the requested period. Latest available snapshot ` +
           `is ${latestSnapshot}.`,
-    latest_snapshot: latestSnapshot,
+    ...(stats.stop_reason ? {} : { latest_snapshot: latestSnapshot }),
     ...reportScanMetadataFromStats(stats),
   };
 }

--- a/src/b2/insights.ts
+++ b/src/b2/insights.ts
@@ -270,6 +270,7 @@ const NOT_ENABLED = {
     "enabled by Backblaze Support / your account representative (Partner, Enterprise, or Groups). " +
     "Once enabled, B2 backfills the previous 7 days.",
 };
+const NO_USAGE_REPORT_SNAPSHOTS_NOTE = "No usage-report snapshots found yet.";
 
 const REPORT_SCAN_LIMITS = {
   maxPages: 100,
@@ -386,6 +387,14 @@ function reportScanMetadata(...loads: ReportRowsResult[]): Record<string, unknow
     return acc;
   }, newReportStats());
   return reportScanMetadataFromStats(totals);
+}
+
+function noUsageReportSnapshots(stats: ReportLoadStats): Record<string, unknown> {
+  return {
+    reports_enabled: true,
+    note: NO_USAGE_REPORT_SNAPSHOTS_NOTE,
+    ...reportScanMetadataFromStats(stats),
+  };
 }
 
 /**
@@ -1033,12 +1042,7 @@ export function registerInsightTools(
 
         const latest = await latestSnapshotDate(reportClient, bucket, today, reportBudget);
         if (latest.bucketMissing) return toolJson(NOT_ENABLED);
-        if (!latest.date)
-          return toolJson({
-            reports_enabled: true,
-            note: "No usage-report snapshots found yet.",
-            ...reportScanMetadataFromStats(reportBudget.stats),
-          });
+        if (!latest.date) return toolJson(noUsageReportSnapshots(reportBudget.stats));
 
         const then = await nearestSnapshotDate(reportClient, bucket, targetThen, reportBudget);
         if (then.bucketMissing) return toolJson(NOT_ENABLED);
@@ -1109,11 +1113,20 @@ export function registerInsightTools(
         const since = args.days != null ? daysAgo(args.days) : startOfMonthUTC();
         const loaded = await loadReportRows(reportClient, await reportsBucketName(auth), since);
         if (loaded === null) return toolJson(NOT_ENABLED);
+        const period = args.days != null ? `last ${args.days} days` : "current month to date";
+        if (loaded.stats.selected_keys === 0) {
+          return toolJson({
+            period,
+            rank_by: args.by,
+            ...noUsageReportSnapshots(loaded.stats),
+            leaders: [],
+          });
+        }
         const leaders = computeEgressLeaders(loaded.rows, args.by);
         const total = leaders.reduce((s, l) => s + l.egress, 0);
         const top = leaders.slice(0, args.limit);
         return toolJson({
-          period: args.days != null ? `last ${args.days} days` : "current month to date",
+          period,
           rank_by: args.by,
           total_egress_gb: gb(total),
           ...reportScanMetadata(loaded),

--- a/tests/unit/insights-read-paths.unit.test.ts
+++ b/tests/unit/insights-read-paths.unit.test.ts
@@ -312,6 +312,74 @@ describe("insight usage-report read paths", () => {
     expect(result.report_scan.parsed_rows).toBe(0);
   });
 
+  it("keeps empty b2_egress_leaders scans inconclusive when truncated", async () => {
+    const day = daysAgo(1);
+    const report = createPagedReportClient(
+      Object.fromEntries(
+        Array.from({ length: 101 }, (_, index) => [
+          `${day}/notes-${String(index).padStart(3, "0")}.txt`,
+          "ignored",
+        ]),
+      ),
+      { pageSize: 1 },
+    );
+    const tools = registerTools(report.client);
+
+    const result = parseResult(
+      await tools.call("b2_egress_leaders", { by: "account", days: 7, limit: 5 }),
+    );
+
+    expect(result.reports_enabled).toBe(true);
+    expect(result.note).toContain("inconclusive");
+    expect(result.note).toContain("scan budget");
+    expect(result).not.toHaveProperty("total_egress_gb");
+    expect(result.leaders).toEqual([]);
+    expect(result.truncated).toBe(true);
+    expect(result.partial).toBe(true);
+    expect(result.report_scan.selected_keys).toBe(0);
+    expect(result.report_scan.stop_reasons).toEqual(["max_pages"]);
+  });
+
+  it("distinguishes an empty b2_egress_leaders window from no snapshots yet", async () => {
+    const staleDay = daysAgo(31);
+    const report = createPagedReportClient({
+      [`${staleDay}/usage.account-stale.csv`]: csv([
+        `stale,${staleDay},bucket-stale,bucket-stale,1,4,0,0\n`,
+      ]),
+    });
+    const tools = registerTools(report.client);
+
+    const result = parseResult(
+      await tools.call("b2_egress_leaders", { by: "account", days: 30, limit: 5 }),
+    );
+
+    expect(result.reports_enabled).toBe(true);
+    expect(result.note).toContain("requested period");
+    expect(result.note).toContain(staleDay);
+    expect(result.latest_snapshot).toBe(staleDay);
+    expect(result).not.toHaveProperty("total_egress_gb");
+    expect(result.leaders).toEqual([]);
+  });
+
+  it("does not report measured zero when b2_egress_leaders parses no usage rows", async () => {
+    const day = daysAgo(1);
+    const report = createPagedReportClient({
+      [`${day}/usage.account-empty.csv`]: "",
+    });
+    const tools = registerTools(report.client);
+
+    const result = parseResult(
+      await tools.call("b2_egress_leaders", { by: "account", days: 7, limit: 5 }),
+    );
+
+    expect(result.reports_enabled).toBe(true);
+    expect(result.note).toContain("no parseable usage rows");
+    expect(result).not.toHaveProperty("total_egress_gb");
+    expect(result.leaders).toEqual([]);
+    expect(result.report_scan.selected_keys).toBe(1);
+    expect(result.report_scan.parsed_rows).toBe(0);
+  });
+
   it("paginates b2_egress_leaders report keys and skips empty or malformed CSV rows", async () => {
     const oldDay = daysAgo(120);
     const dayOne = daysAgo(3);

--- a/tests/unit/insights-read-paths.unit.test.ts
+++ b/tests/unit/insights-read-paths.unit.test.ts
@@ -291,6 +291,27 @@ describe("insight usage-report read paths", () => {
     ]);
   });
 
+  it.each([
+    [{ by: "account" as const, days: 30, limit: 5 }, "last 30 days"],
+    [{ by: "bucket" as const, limit: 5 }, "current month to date"],
+  ])("returns a clean empty-snapshot result for b2_egress_leaders", async (args, period) => {
+    const report = createPagedReportClient({});
+    const tools = registerTools(report.client);
+
+    const result = parseResult(await tools.call("b2_egress_leaders", args));
+
+    expect(result.period).toBe(period);
+    expect(result.rank_by).toBe(args.by);
+    expect(result.reports_enabled).toBe(true);
+    expect(result.note).toBe("No usage-report snapshots found yet.");
+    expect(result).not.toHaveProperty("total_egress_gb");
+    expect(result.leaders).toEqual([]);
+    expect(result.report_scan.pages).toEqual(expect.any(Number));
+    expect(result.report_scan.pages).toBeGreaterThan(0);
+    expect(result.report_scan.listed_keys).toBe(0);
+    expect(result.report_scan.parsed_rows).toBe(0);
+  });
+
   it("paginates b2_egress_leaders report keys and skips empty or malformed CSV rows", async () => {
     const oldDay = daysAgo(120);
     const dayOne = daysAgo(3);

--- a/tests/unit/insights-read-paths.unit.test.ts
+++ b/tests/unit/insights-read-paths.unit.test.ts
@@ -219,7 +219,8 @@ describe("insight usage-report read paths", () => {
     );
 
     expect(result.reports_enabled).toBe(true);
-    expect(result.note).toBe("No usage-report snapshots found yet.");
+    expect(result.note).toContain("No usage-report snapshots found in the last 180 days");
+    expect(result.searched_since).toBe(daysAgo(180));
     expect(result.report_scan.pages).toEqual(expect.any(Number));
     expect(result.report_scan.pages).toBeGreaterThan(0);
   });
@@ -303,7 +304,8 @@ describe("insight usage-report read paths", () => {
     expect(result.period).toBe(period);
     expect(result.rank_by).toBe(args.by);
     expect(result.reports_enabled).toBe(true);
-    expect(result.note).toBe("No usage-report snapshots found yet.");
+    expect(result.note).toContain("No usage-report snapshots found in the last 180 days");
+    expect(result.searched_since).toBe(daysAgo(180));
     expect(result).not.toHaveProperty("total_egress_gb");
     expect(result.leaders).toEqual([]);
     expect(result.report_scan.pages).toEqual(expect.any(Number));
@@ -359,6 +361,47 @@ describe("insight usage-report read paths", () => {
     expect(result.latest_snapshot).toBe(staleDay);
     expect(result).not.toHaveProperty("total_egress_gb");
     expect(result.leaders).toEqual([]);
+  });
+
+  it("qualifies b2_egress_leaders with the horizon when snapshots predate 180 days", async () => {
+    const ancientDay = daysAgo(200);
+    const report = createPagedReportClient({
+      [`${ancientDay}/usage.account-old.csv`]: csv([
+        `old,${ancientDay},bucket-old,bucket-old,1,4,0,0\n`,
+      ]),
+    });
+    const tools = registerTools(report.client);
+
+    const result = parseResult(
+      await tools.call("b2_egress_leaders", { by: "account", days: 30, limit: 5 }),
+    );
+
+    expect(result.reports_enabled).toBe(true);
+    expect(result.note).toContain("No usage-report snapshots found in the last 180 days");
+    expect(result.note).not.toContain("found yet");
+    expect(result.searched_since).toBe(daysAgo(180));
+    expect(result).not.toHaveProperty("latest_snapshot");
+    expect(result).not.toHaveProperty("total_egress_gb");
+    expect(result.leaders).toEqual([]);
+  });
+
+  it("qualifies b2_usage_growth with the horizon when snapshots predate 180 days", async () => {
+    const ancientDay = daysAgo(200);
+    const report = createPagedReportClient({
+      [`${ancientDay}/usage.account-old.csv`]: csv([
+        `old,${ancientDay},bucket-old,bucket-old,1,4,0,0\n`,
+      ]),
+    });
+    const tools = registerTools(report.client);
+
+    const result = parseResult(
+      await tools.call("b2_usage_growth", { period: "month", order: "most_grown", limit: 10 }),
+    );
+
+    expect(result.reports_enabled).toBe(true);
+    expect(result.note).toContain("No usage-report snapshots found in the last 180 days");
+    expect(result.note).not.toContain("found yet");
+    expect(result.searched_since).toBe(daysAgo(180));
   });
 
   it("omits latest_snapshot when empty b2_egress_leaders discovery is truncated", async () => {

--- a/tests/unit/insights-read-paths.unit.test.ts
+++ b/tests/unit/insights-read-paths.unit.test.ts
@@ -361,6 +361,32 @@ describe("insight usage-report read paths", () => {
     expect(result.leaders).toEqual([]);
   });
 
+  it("omits latest_snapshot when empty b2_egress_leaders discovery is truncated", async () => {
+    const staleDay = daysAgo(2);
+    const report = createPagedReportClient(
+      Object.fromEntries(
+        Array.from({ length: 101 }, (_, index) => [
+          `${staleDay}/usage.account-${String(index).padStart(3, "0")}.csv`,
+          csv([`stale-${index},${staleDay},bucket-stale,bucket-stale,1,4,0,0\n`]),
+        ]),
+      ),
+      { pageSize: 1 },
+    );
+    const tools = registerTools(report.client);
+
+    const result = parseResult(
+      await tools.call("b2_egress_leaders", { by: "account", days: 1, limit: 5 }),
+    );
+
+    expect(result.reports_enabled).toBe(true);
+    expect(result.note).toContain("inconclusive");
+    expect(result).not.toHaveProperty("latest_snapshot");
+    expect(result).not.toHaveProperty("total_egress_gb");
+    expect(result.leaders).toEqual([]);
+    expect(result.truncated).toBe(true);
+    expect(result.report_scan.stop_reasons).toEqual(["max_pages"]);
+  });
+
   it("does not report measured zero when b2_egress_leaders parses no usage rows", async () => {
     const day = daysAgo(1);
     const report = createPagedReportClient({

--- a/tests/unit/insights-read-paths.unit.test.ts
+++ b/tests/unit/insights-read-paths.unit.test.ts
@@ -363,6 +363,27 @@ describe("insight usage-report read paths", () => {
     expect(result.leaders).toEqual([]);
   });
 
+  it("does not treat non-usage date-prefixed objects as b2_egress_leaders snapshots", async () => {
+    const day = daysAgo(2);
+    const report = createPagedReportClient({
+      [`${day}/notes.txt`]: "not a usage report",
+      [`${day}/usage.audit-account-a.csv`]: csv([`a,${day},bucket-a,bucket-a,1,4,0,0\n`]),
+    });
+    const tools = registerTools(report.client);
+
+    const result = parseResult(
+      await tools.call("b2_egress_leaders", { by: "account", days: 7, limit: 5 }),
+    );
+
+    expect(result.reports_enabled).toBe(true);
+    expect(result.note).toContain("No usage-report snapshots found in the last 180 days");
+    expect(result.note).not.toContain("Report snapshots exist");
+    expect(result.searched_since).toBe(daysAgo(180));
+    expect(result).not.toHaveProperty("latest_snapshot");
+    expect(result).not.toHaveProperty("total_egress_gb");
+    expect(result.leaders).toEqual([]);
+  });
+
   it("qualifies b2_egress_leaders with the horizon when snapshots predate 180 days", async () => {
     const ancientDay = daysAgo(200);
     const report = createPagedReportClient({

--- a/tests/unit/insights-read-paths.unit.test.ts
+++ b/tests/unit/insights-read-paths.unit.test.ts
@@ -425,6 +425,33 @@ describe("insight usage-report read paths", () => {
     expect(result.searched_since).toBe(daysAgo(180));
   });
 
+  it("keeps b2_usage_growth inconclusive when latest-snapshot discovery is truncated", async () => {
+    const report = createPagedReportClient(
+      Object.fromEntries(
+        Array.from({ length: 101 }, (_, index) => {
+          const day = daysAgo(1 + (index % 9));
+          return [
+            `${day}/usage.account-${String(index).padStart(3, "0")}.csv`,
+            csv([`acct-${index},${day},bucket-a,bucket-a,1,4,0,0\n`]),
+          ];
+        }),
+      ),
+      { pageSize: 1 },
+    );
+    const tools = registerTools(report.client);
+
+    const result = parseResult(
+      await tools.call("b2_usage_growth", { period: "month", order: "most_grown", limit: 10 }),
+    );
+
+    expect(result.reports_enabled).toBe(true);
+    expect(result.note).toContain("inconclusive");
+    expect(result).not.toHaveProperty("latest_snapshot");
+    expect(result).not.toHaveProperty("comparison");
+    expect(result.truncated).toBe(true);
+    expect(result.report_scan.stop_reasons).toEqual(["max_pages"]);
+  });
+
   it("omits latest_snapshot when empty b2_egress_leaders discovery is truncated", async () => {
     const staleDay = daysAgo(2);
     const report = createPagedReportClient(

--- a/tests/unit/insights.unit.test.ts
+++ b/tests/unit/insights.unit.test.ts
@@ -322,7 +322,7 @@ describe("insights — snapshot selection (fake report client)", () => {
     expect(rows.reduce((s, r) => s + (r.storageBytes ?? 0), 0)).toBe(100 * GB);
   });
 
-  it("latestSnapshotDate stops at the report listing page budget", async () => {
+  it("latestSnapshotDate reports inconclusive when truncated at the page budget", async () => {
     let calls = 0;
     const b2Client = {
       listReportObjectKeys: async () => {
@@ -343,7 +343,11 @@ describe("insights — snapshot selection (fake report client)", () => {
     );
 
     expect(calls).toBe(100);
-    expect(result.date).toBe("2026-06-28");
+    // A truncated scan only saw the older (lexically earlier) keys, so it must not
+    // publish a partial max as an authoritative latest snapshot.
+    expect(result.date).toBeNull();
+    expect(result.bucketMissing).toBe(false);
+    expect(result.searchedSince).toBeUndefined();
   });
 });
 

--- a/tests/unit/insights.unit.test.ts
+++ b/tests/unit/insights.unit.test.ts
@@ -349,6 +349,30 @@ describe("insights — snapshot selection (fake report client)", () => {
     expect(result.bucketMissing).toBe(false);
     expect(result.searchedSince).toBeUndefined();
   });
+
+  it("latestSnapshotDate caps candidate collection and reports inconclusive", async () => {
+    // A single page with more matching keys than maxCandidateKeys (5000) must not
+    // be buffered whole; discovery caps the collection and falls through as
+    // inconclusive rather than holding the entire namespace in memory.
+    const keys = Array.from(
+      { length: 6000 },
+      (_, i) => `2026-06-01/usage.account.${String(i).padStart(5, "0")}.csv`,
+    );
+    const b2Client = {
+      listReportObjectKeys: async () => ({ keys, isTruncated: false }),
+      downloadReportObjectText: async () => ({ text: "", bytes: 0, truncated: false }),
+    };
+
+    const result = await latestSnapshotDate(
+      b2Client as any,
+      "b2-reports-x",
+      new Date(Date.UTC(2026, 5, 28)),
+    );
+
+    expect(result.date).toBeNull();
+    expect(result.bucketMissing).toBe(false);
+    expect(result.searchedSince).toBeUndefined();
+  });
 });
 
 describe("insights — report scan bounds", () => {


### PR DESCRIPTION
Summary:
- Added a shared empty usage-report snapshot response for report-backed insight tools.
- Updated b2_egress_leaders to return reports_enabled and a qualified note without total_egress_gb when no usage-report data can support a measured total.
- Clarified review edge cases: truncated empty scans are inconclusive, stale windows report the latest available snapshot only for complete discovery, and selected snapshots with no parseable rows do not become measured zeroes.
- Qualified null latest-snapshot discovery with the searched horizon: latestSnapshotDate now returns searchedSince, and b2_egress_leaders and b2_usage_growth report "no snapshots in the last 180 days (searched back to <date>)" with a searched_since field instead of asserting snapshots never existed when reporting stopped before the bounded window.
- Restricted latest-snapshot discovery to usage-report data keys: latestSnapshotDate now collects only date-prefixed CSV keys and runs them through the same selectUsageKeys selection the row loader uses (shared REPORT_DAY_CSV_RE), so a bucket holding only non-usage objects (e.g. YYYY-MM-DD/notes.txt) or an audit-only mirror is no longer mistaken for a snapshot.
- Dropped truncated latest-snapshot dates: discovery now breaks to the inconclusive path as soon as a stop_reason is set, so a partial (lexically older) max is never published as an authoritative latest_snapshot.
- Bounded latest-snapshot candidate collection: latestSnapshotDate now caps the buffered candidate keys at maxCandidateKeys (5000) and falls through to the inconclusive path when capped, so an audit-heavy or non-usage bucket can no longer buffer the whole namespace (up to maxPages * maxKeysPerPage keys) in memory.
- Covered account/bucket empty results, truncated zero-selected scans, aged snapshots outside the window, parse-empty usage files, truncated latest-snapshot discovery, capped candidate collection, snapshots older than the 180-day horizon, and non-usage/audit-only date-prefixed objects with unit tests; updated the existing latestSnapshotDate page-budget test to assert the inconclusive result.

Housekeeping:
- Formatted insights.ts and trimmed the horizon-discovery docs.
- Refreshed the package-budget baseline and raised the unpacked-bytes limit to cover the horizon-discovery source growth (no new runtime dependencies).

Linked issue:
Fixes #319

Tests run:
- pnpm exec vitest run --config vitest.config.mts --project=unit tests/unit/insights-read-paths.unit.test.ts tests/unit/insights.unit.test.ts
- pnpm run typecheck
- pnpm run lint
- pnpm run format:check
- pnpm test
- pnpm run test:contract
- pnpm run docs
- pnpm run build
- node scripts/check-package-budget.mjs

Follow-up notes:
- None.

