### PR TITLE
Fix stdio capability bootstrap deadlock

### DIFF
--- a/src/auth.ts
+++ b/src/auth.ts
@@ -415,51 +415,30 @@ export class B2AuthManager {
   /**
    * Return cached auth or share one in-flight authorize call.
    *
+   * @param signal - Optional signal for a one-shot authorize call.
+   *
    * @returns Cached or fresh B2 auth.
    */
-  async getAuth(): Promise<B2AuthResponse> {
+  async getAuth(signal?: AbortSignal): Promise<B2AuthResponse> {
     this.syncCachedAuthFromSdk();
     if (this.isValid()) {
       return this.cachedAuth!;
+    }
+
+    if (signal) {
+      if (signal.aborted) throw abortReason(signal);
+      return runWithMcpRequestSignal(signal, () => this.authorize());
     }
 
     const callerSignal = currentMcpRequestSignal();
-    if (this.inflightAuth) {
-      return raceWithCallerAbort(this.inflightAuth, callerSignal);
+    if (!this.inflightAuth) {
+      this.inflightAuth = runWithMcpRequestSignal(undefined, () =>
+        this.authorize().finally(() => {
+          this.inflightAuth = null;
+        }),
+      );
     }
-
-    this.inflightAuth = runWithMcpRequestSignal(undefined, () =>
-      this.authorize().finally(() => {
-        this.inflightAuth = null;
-      }),
-    );
-
     return raceWithCallerAbort(this.inflightAuth, callerSignal);
-  }
-
-  /**
-   * Return cached auth or perform a fresh authorize bound to an abort signal.
-   *
-   * @remarks
-   * This is for one-shot bootstrap discovery where the underlying B2 request
-   * must be cancelled when the caller's deadline expires. Normal request paths
-   * should use {@link getAuth} so one caller aborting cannot cancel shared
-   * authorization work for other waiters.
-   *
-   * @param signal - Abort signal that should cancel the underlying authorize.
-   *
-   * @returns Cached or fresh B2 auth.
-   */
-  async getAuthBoundToSignal(signal: AbortSignal): Promise<B2AuthResponse> {
-    this.syncCachedAuthFromSdk();
-    if (this.isValid()) {
-      return this.cachedAuth!;
-    }
-    if (signal.aborted) {
-      throw abortReason(signal);
-    }
-
-    return runWithMcpRequestSignal(signal, () => this.authorize());
   }
 
   /**

--- a/src/auth.ts
+++ b/src/auth.ts
@@ -438,6 +438,31 @@ export class B2AuthManager {
   }
 
   /**
+   * Return cached auth or perform a fresh authorize bound to an abort signal.
+   *
+   * @remarks
+   * This is for one-shot bootstrap discovery where the underlying B2 request
+   * must be cancelled when the caller's deadline expires. Normal request paths
+   * should use {@link getAuth} so one caller aborting cannot cancel shared
+   * authorization work for other waiters.
+   *
+   * @param signal - Abort signal that should cancel the underlying authorize.
+   *
+   * @returns Cached or fresh B2 auth.
+   */
+  async getAuthBoundToSignal(signal: AbortSignal): Promise<B2AuthResponse> {
+    this.syncCachedAuthFromSdk();
+    if (this.isValid()) {
+      return this.cachedAuth!;
+    }
+    if (signal.aborted) {
+      throw abortReason(signal);
+    }
+
+    return runWithMcpRequestSignal(signal, () => this.authorize());
+  }
+
+  /**
    * Return the official SDK client with valid authorization metadata.
    *
    * @returns Authorized SDK client and flattened auth metadata.

--- a/src/index.ts
+++ b/src/index.ts
@@ -94,7 +94,10 @@ function stdioCapabilityFallback(err: unknown): StdioCapabilityFallback | null {
         message: timeout.message,
         timeoutMs: timeout.timeoutMs,
       },
-      serverOptions: { suppressDurableSecretCompatibilityStubs: true },
+      serverOptions: {
+        suppressDurableSecretCompatibilityStubs: true,
+        suppressPartnerTools: true,
+      },
     };
   }
   if (err.code !== "capability_upstream_unavailable") return null;

--- a/src/index.ts
+++ b/src/index.ts
@@ -88,9 +88,9 @@ function stdioCapabilityFallback(err: unknown) {
   }
   if (err.code !== "capability_upstream_unavailable") return null;
   return {
-    capabilities: null,
+    capabilities: [],
     log,
-    serverOptions: {},
+    serverOptions: { failClosed: true },
   };
 }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -54,59 +54,42 @@ type GlobalWithIndexTestSeams = typeof globalThis & {
   __b2McpIndexTestSeams?: IndexTestSeams;
 };
 
-// Keep this fixed and comfortably below common 60s MCP initialize budgets;
-// making it deployment-tunable can reintroduce the stdio startup deadlock.
-const STDIO_CAPABILITY_BOOTSTRAP_TIMEOUT_MS = 10_000;
-const STDIO_CAPABILITY_BOOTSTRAP_TIMEOUT_CODE = "capability_bootstrap_timeout";
+// Fixed below common 60s MCP initialize budgets.
+const STDIO_TIMEOUT_MS = 10_000;
+const STDIO_TIMEOUT_CODE = "capability_bootstrap_timeout";
 
-type StdioCapabilityTimeoutError = CredentialResolutionError & {
-  readonly elapsedMs: number;
-  readonly timeoutMs: number;
-};
-
-interface StdioCapabilityFallback {
-  capabilities: string[] | null;
-  log: Record<string, unknown>;
-  serverOptions: CreateServerOptions;
-}
-
-function stdioCapabilityTimeoutError(startedAt: number): StdioCapabilityTimeoutError {
+function stdioCapabilityTimeoutError(startedAt: number) {
   const elapsedMs = Date.now() - startedAt;
   return Object.assign(
     new CredentialResolutionError(
-      `B2 capability lookup exceeded the ${STDIO_CAPABILITY_BOOTSTRAP_TIMEOUT_MS} ms stdio bootstrap deadline`,
+      `B2 capability lookup exceeded the ${STDIO_TIMEOUT_MS} ms stdio bootstrap deadline`,
       503,
-      STDIO_CAPABILITY_BOOTSTRAP_TIMEOUT_CODE,
+      STDIO_TIMEOUT_CODE,
     ),
-    { elapsedMs, timeoutMs: STDIO_CAPABILITY_BOOTSTRAP_TIMEOUT_MS },
+    { elapsedMs, timeoutMs: STDIO_TIMEOUT_MS },
   );
 }
 
-function stdioCapabilityFallback(err: unknown): StdioCapabilityFallback | null {
+function stdioCapabilityFallback(err: unknown) {
   if (!(err instanceof CredentialResolutionError)) return null;
-  if (err.code === STDIO_CAPABILITY_BOOTSTRAP_TIMEOUT_CODE) {
-    const timeout = err as StdioCapabilityTimeoutError;
+  const log: Record<string, unknown> = {
+    code: err.code,
+    message: err.message,
+  };
+  if (err.code === STDIO_TIMEOUT_CODE) {
+    const timeout = err as ReturnType<typeof stdioCapabilityTimeoutError>;
+    log.elapsedMs = timeout.elapsedMs;
+    log.timeoutMs = timeout.timeoutMs;
     return {
       capabilities: [],
-      log: {
-        code: timeout.code,
-        elapsedMs: timeout.elapsedMs,
-        message: timeout.message,
-        timeoutMs: timeout.timeoutMs,
-      },
-      serverOptions: {
-        suppressDurableSecretCompatibilityStubs: true,
-        suppressPartnerTools: true,
-      },
+      log,
+      serverOptions: { failClosed: true },
     };
   }
   if (err.code !== "capability_upstream_unavailable") return null;
   return {
     capabilities: null,
-    log: {
-      code: err.code,
-      message: err.message,
-    },
+    log,
     serverOptions: {},
   };
 }
@@ -120,13 +103,15 @@ async function fetchStdioCapabilitiesWithDeadline(config: B2Config): Promise<str
       const err = stdioCapabilityTimeoutError(startedAt);
       abort.abort(err);
       reject(err);
-    }, STDIO_CAPABILITY_BOOTSTRAP_TIMEOUT_MS);
-    // Keep referenced until the race settles; stdio is not attached yet, so
-    // this can be the only handle keeping the degraded startup path alive.
+    }, STDIO_TIMEOUT_MS);
+    // Keep referenced until stdio is attached so degraded startup can run.
   });
-  const capabilityFetch = serverModule.fetchCapabilities(config, undefined, undefined, {
-    signal: abort.signal,
-  });
+  const capabilityFetch = serverModule.fetchCapabilities(
+    config,
+    undefined,
+    undefined,
+    abort.signal,
+  );
 
   try {
     return await Promise.race([capabilityFetch, deadline]);

--- a/src/index.ts
+++ b/src/index.ts
@@ -41,6 +41,7 @@ import * as serverModule from "./server.js";
 import { PortUsageError } from "./utils/config.js";
 import { flushLogsSync, initLogging, logger } from "./utils/logger.js";
 import { bootstrapErrorMessage } from "./utils/secret-sanitizer.js";
+import type { B2Config } from "./utils/types.js";
 import { VERSION } from "./version.js";
 
 type IndexTestSeams = {
@@ -52,14 +53,52 @@ type GlobalWithIndexTestSeams = typeof globalThis & {
   __b2McpIndexTestSeams?: IndexTestSeams;
 };
 
+const STDIO_CAPABILITY_BOOTSTRAP_TIMEOUT_MS = 10_000;
+const STDIO_CAPABILITY_BOOTSTRAP_TIMEOUT_CODE = "capability_bootstrap_timeout";
+
+class StdioCapabilityBootstrapTimeoutError extends Error {
+  readonly code = STDIO_CAPABILITY_BOOTSTRAP_TIMEOUT_CODE;
+
+  constructor(readonly timeoutMs: number) {
+    super(`Timed out after ${timeoutMs}ms while fetching stdio capabilities`);
+  }
+}
+
+function isStdioCapabilityBootstrapTimeout(
+  err: unknown,
+): err is StdioCapabilityBootstrapTimeoutError {
+  return (
+    err instanceof StdioCapabilityBootstrapTimeoutError ||
+    ((err as { code?: unknown })?.code === STDIO_CAPABILITY_BOOTSTRAP_TIMEOUT_CODE &&
+      typeof (err as { timeoutMs?: unknown }).timeoutMs === "number")
+  );
+}
+
+async function fetchStdioCapabilitiesWithDeadline(config: B2Config): Promise<string[] | null> {
+  let timeout: ReturnType<typeof setTimeout> | undefined;
+  const deadline = new Promise<never>((_, reject) => {
+    timeout = setTimeout(() => {
+      reject(new StdioCapabilityBootstrapTimeoutError(STDIO_CAPABILITY_BOOTSTRAP_TIMEOUT_MS));
+    }, STDIO_CAPABILITY_BOOTSTRAP_TIMEOUT_MS);
+    timeout.unref?.();
+  });
+
+  try {
+    return await Promise.race([serverModule.fetchCapabilities(config), deadline]);
+  } finally {
+    if (timeout) clearTimeout(timeout);
+  }
+}
+
 /**
  * Start the MCP server over stdio.
  *
  * @remarks
  * The stdio path reads credentials from the process environment, attempts
  * capability discovery once, and deliberately degrades to the full tool surface
- * only when B2 capability lookup is temporarily unavailable. Other credential
- * errors remain fatal during bootstrap.
+ * when B2 capability lookup is temporarily unavailable or too slow for MCP
+ * client handshake budgets. Fast credential errors remain fatal during
+ * bootstrap.
  *
  * @returns A promise that resolves after the stdio transport has been
  * registered with the MCP SDK.
@@ -75,23 +114,34 @@ type GlobalWithIndexTestSeams = typeof globalThis & {
 export async function startStdio(): Promise<void> {
   initLogging();
   const config = serverModule.loadConfig();
+  logger.info({ transport: "stdio" }, "server.starting");
   let capabilities: string[] | null;
   try {
-    capabilities = await serverModule.fetchCapabilities(config);
+    capabilities = await fetchStdioCapabilitiesWithDeadline(config);
   } catch (err) {
-    if (
-      !(err instanceof CredentialResolutionError) ||
-      err.code !== "capability_upstream_unavailable"
+    if (isStdioCapabilityBootstrapTimeout(err)) {
+      logger.warn(
+        {
+          code: err.code,
+          timeoutMs: err.timeoutMs,
+        },
+        "capability.fetch.stdio_degraded",
+      );
+      capabilities = null;
+    } else if (
+      err instanceof CredentialResolutionError &&
+      err.code === "capability_upstream_unavailable"
     ) {
+      logger.warn(
+        {
+          code: err.code,
+        },
+        "capability.fetch.stdio_degraded",
+      );
+      capabilities = null;
+    } else {
       throw err;
     }
-    logger.warn(
-      {
-        code: err.code,
-      },
-      "capability.fetch.stdio_degraded",
-    );
-    capabilities = null;
   }
   stdioTransport.serveStdio(() => serverModule.createServer(config, capabilities), {
     onerror: (error) => logger.warn({ err: error.message }, "mcp.stdio.error"),

--- a/src/index.ts
+++ b/src/index.ts
@@ -37,6 +37,7 @@
 import * as stdioTransport from "@modelcontextprotocol/server/stdio";
 import { CliUsageError, helpText, parseCliArgs } from "./cli.js";
 import { CredentialResolutionError } from "./credentials.js";
+import type { CreateServerOptions } from "./server.js";
 import * as serverModule from "./server.js";
 import { PortUsageError } from "./utils/config.js";
 import { flushLogsSync, initLogging, logger } from "./utils/logger.js";
@@ -53,40 +54,82 @@ type GlobalWithIndexTestSeams = typeof globalThis & {
   __b2McpIndexTestSeams?: IndexTestSeams;
 };
 
+// Keep this fixed and comfortably below common 60s MCP initialize budgets;
+// making it deployment-tunable can reintroduce the stdio startup deadlock.
 const STDIO_CAPABILITY_BOOTSTRAP_TIMEOUT_MS = 10_000;
 const STDIO_CAPABILITY_BOOTSTRAP_TIMEOUT_CODE = "capability_bootstrap_timeout";
 
-class StdioCapabilityBootstrapTimeoutError extends Error {
-  readonly code = STDIO_CAPABILITY_BOOTSTRAP_TIMEOUT_CODE;
+type StdioCapabilityTimeoutError = CredentialResolutionError & {
+  readonly elapsedMs: number;
+  readonly timeoutMs: number;
+};
 
-  constructor(readonly timeoutMs: number) {
-    super(`Timed out after ${timeoutMs}ms while fetching stdio capabilities`);
-  }
+interface StdioCapabilityFallback {
+  capabilities: string[] | null;
+  log: Record<string, unknown>;
+  serverOptions: CreateServerOptions;
 }
 
-function isStdioCapabilityBootstrapTimeout(
-  err: unknown,
-): err is StdioCapabilityBootstrapTimeoutError {
-  return (
-    err instanceof StdioCapabilityBootstrapTimeoutError ||
-    ((err as { code?: unknown })?.code === STDIO_CAPABILITY_BOOTSTRAP_TIMEOUT_CODE &&
-      typeof (err as { timeoutMs?: unknown }).timeoutMs === "number")
+function stdioCapabilityTimeoutError(startedAt: number): StdioCapabilityTimeoutError {
+  const elapsedMs = Date.now() - startedAt;
+  return Object.assign(
+    new CredentialResolutionError(
+      `B2 capability lookup exceeded the ${STDIO_CAPABILITY_BOOTSTRAP_TIMEOUT_MS} ms stdio bootstrap deadline`,
+      503,
+      STDIO_CAPABILITY_BOOTSTRAP_TIMEOUT_CODE,
+    ),
+    { elapsedMs, timeoutMs: STDIO_CAPABILITY_BOOTSTRAP_TIMEOUT_MS },
   );
 }
 
+function stdioCapabilityFallback(err: unknown): StdioCapabilityFallback | null {
+  if (!(err instanceof CredentialResolutionError)) return null;
+  if (err.code === STDIO_CAPABILITY_BOOTSTRAP_TIMEOUT_CODE) {
+    const timeout = err as StdioCapabilityTimeoutError;
+    return {
+      capabilities: [],
+      log: {
+        code: timeout.code,
+        elapsedMs: timeout.elapsedMs,
+        message: timeout.message,
+        timeoutMs: timeout.timeoutMs,
+      },
+      serverOptions: { suppressDurableSecretCompatibilityStubs: true },
+    };
+  }
+  if (err.code !== "capability_upstream_unavailable") return null;
+  return {
+    capabilities: null,
+    log: {
+      code: err.code,
+      message: err.message,
+    },
+    serverOptions: {},
+  };
+}
+
 async function fetchStdioCapabilitiesWithDeadline(config: B2Config): Promise<string[] | null> {
+  const abort = new AbortController();
+  const startedAt = Date.now();
   let timeout: ReturnType<typeof setTimeout> | undefined;
   const deadline = new Promise<never>((_, reject) => {
     timeout = setTimeout(() => {
-      reject(new StdioCapabilityBootstrapTimeoutError(STDIO_CAPABILITY_BOOTSTRAP_TIMEOUT_MS));
+      const err = stdioCapabilityTimeoutError(startedAt);
+      abort.abort(err);
+      reject(err);
     }, STDIO_CAPABILITY_BOOTSTRAP_TIMEOUT_MS);
-    timeout.unref?.();
+    // Keep referenced until the race settles; stdio is not attached yet, so
+    // this can be the only handle keeping the degraded startup path alive.
+  });
+  const capabilityFetch = serverModule.fetchCapabilities(config, undefined, undefined, {
+    signal: abort.signal,
   });
 
   try {
-    return await Promise.race([serverModule.fetchCapabilities(config), deadline]);
+    return await Promise.race([capabilityFetch, deadline]);
   } finally {
     if (timeout) clearTimeout(timeout);
+    capabilityFetch.catch(() => undefined);
   }
 }
 
@@ -95,9 +138,9 @@ async function fetchStdioCapabilitiesWithDeadline(config: B2Config): Promise<str
  *
  * @remarks
  * The stdio path reads credentials from the process environment, attempts
- * capability discovery once, and deliberately degrades to the full tool surface
- * when B2 capability lookup is temporarily unavailable or too slow for MCP
- * client handshake budgets. Fast credential errors remain fatal during
+ * capability discovery once, and degrades on transient lookup failures. A slow
+ * bootstrap lookup fails closed to an empty tool surface before MCP client
+ * handshake budgets expire. Fast credential errors remain fatal during
  * bootstrap.
  *
  * @returns A promise that resolves after the stdio transport has been
@@ -115,35 +158,19 @@ export async function startStdio(): Promise<void> {
   initLogging();
   const config = serverModule.loadConfig();
   logger.info({ transport: "stdio" }, "server.starting");
+  flushLogsSync();
   let capabilities: string[] | null;
+  let serverOptions: CreateServerOptions = {};
   try {
     capabilities = await fetchStdioCapabilitiesWithDeadline(config);
   } catch (err) {
-    if (isStdioCapabilityBootstrapTimeout(err)) {
-      logger.warn(
-        {
-          code: err.code,
-          timeoutMs: err.timeoutMs,
-        },
-        "capability.fetch.stdio_degraded",
-      );
-      capabilities = null;
-    } else if (
-      err instanceof CredentialResolutionError &&
-      err.code === "capability_upstream_unavailable"
-    ) {
-      logger.warn(
-        {
-          code: err.code,
-        },
-        "capability.fetch.stdio_degraded",
-      );
-      capabilities = null;
-    } else {
-      throw err;
-    }
+    const fallback = stdioCapabilityFallback(err);
+    if (!fallback) throw err;
+    logger.warn(fallback.log, "capability.fetch.stdio_degraded");
+    capabilities = fallback.capabilities;
+    serverOptions = fallback.serverOptions;
   }
-  stdioTransport.serveStdio(() => serverModule.createServer(config, capabilities), {
+  stdioTransport.serveStdio(() => serverModule.createServer(config, capabilities, serverOptions), {
     onerror: (error) => logger.warn({ err: error.message }, "mcp.stdio.error"),
   });
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -142,9 +142,9 @@ async function fetchStdioCapabilitiesWithDeadline(config: B2Config): Promise<str
  * @remarks
  * The stdio path reads credentials from the process environment, attempts
  * capability discovery once, and degrades on transient lookup failures. A slow
- * bootstrap lookup fails closed to an empty tool surface before MCP client
- * handshake budgets expire. Fast credential errors remain fatal during
- * bootstrap.
+ * bootstrap lookup fails closed to a capability-empty degraded surface before
+ * MCP client handshake budgets expire. Fast credential errors remain fatal
+ * during bootstrap.
  *
  * @returns A promise that resolves after the stdio transport has been
  * registered with the MCP SDK.

--- a/src/server.ts
+++ b/src/server.ts
@@ -159,26 +159,12 @@ function registerDurableSecretCompatibilityStubs(
   }
 }
 
-/**
- * Optional server-construction controls.
- *
- * @remarks
- * HTTP deployments pass verified OAuth scopes here after authentication. Stdio
- * callers normally omit this so tool availability is governed only by B2 key
- * capabilities and local destructive policy.
- */
+/** Optional server-construction controls. */
 export interface CreateServerOptions {
   /** Verified MCP/OAuth scopes for the current caller. */
   oauthScopes?: readonly string[];
-  /**
-   * Suppress durable-secret compatibility stubs when the caller intentionally
-   * wants an empty capability set to expose no write/admin fallback names.
-   */
-  suppressDurableSecretCompatibilityStubs?: boolean;
-  /**
-   * Suppress Partner API tools even when a distinct master key is configured.
-   */
-  suppressPartnerTools?: boolean;
+  /** Hide fallback tools when capabilities intentionally fail closed. */
+  failClosed?: boolean;
 }
 
 /**
@@ -261,14 +247,8 @@ export function createServer(
     },
   );
 
-  // Capability-aware registration: when capabilities are supplied, a tool is
-  // only registered if the key can use it. Tools not in the capability map
-  // (b2_authorize_account, Partner tools) are allowed through here; Partner
-  // tools are additionally gated on a master key below. Durable-secret
-  // producers register as real handlers only when a reviewed secret sink is
-  // active; otherwise createServer adds non-secret compatibility stubs. null /
-  // undefined remains the explicit full-surface path, while an empty array is
-  // fail-closed rather than "unknown".
+  // Capability-aware mode filters by B2 capabilities and OAuth scopes.
+  // null/undefined is full surface; [] is fail closed.
   const filterActive = Array.isArray(capabilities);
   const capsSet = filterActive ? new Set(capabilities) : null;
   const oauthAllowsRead = oauthScopesAllowOperation(oauthScopes, "read");
@@ -284,10 +264,8 @@ export function createServer(
       }),
   });
 
-  // Initialize clients. The application (workhorse) key drives the B2 native
-  // API, S3, and key management. The Partner API tools use the master
-  // key; when no distinct master key is configured they fall back to the same
-  // application-key client, so a single non-master key needs no extra wiring.
+  // The application key drives native B2, S3, and key management; Partner tools
+  // use a distinct master key when configured.
   const auth = getCachedAuthManager(`credential:${verificationFingerprintConfig(config)}`, config);
   const b2Client = new B2Client(auth);
   const reportClient = new B2ReportClient(auth);
@@ -319,11 +297,8 @@ export function createServer(
   registerObjectLockTools(registrar, b2Client, config);
 
   // ── Partner API tools (master key) ──────────────────────────────────────
-  // Partner tools need a master key + Partner-API entitlement, not a standard
-  // capability. Under capability-aware registration, only surface them when a
-  // distinct master key is configured; otherwise (and in full-surface mode) keep
-  // the prior behavior of always registering them.
-  if (!options.suppressPartnerTools && (!filterActive || masterIsDistinct)) {
+  // Partner tools need a distinct master key in capability-aware mode.
+  if (!options.failClosed && (!filterActive || masterIsDistinct)) {
     registerPartnerTools(registrar, masterClient, masterAuth, config);
   }
 
@@ -353,12 +328,8 @@ export function createServer(
   // Phase 2 is live per-bucket S3 listing.
   registerInsightTools(registrar, b2Client, auth, reportClient);
 
-  // Rolling deploy compatibility: clients can cache tools/list entries for
-  // durable-secret-producing tools. In off mode keep those names callable with
-  // a stable non-secret unavailable error. File mode keeps filtered durable
-  // secret tool names callable as non-secret unavailable errors; Reserve Trial
-  // is always stubbed because the provider has no post-create recovery action.
-  if (!options.suppressDurableSecretCompatibilityStubs) {
+  // Rolling deploy compatibility for clients with cached tools/list entries.
+  if (!options.failClosed) {
     if (config.secretSink?.mode === "file") {
       registerDurableSecretCompatibilityStubs(
         registrar,
@@ -653,38 +624,6 @@ function throwCapabilityResolutionError(
   throw new CredentialResolutionError(details.message, details.status, details.code);
 }
 
-/** Options for one-shot B2 capability discovery. */
-export interface FetchCapabilitiesOptions {
-  /**
-   * Abort signal that should cancel this discovery's underlying authorize
-   * request instead of leaving it as shared background work.
-   */
-  signal?: AbortSignal;
-}
-
-function abortReason(signal: AbortSignal): unknown {
-  return signal.reason ?? abortError("Capability fetch aborted");
-}
-
-function throwIfCapabilityFetchAborted(signal: AbortSignal | undefined): void {
-  if (signal?.aborted) throw abortReason(signal);
-}
-
-async function discoverCapabilities(
-  config: B2Config,
-  resolvedCacheKey: string,
-  now: number,
-  signal: AbortSignal | undefined,
-): Promise<string[]> {
-  throwIfCapabilityFetchAborted(signal);
-  const auth = new B2AuthManager(config);
-  const info = signal ? await auth.getAuthBoundToSignal(signal) : await auth.getAuth();
-  throwIfCapabilityFetchAborted(signal);
-  const capabilities = info.capabilities ?? [];
-  rememberCapabilities(resolvedCacheKey, capabilities, now);
-  return capabilities;
-}
-
 /**
  * Discover the B2 key capabilities used for capability-aware registration.
  *
@@ -695,15 +634,14 @@ async function discoverCapabilities(
  * returns `null`; all other authorization failures are sanitized and thrown so
  * internet-facing servers fail closed.
  *
- * Positive non-empty results are cached briefly by credential fingerprint.
- * Concurrent non-abort-bound discoveries for the same key share one in-flight
- * authorize call.
+ * Positive non-empty results are cached briefly by credential fingerprint;
+ * concurrent non-abort-bound discoveries share one in-flight authorize call.
  *
  * @param config - B2 credential and runtime configuration.
  * @param capabilityCacheKey - Optional cache key override for tests or
  * caller-specific HTTP routing.
  * @param logKey - Optional non-secret log key override.
- * @param options - Optional abort controls for deadline-bound callers.
+ * @param signal - Optional abort signal for deadline-bound callers.
  *
  * @returns A copy of the discovered capabilities, or `null` when registration
  * should expose the full tool surface.
@@ -721,10 +659,9 @@ export async function fetchCapabilities(
   config: B2Config,
   capabilityCacheKey?: string,
   logKey?: string,
-  options: FetchCapabilitiesOptions = {},
+  signal?: AbortSignal,
 ): Promise<string[] | null> {
   if (process.env.B2_REGISTER_ALL_TOOLS === "true") return null;
-  const { signal } = options;
   const shareInflight = !signal;
   const resolvedCacheKey =
     capabilityCacheKey ?? `credential:${verificationFingerprintConfig(config)}`;
@@ -746,9 +683,15 @@ export async function fetchCapabilities(
 
   const discovery = (async () => {
     try {
-      return await discoverCapabilities(config, resolvedCacheKey, now, signal);
+      if (signal?.aborted) throw signal.reason ?? abortError("Capability fetch aborted");
+      const auth = new B2AuthManager(config);
+      const info = await auth.getAuth(signal);
+      if (signal?.aborted) throw signal.reason ?? abortError("Capability fetch aborted");
+      const capabilities = info.capabilities ?? [];
+      rememberCapabilities(resolvedCacheKey, capabilities, now);
+      return capabilities;
     } catch (err) {
-      if (signal?.aborted) throw abortReason(signal);
+      if (signal?.aborted) throw signal.reason ?? abortError("Capability fetch aborted");
       throwCapabilityResolutionError(err, config, credentialLogKey);
     } finally {
       if (shareInflight) capabilityInflight.delete(resolvedCacheKey);

--- a/src/server.ts
+++ b/src/server.ts
@@ -175,6 +175,10 @@ export interface CreateServerOptions {
    * wants an empty capability set to expose no write/admin fallback names.
    */
   suppressDurableSecretCompatibilityStubs?: boolean;
+  /**
+   * Suppress Partner API tools even when a distinct master key is configured.
+   */
+  suppressPartnerTools?: boolean;
 }
 
 /**
@@ -319,7 +323,7 @@ export function createServer(
   // capability. Under capability-aware registration, only surface them when a
   // distinct master key is configured; otherwise (and in full-surface mode) keep
   // the prior behavior of always registering them.
-  if (!filterActive || masterIsDistinct) {
+  if (!options.suppressPartnerTools && (!filterActive || masterIsDistinct)) {
     registerPartnerTools(registrar, masterClient, masterAuth, config);
   }
 

--- a/src/server.ts
+++ b/src/server.ts
@@ -58,6 +58,7 @@ import {
   StdioEnvCredentialProvider,
   verificationFingerprintConfig,
 } from "./credentials.js";
+import { abortError } from "./utils/named-error.js";
 import { currentMcpRequestSignal, runWithMcpRequestSignal } from "./request-context.js";
 import {
   createDestructiveElicitationRequestStateCodec,
@@ -169,6 +170,11 @@ function registerDurableSecretCompatibilityStubs(
 export interface CreateServerOptions {
   /** Verified MCP/OAuth scopes for the current caller. */
   oauthScopes?: readonly string[];
+  /**
+   * Suppress durable-secret compatibility stubs when the caller intentionally
+   * wants an empty capability set to expose no write/admin fallback names.
+   */
+  suppressDurableSecretCompatibilityStubs?: boolean;
 }
 
 /**
@@ -348,16 +354,18 @@ export function createServer(
   // a stable non-secret unavailable error. File mode keeps filtered durable
   // secret tool names callable as non-secret unavailable errors; Reserve Trial
   // is always stubbed because the provider has no post-create recovery action.
-  if (config.secretSink?.mode === "file") {
-    registerDurableSecretCompatibilityStubs(
-      registrar,
-      config.secretSink,
-      (name) => !registrar.hasTool(name) && isToolAllowedByOAuthScopes(name, oauthScopes),
-    );
-  } else if (config.secretSink?.mode !== "inline") {
-    registerDurableSecretCompatibilityStubs(registrar, config.secretSink, (name) =>
-      isToolAllowedByOAuthScopes(name, oauthScopes),
-    );
+  if (!options.suppressDurableSecretCompatibilityStubs) {
+    if (config.secretSink?.mode === "file") {
+      registerDurableSecretCompatibilityStubs(
+        registrar,
+        config.secretSink,
+        (name) => !registrar.hasTool(name) && isToolAllowedByOAuthScopes(name, oauthScopes),
+      );
+    } else if (config.secretSink?.mode !== "inline") {
+      registerDurableSecretCompatibilityStubs(registrar, config.secretSink, (name) =>
+        isToolAllowedByOAuthScopes(name, oauthScopes),
+      );
+    }
   }
 
   const toolCount = registrar.commit();
@@ -641,6 +649,38 @@ function throwCapabilityResolutionError(
   throw new CredentialResolutionError(details.message, details.status, details.code);
 }
 
+/** Options for one-shot B2 capability discovery. */
+export interface FetchCapabilitiesOptions {
+  /**
+   * Abort signal that should cancel this discovery's underlying authorize
+   * request instead of leaving it as shared background work.
+   */
+  signal?: AbortSignal;
+}
+
+function abortReason(signal: AbortSignal): unknown {
+  return signal.reason ?? abortError("Capability fetch aborted");
+}
+
+function throwIfCapabilityFetchAborted(signal: AbortSignal | undefined): void {
+  if (signal?.aborted) throw abortReason(signal);
+}
+
+async function discoverCapabilities(
+  config: B2Config,
+  resolvedCacheKey: string,
+  now: number,
+  signal: AbortSignal | undefined,
+): Promise<string[]> {
+  throwIfCapabilityFetchAborted(signal);
+  const auth = new B2AuthManager(config);
+  const info = signal ? await auth.getAuthBoundToSignal(signal) : await auth.getAuth();
+  throwIfCapabilityFetchAborted(signal);
+  const capabilities = info.capabilities ?? [];
+  rememberCapabilities(resolvedCacheKey, capabilities, now);
+  return capabilities;
+}
+
 /**
  * Discover the B2 key capabilities used for capability-aware registration.
  *
@@ -651,13 +691,15 @@ function throwCapabilityResolutionError(
  * returns `null`; all other authorization failures are sanitized and thrown so
  * internet-facing servers fail closed.
  *
- * Positive non-empty results are cached briefly by credential fingerprint and
- * concurrent discoveries for the same key share one in-flight authorize call.
+ * Positive non-empty results are cached briefly by credential fingerprint.
+ * Concurrent non-abort-bound discoveries for the same key share one in-flight
+ * authorize call.
  *
  * @param config - B2 credential and runtime configuration.
  * @param capabilityCacheKey - Optional cache key override for tests or
  * caller-specific HTTP routing.
  * @param logKey - Optional non-secret log key override.
+ * @param options - Optional abort controls for deadline-bound callers.
  *
  * @returns A copy of the discovered capabilities, or `null` when registration
  * should expose the full tool surface.
@@ -675,8 +717,11 @@ export async function fetchCapabilities(
   config: B2Config,
   capabilityCacheKey?: string,
   logKey?: string,
+  options: FetchCapabilitiesOptions = {},
 ): Promise<string[] | null> {
   if (process.env.B2_REGISTER_ALL_TOOLS === "true") return null;
+  const { signal } = options;
+  const shareInflight = !signal;
   const resolvedCacheKey =
     capabilityCacheKey ?? `credential:${verificationFingerprintConfig(config)}`;
   const credentialLogKey =
@@ -690,23 +735,22 @@ export async function fetchCapabilities(
     return [...cached.capabilities];
   }
 
-  const existingInflight = capabilityInflight.get(resolvedCacheKey);
-  if (existingInflight) return [...(await existingInflight)];
+  if (shareInflight) {
+    const existingInflight = capabilityInflight.get(resolvedCacheKey);
+    if (existingInflight) return [...(await existingInflight)];
+  }
 
   const discovery = (async () => {
     try {
-      const auth = new B2AuthManager(config);
-      const info = await auth.getAuth();
-      const capabilities = info.capabilities ?? [];
-      rememberCapabilities(resolvedCacheKey, capabilities, now);
-      return capabilities;
+      return await discoverCapabilities(config, resolvedCacheKey, now, signal);
     } catch (err) {
+      if (signal?.aborted) throw abortReason(signal);
       throwCapabilityResolutionError(err, config, credentialLogKey);
     } finally {
-      capabilityInflight.delete(resolvedCacheKey);
+      if (shareInflight) capabilityInflight.delete(resolvedCacheKey);
     }
   })();
-  capabilityInflight.set(resolvedCacheKey, discovery);
+  if (shareInflight) capabilityInflight.set(resolvedCacheKey, discovery);
 
   return [...(await discovery)];
 }

--- a/tests/unit/index.unit.test.ts
+++ b/tests/unit/index.unit.test.ts
@@ -168,10 +168,14 @@ describe("stdio entry point", () => {
     );
   });
 
-  it("falls back to the full stdio surface when capability lookup is unavailable", async () => {
-    const config = testConfig();
-    const server = { close: vi.fn(async () => undefined) };
-    const createServer = vi.spyOn(serverModule, "createServer").mockReturnValue(server as never);
+  it("falls back to a reduced stdio surface when capability lookup is unavailable", async () => {
+    const config: B2Config = {
+      ...testConfig(),
+      masterKeyId: "distinct-master-id",
+      masterKey: "distinct-master-secret",
+      secretSink: { mode: "off" },
+    };
+    const createServer = vi.spyOn(serverModule, "createServer");
     vi.spyOn(serverModule, "loadConfig").mockReturnValue(config);
     vi.spyOn(serverModule, "fetchCapabilities").mockRejectedValue(
       new CredentialResolutionError(
@@ -191,8 +195,20 @@ describe("stdio entry point", () => {
     await startStdio();
 
     const factory = serveStdio.mock.calls[0]?.[0] as (() => unknown) | undefined;
-    expect(factory?.()).toBe(server);
-    expect(createServer).toHaveBeenCalledWith(config, null, {});
+    const server = factory?.() as Parameters<typeof serverModule.getRegisteredTools>[0];
+    const tools = serverModule.getRegisteredTools(server);
+    expect(createServer).toHaveBeenCalledWith(config, [], {
+      failClosed: true,
+    });
+    expect(tools).not.toHaveProperty("s3_put_object");
+    expect(tools).not.toHaveProperty("s3_delete_objects");
+    expect(tools).not.toHaveProperty("s3_get_presigned_url");
+    expect(tools).not.toHaveProperty("b2_create_key");
+    expect(tools).not.toHaveProperty("b2_list_groups");
+    expect(tools).not.toHaveProperty("b2_create_group_member");
+    expect(tools).not.toHaveProperty("b2_eject_group_member");
+    expect(tools).not.toHaveProperty("b2_list_group_members");
+    expect(tools).not.toHaveProperty("b2_reserve_trial_create_account");
     expect(warn).toHaveBeenCalledWith(
       {
         code: "capability_upstream_unavailable",

--- a/tests/unit/index.unit.test.ts
+++ b/tests/unit/index.unit.test.ts
@@ -102,6 +102,7 @@ describe("stdio entry point", () => {
   });
 
   afterEach(() => {
+    vi.useRealTimers();
     for (const key of credentialEnvKeys) {
       const value = savedEnv[key];
       if (value === undefined) delete process.env[key];
@@ -116,7 +117,9 @@ describe("stdio entry point", () => {
     const server = { close: vi.fn(async () => undefined) };
     const createServer = vi.spyOn(serverModule, "createServer").mockReturnValue(server as never);
     vi.spyOn(serverModule, "loadConfig").mockReturnValue(config);
-    vi.spyOn(serverModule, "fetchCapabilities").mockResolvedValue(["listBuckets"]);
+    const fetchCapabilities = vi
+      .spyOn(serverModule, "fetchCapabilities")
+      .mockResolvedValue(["listBuckets"]);
     const serveStdio = vi.mocked(stdioTransport.serveStdio).mockImplementation(
       () =>
         ({
@@ -124,6 +127,7 @@ describe("stdio entry point", () => {
         }) as ReturnType<typeof stdioTransport.serveStdio>,
     );
     const warn = vi.spyOn(loggerModule.logger, "warn").mockImplementation(() => undefined);
+    const info = vi.spyOn(loggerModule.logger, "info").mockImplementation(() => undefined);
 
     await startStdio();
 
@@ -133,6 +137,11 @@ describe("stdio entry point", () => {
     options?.onerror(new Error("stdio failed"));
     expect(createServer).toHaveBeenCalledWith(config, ["listBuckets"]);
     expect(warn).toHaveBeenCalledWith({ err: "stdio failed" }, "mcp.stdio.error");
+    expect(info).toHaveBeenCalledWith({ transport: "stdio" }, "server.starting");
+    expect(info).toHaveBeenCalledWith({ transport: "stdio" }, "server.started");
+    expect(fetchCapabilities.mock.invocationCallOrder[0]).toBeGreaterThan(
+      info.mock.invocationCallOrder[0] ?? 0,
+    );
   });
 
   it("falls back to the full stdio surface when capability lookup is unavailable", async () => {
@@ -162,6 +171,36 @@ describe("stdio entry point", () => {
     expect(createServer).toHaveBeenCalledWith(config, null);
     expect(warn).toHaveBeenCalledWith(
       { code: "capability_upstream_unavailable" },
+      "capability.fetch.stdio_degraded",
+    );
+  });
+
+  it("bounds stdio capability discovery and degrades before client handshakes time out", async () => {
+    vi.useFakeTimers();
+    const config = testConfig();
+    const server = { close: vi.fn(async () => undefined) };
+    const createServer = vi.spyOn(serverModule, "createServer").mockReturnValue(server as never);
+    vi.spyOn(serverModule, "loadConfig").mockReturnValue(config);
+    vi.spyOn(serverModule, "fetchCapabilities").mockReturnValue(
+      new Promise<string[] | null>(() => undefined),
+    );
+    const warn = vi.spyOn(loggerModule.logger, "warn").mockImplementation(() => undefined);
+    const serveStdio = vi.mocked(stdioTransport.serveStdio).mockImplementation(
+      () =>
+        ({
+          close: vi.fn(async () => undefined),
+        }) as ReturnType<typeof stdioTransport.serveStdio>,
+    );
+
+    const started = startStdio();
+    await vi.advanceTimersByTimeAsync(10_000);
+
+    await expect(started).resolves.toBeUndefined();
+    const factory = serveStdio.mock.calls[0]?.[0] as (() => unknown) | undefined;
+    expect(factory?.()).toBe(server);
+    expect(createServer).toHaveBeenCalledWith(config, null);
+    expect(warn).toHaveBeenCalledWith(
+      { code: "capability_bootstrap_timeout", timeoutMs: 10_000 },
       "capability.fetch.stdio_degraded",
     );
   });

--- a/tests/unit/index.unit.test.ts
+++ b/tests/unit/index.unit.test.ts
@@ -10,6 +10,13 @@ import * as serverModule from "../../src/server";
 import * as loggerModule from "../../src/utils/logger";
 import type { B2Config } from "../../src/utils/types";
 import { VERSION } from "../../src/version";
+import { restoreB2SdkTransportForTests } from "../support/sdk-factory-hook";
+import {
+  b2EndpointName,
+  installSdkTransport,
+  RecordingTransport,
+  StaticHttpResponse,
+} from "../support/sdk-test-helpers";
 
 vi.mock("@modelcontextprotocol/server/stdio", () => ({
   serveStdio: vi.fn(),
@@ -94,6 +101,13 @@ function runEntrypoint(args: string[], env: NodeJS.ProcessEnv = {}) {
   });
 }
 
+async function waitForRecordedRequests(transport: RecordingTransport, count: number) {
+  for (let i = 0; i < 20 && transport.requests.length < count; i++) {
+    await Promise.resolve();
+  }
+  expect(transport.requests).toHaveLength(count);
+}
+
 describe("stdio entry point", () => {
   let savedEnv: Record<string, string | undefined>;
 
@@ -103,6 +117,9 @@ describe("stdio entry point", () => {
 
   afterEach(() => {
     vi.useRealTimers();
+    restoreB2SdkTransportForTests();
+    serverModule.invalidateCapabilityCache();
+    serverModule.invalidateAuthManagerCache();
     for (const key of credentialEnvKeys) {
       const value = savedEnv[key];
       if (value === undefined) delete process.env[key];
@@ -128,6 +145,9 @@ describe("stdio entry point", () => {
     );
     const warn = vi.spyOn(loggerModule.logger, "warn").mockImplementation(() => undefined);
     const info = vi.spyOn(loggerModule.logger, "info").mockImplementation(() => undefined);
+    const flushLogsSync = vi
+      .spyOn(loggerModule, "flushLogsSync")
+      .mockImplementation(() => undefined);
 
     await startStdio();
 
@@ -135,12 +155,16 @@ describe("stdio entry point", () => {
     const options = serveStdio.mock.calls[0]?.[1] as { onerror(error: Error): void } | undefined;
     expect(factory?.()).toBe(server);
     options?.onerror(new Error("stdio failed"));
-    expect(createServer).toHaveBeenCalledWith(config, ["listBuckets"]);
+    expect(createServer).toHaveBeenCalledWith(config, ["listBuckets"], {});
     expect(warn).toHaveBeenCalledWith({ err: "stdio failed" }, "mcp.stdio.error");
     expect(info).toHaveBeenCalledWith({ transport: "stdio" }, "server.starting");
     expect(info).toHaveBeenCalledWith({ transport: "stdio" }, "server.started");
     expect(fetchCapabilities.mock.invocationCallOrder[0]).toBeGreaterThan(
       info.mock.invocationCallOrder[0] ?? 0,
+    );
+    expect(flushLogsSync).toHaveBeenCalled();
+    expect(fetchCapabilities.mock.invocationCallOrder[0]).toBeGreaterThan(
+      flushLogsSync.mock.invocationCallOrder[0] ?? 0,
     );
   });
 
@@ -168,9 +192,12 @@ describe("stdio entry point", () => {
 
     const factory = serveStdio.mock.calls[0]?.[0] as (() => unknown) | undefined;
     expect(factory?.()).toBe(server);
-    expect(createServer).toHaveBeenCalledWith(config, null);
+    expect(createServer).toHaveBeenCalledWith(config, null, {});
     expect(warn).toHaveBeenCalledWith(
-      { code: "capability_upstream_unavailable" },
+      {
+        code: "capability_upstream_unavailable",
+        message: "capability service unavailable",
+      },
       "capability.fetch.stdio_degraded",
     );
   });
@@ -198,11 +225,107 @@ describe("stdio entry point", () => {
     await expect(started).resolves.toBeUndefined();
     const factory = serveStdio.mock.calls[0]?.[0] as (() => unknown) | undefined;
     expect(factory?.()).toBe(server);
-    expect(createServer).toHaveBeenCalledWith(config, null);
+    expect(createServer).toHaveBeenCalledWith(config, [], {
+      suppressDurableSecretCompatibilityStubs: true,
+    });
     expect(warn).toHaveBeenCalledWith(
-      { code: "capability_bootstrap_timeout", timeoutMs: 10_000 },
+      {
+        code: "capability_bootstrap_timeout",
+        elapsedMs: 10_000,
+        message: "B2 capability lookup exceeded the 10000 ms stdio bootstrap deadline",
+        timeoutMs: 10_000,
+      },
       "capability.fetch.stdio_degraded",
     );
+  });
+
+  it("aborts timed-out stdio capability discovery instead of leaving authorize work", async () => {
+    vi.useFakeTimers();
+    const config = testConfig();
+    const server = { close: vi.fn(async () => undefined) };
+    vi.spyOn(serverModule, "loadConfig").mockReturnValue(config);
+    const createServer = vi.spyOn(serverModule, "createServer").mockReturnValue(server as never);
+    const warn = vi.spyOn(loggerModule.logger, "warn").mockImplementation(() => undefined);
+    vi.spyOn(loggerModule.logger, "info").mockImplementation(() => undefined);
+    const serveStdio = vi.mocked(stdioTransport.serveStdio).mockImplementation(
+      () =>
+        ({
+          close: vi.fn(async () => undefined),
+        }) as ReturnType<typeof stdioTransport.serveStdio>,
+    );
+    let abortObserved = false;
+    let authorizeSettled = false;
+    const transport = new RecordingTransport((request) => {
+      if (b2EndpointName(request) !== "b2_authorize_account") {
+        return new StaticHttpResponse(200, {});
+      }
+      return new Promise<StaticHttpResponse>((_resolve, reject) => {
+        request.signal?.addEventListener(
+          "abort",
+          () => {
+            abortObserved = true;
+            authorizeSettled = true;
+            reject(request.signal?.reason ?? new Error("authorize aborted"));
+          },
+          { once: true },
+        );
+      });
+    });
+    installSdkTransport(transport);
+
+    const started = startStdio();
+    await waitForRecordedRequests(transport, 1);
+    await vi.advanceTimersByTimeAsync(10_000);
+
+    await expect(started).resolves.toBeUndefined();
+    await Promise.resolve();
+    expect(abortObserved).toBe(true);
+    expect(authorizeSettled).toBe(true);
+    expect(transport.requests[0].signal?.aborted).toBe(true);
+    expect(serverModule.capabilityCacheSizeForTests()).toBe(0);
+    const factory = serveStdio.mock.calls[0]?.[0] as (() => unknown) | undefined;
+    expect(factory?.()).toBe(server);
+    expect(createServer).toHaveBeenCalledWith(config, [], {
+      suppressDurableSecretCompatibilityStubs: true,
+    });
+    expect(warn).toHaveBeenCalledWith(
+      expect.objectContaining({
+        code: "capability_bootstrap_timeout",
+        message: "B2 capability lookup exceeded the 10000 ms stdio bootstrap deadline",
+        timeoutMs: 10_000,
+      }),
+      "capability.fetch.stdio_degraded",
+    );
+    expect(warn).not.toHaveBeenCalledWith(expect.anything(), "capability.fetch.failed");
+  });
+
+  it("does not expose write or admin tools after a stdio capability timeout", async () => {
+    vi.useFakeTimers();
+    const config: B2Config = { ...testConfig(), secretSink: { mode: "off" } };
+    vi.spyOn(serverModule, "loadConfig").mockReturnValue(config);
+    vi.spyOn(serverModule, "fetchCapabilities").mockReturnValue(
+      new Promise<string[] | null>(() => undefined),
+    );
+    vi.spyOn(loggerModule.logger, "warn").mockImplementation(() => undefined);
+    vi.spyOn(loggerModule.logger, "info").mockImplementation(() => undefined);
+    const serveStdio = vi.mocked(stdioTransport.serveStdio).mockImplementation(
+      () =>
+        ({
+          close: vi.fn(async () => undefined),
+        }) as ReturnType<typeof stdioTransport.serveStdio>,
+    );
+
+    const started = startStdio();
+    await vi.advanceTimersByTimeAsync(10_000);
+
+    await expect(started).resolves.toBeUndefined();
+    const factory = serveStdio.mock.calls[0]?.[0] as (() => unknown) | undefined;
+    const server = factory?.() as Parameters<typeof serverModule.getRegisteredTools>[0];
+    const tools = serverModule.getRegisteredTools(server);
+    expect(tools).not.toHaveProperty("s3_put_object");
+    expect(tools).not.toHaveProperty("s3_delete_objects");
+    expect(tools).not.toHaveProperty("s3_get_presigned_url");
+    expect(tools).not.toHaveProperty("b2_create_key");
   });
 
   it("rethrows unexpected capability lookup failures", async () => {

--- a/tests/unit/index.unit.test.ts
+++ b/tests/unit/index.unit.test.ts
@@ -227,6 +227,7 @@ describe("stdio entry point", () => {
     expect(factory?.()).toBe(server);
     expect(createServer).toHaveBeenCalledWith(config, [], {
       suppressDurableSecretCompatibilityStubs: true,
+      suppressPartnerTools: true,
     });
     expect(warn).toHaveBeenCalledWith(
       {
@@ -287,6 +288,7 @@ describe("stdio entry point", () => {
     expect(factory?.()).toBe(server);
     expect(createServer).toHaveBeenCalledWith(config, [], {
       suppressDurableSecretCompatibilityStubs: true,
+      suppressPartnerTools: true,
     });
     expect(warn).toHaveBeenCalledWith(
       expect.objectContaining({
@@ -301,7 +303,12 @@ describe("stdio entry point", () => {
 
   it("does not expose write or admin tools after a stdio capability timeout", async () => {
     vi.useFakeTimers();
-    const config: B2Config = { ...testConfig(), secretSink: { mode: "off" } };
+    const config: B2Config = {
+      ...testConfig(),
+      masterKeyId: "distinct-master-id",
+      masterKey: "distinct-master-secret",
+      secretSink: { mode: "off" },
+    };
     vi.spyOn(serverModule, "loadConfig").mockReturnValue(config);
     vi.spyOn(serverModule, "fetchCapabilities").mockReturnValue(
       new Promise<string[] | null>(() => undefined),
@@ -326,6 +333,11 @@ describe("stdio entry point", () => {
     expect(tools).not.toHaveProperty("s3_delete_objects");
     expect(tools).not.toHaveProperty("s3_get_presigned_url");
     expect(tools).not.toHaveProperty("b2_create_key");
+    expect(tools).not.toHaveProperty("b2_list_groups");
+    expect(tools).not.toHaveProperty("b2_create_group_member");
+    expect(tools).not.toHaveProperty("b2_eject_group_member");
+    expect(tools).not.toHaveProperty("b2_list_group_members");
+    expect(tools).not.toHaveProperty("b2_reserve_trial_create_account");
   });
 
   it("rethrows unexpected capability lookup failures", async () => {

--- a/tests/unit/index.unit.test.ts
+++ b/tests/unit/index.unit.test.ts
@@ -272,7 +272,14 @@ describe("stdio entry point", () => {
         );
       });
     });
-    installSdkTransport(transport);
+    installSdkTransport(transport, {
+      maxRetries: 3,
+      initialRetryDelayMs: 1,
+      maxRetryDelayMs: 1,
+      requestTimeoutMs: 30_000,
+    });
+    const authorizeRequests = () =>
+      transport.requests.filter((request) => b2EndpointName(request) === "b2_authorize_account");
 
     const started = startStdio();
     await waitForRecordedRequests(transport, 1);
@@ -283,6 +290,10 @@ describe("stdio entry point", () => {
     expect(abortObserved).toBe(true);
     expect(authorizeSettled).toBe(true);
     expect(transport.requests[0].signal?.aborted).toBe(true);
+    await vi.advanceTimersByTimeAsync(1);
+    await vi.runOnlyPendingTimersAsync();
+    await Promise.resolve();
+    expect(authorizeRequests()).toHaveLength(1);
     expect(serverModule.capabilityCacheSizeForTests()).toBe(0);
     const factory = serveStdio.mock.calls[0]?.[0] as (() => unknown) | undefined;
     expect(factory?.()).toBe(server);

--- a/tests/unit/index.unit.test.ts
+++ b/tests/unit/index.unit.test.ts
@@ -226,8 +226,7 @@ describe("stdio entry point", () => {
     const factory = serveStdio.mock.calls[0]?.[0] as (() => unknown) | undefined;
     expect(factory?.()).toBe(server);
     expect(createServer).toHaveBeenCalledWith(config, [], {
-      suppressDurableSecretCompatibilityStubs: true,
-      suppressPartnerTools: true,
+      failClosed: true,
     });
     expect(warn).toHaveBeenCalledWith(
       {
@@ -298,8 +297,7 @@ describe("stdio entry point", () => {
     const factory = serveStdio.mock.calls[0]?.[0] as (() => unknown) | undefined;
     expect(factory?.()).toBe(server);
     expect(createServer).toHaveBeenCalledWith(config, [], {
-      suppressDurableSecretCompatibilityStubs: true,
-      suppressPartnerTools: true,
+      failClosed: true,
     });
     expect(warn).toHaveBeenCalledWith(
       expect.objectContaining({


### PR DESCRIPTION
Summary:
- Bound stdio capability discovery to a fixed 10s bootstrap deadline so MCP clients can complete initialization instead of waiting on a slow B2 authorize call.
- Abort the deadline-bound authorize request when the stdio bootstrap deadline fires, avoiding lingering retry work, cache mutation, and late failure logs after degraded startup.
- Fail closed on stdio capability timeout or transient upstream unavailability with an empty capability set, including suppressed durable-secret fallback names and Partner tools; full-surface mode remains limited to B2_REGISTER_ALL_TOOLS=true.
- Emit and synchronously flush server.starting before capability discovery, and include the degraded error message plus timeout timing in warning logs.
- Centralized stdio capability fallback handling, removed the speculative timeout guard, added retry-drain/negative-surface coverage, and kept the package/coverage CI gates passing after rebasing on latest main.

Linked issue:
Closes #320

Tests:
- pnpm exec vitest run --config vitest.config.mts --project=unit tests/unit/index.unit.test.ts tests/unit/capability-registration.unit.test.ts tests/unit/auth.unit.test.ts
- pnpm exec vitest run --config vitest.config.mts --project=unit tests/unit/index.unit.test.ts
- pnpm run typecheck
- pnpm run build
- pnpm run check:package-budget
- pnpm run test:coverage
- pnpm run lint
- pnpm run format:check
- pnpm run lint:docs
- pnpm test
- pnpm run test:protocol
- pnpm run test:observability

Follow-up notes:
- None.
