### PR TITLE
fix: bound stdio capability bootstrap

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -64,6 +64,9 @@ B2_APPLICATION_KEY=
 # closed. Set to true to explicitly register the full surface regardless of the
 # key's capabilities.
 # B2_REGISTER_ALL_TOOLS=false
+# Stdio only: bound startup capability discovery so a stalled authorize does not
+# block MCP client handshakes indefinitely. Deadline expiry starts fail-closed.
+# B2_STDIO_CAPABILITY_TIMEOUT_MS=10000
 # Bounded capability-discovery cache TTL and size. Cache identity is secret-bound;
 # logs use only non-secret credential fingerprints or verified principal labels.
 # B2_CAPABILITY_CACHE_TTL_MS=300000

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   exported members, and invalid links now fail `pnpm run docs` and the docs
   workflow. (#308)
 
+### Fixed
+- Bound stdio capability discovery with a tunable 10s bootstrap deadline; local
+  deadline expiry now starts with a fail-closed tool surface instead of hanging
+  the MCP client handshake. (#320)
+
 ## [0.1.2] - 2026-08-23
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -252,6 +252,7 @@ S3-compatible and report tools use the `s3ApiUrl` returned by `b2_authorize_acco
 | `B2_TRUST_PROXY_HEADERS`                                         | `false`            | HTTP transport: trust `X-Forwarded-For` / `X-Real-IP` for unauthenticated admission keys only behind a trusted proxy       |
 | `B2_MCP_RATE_LIMIT_RPS` / `B2_MCP_RATE_LIMIT_BURST`              | `60` / `120`       | HTTP transport: per-credential request throttling                                                                         |
 | `B2_MAX_SESSIONS` / `B2_MAX_SESSIONS_PER_KEY`                    | `1000` / `20`      | HTTP transport: global and per-credential concurrent in-flight request caps                                               |
+| `B2_STDIO_CAPABILITY_TIMEOUT_MS`                                 | `10000`            | Stdio bootstrap capability-discovery deadline; local expiry starts with a fail-closed tool surface                         |
 | `B2_CAPABILITY_CACHE_TTL_MS` / `B2_CAPABILITY_CACHE_MAX_ENTRIES` | `300000` / `10000` | Bounded capability-discovery cache TTL and size. Cache identity is secret-bound; log labels are non-secret fingerprints   |
 | `B2_S3_SAVE_TO_PATH_IDLE_TIMEOUT_MS`                             | `60000`            | Idle timeout while streaming `s3_get_object` results to `saveToPath`                                                      |
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -83,7 +83,8 @@ async function fetchStdioCapabilities(
 
   try {
     // The SDK authorize cannot be cancelled safely outside an MCP request; if
-    // the local deadline wins, Promise.race still observes a late rejection.
+    // the local deadline wins, a late success is intentionally ignored and
+    // Promise.race still observes a late rejection.
     return await Promise.race([capabilityFetch, timeoutPromise]);
   } finally {
     if (timeout) clearTimeout(timeout);

--- a/src/index.ts
+++ b/src/index.ts
@@ -38,7 +38,7 @@ import * as stdioTransport from "@modelcontextprotocol/server/stdio";
 import { CliUsageError, helpText, parseCliArgs } from "./cli.js";
 import { CredentialResolutionError } from "./credentials.js";
 import * as serverModule from "./server.js";
-import { PortUsageError } from "./utils/config.js";
+import { parseIntEnv, PortUsageError } from "./utils/config.js";
 import { flushLogsSync, initLogging, logger } from "./utils/logger.js";
 import { bootstrapErrorMessage } from "./utils/secret-sanitizer.js";
 import { VERSION } from "./version.js";
@@ -52,30 +52,39 @@ type GlobalWithIndexTestSeams = typeof globalThis & {
   __b2McpIndexTestSeams?: IndexTestSeams;
 };
 
-const STDIO_CAPABILITY_FETCH_TIMEOUT_MS = 10_000;
+const DEFAULT_STDIO_CAPABILITY_FETCH_TIMEOUT_MS = 10_000;
+const STDIO_CAPABILITY_DEADLINE_CODE = "stdio_capability_deadline_exceeded";
 
-function stdioCapabilityTimeoutError(): CredentialResolutionError {
-  return new CredentialResolutionError(
-    `B2 capability lookup exceeded the ${STDIO_CAPABILITY_FETCH_TIMEOUT_MS} ms stdio bootstrap deadline`,
-    503,
-    "capability_upstream_unavailable",
+class StdioCapabilityDeadlineError extends Error {
+  readonly code = STDIO_CAPABILITY_DEADLINE_CODE;
+
+  constructor(readonly deadlineMs: number) {
+    super(`B2 capability lookup exceeded the ${deadlineMs} ms stdio bootstrap deadline`);
+    this.name = "StdioCapabilityDeadlineError";
+  }
+}
+
+function stdioCapabilityFetchTimeoutMs(env: NodeJS.ProcessEnv = process.env): number {
+  return Math.max(
+    1,
+    parseIntEnv(env.B2_STDIO_CAPABILITY_TIMEOUT_MS, DEFAULT_STDIO_CAPABILITY_FETCH_TIMEOUT_MS),
   );
 }
 
 async function fetchStdioCapabilities(
   config: ReturnType<typeof serverModule.loadConfig>,
+  timeoutMs: number,
 ): Promise<string[] | null> {
   let timeout: ReturnType<typeof setTimeout> | undefined;
   const timeoutPromise = new Promise<never>((_, reject) => {
-    timeout = setTimeout(
-      () => reject(stdioCapabilityTimeoutError()),
-      STDIO_CAPABILITY_FETCH_TIMEOUT_MS,
-    );
-    timeout.unref?.();
+    timeout = setTimeout(() => reject(new StdioCapabilityDeadlineError(timeoutMs)), timeoutMs);
   });
+  const capabilityFetch = serverModule.fetchCapabilities(config);
 
   try {
-    return await Promise.race([serverModule.fetchCapabilities(config), timeoutPromise]);
+    // The SDK authorize cannot be cancelled safely outside an MCP request; if
+    // the local deadline wins, Promise.race still observes a late rejection.
+    return await Promise.race([capabilityFetch, timeoutPromise]);
   } finally {
     if (timeout) clearTimeout(timeout);
   }
@@ -86,9 +95,10 @@ async function fetchStdioCapabilities(
  *
  * @remarks
  * The stdio path reads credentials from the process environment, attempts
- * capability discovery once, and deliberately degrades to the full tool surface
- * only when B2 capability lookup is temporarily unavailable. Other credential
- * errors remain fatal during bootstrap.
+ * capability discovery once with a `B2_STDIO_CAPABILITY_TIMEOUT_MS` bootstrap
+ * deadline (10s by default). A local deadline expiry starts with an empty
+ * fail-closed capability set; a returned transient upstream outage degrades to
+ * the full tool surface. Other credential errors remain fatal during bootstrap.
  *
  * @returns A promise that resolves after the stdio transport has been
  * registered with the MCP SDK.
@@ -104,32 +114,53 @@ async function fetchStdioCapabilities(
 export async function startStdio(): Promise<void> {
   initLogging();
   const config = serverModule.loadConfig();
+  const capabilityTimeoutMs = stdioCapabilityFetchTimeoutMs();
   let capabilities: string[] | null;
+  let createServerOptions: serverModule.CreateServerOptions | undefined;
   logger.info(
-    { transport: "stdio", timeoutMs: STDIO_CAPABILITY_FETCH_TIMEOUT_MS },
+    { transport: "stdio", timeoutMs: capabilityTimeoutMs },
     "capability.fetch.stdio_starting",
   );
   flushLogsSync();
   try {
-    capabilities = await fetchStdioCapabilities(config);
+    capabilities = await fetchStdioCapabilities(config, capabilityTimeoutMs);
   } catch (err) {
-    if (
-      !(err instanceof CredentialResolutionError) ||
-      err.code !== "capability_upstream_unavailable"
+    if (err instanceof StdioCapabilityDeadlineError) {
+      logger.warn(
+        {
+          code: err.code,
+          reason: "stdio_bootstrap_deadline",
+          deadlineMs: err.deadlineMs,
+        },
+        "capability.fetch.stdio_degraded",
+      );
+      capabilities = [];
+      createServerOptions = { failClosedUnknownCapabilities: true };
+    } else if (
+      err instanceof CredentialResolutionError &&
+      err.code === "capability_upstream_unavailable"
     ) {
+      logger.warn(
+        {
+          code: err.code,
+          reason: "upstream_unavailable",
+        },
+        "capability.fetch.stdio_degraded",
+      );
+      capabilities = null;
+    } else {
       throw err;
     }
-    logger.warn(
-      {
-        code: err.code,
-      },
-      "capability.fetch.stdio_degraded",
-    );
-    capabilities = null;
   }
-  stdioTransport.serveStdio(() => serverModule.createServer(config, capabilities), {
-    onerror: (error) => logger.warn({ err: error.message }, "mcp.stdio.error"),
-  });
+  stdioTransport.serveStdio(
+    () =>
+      createServerOptions
+        ? serverModule.createServer(config, capabilities, createServerOptions)
+        : serverModule.createServer(config, capabilities),
+    {
+      onerror: (error) => logger.warn({ err: error.message }, "mcp.stdio.error"),
+    },
+  );
 
   logger.info({ transport: "stdio" }, "server.started");
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -52,6 +52,35 @@ type GlobalWithIndexTestSeams = typeof globalThis & {
   __b2McpIndexTestSeams?: IndexTestSeams;
 };
 
+const STDIO_CAPABILITY_FETCH_TIMEOUT_MS = 10_000;
+
+function stdioCapabilityTimeoutError(): CredentialResolutionError {
+  return new CredentialResolutionError(
+    `B2 capability lookup exceeded the ${STDIO_CAPABILITY_FETCH_TIMEOUT_MS} ms stdio bootstrap deadline`,
+    503,
+    "capability_upstream_unavailable",
+  );
+}
+
+async function fetchStdioCapabilities(
+  config: ReturnType<typeof serverModule.loadConfig>,
+): Promise<string[] | null> {
+  let timeout: ReturnType<typeof setTimeout> | undefined;
+  const timeoutPromise = new Promise<never>((_, reject) => {
+    timeout = setTimeout(
+      () => reject(stdioCapabilityTimeoutError()),
+      STDIO_CAPABILITY_FETCH_TIMEOUT_MS,
+    );
+    timeout.unref?.();
+  });
+
+  try {
+    return await Promise.race([serverModule.fetchCapabilities(config), timeoutPromise]);
+  } finally {
+    if (timeout) clearTimeout(timeout);
+  }
+}
+
 /**
  * Start the MCP server over stdio.
  *
@@ -76,8 +105,13 @@ export async function startStdio(): Promise<void> {
   initLogging();
   const config = serverModule.loadConfig();
   let capabilities: string[] | null;
+  logger.info(
+    { transport: "stdio", timeoutMs: STDIO_CAPABILITY_FETCH_TIMEOUT_MS },
+    "capability.fetch.stdio_starting",
+  );
+  flushLogsSync();
   try {
-    capabilities = await serverModule.fetchCapabilities(config);
+    capabilities = await fetchStdioCapabilities(config);
   } catch (err) {
     if (
       !(err instanceof CredentialResolutionError) ||

--- a/src/server.ts
+++ b/src/server.ts
@@ -42,6 +42,8 @@ import {
   isToolAllowedByOAuthScopes,
   isToolEnabled,
   oauthScopesAllowOperation,
+  PARTNER_TOOLS,
+  TOOL_CAPABILITIES,
 } from "./utils/tool-capabilities.js";
 import {
   sanitizeError,
@@ -169,6 +171,18 @@ function registerDurableSecretCompatibilityStubs(
 export interface CreateServerOptions {
   /** Verified MCP/OAuth scopes for the current caller. */
   oauthScopes?: readonly string[];
+  /**
+   * Register only capability-mapped tools plus the bootstrap authorization tool.
+   *
+   * @remarks
+   * Used when stdio capability discovery times out locally before B2 verifies
+   * the key's allowed capabilities. This keeps the server responsive to the MCP
+   * handshake without widening the surface to unmapped Partner tools or
+   * durable-secret compatibility stubs.
+   *
+   * @internal
+   */
+  failClosedUnknownCapabilities?: boolean;
 }
 
 /**
@@ -263,9 +277,16 @@ export function createServer(
   const capsSet = filterActive ? new Set(capabilities) : null;
   const oauthAllowsRead = oauthScopesAllowOperation(oauthScopes, "read");
   const oauthAllowsWrite = oauthScopesAllowOperation(oauthScopes, "write");
+  const failClosedUnknownCapabilities = options.failClosedUnknownCapabilities === true;
+  const shouldRegisterForResolvedAuthz = (name: string) =>
+    (!failClosedUnknownCapabilities ||
+      name === "b2_authorize_account" ||
+      (TOOL_CAPABILITIES[name] !== undefined && !PARTNER_TOOLS.has(name))) &&
+    isToolEnabled(name, capsSet) &&
+    isToolAllowedByOAuthScopes(name, oauthScopes);
+
   const registrar = new ToolRegistrationAdapter(server, {
-    shouldRegister: (name) =>
-      isToolEnabled(name, capsSet) && isToolAllowedByOAuthScopes(name, oauthScopes),
+    shouldRegister: shouldRegisterForResolvedAuthz,
     wrapCallback: (name, callback) =>
       createAuditedToolCallback(name, callback, config, {
         getClientCapabilities: () => getMcpClientCapabilities(server),
@@ -348,7 +369,10 @@ export function createServer(
   // a stable non-secret unavailable error. File mode keeps filtered durable
   // secret tool names callable as non-secret unavailable errors; Reserve Trial
   // is always stubbed because the provider has no post-create recovery action.
-  if (config.secretSink?.mode === "file") {
+  if (failClosedUnknownCapabilities) {
+    // Do not reintroduce privileged names after a local stdio capability
+    // deadline. The caller has not verified the credential's real surface yet.
+  } else if (config.secretSink?.mode === "file") {
     registerDurableSecretCompatibilityStubs(
       registrar,
       config.secretSink,

--- a/tests/protocol/stdio.transport.modern-protocol.test.ts
+++ b/tests/protocol/stdio.transport.modern-protocol.test.ts
@@ -104,6 +104,14 @@ describe("stdio transport (MCP 2026-07-28)", () => {
     child.stderr.on("data", (chunk) => {
       stderr += chunk.toString();
     });
+    let childExited = false;
+    const childExit = once(child, "exit")
+      .then(() => {
+        childExited = true;
+      })
+      .catch(() => {
+        childExited = true;
+      });
 
     const waitForFrame = (id: number) =>
       new Promise<any>((resolve, reject) => {
@@ -113,6 +121,7 @@ describe("stdio transport (MCP 2026-07-28)", () => {
           child.off("exit", onExit);
         };
         const onExit = (code: number | null, signal: NodeJS.Signals | null) => {
+          childExited = true;
           cleanup();
           reject(
             new Error(`stdio child exited before response ${id}: ${code ?? signal}\n${stderr}`),
@@ -149,11 +158,17 @@ describe("stdio transport (MCP 2026-07-28)", () => {
       expect(stderr).toContain("stdio_capability_deadline_exceeded");
     } finally {
       child.stdin.end();
-      child.kill("SIGTERM");
-      const timer = setTimeout(() => child.kill("SIGKILL"), 2_000);
-      timer.unref();
-      await once(child, "exit").catch(() => undefined);
-      clearTimeout(timer);
+      const timer = setTimeout(() => {
+        if (!childExited) child.kill("SIGKILL");
+      }, 2_000);
+      try {
+        if (!childExited) {
+          child.kill("SIGTERM");
+          await childExit;
+        }
+      } finally {
+        clearTimeout(timer);
+      }
     }
   });
 

--- a/tests/protocol/stdio.transport.modern-protocol.test.ts
+++ b/tests/protocol/stdio.transport.modern-protocol.test.ts
@@ -1,8 +1,10 @@
-import { spawnSync } from "child_process";
+import { spawn, spawnSync, type ChildProcessWithoutNullStreams } from "child_process";
+import { once } from "events";
 import {
   MODERN_META,
   MODERN_PROTOCOL_VERSION,
   RawStdioSession,
+  ROOT,
   protocolEnv,
 } from "../support/protocol";
 import { closeClient, connectModernStdioClient } from "./support/clients";
@@ -17,6 +19,12 @@ function errorOf(frame: any): any {
   expect(frame.result).toBeUndefined();
   expect(frame.error).toBeDefined();
   return frame.error;
+}
+
+function send(child: ChildProcessWithoutNullStreams, id: number, method: string): void {
+  child.stdin.write(
+    `${JSON.stringify({ jsonrpc: "2.0", id, method, params: { _meta: MODERN_META } })}\n`,
+  );
 }
 
 describe("stdio transport (MCP 2026-07-28)", () => {
@@ -58,6 +66,94 @@ describe("stdio transport (MCP 2026-07-28)", () => {
         if (value === undefined) delete process.env[name];
         else process.env[name] = value;
       }
+    }
+  });
+
+  it("keeps a never-settling capability bootstrap alive until the fail-closed deadline", async () => {
+    const script = [
+      'const server = require("./dist/server.js");',
+      "server.fetchCapabilities = () => new Promise(() => undefined);",
+      'require("./dist/index.js").startStdio().catch((err) => {',
+      "  console.error(err && err.stack ? err.stack : err);",
+      "  process.exit(1);",
+      "});",
+    ].join("\n");
+    const child = spawn(process.execPath, ["-e", script], {
+      cwd: ROOT,
+      env: protocolEnv({
+        B2_REGISTER_ALL_TOOLS: "false",
+        B2_SECRET_SINK: "off",
+        B2_STDIO_CAPABILITY_TIMEOUT_MS: "50",
+        LOG_LEVEL: "info",
+      }),
+      stdio: ["pipe", "pipe", "pipe"],
+    });
+    const frames: any[] = [];
+    let stdoutBuffer = "";
+    let stderr = "";
+    child.stdout.on("data", (chunk) => {
+      stdoutBuffer += chunk.toString();
+      for (;;) {
+        const newline = stdoutBuffer.indexOf("\n");
+        if (newline === -1) return;
+        const line = stdoutBuffer.slice(0, newline).trim();
+        stdoutBuffer = stdoutBuffer.slice(newline + 1);
+        if (line) frames.push(JSON.parse(line));
+      }
+    });
+    child.stderr.on("data", (chunk) => {
+      stderr += chunk.toString();
+    });
+
+    const waitForFrame = (id: number) =>
+      new Promise<any>((resolve, reject) => {
+        const cleanup = () => {
+          clearInterval(interval);
+          clearTimeout(timer);
+          child.off("exit", onExit);
+        };
+        const onExit = (code: number | null, signal: NodeJS.Signals | null) => {
+          cleanup();
+          reject(
+            new Error(`stdio child exited before response ${id}: ${code ?? signal}\n${stderr}`),
+          );
+        };
+        const interval = setInterval(() => {
+          const frame = frames.find((candidate) => candidate.id === id);
+          if (!frame) return;
+          cleanup();
+          resolve(frame);
+        }, 10);
+        const timer = setTimeout(() => {
+          cleanup();
+          reject(new Error(`timed out waiting for response ${id}\n${stderr}`));
+        }, 2_000);
+        child.on("exit", onExit);
+      });
+
+    try {
+      send(child, 1, "server/discover");
+      const discover = resultOf(await waitForFrame(1));
+      expect(discover.supportedVersions).toEqual([MODERN_PROTOCOL_VERSION]);
+
+      send(child, 2, "tools/list");
+      const listed = resultOf(await waitForFrame(2));
+      const toolNames = listed.tools.map((tool: { name: string }) => tool.name);
+      expect(toolNames).toContain("b2_authorize_account");
+      expect(toolNames).not.toContain("b2_create_bucket");
+      expect(toolNames).not.toContain("b2_create_key");
+      expect(toolNames).not.toContain("s3_put_object");
+      expect(toolNames).not.toContain("s3_delete_object");
+      expect(toolNames).not.toContain("b2_list_groups");
+      expect(stderr).toContain("capability.fetch.stdio_degraded");
+      expect(stderr).toContain("stdio_capability_deadline_exceeded");
+    } finally {
+      child.stdin.end();
+      child.kill("SIGTERM");
+      const timer = setTimeout(() => child.kill("SIGKILL"), 2_000);
+      timer.unref();
+      await once(child, "exit").catch(() => undefined);
+      clearTimeout(timer);
     }
   });
 

--- a/tests/unit/capability-registration.unit.test.ts
+++ b/tests/unit/capability-registration.unit.test.ts
@@ -9,6 +9,7 @@ import {
   getRegisteredTools,
   fetchCapabilities,
   invalidateCapabilityCache,
+  type CreateServerOptions,
 } from "../../src/server";
 import { CredentialResolutionError, verificationFingerprintConfig } from "../../src/credentials";
 import { logger } from "../../src/utils/logger";
@@ -40,8 +41,12 @@ const baseConfig = {
   fileRoot: null,
 } as unknown as B2Config;
 
-function toolNames(caps: string[] | null, cfg: B2Config = baseConfig): string[] {
-  const server = createServer(cfg, caps);
+function toolNames(
+  caps: string[] | null,
+  cfg: B2Config = baseConfig,
+  options: CreateServerOptions = {},
+): string[] {
+  const server = createServer(cfg, caps, options);
   return Object.keys(getRegisteredTools(server) ?? {});
 }
 
@@ -81,6 +86,11 @@ describe("capability-aware registration", () => {
     expect(names).toContain("b2_authorize_account");
     expect(names).toContain("b2_create_key");
     expect(names).not.toContain("b2_usage_growth");
+  });
+
+  it("suppresses privileged stubs for fail-closed unknown capabilities", () => {
+    const names = toolNames([], baseConfig, { failClosedUnknownCapabilities: true });
+    expect(names).toEqual(["b2_authorize_account"]);
   });
 
   it("read-only key drops every write/delete/admin tool", () => {

--- a/tests/unit/index.unit.test.ts
+++ b/tests/unit/index.unit.test.ts
@@ -166,6 +166,52 @@ describe("stdio entry point", () => {
     );
   });
 
+  it("bounds stdio capability lookup before falling back to the full surface", async () => {
+    vi.useFakeTimers();
+    try {
+      const config = testConfig();
+      const server = { close: vi.fn(async () => undefined) };
+      const createServer = vi.spyOn(serverModule, "createServer").mockReturnValue(server as never);
+      vi.spyOn(serverModule, "loadConfig").mockReturnValue(config);
+      vi.spyOn(serverModule, "fetchCapabilities").mockReturnValue(
+        new Promise<string[] | null>(() => undefined),
+      );
+      const info = vi.spyOn(loggerModule.logger, "info").mockImplementation(() => undefined);
+      const warn = vi.spyOn(loggerModule.logger, "warn").mockImplementation(() => undefined);
+      const flushLogsSync = vi
+        .spyOn(loggerModule, "flushLogsSync")
+        .mockImplementation(() => undefined);
+      const serveStdio = vi.mocked(stdioTransport.serveStdio).mockImplementation(
+        () =>
+          ({
+            close: vi.fn(async () => undefined),
+          }) as ReturnType<typeof stdioTransport.serveStdio>,
+      );
+
+      const started = startStdio();
+
+      expect(serveStdio).not.toHaveBeenCalled();
+      expect(info).toHaveBeenCalledWith(
+        { transport: "stdio", timeoutMs: 10_000 },
+        "capability.fetch.stdio_starting",
+      );
+      expect(flushLogsSync).toHaveBeenCalledOnce();
+
+      await vi.runOnlyPendingTimersAsync();
+      await expect(started).resolves.toBeUndefined();
+
+      const factory = serveStdio.mock.calls[0]?.[0] as (() => unknown) | undefined;
+      expect(factory?.()).toBe(server);
+      expect(createServer).toHaveBeenCalledWith(config, null);
+      expect(warn).toHaveBeenCalledWith(
+        { code: "capability_upstream_unavailable" },
+        "capability.fetch.stdio_degraded",
+      );
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   it("rethrows unexpected capability lookup failures", async () => {
     const config = testConfig();
     vi.spyOn(serverModule, "loadConfig").mockReturnValue(config);

--- a/tests/unit/index.unit.test.ts
+++ b/tests/unit/index.unit.test.ts
@@ -29,7 +29,8 @@ const credentialEnvKeys = [
 ] as const;
 
 const transportEnvKeys = ["B2_MCP_TRANSPORT"] as const;
-const executableEnvKeys = [...credentialEnvKeys, ...transportEnvKeys] as const;
+const bootstrapEnvKeys = ["B2_STDIO_CAPABILITY_TIMEOUT_MS"] as const;
+const executableEnvKeys = [...credentialEnvKeys, ...transportEnvKeys, ...bootstrapEnvKeys] as const;
 const { startStdio } = packageRoot;
 
 type IndexTestSeams = {
@@ -98,11 +99,13 @@ describe("stdio entry point", () => {
   let savedEnv: Record<string, string | undefined>;
 
   beforeEach(() => {
-    savedEnv = Object.fromEntries(credentialEnvKeys.map((key) => [key, process.env[key]]));
+    savedEnv = Object.fromEntries(
+      [...credentialEnvKeys, ...bootstrapEnvKeys].map((key) => [key, process.env[key]]),
+    );
   });
 
   afterEach(() => {
-    for (const key of credentialEnvKeys) {
+    for (const key of [...credentialEnvKeys, ...bootstrapEnvKeys]) {
       const value = savedEnv[key];
       if (value === undefined) delete process.env[key];
       else process.env[key] = value;
@@ -161,14 +164,15 @@ describe("stdio entry point", () => {
     expect(factory?.()).toBe(server);
     expect(createServer).toHaveBeenCalledWith(config, null);
     expect(warn).toHaveBeenCalledWith(
-      { code: "capability_upstream_unavailable" },
+      { code: "capability_upstream_unavailable", reason: "upstream_unavailable" },
       "capability.fetch.stdio_degraded",
     );
   });
 
-  it("bounds stdio capability lookup before falling back to the full surface", async () => {
+  it("bounds stdio capability lookup before starting with a fail-closed surface", async () => {
     vi.useFakeTimers();
     try {
+      process.env.B2_STDIO_CAPABILITY_TIMEOUT_MS = "25";
       const config = testConfig();
       const server = { close: vi.fn(async () => undefined) };
       const createServer = vi.spyOn(serverModule, "createServer").mockReturnValue(server as never);
@@ -192,19 +196,28 @@ describe("stdio entry point", () => {
 
       expect(serveStdio).not.toHaveBeenCalled();
       expect(info).toHaveBeenCalledWith(
-        { transport: "stdio", timeoutMs: 10_000 },
+        { transport: "stdio", timeoutMs: 25 },
         "capability.fetch.stdio_starting",
       );
       expect(flushLogsSync).toHaveBeenCalledOnce();
 
-      await vi.runOnlyPendingTimersAsync();
+      await vi.advanceTimersByTimeAsync(24);
+      expect(serveStdio).not.toHaveBeenCalled();
+
+      await vi.advanceTimersByTimeAsync(1);
       await expect(started).resolves.toBeUndefined();
 
       const factory = serveStdio.mock.calls[0]?.[0] as (() => unknown) | undefined;
       expect(factory?.()).toBe(server);
-      expect(createServer).toHaveBeenCalledWith(config, null);
+      expect(createServer).toHaveBeenCalledWith(config, [], {
+        failClosedUnknownCapabilities: true,
+      });
       expect(warn).toHaveBeenCalledWith(
-        { code: "capability_upstream_unavailable" },
+        {
+          code: "stdio_capability_deadline_exceeded",
+          reason: "stdio_bootstrap_deadline",
+          deadlineMs: 25,
+        },
         "capability.fetch.stdio_degraded",
       );
     } finally {


### PR DESCRIPTION
## Summary
- Adds a tunable stdio capability bootstrap deadline via `B2_STDIO_CAPABILITY_TIMEOUT_MS` (10s default) and logs before capability discovery starts.
- Treats local deadline expiry as a distinct fail-closed path: stdio starts with empty capabilities plus `failClosedUnknownCapabilities`, avoiding full-surface registration and privileged compatibility stubs.
- Keeps true transient upstream capability failures on the existing full-surface degraded path, with structured logs that distinguish upstream outage from local deadline expiry.
- Keeps the bootstrap deadline timer referenced and covers the never-settling capability promise path with a real child-process stdio protocol regression test.
- Hardens that regression test cleanup by registering the child exit promise before termination and skipping the wait when the child has already exited.
- Notes that late capability-fetch results after the stdio deadline are intentionally abandoned while late rejections remain observed by the race.
- Documents the env knob and records the #320 fix in the Unreleased changelog.

## Linked issue
Fixes #320

## Tests run
- `pnpm exec vitest run --config vitest.config.mts --project=unit tests/unit/index.unit.test.ts tests/unit/capability-registration.unit.test.ts`
- `pnpm run typecheck`
- `pnpm run build`
- `pnpm exec biome lint src/index.ts src/server.ts tests/unit/index.unit.test.ts tests/unit/capability-registration.unit.test.ts tests/protocol/stdio.transport.modern-protocol.test.ts`
- `pnpm exec vitest run --config vitest.config.mts --project=protocol-modern tests/protocol/stdio.transport.modern-protocol.test.ts`
- `pnpm run lint:docs`
- `pnpm run build && pnpm run test:contract`
- `pnpm run test:protocol`
- `pnpm test`
- `pnpm run docs`
- `pnpm exec vitest run --config vitest.config.mts --project=unit tests/unit/index.unit.test.ts`

## Follow-up notes
None.