### PR TITLE
fix: attribute destructive confirm source

### DIFF
--- a/src/server.ts
+++ b/src/server.ts
@@ -819,6 +819,13 @@ export function createAuditedToolCallback(
           ...(destructiveElicitationAudit && {
             elicitationOutcome: destructiveElicitationAudit.outcome,
             handlerRan,
+            ...(destructiveElicitationAudit.confirmationSource && {
+              destructiveConfirmationSource: destructiveElicitationAudit.confirmationSource,
+            }),
+            ...(destructiveElicitationAudit.confirmationFallbackReason && {
+              destructiveConfirmationFallbackReason:
+                destructiveElicitationAudit.confirmationFallbackReason,
+            }),
             ...(destructiveElicitationAudit.reason && {
               elicitationReason: destructiveElicitationAudit.reason,
             }),

--- a/src/server.ts
+++ b/src/server.ts
@@ -766,18 +766,19 @@ export function createAuditedToolCallback(
     const start = Date.now();
     const argKeys =
       args && typeof args === "object" && !Array.isArray(args) ? Object.keys(args) : [];
+    const outputFormat = config.outputFormat ?? DEFAULT_MCP_OUTPUT_FORMAT;
+    let destructiveElicitationAudit: DestructiveElicitationAuditEvent | undefined;
+    let handlerRan = false;
     try {
       const sanitizerOptions = sanitizerOptionsFromConfig(config);
-      const outputFormat = config.outputFormat ?? DEFAULT_MCP_OUTPUT_FORMAT;
       const signal = extra?.mcpReq?.signal ?? currentMcpRequestSignal();
-      let destructiveElicitationAudit: DestructiveElicitationAuditEvent | undefined;
-      let handlerRan = false;
       const callOriginal = () =>
-        runWithMcpRequestSignal(signal, () =>
-          runWithSanitizerOptions(sanitizerOptions, () =>
+        runWithMcpRequestSignal(signal, () => {
+          handlerRan = true;
+          return runWithSanitizerOptions(sanitizerOptions, () =>
             runWithResultSerializationOptions({ outputFormat }, () => original(args, extra)),
-          ),
-        );
+          );
+        });
       const rawResult = await maybeRequireDestructiveElicitation({
         toolName: name,
         args: args ?? {},
@@ -790,7 +791,6 @@ export function createAuditedToolCallback(
         },
         runOriginal: callOriginal,
       });
-      handlerRan = destructiveElicitationAudit?.outcome === "accepted";
       const result = isSanitizedMcpResponse(rawResult)
         ? rawResult
         : sanitizeMcpResponse(rawResult, sanitizerOptions);
@@ -817,18 +817,7 @@ export function createAuditedToolCallback(
           error: isError,
           resultType,
           ...(destructiveElicitationAudit && {
-            elicitationOutcome: destructiveElicitationAudit.outcome,
-            handlerRan,
-            ...(destructiveElicitationAudit.confirmationSource && {
-              destructiveConfirmationSource: destructiveElicitationAudit.confirmationSource,
-            }),
-            ...(destructiveElicitationAudit.confirmationFallbackReason && {
-              destructiveConfirmationFallbackReason:
-                destructiveElicitationAudit.confirmationFallbackReason,
-            }),
-            ...(destructiveElicitationAudit.reason && {
-              elicitationReason: destructiveElicitationAudit.reason,
-            }),
+            ...destructiveAuditLogFields(destructiveElicitationAudit, handlerRan),
           }),
           ...(safeErrInfo && {
             code: safeErrInfo.code,
@@ -847,14 +836,36 @@ export function createAuditedToolCallback(
         {
           tool: name,
           credential: keyFingerprint,
-          outputFormat: config.outputFormat ?? DEFAULT_MCP_OUTPUT_FORMAT,
+          outputFormat,
           argKeys,
           durationMs,
+          ...(destructiveElicitationAudit && {
+            ...destructiveAuditLogFields(destructiveElicitationAudit, handlerRan),
+          }),
           err: safeErr.message,
         },
         "tool.error",
       );
       throw safeErr;
     }
+  };
+}
+
+function destructiveAuditLogFields(
+  event: DestructiveElicitationAuditEvent,
+  handlerRan: boolean,
+): Record<string, unknown> {
+  return {
+    elicitationOutcome: event.outcome,
+    handlerRan,
+    ...("confirmationSource" in event && {
+      destructiveConfirmationSource: event.confirmationSource,
+    }),
+    ...("confirmationFallbackReason" in event && {
+      destructiveConfirmationFallbackReason: event.confirmationFallbackReason,
+    }),
+    ...("reason" in event && {
+      elicitationReason: event.reason,
+    }),
   };
 }

--- a/src/utils/destructive-elicitation.ts
+++ b/src/utils/destructive-elicitation.ts
@@ -40,18 +40,6 @@ export type ProtocolVersionProvider = () => string | undefined;
 export type DestructiveElicitationRequestStateCodec =
   RequestStateCodec<DestructiveElicitationState>;
 
-/** Audit payload emitted when destructive elicitation makes a decision. */
-export interface DestructiveElicitationAuditEvent {
-  /** Final decision outcome. */
-  outcome: ElicitationDecision;
-  /** Optional refusal/decline/cancel reason. */
-  reason?: string;
-  /** Source that satisfied destructive confirmation, when any. */
-  confirmationSource?: DestructiveConfirmationSource;
-  /** Why the legacy `confirm` fallback was used, when applicable. */
-  confirmationFallbackReason?: DestructiveConfirmationFallbackReason;
-}
-
 /** Optional context hooks used by tests and protocol adapters. */
 export interface DestructiveElicitationContextProviders {
   /** Returns request-local MCP client capabilities. */
@@ -91,12 +79,52 @@ export interface DestructiveElicitationState {
   issuedAt: number;
 }
 
-/** Decision lifecycle for return-based destructive-operation elicitation. */
-export type ElicitationDecision = "requested" | "accepted" | "declined" | "cancelled" | "refused";
+/** Decision lifecycle for destructive-operation confirmation auditing. */
+export type ElicitationDecision =
+  | "requested"
+  | "accepted"
+  | "fallback_accepted"
+  | "declined"
+  | "cancelled"
+  | "refused";
 /** Source that supplied destructive-operation confirmation. */
 export type DestructiveConfirmationSource = "human_mcp_elicitation" | "model_confirm_parameter";
 /** Reason the server degraded to the legacy model-supplied `confirm` path. */
 export type DestructiveConfirmationFallbackReason = "elicitation_disabled" | "client_cannot_elicit";
+/** Destructive elicitation prompt was returned to the MCP client. */
+export interface DestructiveElicitationRequestedAuditEvent {
+  /** Final decision outcome. */
+  outcome: "requested";
+}
+/** Destructive operation was approved by MCP human elicitation. */
+export interface DestructiveElicitationAcceptedAuditEvent {
+  /** Final decision outcome. */
+  outcome: "accepted";
+  /** Source that satisfied destructive confirmation. */
+  confirmationSource: "human_mcp_elicitation";
+}
+/** Destructive operation was approved by the legacy confirm-parameter fallback. */
+export interface DestructiveConfirmFallbackAuditEvent {
+  /** Final decision outcome. */
+  outcome: "fallback_accepted";
+  /** Source that satisfied destructive confirmation. */
+  confirmationSource: "model_confirm_parameter";
+  /** Why the legacy `confirm` fallback was used. */
+  confirmationFallbackReason: DestructiveConfirmationFallbackReason;
+}
+/** Destructive elicitation was declined, cancelled, or refused. */
+export interface DestructiveElicitationRefusedAuditEvent {
+  /** Final decision outcome. */
+  outcome: "declined" | "cancelled" | "refused";
+  /** Refusal, decline, or cancel reason. */
+  reason: string;
+}
+/** Audit payload emitted when destructive confirmation makes a decision. */
+export type DestructiveElicitationAuditEvent =
+  | DestructiveElicitationRequestedAuditEvent
+  | DestructiveElicitationAcceptedAuditEvent
+  | DestructiveConfirmFallbackAuditEvent
+  | DestructiveElicitationRefusedAuditEvent;
 type StateVerification =
   | { ok: true; state: DestructiveElicitationState }
   | { ok: false; reason: string };
@@ -195,7 +223,14 @@ export async function maybeRequireDestructiveElicitation<T>({
         onDecision,
       );
     }
-    recordLegacyConfirmFallback(args, "elicitation_disabled", onDecision);
+    recordLegacyConfirmFallback(
+      toolName,
+      effect,
+      args,
+      "elicitation_disabled",
+      sanitizerOptions,
+      onDecision,
+    );
     return runOriginal();
   }
   if (!clientCanUseReturnBasedElicitation(requestExtra, contextProviders)) {
@@ -208,7 +243,14 @@ export async function maybeRequireDestructiveElicitation<T>({
         onDecision,
       );
     }
-    recordLegacyConfirmFallback(args, "client_cannot_elicit", onDecision);
+    recordLegacyConfirmFallback(
+      toolName,
+      effect,
+      args,
+      "client_cannot_elicit",
+      sanitizerOptions,
+      onDecision,
+    );
     return runOriginal();
   }
 
@@ -237,7 +279,7 @@ export async function maybeRequireDestructiveElicitation<T>({
     recordDestructiveElicitationDecision(
       toolName,
       effect,
-      "requested",
+      { outcome: "requested" },
       sanitizerOptions,
       onDecision,
     );
@@ -314,9 +356,13 @@ export async function maybeRequireDestructiveElicitation<T>({
     );
   }
 
-  recordDestructiveElicitationDecision(toolName, effect, "accepted", sanitizerOptions, onDecision, {
-    confirmationSource: "human_mcp_elicitation",
-  });
+  recordDestructiveElicitationDecision(
+    toolName,
+    effect,
+    { outcome: "accepted", confirmationSource: "human_mcp_elicitation" },
+    sanitizerOptions,
+    onDecision,
+  );
   return runWithDestructiveElicitationConsent(
     toolName,
     destructiveTargetDigest(config, args),
@@ -426,11 +472,15 @@ function destructiveElicitationRefused(
   reason: string,
   sanitizerOptions: SanitizerOptions = {},
   onDecision?: (event: DestructiveElicitationAuditEvent) => void,
-  outcome: ElicitationDecision = "refused",
+  outcome: DestructiveElicitationRefusedAuditEvent["outcome"] = "refused",
 ): ToolErrorResult {
-  recordDestructiveElicitationDecision(toolName, effect, outcome, sanitizerOptions, onDecision, {
-    reason,
-  });
+  recordDestructiveElicitationDecision(
+    toolName,
+    effect,
+    { outcome, reason },
+    sanitizerOptions,
+    onDecision,
+  );
   return toolError({
     status: 409,
     code: "destructive_confirmation_refused",
@@ -800,43 +850,64 @@ function destructiveElicitationKeyMaterial(config: B2Config): string {
 function recordDestructiveElicitationDecision(
   toolName: string,
   effect: string,
-  decision: ElicitationDecision,
+  event: DestructiveElicitationAuditEvent,
   sanitizerOptions: SanitizerOptions,
   onDecision?: (event: DestructiveElicitationAuditEvent) => void,
-  event: Omit<DestructiveElicitationAuditEvent, "outcome"> = {},
 ): void {
-  logDestructiveElicitation(toolName, effect, decision, sanitizerOptions, event.reason);
-  onDecision?.({ outcome: decision, ...event });
+  logDestructiveElicitation(toolName, effect, event, sanitizerOptions);
+  onDecision?.(event);
 }
 
 function recordLegacyConfirmFallback(
+  toolName: string,
+  effect: string,
   args: Record<string, unknown>,
   reason: DestructiveConfirmationFallbackReason,
+  sanitizerOptions: SanitizerOptions,
   onDecision?: (event: DestructiveElicitationAuditEvent) => void,
 ): void {
   if (args.confirm !== true) return;
-  onDecision?.({
-    outcome: "accepted",
-    confirmationSource: "model_confirm_parameter",
-    confirmationFallbackReason: reason,
-  });
+  recordDestructiveElicitationDecision(
+    toolName,
+    effect,
+    {
+      outcome: "fallback_accepted",
+      confirmationSource: "model_confirm_parameter",
+      confirmationFallbackReason: reason,
+    },
+    sanitizerOptions,
+    onDecision,
+  );
 }
 
 function logDestructiveElicitation(
   toolName: string,
   effect: string,
-  decision: ElicitationDecision,
+  event: DestructiveElicitationAuditEvent,
   sanitizerOptions: SanitizerOptions = {},
-  reason?: string,
 ): void {
   logger.info(
     {
       tool: toolName,
       effect: sanitizeText(effect, sanitizerOptions),
-      decision,
-      outcome: decision,
-      ...(reason && { reason }),
+      decision: event.outcome,
+      outcome: event.outcome,
+      ...destructiveConfirmationLogFields(event),
+      ...("reason" in event && { reason: event.reason }),
     },
     "destructive.elicitation",
   );
+}
+
+function destructiveConfirmationLogFields(
+  event: DestructiveElicitationAuditEvent,
+): Record<string, string> {
+  return "confirmationSource" in event
+    ? {
+        destructiveConfirmationSource: event.confirmationSource,
+        ...("confirmationFallbackReason" in event && {
+          destructiveConfirmationFallbackReason: event.confirmationFallbackReason,
+        }),
+      }
+    : {};
 }

--- a/src/utils/destructive-elicitation.ts
+++ b/src/utils/destructive-elicitation.ts
@@ -46,6 +46,10 @@ export interface DestructiveElicitationAuditEvent {
   outcome: ElicitationDecision;
   /** Optional refusal/decline/cancel reason. */
   reason?: string;
+  /** Source that satisfied destructive confirmation, when any. */
+  confirmationSource?: DestructiveConfirmationSource;
+  /** Why the legacy `confirm` fallback was used, when applicable. */
+  confirmationFallbackReason?: DestructiveConfirmationFallbackReason;
 }
 
 /** Optional context hooks used by tests and protocol adapters. */
@@ -89,6 +93,10 @@ export interface DestructiveElicitationState {
 
 /** Decision lifecycle for return-based destructive-operation elicitation. */
 export type ElicitationDecision = "requested" | "accepted" | "declined" | "cancelled" | "refused";
+/** Source that supplied destructive-operation confirmation. */
+export type DestructiveConfirmationSource = "human_mcp_elicitation" | "model_confirm_parameter";
+/** Reason the server degraded to the legacy model-supplied `confirm` path. */
+export type DestructiveConfirmationFallbackReason = "elicitation_disabled" | "client_cannot_elicit";
 type StateVerification =
   | { ok: true; state: DestructiveElicitationState }
   | { ok: false; reason: string };
@@ -187,6 +195,7 @@ export async function maybeRequireDestructiveElicitation<T>({
         onDecision,
       );
     }
+    recordLegacyConfirmFallback(args, "elicitation_disabled", onDecision);
     return runOriginal();
   }
   if (!clientCanUseReturnBasedElicitation(requestExtra, contextProviders)) {
@@ -199,6 +208,7 @@ export async function maybeRequireDestructiveElicitation<T>({
         onDecision,
       );
     }
+    recordLegacyConfirmFallback(args, "client_cannot_elicit", onDecision);
     return runOriginal();
   }
 
@@ -304,7 +314,9 @@ export async function maybeRequireDestructiveElicitation<T>({
     );
   }
 
-  recordDestructiveElicitationDecision(toolName, effect, "accepted", sanitizerOptions, onDecision);
+  recordDestructiveElicitationDecision(toolName, effect, "accepted", sanitizerOptions, onDecision, {
+    confirmationSource: "human_mcp_elicitation",
+  });
   return runWithDestructiveElicitationConsent(
     toolName,
     destructiveTargetDigest(config, args),
@@ -416,14 +428,9 @@ function destructiveElicitationRefused(
   onDecision?: (event: DestructiveElicitationAuditEvent) => void,
   outcome: ElicitationDecision = "refused",
 ): ToolErrorResult {
-  recordDestructiveElicitationDecision(
-    toolName,
-    effect,
-    outcome,
-    sanitizerOptions,
-    onDecision,
+  recordDestructiveElicitationDecision(toolName, effect, outcome, sanitizerOptions, onDecision, {
     reason,
-  );
+  });
   return toolError({
     status: 409,
     code: "destructive_confirmation_refused",
@@ -796,10 +803,23 @@ function recordDestructiveElicitationDecision(
   decision: ElicitationDecision,
   sanitizerOptions: SanitizerOptions,
   onDecision?: (event: DestructiveElicitationAuditEvent) => void,
-  reason?: string,
+  event: Omit<DestructiveElicitationAuditEvent, "outcome"> = {},
 ): void {
-  logDestructiveElicitation(toolName, effect, decision, sanitizerOptions, reason);
-  onDecision?.({ outcome: decision, ...(reason && { reason }) });
+  logDestructiveElicitation(toolName, effect, decision, sanitizerOptions, event.reason);
+  onDecision?.({ outcome: decision, ...event });
+}
+
+function recordLegacyConfirmFallback(
+  args: Record<string, unknown>,
+  reason: DestructiveConfirmationFallbackReason,
+  onDecision?: (event: DestructiveElicitationAuditEvent) => void,
+): void {
+  if (args.confirm !== true) return;
+  onDecision?.({
+    outcome: "accepted",
+    confirmationSource: "model_confirm_parameter",
+    confirmationFallbackReason: reason,
+  });
 }
 
 function logDestructiveElicitation(

--- a/tests/observability/logging.behavior.observability.test.ts
+++ b/tests/observability/logging.behavior.observability.test.ts
@@ -26,6 +26,7 @@ const SAFE_ENV_NAMES = [
 type ProbeName =
   | "accessor-safety"
   | "environment"
+  | "policy-confirm-fallback"
   | "policy-confirmation"
   | "redaction"
   | "retry-budget"
@@ -231,6 +232,30 @@ describe("observability logging behavior", () => {
       resultType: "complete",
       code: "destructive_confirmation_required",
       status: 409,
+    });
+    expect(call.argKeys).toEqual(["bucketId", "confirm", "nested"]);
+    expectNoIncidentLogs(logs);
+  });
+
+  it("attributes legacy confirm fallback in the tool audit record", () => {
+    const result = runProbe("policy-confirm-fallback");
+    expectProbeSucceeded(result);
+    const response = JSON.parse(result.stdout) as { isError?: boolean; content?: unknown[] };
+    expect(response.isError).not.toBe(true);
+    expect(JSON.stringify(response.content)).toContain("deleted");
+
+    const logs = parseLogLines(result.stderr);
+    const call = findLog(logs, "tool.call");
+    expect(call).toMatchObject({
+      level: "info",
+      tool: "b2_delete_bucket",
+      credential: "fallback-fingerprint",
+      error: false,
+      resultType: "complete",
+      elicitationOutcome: "accepted",
+      handlerRan: true,
+      destructiveConfirmationSource: "model_confirm_parameter",
+      destructiveConfirmationFallbackReason: "client_cannot_elicit",
     });
     expect(call.argKeys).toEqual(["bucketId", "confirm", "nested"]);
     expectNoIncidentLogs(logs);

--- a/tests/observability/logging.behavior.observability.test.ts
+++ b/tests/observability/logging.behavior.observability.test.ts
@@ -252,12 +252,18 @@ describe("observability logging behavior", () => {
       credential: "fallback-fingerprint",
       error: false,
       resultType: "complete",
-      elicitationOutcome: "accepted",
+      elicitationOutcome: "fallback_accepted",
       handlerRan: true,
       destructiveConfirmationSource: "model_confirm_parameter",
       destructiveConfirmationFallbackReason: "client_cannot_elicit",
     });
     expect(call.argKeys).toEqual(["bucketId", "confirm", "nested"]);
+    expect(findLog(logs, "destructive.elicitation")).toMatchObject({
+      decision: "fallback_accepted",
+      outcome: "fallback_accepted",
+      destructiveConfirmationSource: "model_confirm_parameter",
+      destructiveConfirmationFallbackReason: "client_cannot_elicit",
+    });
     expectNoIncidentLogs(logs);
   });
 

--- a/tests/observability/support/logging-probe-fixture.ts
+++ b/tests/observability/support/logging-probe-fixture.ts
@@ -7,6 +7,7 @@ import type { B2Config } from "../../../src/utils/types";
 
 type ProbeName =
   | "accessor-safety"
+  | "policy-confirm-fallback"
   | "environment"
   | "policy-confirmation"
   | "redaction"
@@ -124,6 +125,29 @@ async function policyConfirmationProbe(): Promise<void> {
   flushLogsSync();
 }
 
+async function policyConfirmFallbackProbe(): Promise<void> {
+  initLogging();
+  const config = testConfig("fallback");
+  const wrapped = createAuditedToolCallback(
+    "b2_delete_bucket",
+    async (args) => {
+      const gate = checkDestructive("b2_delete_bucket", args, config);
+      return gate.ok ? toolSuccess("deleted") : toolError(gate.error);
+    },
+    config,
+  );
+  const result = await wrapped(
+    {
+      bucketId: "bucket-with-model-confirm",
+      confirm: true,
+      nested: { applicationKey: "B2_MCP_CANARY_SECRET_FALLBACK_ARG" },
+    },
+    {},
+  );
+  writeJson(result);
+  flushLogsSync();
+}
+
 async function thrownFailureProbe(): Promise<void> {
   initLogging();
   const config = testConfig("failure");
@@ -214,6 +238,7 @@ async function environmentProbe(): Promise<void> {
 const probes: Record<ProbeName, () => Promise<void>> = {
   "accessor-safety": accessorSafetyProbe,
   environment: environmentProbe,
+  "policy-confirm-fallback": policyConfirmFallbackProbe,
   "policy-confirmation": policyConfirmationProbe,
   redaction: redactionProbe,
   "retry-budget": retryBudgetProbe,

--- a/tests/unit/destructive-elicitation.unit.test.ts
+++ b/tests/unit/destructive-elicitation.unit.test.ts
@@ -513,6 +513,38 @@ describe("destructive elicitation", () => {
   });
 
   it.each([
+    ["server-disabled elicitation", "elicitation_disabled" as const, providers(), {}],
+    [
+      "unsupported client elicitation",
+      "client_cannot_elicit" as const,
+      providers(URL_ONLY_ELICITATION),
+      { mcpReq: { clientCapabilities: URL_ONLY_ELICITATION, envelope: envelope() } },
+    ],
+  ])(
+    "audits model-supplied confirm attribution for %s",
+    async (_case, expectedReason, context, extra) => {
+      const info = vi.spyOn(logger, "info").mockImplementation(() => undefined);
+      if (expectedReason === "elicitation_disabled") {
+        process.env.B2_DESTRUCTIVE_ELICITATION = "off";
+      }
+      const config = cfg("confirm");
+      const original = destructiveOriginal(config);
+      const wrapped = createAuditedToolCallback("s3_delete_object", original, config, context);
+
+      const result = await wrapped({ bucket: "photos", key: "old.jpg", confirm: true }, extra);
+
+      expect(result.content?.[0]?.text).toBe("deleted");
+      expect(original).toHaveBeenCalledTimes(1);
+      expect(info.mock.calls.find(([, message]) => message === "tool.call")?.[0]).toMatchObject({
+        elicitationOutcome: "accepted",
+        handlerRan: true,
+        destructiveConfirmationSource: "model_confirm_parameter",
+        destructiveConfirmationFallbackReason: expectedReason,
+      });
+    },
+  );
+
+  it.each([
     [
       "missing legacy confirmation",
       cfg("confirm"),
@@ -779,12 +811,18 @@ describe("destructive elicitation", () => {
         resultType: (entry as { resultType: string }).resultType,
         outcome: (entry as { elicitationOutcome?: string }).elicitationOutcome,
         handlerRan: (entry as { handlerRan?: boolean }).handlerRan,
+        source: (entry as { destructiveConfirmationSource?: string }).destructiveConfirmationSource,
       })),
     ).toEqual([
-      { resultType: "input_required", outcome: "requested", handlerRan: false },
-      { resultType: "complete", outcome: "accepted", handlerRan: true },
-      { resultType: "input_required", outcome: "requested", handlerRan: false },
-      { resultType: "complete", outcome: "declined", handlerRan: false },
+      { resultType: "input_required", outcome: "requested", handlerRan: false, source: undefined },
+      {
+        resultType: "complete",
+        outcome: "accepted",
+        handlerRan: true,
+        source: "human_mcp_elicitation",
+      },
+      { resultType: "input_required", outcome: "requested", handlerRan: false, source: undefined },
+      { resultType: "complete", outcome: "declined", handlerRan: false, source: undefined },
     ]);
     expect(toolCallLogs[toolCallLogs.length - 1]?.[0]).toMatchObject({
       code: "destructive_confirmation_refused",

--- a/tests/unit/destructive-elicitation.unit.test.ts
+++ b/tests/unit/destructive-elicitation.unit.test.ts
@@ -536,13 +536,87 @@ describe("destructive elicitation", () => {
       expect(result.content?.[0]?.text).toBe("deleted");
       expect(original).toHaveBeenCalledTimes(1);
       expect(info.mock.calls.find(([, message]) => message === "tool.call")?.[0]).toMatchObject({
-        elicitationOutcome: "accepted",
+        elicitationOutcome: "fallback_accepted",
         handlerRan: true,
+        destructiveConfirmationSource: "model_confirm_parameter",
+        destructiveConfirmationFallbackReason: expectedReason,
+      });
+      expect(
+        info.mock.calls.find(([, message]) => message === "destructive.elicitation")?.[0],
+      ).toMatchObject({
+        decision: "fallback_accepted",
+        outcome: "fallback_accepted",
         destructiveConfirmationSource: "model_confirm_parameter",
         destructiveConfirmationFallbackReason: expectedReason,
       });
     },
   );
+
+  it("keeps human approval attribution when the approved handler throws", async () => {
+    const warn = vi.spyOn(logger, "warn").mockImplementation(() => undefined);
+    const config = cfg("confirm");
+    const original = vi.fn((args: Record<string, unknown>) => {
+      const gate = checkDestructive("s3_delete_object", args, config);
+      if (!gate.ok) return toolError(gate.error);
+      throw new Error("provider timeout after approval");
+    });
+    const wrapped = createAuditedToolCallback("s3_delete_object", original, config, providers());
+    const args = { bucket: "photos", key: "old.jpg" };
+    const requestState = await requestStateFor(wrapped, args);
+
+    await expect(
+      wrapped(args, extraWithElicitation(acceptedResponse(), requestState)),
+    ).rejects.toThrow("provider timeout after approval");
+
+    expect(original).toHaveBeenCalledTimes(1);
+    expect(warn.mock.calls.find(([, message]) => message === "tool.error")?.[0]).toMatchObject({
+      elicitationOutcome: "accepted",
+      handlerRan: true,
+      destructiveConfirmationSource: "human_mcp_elicitation",
+      err: "provider timeout after approval",
+    });
+  });
+
+  it("keeps model-confirm attribution when the fallback-approved handler throws", async () => {
+    const info = vi.spyOn(logger, "info").mockImplementation(() => undefined);
+    const warn = vi.spyOn(logger, "warn").mockImplementation(() => undefined);
+    const config = cfg("confirm");
+    const original = vi.fn((args: Record<string, unknown>) => {
+      const gate = checkDestructive("s3_delete_object", args, config);
+      if (!gate.ok) return toolError(gate.error);
+      throw new Error("provider timeout after model confirm");
+    });
+    const wrapped = createAuditedToolCallback(
+      "s3_delete_object",
+      original,
+      config,
+      providers(URL_ONLY_ELICITATION),
+    );
+
+    await expect(
+      wrapped(
+        { bucket: "photos", key: "old.jpg", confirm: true },
+        { mcpReq: { clientCapabilities: URL_ONLY_ELICITATION, envelope: envelope() } },
+      ),
+    ).rejects.toThrow("provider timeout after model confirm");
+
+    expect(original).toHaveBeenCalledTimes(1);
+    expect(
+      info.mock.calls.find(([, message]) => message === "destructive.elicitation")?.[0],
+    ).toMatchObject({
+      decision: "fallback_accepted",
+      outcome: "fallback_accepted",
+      destructiveConfirmationSource: "model_confirm_parameter",
+      destructiveConfirmationFallbackReason: "client_cannot_elicit",
+    });
+    expect(warn.mock.calls.find(([, message]) => message === "tool.error")?.[0]).toMatchObject({
+      elicitationOutcome: "fallback_accepted",
+      handlerRan: true,
+      destructiveConfirmationSource: "model_confirm_parameter",
+      destructiveConfirmationFallbackReason: "client_cannot_elicit",
+      err: "provider timeout after model confirm",
+    });
+  });
 
   it.each([
     [


### PR DESCRIPTION
## Summary
- Add destructive confirmation source fields to tool.call and tool.error audit logs.
- Keep human MCP approvals as elicitationOutcome: accepted, and record legacy confirm fallback as elicitationOutcome: fallback_accepted with source and fallback reason.
- Emit legacy confirm fallback approvals on the destructive.elicitation stream and tighten the exported audit event union.

## Linked Issue
Fixes #318

## Tests
- pnpm test
- pnpm exec vitest run --config vitest.config.mts --project=unit tests/unit/destructive-elicitation.unit.test.ts tests/unit/audit-wrapper.unit.test.ts
- pnpm exec vitest run --config vitest.config.mts --project=observability tests/observability/logging.behavior.observability.test.ts
- pnpm run typecheck
- pnpm run lint
- pnpm run format:check
- pnpm run build
- pnpm run docs

## Follow-up Notes
- Review comments addressed in commit 18f62c4.