### PR TITLE
build: raise Node floor to 22.22.2, bump eslint-plugin-jsdoc to 64.2.1

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -360,13 +360,13 @@ jobs:
       # actions/setup-node v7, reviewed 2026-08-06.
       - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020
         with:
-          node-version: 22.3.0
+          node-version: 22.22.2
       # actions/download-artifact v8, reviewed 2026-08-25.
       - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c
         with:
           name: package-install-smoke
           path: reports/package-install-smoke
-      - name: Run packed consumer smoke on Node.js 22.3.0
+      - name: Run packed consumer smoke on Node.js 22.22.2
         run: |
           set -euo pipefail
           tarball="$(find reports/package-install-smoke -name '*.tgz' -type f -print -quit)"
@@ -375,7 +375,7 @@ jobs:
             exit 1
           fi
           node scripts/packed-consumer-smoke.mjs --tarball "$tarball"
-      - name: Run local runtime smoke on Node.js 22.3.0
+      - name: Run local runtime smoke on Node.js 22.22.2
         run: |
           set -euo pipefail
           tarball="$(find reports/package-install-smoke -name '*.tgz' -type f -print -quit)"
@@ -732,7 +732,7 @@ jobs:
           | Observability logging | Structured lifecycle, warning, failure, redaction, and stream-separation canaries |
           | Linux deterministic Node matrix | 22.23.1, 24, 26 |
           | Deterministic dependency failures | B2/S3/OAuth outage suite |
-          | Runtime engine floor | Node.js 22.3.0 package install smoke |
+          | Runtime engine floor | Node.js 22.22.2 package install smoke |
           | Cross-platform fast suite | Linux, Windows, macOS on Node.js 22.23.1 |
           | Package budget metrics | Uploaded as package-budget artifact |
           | Vercel adapter budget | Uploaded as vercel-bundle artifact path |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   and secret-sink contracts.
 
 ### Changed
+- Raised the declared Node engine floor from `22.3.0` to `22.22.2`
+  (`engines.node` is now `^22.22.2 || ^24 || ^26`). The floor now matches the
+  Node.js version CI already tests and pins (`.nvmrc`/matrix use 22.23.1), and
+  unblocks the `eslint-plugin-jsdoc` 64.x doc-lint toolchain, which requires
+  `^22.22.2 || >=24.15.0`. Node 22 users on an older patch should update within
+  the 22 LTS line; `@types/node` stays pinned to its conservative 22.3.0
+  baseline. (#329)
+- Bumped `eslint-plugin-jsdoc` `50.8.0` → `64.2.1` (doc-lint dev dependency).
 - Enforce strict TypeDoc validation for public API docs: undocumented modules,
   exported members, and invalid links now fail `pnpm run docs` and the docs
   workflow. (#308)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -59,7 +59,7 @@ opening a PR when practical:
 
 | Layer | Command | What it proves |
 | --- | --- | --- |
-| Typecheck | `pnpm run typecheck` | Source and tests compile against the Node 22.22.2 engine-floor types. |
+| Typecheck | `pnpm run typecheck` | Source and tests compile against the conservative `@types/node` 22.3.0 baseline (below the 22.22.2 engine floor; see the note near the end of this guide). |
 | Unit | `pnpm run test:unit` | Fast isolated behavior for handlers, config, adapters, sanitizer, CLI, and utilities. |
 | Contract | `pnpm run test:contract` | Public docs, package surface, tool profiles, workflow policy, schema drift, and support claims stay synchronized. |
 | Protocol modern | `pnpm run test:protocol:modern` | MCP `2026-07-28` HTTP and stdio behavior, including stateless POST serving. |

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -7,8 +7,8 @@ By participating you agree to abide by our [Code of Conduct](./CODE_OF_CONDUCT.m
 
 ## Development setup
 
-The package engine range is `^22.3.0 || ^24 || ^26`: it preserves the official
-B2 SDK's Node 22.3.0 floor and excludes Node.js lines outside opossum's supported
+The package engine range is `^22.22.2 || ^24 || ^26`: it preserves the official
+B2 SDK's Node 22.3.0 baseline, raised to a 22.22.2 floor, and excludes Node.js lines outside opossum's supported
 range. For local development and deployed 22.x hosts, use the patched Node 22
 LTS release pinned in `.nvmrc` (`22.23.1` at the time of writing) or a later
 patched 22.x release. CI runs the full toolchain on Node.js 22.23.1, 24, and 26.
@@ -59,7 +59,7 @@ opening a PR when practical:
 
 | Layer | Command | What it proves |
 | --- | --- | --- |
-| Typecheck | `pnpm run typecheck` | Source and tests compile against the Node 22.3 engine-floor types. |
+| Typecheck | `pnpm run typecheck` | Source and tests compile against the Node 22.22.2 engine-floor types. |
 | Unit | `pnpm run test:unit` | Fast isolated behavior for handlers, config, adapters, sanitizer, CLI, and utilities. |
 | Contract | `pnpm run test:contract` | Public docs, package surface, tool profiles, workflow policy, schema drift, and support claims stay synchronized. |
 | Protocol modern | `pnpm run test:protocol:modern` | MCP `2026-07-28` HTTP and stdio behavior, including stateless POST serving. |
@@ -91,7 +91,7 @@ touches the corresponding contract.
 - `pnpm run verify` must pass before opening a PR. CI runs deterministic
   coverage, slow lifecycle, and production dependency audit evidence on Node.js
   22.23.1, 24, and 26, runs a patched Node 22 LTS cross-platform suite, and
-  exercises the advertised Node.js 22.3.0 engine floor with a packed-package
+  exercises the advertised Node.js 22.22.2 engine floor with a packed-package
   smoke. Package-install evidence is a separate required gate.
 - Add or update unit tests for any behavior change. New tools need a schema entry
   in `tests/contract/tools-schema.contract.test.ts` and at least one handler test.
@@ -165,7 +165,7 @@ contract before review: `pnpm run test:contract`, `pnpm run test:protocol`,
 `pnpm run audit:supply-chain`. The live contract suite must pass before release
 accepts the SDK upgrade.
 
-`@types/node` tracks the Node 22.3.0 engine floor so TypeScript does not allow
+`@types/node` is pinned to a conservative 22.3.0 baseline (below the 22.22.2 engine floor; @types/node has no 22.22.x release) so TypeScript does not allow
 newer Node standard-library APIs that would fail for minimum-supported
 consumers. Node 24 and 26 remain covered by execution tests in CI.
 

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ Destructive actions are gated, durable B2 secrets stay out of the model's contex
 
 ## Quick start
 
-**Prerequisites:** A supported [Node.js](https://nodejs.org) runtime (22.23.1+, or 24 / 26) and a Backblaze B2 [application key](https://www.backblaze.com/docs/cloud-storage-application-keys). A non-master key is all you need. The package engine range is `^22.22.2 || ^24 || ^26`; CI runs on Node.js 22.23.1, 24, and 26.
+**Prerequisites:** A supported [Node.js](https://nodejs.org) runtime (22.22.2+, or 24 / 26) and a Backblaze B2 [application key](https://www.backblaze.com/docs/cloud-storage-application-keys). A non-master key is all you need. The package engine range is `^22.22.2 || ^24 || ^26`; CI runs on Node.js 22.23.1, 24, and 26.
 
 The canonical package name is `@backblaze-labs/b2-mcp` and the canonical binary is `b2-mcp` (`b2-mcp-server` is a transition alias). The fastest setup runs it with `npx`, no clone or build.
 

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 [![npm](https://img.shields.io/npm/v/@backblaze-labs/b2-mcp?color=cb3837)](https://www.npmjs.com/package/@backblaze-labs/b2-mcp)
 [![License: MIT](https://img.shields.io/badge/license-MIT-blue.svg)](LICENSE)
 [![TypeScript](https://img.shields.io/badge/TypeScript-6.x-3178c6?logo=typescript&logoColor=white)](https://www.typescriptlang.org/)
-[![Node.js](https://img.shields.io/badge/Node.js-22.3%2B%20%7C%2024%20%7C%2026-339933?logo=nodedotjs&logoColor=white)](https://nodejs.org/)
+[![Node.js](https://img.shields.io/badge/Node.js-22.22%2B%20%7C%2024%20%7C%2026-339933?logo=nodedotjs&logoColor=white)](https://nodejs.org/)
 [![MCP](https://img.shields.io/badge/MCP-2026--07--28-5b5fc7)](https://modelcontextprotocol.io/specification/2026-07-28)
 <!-- Directory badges point at deterministic per-server URLs derived from the locked
      name (io.github.backblaze-labs/b2-mcp) and repo path, so they activate automatically
@@ -39,7 +39,7 @@ Destructive actions are gated, durable B2 secrets stay out of the model's contex
 
 ## Quick start
 
-**Prerequisites:** A supported [Node.js](https://nodejs.org) runtime (22.23.1+, or 24 / 26) and a Backblaze B2 [application key](https://www.backblaze.com/docs/cloud-storage-application-keys). A non-master key is all you need. The package engine range is `^22.3.0 || ^24 || ^26`; CI runs on Node.js 22.23.1, 24, and 26.
+**Prerequisites:** A supported [Node.js](https://nodejs.org) runtime (22.23.1+, or 24 / 26) and a Backblaze B2 [application key](https://www.backblaze.com/docs/cloud-storage-application-keys). A non-master key is all you need. The package engine range is `^22.22.2 || ^24 || ^26`; CI runs on Node.js 22.23.1, 24, and 26.
 
 The canonical package name is `@backblaze-labs/b2-mcp` and the canonical binary is `b2-mcp` (`b2-mcp-server` is a transition alias). The fastest setup runs it with `npx`, no clone or build.
 

--- a/deploy/customer-hosted/pnpm-lock.yaml
+++ b/deploy/customer-hosted/pnpm-lock.yaml
@@ -99,8 +99,8 @@ importers:
         specifier: 9.39.1
         version: 9.39.1(supports-color@7.2.0)
       eslint-plugin-jsdoc:
-        specifier: 50.8.0
-        version: 50.8.0(eslint@9.39.1(supports-color@7.2.0))(supports-color@7.2.0)
+        specifier: 64.2.1
+        version: 64.2.1(eslint@9.39.1(supports-color@7.2.0))(supports-color@10.2.2)
       eslint-plugin-tsdoc:
         specifier: 0.5.2
         version: 0.5.2(eslint@9.39.1(supports-color@7.2.0))(supports-color@7.2.0)(typescript@6.0.3)
@@ -614,9 +614,13 @@ packages:
   '@emnapi/wasi-threads@1.2.3':
     resolution: {integrity: sha512-ELEBe8PsLvvJ6QMr0zLt8ffvOHW/dc1m3CEzNMg7aJUv3bMaoDtw2TXyDAwkYBuroxxuHEwhRTLJSe5sya547g==}
 
-  '@es-joy/jsdoccomment@0.50.2':
-    resolution: {integrity: sha512-YAdE/IJSpwbOTiaURNCKECdAwqrJuFiZhylmesBcIRawtYKnBR2wxPhoIewMg+Yu+QuYvHfJNReWpoxGBKOChA==}
-    engines: {node: '>=18'}
+  '@es-joy/jsdoccomment@0.95.1':
+    resolution: {integrity: sha512-LO/RI08Fo9bhXwB7Od9G+1j3eSNq63+ZS5CQO8YLXHbDg6kx6S/DhTeY0+Fc9uZrjK1zZSyTx8Sg5gv5DIoCnA==}
+    engines: {node: ^22.22.2 || >=24.15.0}
+
+  '@es-joy/resolve.exports@1.2.0':
+    resolution: {integrity: sha512-Q9hjxWI5xBM+qW2enxfe8wDKdFWMfd0Z29k5ZJnuBqD/CasY5Zryj09aCA6owbGATWz+39p5uIdaHXpopOcG8g==}
+    engines: {node: '>=10'}
 
   '@esbuild/aix-ppc64@0.28.1':
     resolution: {integrity: sha512-Svl7tq8k/08+p6CXPpRjQ1fKX+1odH/BQbb48fV6fj3CWHhsoIOoY87w1oHXm0qEpkIK3ZfVgp0hed3XBXzXMQ==}
@@ -1756,6 +1760,10 @@ packages:
   '@sinclair/typebox@0.25.24':
     resolution: {integrity: sha512-XJfwUVUKDHF5ugKwIcxEgc9k8b7HbznCp6eUfWgu710hMPNIO4aw4/zB5RogDQz8nd6gyCDpU9O/m6qYEWY6yQ==}
 
+  '@sindresorhus/base62@1.0.0':
+    resolution: {integrity: sha512-TeheYy0ILzBEI/CO55CP6zJCSdSWeRtGnHy8U8dWSUH4I68iqTsy7HkMktR4xakThc9jotkPQUXT4ITdbV7cHA==}
+    engines: {node: '>=18'}
+
   '@sindresorhus/is@7.2.0':
     resolution: {integrity: sha512-P1Cz1dWaFfR4IR+U13mqqiGsLFf1KbayybWwdd2vfctdV6hDpUkgCY0nKOLLTMSoRd/jJNjtbqzf13K8DCCXQw==}
     engines: {node: '>=18'}
@@ -1889,10 +1897,6 @@ packages:
 
   '@typescript-eslint/types@8.56.1':
     resolution: {integrity: sha512-dbMkdIUkIkchgGDIv7KLUpa0Mda4IYjo4IAMJUZ+3xNoUXxMsk9YtKpTHSChRS85o+H9ftm51gsK1dZReY9CVw==}
-    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
-
-  '@typescript-eslint/types@8.67.0':
-    resolution: {integrity: sha512-sBtgslww8nsMYUjhdPBiSyUqSzT8uR6g93A2QXnQC8+cGdjz0CyaOdqHDRJb1AtORbZCNUJBBeFA/tNR2uQmww==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
   '@typescript-eslint/types@8.68.0':
@@ -2243,9 +2247,9 @@ packages:
   any-promise@1.3.0:
     resolution: {integrity: sha512-7UvmKalWRt1wgjL1RrGxoSJW/0QZFIegpeGvZG9kjp8vrRu55XTHbwnqq2GpXm9uLbcuhxm3IqX9OB4MZR1b2A==}
 
-  are-docs-informative@0.0.2:
-    resolution: {integrity: sha512-ixiS0nLNNG5jNQzgZJNoUpBKdo9yTYZMGJ+QgT2jmjR7G7+QHRCc4v6LQ3NgE7EBJq+o0ams3waJwkrlBom8Ig==}
-    engines: {node: '>=14'}
+  are-docs-informative@0.1.1:
+    resolution: {integrity: sha512-sqRsNQBwbKLRX0jV5Cu5uzmtflf892n4Vukz7T659ebL4pz3mpOqCMU7lxMoBTFwnp10E3YB5ZcyHM41W5bcDA==}
+    engines: {node: '>=18'}
 
   arg@4.1.0:
     resolution: {integrity: sha512-ZWc51jO3qegGkVh8Hwpv636EkbesNV5ZNQPCtRa+0qytRYPEs9IYT9qITY9buezqUH5uqyzlWLcufrzU2rffdg==}
@@ -2438,8 +2442,8 @@ packages:
     resolution: {integrity: sha512-uiqLcOiVDJtBP8WGkZHEP+FZIhTzP1dxvn59EfoYUi9gqupjrBWVQkO2atDrbnKPwLeotFYDsuNb26uBMqB+hw==}
     engines: {node: '>= 6'}
 
-  comment-parser@1.4.1:
-    resolution: {integrity: sha512-buhp5kePrmda3vhc5B9t7pUQXAb2Tnd0qgpkIhPhkHXxJpiPJ11H0ZEU0oBpJ2QztSbzG/ZxMj/CHsYJqRHmyg==}
+  comment-parser@1.4.8:
+    resolution: {integrity: sha512-rKZTGo4fzKYna8UcL0isTg5wkBNla7bxTypLwZQXjIdi++IdP1OJ41rI5Mti3/jltkPujbu4i9LIARYA+zpotQ==}
     engines: {node: '>= 12.0.0'}
 
   concat-map@0.0.1:
@@ -2666,11 +2670,15 @@ packages:
     resolution: {integrity: sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==}
     engines: {node: '>=10'}
 
-  eslint-plugin-jsdoc@50.8.0:
-    resolution: {integrity: sha512-UyGb5755LMFWPrZTEqqvTJ3urLz1iqj+bYOHFNag+sw3NvaMWP9K2z+uIn37XfNALmQLQyrBlJ5mkiVPL7ADEg==}
-    engines: {node: '>=18'}
+  escape-string-regexp@5.0.0:
+    resolution: {integrity: sha512-/veY75JbMK4j1yjvuUxuVsiS/hr/4iHs9FTT6cgTexxdE0Ly/glccBAkloH/DofkjRbZU3bnoj38mOmhkZ0lHw==}
+    engines: {node: '>=12'}
+
+  eslint-plugin-jsdoc@64.2.1:
+    resolution: {integrity: sha512-6GpSYxLPcbMw38S94Cngrgs1Zv8yLinQS1O17OxJVZ6deLbrMRCERUYQKceweSqEuG2kx5Amn4l3aKPkCp4geQ==}
+    engines: {node: ^22.22.2 || >=24.15.0}
     peerDependencies:
-      eslint: ^7.0.0 || ^8.0.0 || ^9.0.0
+      eslint: ^7.0.0 || ^8.0.0 || ^9.0.0 || ^10.0.0
 
   eslint-plugin-tsdoc@0.5.2:
     resolution: {integrity: sha512-BlvqjWZdBJDIPO/YU3zcPCF23CvjYT3gyu63yo6b609NNV3D1b6zceAREy2xnweuBoDpZcLNuPyAUq9cvx6bbQ==}
@@ -2687,6 +2695,10 @@ packages:
     resolution: {integrity: sha512-Uhdk5sfqcee/9H/rCOJikYz67o0a2Tw2hGRPOG2Y1R2dg7brRe1uG0yaNQDHu+TO/uQPF/5eCapvYSmHUjt7JQ==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
+  eslint-visitor-keys@5.0.1:
+    resolution: {integrity: sha512-tD40eHxA35h0PEIZNeIjkHoDR4YjjJp34biM0mDvplBe//mB+IHCqHDGV7pxF+7MklTvighcCPPZC7ynWyjdTA==}
+    engines: {node: ^20.19.0 || ^22.13.0 || >=24}
+
   eslint@9.39.1:
     resolution: {integrity: sha512-BhHmn2yNOFA9H9JmmIVKJmd288g9hrVRDkdoIgRCRuSySRUHH7r/DI6aAXW9T1WwUuY3DFgrcaqB+deURBLR5g==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
@@ -2701,6 +2713,10 @@ packages:
   espree@10.4.0:
     resolution: {integrity: sha512-j6PAQ2uUr79PZhBjP5C5fhl8e39FmRnOjsD5lGnWrFU8i2G776tBK7+nP8KuQUTTyAZUwfQqXAgrVH5MbH9CYQ==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
+  espree@11.2.0:
+    resolution: {integrity: sha512-7p3DrVEIopW1B1avAGLuCSh1jubc01H2JHc8B4qqGblmg5gI9yumBgACjWo4JlIc04ufug4xJ3SQI8HkS/Rgzw==}
+    engines: {node: ^20.19.0 || ^22.13.0 || >=24}
 
   esprima@4.0.1:
     resolution: {integrity: sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==}
@@ -2935,6 +2951,9 @@ packages:
     resolution: {integrity: sha512-jhunvfHWxd7J5EFfSgH4xsYJzSe/lfqbUCxiyyeaQasUsXeEHXtzVid+7EOGByc5JnFa23SSFL3Y2RV/z1T+eQ==}
     engines: {node: '>=16.9.0'}
 
+  html-entities@2.6.0:
+    resolution: {integrity: sha512-kig+rMn/QOVRvr7c86gQ8lWXq+Hkv6CbAH1hLu+RG338StTpE8Z0b44SDVaqVu7HGKf27frdmUYEs9hTUX/cLQ==}
+
   html-escaper@2.0.2:
     resolution: {integrity: sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==}
 
@@ -3121,9 +3140,9 @@ packages:
     resolution: {integrity: sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==}
     hasBin: true
 
-  jsdoc-type-pratt-parser@4.1.0:
-    resolution: {integrity: sha512-Hicd6JK5Njt2QB6XYFS7ok9e37O8AYk3jTcppG4YVQnYjOemymvTcmc7OWsmq/Qqj5TdRFO5/x/tIPmBeRtGHg==}
-    engines: {node: '>=12.0.0'}
+  jsdoc-type-pratt-parser@9.1.2:
+    resolution: {integrity: sha512-9EXymowgk1mb9RY1VxuwKc+AhaxfBk2CV0dWxgGM+l5RURTtiUoAx7MlKwcsiVcEXK5HEPa7FeH/tsRpqjEPRg==}
+    engines: {node: ^22.22.2 || >=24.15.0}
 
   json-buffer@3.0.1:
     resolution: {integrity: sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==}
@@ -3415,6 +3434,9 @@ packages:
     resolution: {integrity: sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==}
     engines: {node: '>=0.10.0'}
 
+  object-deep-merge@2.0.1:
+    resolution: {integrity: sha512-aKttDKcU3pyZqKcCkDhsMn70WmZFG2JGDQLP9EcLyTSIFQRCPWLAmBZRLJnrVUrhPG1jETEEbfdgbNtJf1LyMg==}
+
   object-inspect@1.13.4:
     resolution: {integrity: sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==}
     engines: {node: '>= 0.4'}
@@ -3654,6 +3676,10 @@ packages:
     resolution: {integrity: sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==}
     engines: {node: '>=0.10.0'}
 
+  reserved-identifiers@1.2.0:
+    resolution: {integrity: sha512-yE7KUfFvaBFzGPs5H3Ops1RevfUEsDc5Iz65rOwWg4lE8HJSYtle77uul3+573457oHvBKuHYDl/xqUkKpEEdw==}
+    engines: {node: '>=18'}
+
   resolve-from@4.0.0:
     resolution: {integrity: sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==}
     engines: {node: '>=4'}
@@ -3813,8 +3839,8 @@ packages:
   spdx-exceptions@2.5.0:
     resolution: {integrity: sha512-PiU42r+xO4UbUS1buo3LPJkjlO7430Xn5SVAhdpzzsPHsjbYVflnnFdATgabnLude+Cqu25p6N+g2lw/PFsa4w==}
 
-  spdx-expression-parse@4.0.0:
-    resolution: {integrity: sha512-Clya5JIij/7C6bRR22+tnGXbc4VKlibKSVj2iHvVeX5iMW7s1SIQlqu699JkODJJIhh/pUu8L0/VLh8xflD+LQ==}
+  spdx-expression-parse@5.0.0:
+    resolution: {integrity: sha512-vngmw3Rgn+o2arXNbnZaj5UtOEBuWBfvaI+Wc8GFfykIhA5/vdK9/Sp/XkLv63dykz2rxKDvKEHupF5P0FORcQ==}
 
   spdx-license-ids@3.0.23:
     resolution: {integrity: sha512-CWLcCCH7VLu13TgOH+r8p1O/Znwhqv/dbb6lqWy67G+pT1kHmeD/+V36AVb/vq8QMIQwVShJ6Ssl5FPh0fuSdw==}
@@ -3955,6 +3981,10 @@ packages:
   to-regex-range@5.0.1:
     resolution: {integrity: sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==}
     engines: {node: '>=8.0'}
+
+  to-valid-identifier@1.0.0:
+    resolution: {integrity: sha512-41wJyvKep3yT2tyPqX/4blcfybknGB4D+oETKLs7Q76UiPqRpUJK3hr1nxelyYO0PHKVzJwlu0aCeEAsGI6rpw==}
+    engines: {node: '>=20'}
 
   toidentifier@1.0.0:
     resolution: {integrity: sha512-yaOH/Pk/VEhBWWTlhI+qXxDFXlejDGcQipMlyxda9nthulaxLZUNcUqFxokp0vcYnvteJln5FNQDRrxj3YcbVw==}
@@ -4830,13 +4860,15 @@ snapshots:
       tslib: 2.8.1
     optional: true
 
-  '@es-joy/jsdoccomment@0.50.2':
+  '@es-joy/jsdoccomment@0.95.1':
     dependencies:
       '@types/estree': 1.0.9
-      '@typescript-eslint/types': 8.56.1
-      comment-parser: 1.4.1
+      '@typescript-eslint/types': 8.68.0
+      comment-parser: 1.4.8
       esquery: 1.7.0
-      jsdoc-type-pratt-parser: 4.1.0
+      jsdoc-type-pratt-parser: 9.1.2
+
+  '@es-joy/resolve.exports@1.2.0': {}
 
   '@esbuild/aix-ppc64@0.28.1':
     optional: true
@@ -5644,6 +5676,8 @@ snapshots:
 
   '@sinclair/typebox@0.25.24': {}
 
+  '@sindresorhus/base62@1.0.0': {}
+
   '@sindresorhus/is@7.2.0': {}
 
   '@smithy/core@3.31.1':
@@ -5755,7 +5789,7 @@ snapshots:
   '@typescript-eslint/project-service@8.56.1(supports-color@7.2.0)(typescript@6.0.3)':
     dependencies:
       '@typescript-eslint/tsconfig-utils': 8.67.0(typescript@6.0.3)
-      '@typescript-eslint/types': 8.67.0
+      '@typescript-eslint/types': 8.68.0
       debug: 4.4.3(supports-color@7.2.0)
       typescript: 6.0.3
     transitivePeerDependencies:
@@ -5805,8 +5839,6 @@ snapshots:
       - supports-color
 
   '@typescript-eslint/types@8.56.1': {}
-
-  '@typescript-eslint/types@8.67.0': {}
 
   '@typescript-eslint/types@8.68.0': {}
 
@@ -6424,7 +6456,7 @@ snapshots:
 
   any-promise@1.3.0: {}
 
-  are-docs-informative@0.0.2: {}
+  are-docs-informative@0.1.1: {}
 
   arg@4.1.0: {}
 
@@ -6585,7 +6617,7 @@ snapshots:
       array-timsort: 1.0.3
       esprima: 4.0.1
 
-  comment-parser@1.4.1: {}
+  comment-parser@1.4.8: {}
 
   concat-map@0.0.1: {}
 
@@ -6842,19 +6874,25 @@ snapshots:
 
   escape-string-regexp@4.0.0: {}
 
-  eslint-plugin-jsdoc@50.8.0(eslint@9.39.1(supports-color@7.2.0))(supports-color@7.2.0):
+  escape-string-regexp@5.0.0: {}
+
+  eslint-plugin-jsdoc@64.2.1(eslint@9.39.1(supports-color@7.2.0))(supports-color@10.2.2):
     dependencies:
-      '@es-joy/jsdoccomment': 0.50.2
-      are-docs-informative: 0.0.2
-      comment-parser: 1.4.1
-      debug: 4.4.3(supports-color@7.2.0)
-      escape-string-regexp: 4.0.0
+      '@es-joy/jsdoccomment': 0.95.1
+      '@es-joy/resolve.exports': 1.2.0
+      are-docs-informative: 0.1.1
+      comment-parser: 1.4.8
+      debug: 4.4.3(supports-color@10.2.2)
+      escape-string-regexp: 5.0.0
       eslint: 9.39.1(supports-color@7.2.0)
-      espree: 10.4.0
+      espree: 11.2.0
       esquery: 1.7.0
+      html-entities: 2.6.0
+      object-deep-merge: 2.0.1
       parse-imports-exports: 0.2.4
       semver: 7.8.5
-      spdx-expression-parse: 4.0.0
+      spdx-expression-parse: 5.0.0
+      to-valid-identifier: 1.0.0
     transitivePeerDependencies:
       - supports-color
 
@@ -6876,6 +6914,8 @@ snapshots:
   eslint-visitor-keys@3.4.3: {}
 
   eslint-visitor-keys@4.2.1: {}
+
+  eslint-visitor-keys@5.0.1: {}
 
   eslint@9.39.1(supports-color@7.2.0):
     dependencies:
@@ -6921,6 +6961,12 @@ snapshots:
       acorn: 8.16.0
       acorn-jsx: 5.3.2(acorn@8.16.0)
       eslint-visitor-keys: 4.2.1
+
+  espree@11.2.0:
+    dependencies:
+      acorn: 8.16.0
+      acorn-jsx: 5.3.2(acorn@8.16.0)
+      eslint-visitor-keys: 5.0.1
 
   esprima@4.0.1: {}
 
@@ -7182,6 +7228,8 @@ snapshots:
 
   hono@4.13.0: {}
 
+  html-entities@2.6.0: {}
+
   html-escaper@2.0.2: {}
 
   http-errors@1.7.3:
@@ -7349,7 +7397,9 @@ snapshots:
     dependencies:
       argparse: 2.0.1
 
-  jsdoc-type-pratt-parser@4.1.0: {}
+  jsdoc-type-pratt-parser@9.1.2:
+    dependencies:
+      '@types/estree': 1.0.9
 
   json-buffer@3.0.1: {}
 
@@ -7581,6 +7631,8 @@ snapshots:
       path-key: 3.1.1
 
   object-assign@4.1.1: {}
+
+  object-deep-merge@2.0.1: {}
 
   object-inspect@1.13.4: {}
 
@@ -7857,6 +7909,8 @@ snapshots:
 
   require-from-string@2.0.2: {}
 
+  reserved-identifiers@1.2.0: {}
+
   resolve-from@4.0.0: {}
 
   resolve-from@5.0.0: {}
@@ -8087,7 +8141,7 @@ snapshots:
 
   spdx-exceptions@2.5.0: {}
 
-  spdx-expression-parse@4.0.0:
+  spdx-expression-parse@5.0.0:
     dependencies:
       spdx-exceptions: 2.5.0
       spdx-license-ids: 3.0.23
@@ -8229,6 +8283,11 @@ snapshots:
   to-regex-range@5.0.1:
     dependencies:
       is-number: 7.0.0
+
+  to-valid-identifier@1.0.0:
+    dependencies:
+      '@sindresorhus/base62': 1.0.0
+      reserved-identifiers: 1.2.0
 
   toidentifier@1.0.0: {}
 

--- a/deploy/vercel/README.md
+++ b/deploy/vercel/README.md
@@ -57,7 +57,7 @@ and rewrites `/mcp` to the API function. The checked-in JavaScript API files are
 thin launchers; the `vercel-build` hook runs repository typecheck/build and
 compiles the typed Vercel adapter sources into `.vercel/build-runtime/` before
 `@vercel/node` traces functions. The package engine range is
-`^22.3.0 || ^24 || ^26`, while `vercel.json` explicitly pins the deployed
+`^22.22.2 || ^24 || ^26`, while `vercel.json` explicitly pins the deployed
 Vercel Function runtime to the reviewed `nodejs24.x` line. This intentionally
 moves the Vercel deployment from the older Node 22 function runtime to the
 reviewed Node 24 line; CI fails if generated `.vercel/output` runtime configs do

--- a/docs/DEPLOY.md
+++ b/docs/DEPLOY.md
@@ -13,7 +13,7 @@ rotation, CI secret, teardown, health-check, and smoke-test policy.
 
 Supported Node.js runtimes are the repository runtimes, not provider defaults:
 Node.js `22.23.1`, Node.js `24`, and Node.js `26`. Do not add Node 18, 20, 23,
-or 25 support. The package engine range is `^22.3.0 || ^24 || ^26`, and
+or 25 support. The package engine range is `^22.22.2 || ^24 || ^26`, and
 release/build examples use
 `pnpm@11.20.0+sha256.34e198cb1e43237517ecedfd31f9ae26a6c0a3e5366ce58a2d05f4b21fb5f19a`.
 

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -23,7 +23,7 @@ layers. Coverage, slow lifecycle, and packed-package installation evidence stay
 in distinct scripts and CI jobs so their failures do not mask each other.
 Use `pnpm run smoke:local` for deterministic runtime-startup evidence without a
 deployed endpoint or real B2 credentials; CI runs it after the primary
-verification gate and again on the Node.js 22.3.0 runtime floor.
+verification gate and again on the Node.js 22.22.2 runtime floor.
 The individual deterministic layers are:
 
 | Command                 | Layer                                                                                |
@@ -127,7 +127,7 @@ package installs fail independently. The Linux deterministic Node matrix is
 exactly Node.js 22.23.1, 24, and 26. Slow lifecycle tests run in a dedicated
 bounded job with one Vitest worker, and the cross-platform fast suite runs on
 Linux, Windows, and macOS at Node.js 22.23.1. A separate runtime engine floor job
-runs the packed-consumer install smoke on Node.js 22.3.0. A separate container
+runs the packed-consumer install smoke on Node.js 22.22.2. A separate container
 image job runs `scripts/smoke-container-image.mjs`, which builds the Docker
 image and smokes HTTP readiness with and without server-held credentials. The
 release workflow reuses the same smoke script before publishing the signed
@@ -246,7 +246,7 @@ security, runtime floor, slow lifecycle, and cross-platform jobs pass. It is not
 a PR deploy path. Leak diagnostics remain part of `pnpm run verify` and fail on
 `MaxListenersExceededWarning`, EventEmitter leak warnings, or Vitest close-timeout
 open-handle warnings until teardown is clean. Node.js 22.23.1, 24, and 26 are all
-required CI evidence for Phase 1, with Node.js 22.3.0 exercised by the runtime
+required CI evidence for Phase 1, with Node.js 22.22.2 exercised by the runtime
 engine floor package smoke.
 
 Branch protection for `main` must require the stable check names above, require

--- a/docs/TYPESCRIPT_7_MIGRATION.md
+++ b/docs/TYPESCRIPT_7_MIGRATION.md
@@ -39,7 +39,7 @@ on the TypeScript compiler API for this repository's current gates.
 | Consumer | Status | Migration note |
 | --- | --- | --- |
 | `build` | Feasible later | Native compiler output must be compared against TypeScript 6 output for CJS, `.d.ts`, `.d.ts.map`, and package exports. |
-| `typecheck` | Feasible later | Run on the Node.js 22.23.1, 24, and 26 deterministic toolchain matrix and review any diagnostic drift; the separate package smoke covers the Node.js 22.3.0 engine floor. |
+| `typecheck` | Feasible later | Run on the Node.js 22.23.1, 24, and 26 deterministic toolchain matrix and review any diagnostic drift; the separate package smoke covers the Node.js 22.22.2 engine floor. |
 | `lint:docs` | Blocked now | It needs the TypeScript programmatic API through `typescript-eslint`, whose current support excludes TypeScript 7. |
 | `dev` | Already unblocked | The script uses `tsx`, avoiding `ts-node` and its compiler-API dependency. |
 

--- a/docs/V1_SCOPE.md
+++ b/docs/V1_SCOPE.md
@@ -28,11 +28,11 @@ In scope for Phase 1:
 - Customer-operated MCP OAuth resource-server integration.
 - Deterministic tool-profile contracts for the full, default, and read-only
   profiles.
-- A Node.js package engine range of `^22.3.0 || ^24 || ^26`, preserving the
-  official B2 SDK's `>=22.3.0` floor while matching opossum's supported Node.js
+- A Node.js package engine range of `^22.22.2 || ^24 || ^26`, preserving the
+  official B2 SDK's `>=22.22.2` floor while matching opossum's supported Node.js
   lines, with deterministic CI evidence on Node.js 22.23.1, 24, and 26, live B2
   evidence on Node.js 22.23.1, 24, and 26, plus packed-package smoke coverage on
-  the Node.js 22.3.0 engine floor.
+  the Node.js 22.22.2 engine floor.
 - Release, package, CI, protocol, security, and reference-deployment work needed
   to ship `v0.1.0`.
 
@@ -86,17 +86,17 @@ metadata.
 
 Inherited values from the incoming project must be treated as pre-Phase-1
 history. Release work must keep visible metadata aligned with the canonical
-`@backblaze-labs/b2-mcp`, `0.1.0`, and Node.js `^22.3.0 || ^24 || ^26` contract
+`@backblaze-labs/b2-mcp`, `0.1.0`, and Node.js `^22.22.2 || ^24 || ^26` contract
 before `v0.1.0` is released.
 
 ## Runtime
 
-Node.js `^22.3.0 || ^24 || ^26` is the package engine range for Phase 1. Node.js
-22.3.0 remains the minimum 22.x engine floor.
+Node.js `^22.22.2 || ^24 || ^26` is the package engine range for Phase 1. Node.js
+22.22.2 remains the minimum 22.x engine floor.
 
 CI must continuously verify production dependency installation and the full
 implementation, tests, and package toolchain on Node.js 22.23.1, 24, and 26.
-CI must also exercise the packed-package install smoke on Node.js 22.3.0 so the
+CI must also exercise the packed-package install smoke on Node.js 22.22.2 so the
 published engine floor remains backed by evidence, and build the Docker image
 with an HTTP readiness smoke so the container distribution remains deployable.
 Release publishing must verify the pushed GHCR manifest contains both supported

--- a/docs/V1_SCOPE.md
+++ b/docs/V1_SCOPE.md
@@ -28,9 +28,10 @@ In scope for Phase 1:
 - Customer-operated MCP OAuth resource-server integration.
 - Deterministic tool-profile contracts for the full, default, and read-only
   profiles.
-- A Node.js package engine range of `^22.22.2 || ^24 || ^26`, preserving the
-  official B2 SDK's `>=22.22.2` floor while matching opossum's supported Node.js
-  lines, with deterministic CI evidence on Node.js 22.23.1, 24, and 26, live B2
+- A Node.js package engine range of `^22.22.2 || ^24 || ^26`, raising the
+  project's own floor above the official B2 SDK's `>=22.3.0` floor for the JSDoc
+  doc-lint toolchain while matching opossum's supported Node.js lines, with
+  deterministic CI evidence on Node.js 22.23.1, 24, and 26, live B2
   evidence on Node.js 22.23.1, 24, and 26, plus packed-package smoke coverage on
   the Node.js 22.22.2 engine floor.
 - Release, package, CI, protocol, security, and reference-deployment work needed
@@ -92,7 +93,8 @@ before `v0.1.0` is released.
 ## Runtime
 
 Node.js `^22.22.2 || ^24 || ^26` is the package engine range for Phase 1. Node.js
-22.22.2 remains the minimum 22.x engine floor.
+`>=22.22.2` remains the project's minimum 22.x engine floor, above the B2 SDK's
+own `>=22.3.0` baseline.
 
 CI must continuously verify production dependency installation and the full
 implementation, tests, and package toolchain on Node.js 22.23.1, 24, and 26.

--- a/docs/deployment/vercel.md
+++ b/docs/deployment/vercel.md
@@ -39,7 +39,7 @@ compatibility path, Pino, timers, and shared HTTP code. The checked-in
 `api/*.js` files are thin launchers; the package `vercel-build` hook runs
 repository `typecheck`/`build` and compiles `deploy/vercel/**/*.ts` plus `src/`
 into `.vercel/build-runtime/` before `@vercel/node` traces functions. The
-package engine range is `^22.3.0 || ^24 || ^26`; the Vercel builder config
+package engine range is `^22.22.2 || ^24 || ^26`; the Vercel builder config
 explicitly pins the deployed Function runtime to `nodejs24.x`. This is an
 intentional move from the previous Vercel Node 22 function runtime to
 Vercel's reviewed Node 24 line, and CI fails if the generated `.vercel/output`

--- a/package-budget.json
+++ b/package-budget.json
@@ -6,7 +6,7 @@
   },
   "reviewedBaseline": {
     "date": "2026-08-31",
-    "nodeVersions": ["22.3.0", "24", "26"],
+    "nodeVersions": ["22.22.2", "24", "26"],
     "primaryB2Transport": "@backblaze-labs/b2-sdk@0.3.0",
     "sizeBudgetRationale": "Issues #306 and #308 intentionally add TSDoc to the published TypeScript source tree, increasing package source bytes without changing runtime dependencies. Issue #319 adds horizon-qualified empty-snapshot discovery to insights, growing compiled JS/d.ts source bytes with no new runtime dependencies. Issue #314 adds native no-replay write interruption classification, shared cause-chain helpers, and operator logging for operation_status_unknown, including definitive-status preservation for malformed non-2xx and truncated success bodies with no new runtime dependencies.",
     "directProductionDependencyCount": 9,

--- a/package.json
+++ b/package.json
@@ -132,7 +132,7 @@
     "@vitest/coverage-v8": "^4.1.11",
     "cspell": "^10.1.1",
     "eslint": "9.39.1",
-    "eslint-plugin-jsdoc": "50.8.0",
+    "eslint-plugin-jsdoc": "64.2.1",
     "eslint-plugin-tsdoc": "0.5.2",
     "miniflare": "5.20260826.0-alpha",
     "semver": "7.8.5",
@@ -145,7 +145,7 @@
     "wrangler": "4.127.0"
   },
   "engines": {
-    "node": "^22.3.0 || ^24 || ^26"
+    "node": "^22.22.2 || ^24 || ^26"
   },
   "files": [
     ".dockerignore",

--- a/performance-baseline.json
+++ b/performance-baseline.json
@@ -9,7 +9,7 @@
   },
   "reviewedBaseline": {
     "date": "2026-08-21",
-    "nodeVersions": ["22.3.0", "22.23.1", "24", "26"],
+    "nodeVersions": ["22.22.2", "22.23.1", "24", "26"],
     "toolProfiles": ["full", "live-b2-contract", "phase1-default", "read-only"],
     "artifact": "reports/performance/local-baseline.json",
     "summary": "reports/performance/local-baseline-summary.md"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -99,8 +99,8 @@ importers:
         specifier: 9.39.1
         version: 9.39.1(supports-color@7.2.0)
       eslint-plugin-jsdoc:
-        specifier: 50.8.0
-        version: 50.8.0(eslint@9.39.1(supports-color@7.2.0))(supports-color@7.2.0)
+        specifier: 64.2.1
+        version: 64.2.1(eslint@9.39.1(supports-color@7.2.0))(supports-color@10.2.2)
       eslint-plugin-tsdoc:
         specifier: 0.5.2
         version: 0.5.2(eslint@9.39.1(supports-color@7.2.0))(supports-color@7.2.0)(typescript@6.0.3)
@@ -614,9 +614,13 @@ packages:
   '@emnapi/wasi-threads@1.2.3':
     resolution: {integrity: sha512-ELEBe8PsLvvJ6QMr0zLt8ffvOHW/dc1m3CEzNMg7aJUv3bMaoDtw2TXyDAwkYBuroxxuHEwhRTLJSe5sya547g==}
 
-  '@es-joy/jsdoccomment@0.50.2':
-    resolution: {integrity: sha512-YAdE/IJSpwbOTiaURNCKECdAwqrJuFiZhylmesBcIRawtYKnBR2wxPhoIewMg+Yu+QuYvHfJNReWpoxGBKOChA==}
-    engines: {node: '>=18'}
+  '@es-joy/jsdoccomment@0.95.1':
+    resolution: {integrity: sha512-LO/RI08Fo9bhXwB7Od9G+1j3eSNq63+ZS5CQO8YLXHbDg6kx6S/DhTeY0+Fc9uZrjK1zZSyTx8Sg5gv5DIoCnA==}
+    engines: {node: ^22.22.2 || >=24.15.0}
+
+  '@es-joy/resolve.exports@1.2.0':
+    resolution: {integrity: sha512-Q9hjxWI5xBM+qW2enxfe8wDKdFWMfd0Z29k5ZJnuBqD/CasY5Zryj09aCA6owbGATWz+39p5uIdaHXpopOcG8g==}
+    engines: {node: '>=10'}
 
   '@esbuild/aix-ppc64@0.28.1':
     resolution: {integrity: sha512-Svl7tq8k/08+p6CXPpRjQ1fKX+1odH/BQbb48fV6fj3CWHhsoIOoY87w1oHXm0qEpkIK3ZfVgp0hed3XBXzXMQ==}
@@ -1756,6 +1760,10 @@ packages:
   '@sinclair/typebox@0.25.24':
     resolution: {integrity: sha512-XJfwUVUKDHF5ugKwIcxEgc9k8b7HbznCp6eUfWgu710hMPNIO4aw4/zB5RogDQz8nd6gyCDpU9O/m6qYEWY6yQ==}
 
+  '@sindresorhus/base62@1.0.0':
+    resolution: {integrity: sha512-TeheYy0ILzBEI/CO55CP6zJCSdSWeRtGnHy8U8dWSUH4I68iqTsy7HkMktR4xakThc9jotkPQUXT4ITdbV7cHA==}
+    engines: {node: '>=18'}
+
   '@sindresorhus/is@7.2.0':
     resolution: {integrity: sha512-P1Cz1dWaFfR4IR+U13mqqiGsLFf1KbayybWwdd2vfctdV6hDpUkgCY0nKOLLTMSoRd/jJNjtbqzf13K8DCCXQw==}
     engines: {node: '>=18'}
@@ -1889,10 +1897,6 @@ packages:
 
   '@typescript-eslint/types@8.56.1':
     resolution: {integrity: sha512-dbMkdIUkIkchgGDIv7KLUpa0Mda4IYjo4IAMJUZ+3xNoUXxMsk9YtKpTHSChRS85o+H9ftm51gsK1dZReY9CVw==}
-    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
-
-  '@typescript-eslint/types@8.67.0':
-    resolution: {integrity: sha512-sBtgslww8nsMYUjhdPBiSyUqSzT8uR6g93A2QXnQC8+cGdjz0CyaOdqHDRJb1AtORbZCNUJBBeFA/tNR2uQmww==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
   '@typescript-eslint/types@8.68.0':
@@ -2243,9 +2247,9 @@ packages:
   any-promise@1.3.0:
     resolution: {integrity: sha512-7UvmKalWRt1wgjL1RrGxoSJW/0QZFIegpeGvZG9kjp8vrRu55XTHbwnqq2GpXm9uLbcuhxm3IqX9OB4MZR1b2A==}
 
-  are-docs-informative@0.0.2:
-    resolution: {integrity: sha512-ixiS0nLNNG5jNQzgZJNoUpBKdo9yTYZMGJ+QgT2jmjR7G7+QHRCc4v6LQ3NgE7EBJq+o0ams3waJwkrlBom8Ig==}
-    engines: {node: '>=14'}
+  are-docs-informative@0.1.1:
+    resolution: {integrity: sha512-sqRsNQBwbKLRX0jV5Cu5uzmtflf892n4Vukz7T659ebL4pz3mpOqCMU7lxMoBTFwnp10E3YB5ZcyHM41W5bcDA==}
+    engines: {node: '>=18'}
 
   arg@4.1.0:
     resolution: {integrity: sha512-ZWc51jO3qegGkVh8Hwpv636EkbesNV5ZNQPCtRa+0qytRYPEs9IYT9qITY9buezqUH5uqyzlWLcufrzU2rffdg==}
@@ -2438,8 +2442,8 @@ packages:
     resolution: {integrity: sha512-uiqLcOiVDJtBP8WGkZHEP+FZIhTzP1dxvn59EfoYUi9gqupjrBWVQkO2atDrbnKPwLeotFYDsuNb26uBMqB+hw==}
     engines: {node: '>= 6'}
 
-  comment-parser@1.4.1:
-    resolution: {integrity: sha512-buhp5kePrmda3vhc5B9t7pUQXAb2Tnd0qgpkIhPhkHXxJpiPJ11H0ZEU0oBpJ2QztSbzG/ZxMj/CHsYJqRHmyg==}
+  comment-parser@1.4.8:
+    resolution: {integrity: sha512-rKZTGo4fzKYna8UcL0isTg5wkBNla7bxTypLwZQXjIdi++IdP1OJ41rI5Mti3/jltkPujbu4i9LIARYA+zpotQ==}
     engines: {node: '>= 12.0.0'}
 
   concat-map@0.0.1:
@@ -2666,11 +2670,15 @@ packages:
     resolution: {integrity: sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==}
     engines: {node: '>=10'}
 
-  eslint-plugin-jsdoc@50.8.0:
-    resolution: {integrity: sha512-UyGb5755LMFWPrZTEqqvTJ3urLz1iqj+bYOHFNag+sw3NvaMWP9K2z+uIn37XfNALmQLQyrBlJ5mkiVPL7ADEg==}
-    engines: {node: '>=18'}
+  escape-string-regexp@5.0.0:
+    resolution: {integrity: sha512-/veY75JbMK4j1yjvuUxuVsiS/hr/4iHs9FTT6cgTexxdE0Ly/glccBAkloH/DofkjRbZU3bnoj38mOmhkZ0lHw==}
+    engines: {node: '>=12'}
+
+  eslint-plugin-jsdoc@64.2.1:
+    resolution: {integrity: sha512-6GpSYxLPcbMw38S94Cngrgs1Zv8yLinQS1O17OxJVZ6deLbrMRCERUYQKceweSqEuG2kx5Amn4l3aKPkCp4geQ==}
+    engines: {node: ^22.22.2 || >=24.15.0}
     peerDependencies:
-      eslint: ^7.0.0 || ^8.0.0 || ^9.0.0
+      eslint: ^7.0.0 || ^8.0.0 || ^9.0.0 || ^10.0.0
 
   eslint-plugin-tsdoc@0.5.2:
     resolution: {integrity: sha512-BlvqjWZdBJDIPO/YU3zcPCF23CvjYT3gyu63yo6b609NNV3D1b6zceAREy2xnweuBoDpZcLNuPyAUq9cvx6bbQ==}
@@ -2687,6 +2695,10 @@ packages:
     resolution: {integrity: sha512-Uhdk5sfqcee/9H/rCOJikYz67o0a2Tw2hGRPOG2Y1R2dg7brRe1uG0yaNQDHu+TO/uQPF/5eCapvYSmHUjt7JQ==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
+  eslint-visitor-keys@5.0.1:
+    resolution: {integrity: sha512-tD40eHxA35h0PEIZNeIjkHoDR4YjjJp34biM0mDvplBe//mB+IHCqHDGV7pxF+7MklTvighcCPPZC7ynWyjdTA==}
+    engines: {node: ^20.19.0 || ^22.13.0 || >=24}
+
   eslint@9.39.1:
     resolution: {integrity: sha512-BhHmn2yNOFA9H9JmmIVKJmd288g9hrVRDkdoIgRCRuSySRUHH7r/DI6aAXW9T1WwUuY3DFgrcaqB+deURBLR5g==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
@@ -2701,6 +2713,10 @@ packages:
   espree@10.4.0:
     resolution: {integrity: sha512-j6PAQ2uUr79PZhBjP5C5fhl8e39FmRnOjsD5lGnWrFU8i2G776tBK7+nP8KuQUTTyAZUwfQqXAgrVH5MbH9CYQ==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
+  espree@11.2.0:
+    resolution: {integrity: sha512-7p3DrVEIopW1B1avAGLuCSh1jubc01H2JHc8B4qqGblmg5gI9yumBgACjWo4JlIc04ufug4xJ3SQI8HkS/Rgzw==}
+    engines: {node: ^20.19.0 || ^22.13.0 || >=24}
 
   esprima@4.0.1:
     resolution: {integrity: sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==}
@@ -2935,6 +2951,9 @@ packages:
     resolution: {integrity: sha512-jhunvfHWxd7J5EFfSgH4xsYJzSe/lfqbUCxiyyeaQasUsXeEHXtzVid+7EOGByc5JnFa23SSFL3Y2RV/z1T+eQ==}
     engines: {node: '>=16.9.0'}
 
+  html-entities@2.6.0:
+    resolution: {integrity: sha512-kig+rMn/QOVRvr7c86gQ8lWXq+Hkv6CbAH1hLu+RG338StTpE8Z0b44SDVaqVu7HGKf27frdmUYEs9hTUX/cLQ==}
+
   html-escaper@2.0.2:
     resolution: {integrity: sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==}
 
@@ -3121,9 +3140,9 @@ packages:
     resolution: {integrity: sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==}
     hasBin: true
 
-  jsdoc-type-pratt-parser@4.1.0:
-    resolution: {integrity: sha512-Hicd6JK5Njt2QB6XYFS7ok9e37O8AYk3jTcppG4YVQnYjOemymvTcmc7OWsmq/Qqj5TdRFO5/x/tIPmBeRtGHg==}
-    engines: {node: '>=12.0.0'}
+  jsdoc-type-pratt-parser@9.1.2:
+    resolution: {integrity: sha512-9EXymowgk1mb9RY1VxuwKc+AhaxfBk2CV0dWxgGM+l5RURTtiUoAx7MlKwcsiVcEXK5HEPa7FeH/tsRpqjEPRg==}
+    engines: {node: ^22.22.2 || >=24.15.0}
 
   json-buffer@3.0.1:
     resolution: {integrity: sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==}
@@ -3415,6 +3434,9 @@ packages:
     resolution: {integrity: sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==}
     engines: {node: '>=0.10.0'}
 
+  object-deep-merge@2.0.1:
+    resolution: {integrity: sha512-aKttDKcU3pyZqKcCkDhsMn70WmZFG2JGDQLP9EcLyTSIFQRCPWLAmBZRLJnrVUrhPG1jETEEbfdgbNtJf1LyMg==}
+
   object-inspect@1.13.4:
     resolution: {integrity: sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==}
     engines: {node: '>= 0.4'}
@@ -3654,6 +3676,10 @@ packages:
     resolution: {integrity: sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==}
     engines: {node: '>=0.10.0'}
 
+  reserved-identifiers@1.2.0:
+    resolution: {integrity: sha512-yE7KUfFvaBFzGPs5H3Ops1RevfUEsDc5Iz65rOwWg4lE8HJSYtle77uul3+573457oHvBKuHYDl/xqUkKpEEdw==}
+    engines: {node: '>=18'}
+
   resolve-from@4.0.0:
     resolution: {integrity: sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==}
     engines: {node: '>=4'}
@@ -3813,8 +3839,8 @@ packages:
   spdx-exceptions@2.5.0:
     resolution: {integrity: sha512-PiU42r+xO4UbUS1buo3LPJkjlO7430Xn5SVAhdpzzsPHsjbYVflnnFdATgabnLude+Cqu25p6N+g2lw/PFsa4w==}
 
-  spdx-expression-parse@4.0.0:
-    resolution: {integrity: sha512-Clya5JIij/7C6bRR22+tnGXbc4VKlibKSVj2iHvVeX5iMW7s1SIQlqu699JkODJJIhh/pUu8L0/VLh8xflD+LQ==}
+  spdx-expression-parse@5.0.0:
+    resolution: {integrity: sha512-vngmw3Rgn+o2arXNbnZaj5UtOEBuWBfvaI+Wc8GFfykIhA5/vdK9/Sp/XkLv63dykz2rxKDvKEHupF5P0FORcQ==}
 
   spdx-license-ids@3.0.23:
     resolution: {integrity: sha512-CWLcCCH7VLu13TgOH+r8p1O/Znwhqv/dbb6lqWy67G+pT1kHmeD/+V36AVb/vq8QMIQwVShJ6Ssl5FPh0fuSdw==}
@@ -3955,6 +3981,10 @@ packages:
   to-regex-range@5.0.1:
     resolution: {integrity: sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==}
     engines: {node: '>=8.0'}
+
+  to-valid-identifier@1.0.0:
+    resolution: {integrity: sha512-41wJyvKep3yT2tyPqX/4blcfybknGB4D+oETKLs7Q76UiPqRpUJK3hr1nxelyYO0PHKVzJwlu0aCeEAsGI6rpw==}
+    engines: {node: '>=20'}
 
   toidentifier@1.0.0:
     resolution: {integrity: sha512-yaOH/Pk/VEhBWWTlhI+qXxDFXlejDGcQipMlyxda9nthulaxLZUNcUqFxokp0vcYnvteJln5FNQDRrxj3YcbVw==}
@@ -4830,13 +4860,15 @@ snapshots:
       tslib: 2.8.1
     optional: true
 
-  '@es-joy/jsdoccomment@0.50.2':
+  '@es-joy/jsdoccomment@0.95.1':
     dependencies:
       '@types/estree': 1.0.9
-      '@typescript-eslint/types': 8.56.1
-      comment-parser: 1.4.1
+      '@typescript-eslint/types': 8.68.0
+      comment-parser: 1.4.8
       esquery: 1.7.0
-      jsdoc-type-pratt-parser: 4.1.0
+      jsdoc-type-pratt-parser: 9.1.2
+
+  '@es-joy/resolve.exports@1.2.0': {}
 
   '@esbuild/aix-ppc64@0.28.1':
     optional: true
@@ -5644,6 +5676,8 @@ snapshots:
 
   '@sinclair/typebox@0.25.24': {}
 
+  '@sindresorhus/base62@1.0.0': {}
+
   '@sindresorhus/is@7.2.0': {}
 
   '@smithy/core@3.31.1':
@@ -5755,7 +5789,7 @@ snapshots:
   '@typescript-eslint/project-service@8.56.1(supports-color@7.2.0)(typescript@6.0.3)':
     dependencies:
       '@typescript-eslint/tsconfig-utils': 8.67.0(typescript@6.0.3)
-      '@typescript-eslint/types': 8.67.0
+      '@typescript-eslint/types': 8.68.0
       debug: 4.4.3(supports-color@7.2.0)
       typescript: 6.0.3
     transitivePeerDependencies:
@@ -5805,8 +5839,6 @@ snapshots:
       - supports-color
 
   '@typescript-eslint/types@8.56.1': {}
-
-  '@typescript-eslint/types@8.67.0': {}
 
   '@typescript-eslint/types@8.68.0': {}
 
@@ -6424,7 +6456,7 @@ snapshots:
 
   any-promise@1.3.0: {}
 
-  are-docs-informative@0.0.2: {}
+  are-docs-informative@0.1.1: {}
 
   arg@4.1.0: {}
 
@@ -6585,7 +6617,7 @@ snapshots:
       array-timsort: 1.0.3
       esprima: 4.0.1
 
-  comment-parser@1.4.1: {}
+  comment-parser@1.4.8: {}
 
   concat-map@0.0.1: {}
 
@@ -6842,19 +6874,25 @@ snapshots:
 
   escape-string-regexp@4.0.0: {}
 
-  eslint-plugin-jsdoc@50.8.0(eslint@9.39.1(supports-color@7.2.0))(supports-color@7.2.0):
+  escape-string-regexp@5.0.0: {}
+
+  eslint-plugin-jsdoc@64.2.1(eslint@9.39.1(supports-color@7.2.0))(supports-color@10.2.2):
     dependencies:
-      '@es-joy/jsdoccomment': 0.50.2
-      are-docs-informative: 0.0.2
-      comment-parser: 1.4.1
-      debug: 4.4.3(supports-color@7.2.0)
-      escape-string-regexp: 4.0.0
+      '@es-joy/jsdoccomment': 0.95.1
+      '@es-joy/resolve.exports': 1.2.0
+      are-docs-informative: 0.1.1
+      comment-parser: 1.4.8
+      debug: 4.4.3(supports-color@10.2.2)
+      escape-string-regexp: 5.0.0
       eslint: 9.39.1(supports-color@7.2.0)
-      espree: 10.4.0
+      espree: 11.2.0
       esquery: 1.7.0
+      html-entities: 2.6.0
+      object-deep-merge: 2.0.1
       parse-imports-exports: 0.2.4
       semver: 7.8.5
-      spdx-expression-parse: 4.0.0
+      spdx-expression-parse: 5.0.0
+      to-valid-identifier: 1.0.0
     transitivePeerDependencies:
       - supports-color
 
@@ -6876,6 +6914,8 @@ snapshots:
   eslint-visitor-keys@3.4.3: {}
 
   eslint-visitor-keys@4.2.1: {}
+
+  eslint-visitor-keys@5.0.1: {}
 
   eslint@9.39.1(supports-color@7.2.0):
     dependencies:
@@ -6921,6 +6961,12 @@ snapshots:
       acorn: 8.16.0
       acorn-jsx: 5.3.2(acorn@8.16.0)
       eslint-visitor-keys: 4.2.1
+
+  espree@11.2.0:
+    dependencies:
+      acorn: 8.16.0
+      acorn-jsx: 5.3.2(acorn@8.16.0)
+      eslint-visitor-keys: 5.0.1
 
   esprima@4.0.1: {}
 
@@ -7182,6 +7228,8 @@ snapshots:
 
   hono@4.13.0: {}
 
+  html-entities@2.6.0: {}
+
   html-escaper@2.0.2: {}
 
   http-errors@1.7.3:
@@ -7349,7 +7397,9 @@ snapshots:
     dependencies:
       argparse: 2.0.1
 
-  jsdoc-type-pratt-parser@4.1.0: {}
+  jsdoc-type-pratt-parser@9.1.2:
+    dependencies:
+      '@types/estree': 1.0.9
 
   json-buffer@3.0.1: {}
 
@@ -7581,6 +7631,8 @@ snapshots:
       path-key: 3.1.1
 
   object-assign@4.1.1: {}
+
+  object-deep-merge@2.0.1: {}
 
   object-inspect@1.13.4: {}
 
@@ -7857,6 +7909,8 @@ snapshots:
 
   require-from-string@2.0.2: {}
 
+  reserved-identifiers@1.2.0: {}
+
   resolve-from@4.0.0: {}
 
   resolve-from@5.0.0: {}
@@ -8087,7 +8141,7 @@ snapshots:
 
   spdx-exceptions@2.5.0: {}
 
-  spdx-expression-parse@4.0.0:
+  spdx-expression-parse@5.0.0:
     dependencies:
       spdx-exceptions: 2.5.0
       spdx-license-ids: 3.0.23
@@ -8229,6 +8283,11 @@ snapshots:
   to-regex-range@5.0.1:
     dependencies:
       is-number: 7.0.0
+
+  to-valid-identifier@1.0.0:
+    dependencies:
+      '@sindresorhus/base62': 1.0.0
+      reserved-identifiers: 1.2.0
 
   toidentifier@1.0.0: {}
 

--- a/runtime-policy.json
+++ b/runtime-policy.json
@@ -1,6 +1,7 @@
 {
-  "engineRange": "^22.3.0 || ^24 || ^26",
-  "engineFloor": ">=22.3.0",
+  "engineRange": "^22.22.2 || ^24 || ^26",
+  "engineFloor": ">=22.22.2",
+  "backblazeSdkEngineFloor": ">=22.3.0",
   "runtimeInstallNode": "22.23.1",
   "minimumEvidenceNode": "22.23.1",
   "node22LtsMinimum": "22.11.0",

--- a/scripts/check-runtime-policy.mjs
+++ b/scripts/check-runtime-policy.mjs
@@ -858,11 +858,23 @@ const lock = readPackageManagerLock(root);
 
 requireEqual("package.json engines.node", packageJson.engines?.node, policy.engineRange);
 requireEqual("pnpm lock root engines.node", lock.packages?.[""]?.engines?.node, policy.engineRange);
+const backblazeSdkEngine = lock.packages?.["node_modules/@backblaze-labs/b2-sdk"]?.engines?.node;
 requireEqual(
-  "Backblaze SDK engine floor",
-  lock.packages?.["node_modules/@backblaze-labs/b2-sdk"]?.engines?.node,
-  policy.engineFloor,
+  "Backblaze SDK declared engine floor",
+  backblazeSdkEngine,
+  policy.backblazeSdkEngineFloor,
 );
+// Our engine floor may sit at or above the Backblaze SDK's floor (we can require
+// a newer Node than the SDK does — e.g. for the doc-lint toolchain) but never
+// below it, so we never claim to support a Node the SDK does not.
+if (
+  backblazeSdkEngine &&
+  comparePatch(policy.engineFloor.replace(/^>=/, ""), backblazeSdkEngine.replace(/^>=/, "")) < 0
+) {
+  fail(
+    `runtime-policy engineFloor ${policy.engineFloor} must be >= the Backblaze SDK engine floor ${backblazeSdkEngine}`,
+  );
+}
 requireEqual("runtime-policy runtime install pin", policy.runtimeInstallNode, policy.node22Pinned);
 requireNode22LtsPatch("runtime-policy runtime install pin", policy.runtimeInstallNode, policy);
 

--- a/scripts/check-runtime-policy.mjs
+++ b/scripts/check-runtime-policy.mjs
@@ -864,6 +864,21 @@ requireEqual(
   backblazeSdkEngine,
   policy.backblazeSdkEngineFloor,
 );
+// The declared engineFloor must be exactly the minimum the engineRange
+// advertises, so the floor smoke (which runs at engineFloor) always exercises
+// the lowest Node the package claims to support. Without this tie, engineRange
+// could drop to a lower minor (e.g. ^22.3.0) while engineFloor and the smoke
+// stay at 22.22.2, leaving the advertised floor without evidence.
+const engineRangeMinimum = parseEngineRangeMinimums(policy.engineRange).reduce(
+  (lowest, candidate) => (candidate.major < lowest.major ? candidate : lowest),
+);
+if (engineRangeMinimum.minor === null || engineRangeMinimum.patch === null) {
+  fail(
+    `runtime-policy engineRange minimum ${engineRangeMinimum.raw} must pin a full major.minor.patch floor`,
+  );
+} else {
+  requireEqual("runtime-policy engineFloor", policy.engineFloor, `>=${engineRangeMinimum.raw}`);
+}
 // Our engine floor may sit at or above the Backblaze SDK's floor (we can require
 // a newer Node than the SDK does — e.g. for the doc-lint toolchain) but never
 // below it, so we never claim to support a Node the SDK does not.

--- a/tests/contract/ci-workflow-policy.contract.test.ts
+++ b/tests/contract/ci-workflow-policy.contract.test.ts
@@ -246,7 +246,7 @@ describe("CI workflow policy", () => {
     expect(packageJob).toContain("reports/package/floor/*.tgz");
     expect(runtimeFloorJob).toContain("name: runtime engine floor");
     expect(runtimeFloorJob).toContain("needs: package-install-smoke");
-    expect(runtimeFloorJob).toContain("node-version: 22.3.0");
+    expect(runtimeFloorJob).toContain("node-version: 22.22.2");
     expect(runtimeFloorJob).toContain(
       "actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c",
     );
@@ -299,7 +299,7 @@ describe("CI workflow policy", () => {
     );
     expect(summaryJob).toContain("Linux deterministic Node matrix | 22.23.1, 24, 26");
     expect(summaryJob).toContain("Deterministic dependency failures | B2/S3/OAuth outage suite");
-    expect(summaryJob).toContain("Runtime engine floor | Node.js 22.3.0 package install smoke");
+    expect(summaryJob).toContain("Runtime engine floor | Node.js 22.22.2 package install smoke");
     expect(summaryJob).toContain("Package budget metrics | Uploaded as package-budget artifact");
     expect(summaryJob).toContain("Vercel adapter budget | Uploaded as vercel-bundle artifact path");
     expect(summaryJob).toContain("Vercel build output | Real Vercel build plus leak scan");

--- a/tests/contract/readme-drift.contract.test.ts
+++ b/tests/contract/readme-drift.contract.test.ts
@@ -76,7 +76,7 @@ describe("README project badges", () => {
     const dependencyCount = Object.keys(packageMetadata.dependencies).length;
 
     expect(packageMetadata.name).toBe("@backblaze-labs/b2-mcp");
-    expect(packageMetadata.engines.node).toBe("^22.3.0 || ^24 || ^26");
+    expect(packageMetadata.engines.node).toBe("^22.22.2 || ^24 || ^26");
     // Intentional overlap with typescript-7-migration: this guard owns README
     // badge sync, while the migration test owns the 6.0-line deferral record.
     expect(packageMetadata.devDependencies.typescript).toMatch(/^~6\./);
@@ -85,7 +85,7 @@ describe("README project badges", () => {
     expect(readme).toContain("npm/v/@backblaze-labs/b2-mcp");
     expect(readme).toContain(`license-${packageMetadata.license}-blue.svg`);
     expect(readme).toContain("TypeScript-6.x-3178c6");
-    expect(readme).toContain("Node.js-22.3%2B%20%7C%2024%20%7C%2026-339933");
+    expect(readme).toContain("Node.js-22.22%2B%20%7C%2024%20%7C%2026-339933");
     expect(readme).toContain("MCP-2026--07--28-5b5fc7");
     expect(readme).toContain(`runtime_dependencies-${dependencyCount}-blue`);
   });

--- a/tests/unit/package-surface-policy.unit.test.ts
+++ b/tests/unit/package-surface-policy.unit.test.ts
@@ -409,7 +409,7 @@ describe("package surface policy", () => {
         '      version: "0.1.0",',
         '      main: "dist/index.js",',
         '      bin: { "b2-mcp": "dist/index.js", "b2-mcp-server": "dist/index.js" },',
-        '      engines: { node: "^22.3.0 || ^24 || ^26" }',
+        '      engines: { node: "^22.22.2 || ^24 || ^26" }',
         "    }),",
         "  );",
         '  fs.writeFileSync(path.join(packageRoot, "docs", "CLIENTS.md"), "# Clients\\n");',

--- a/tests/unit/release-scripts.unit.test.ts
+++ b/tests/unit/release-scripts.unit.test.ts
@@ -69,7 +69,7 @@ function withFixture(run: (fixtureRoot: string) => void): void {
           },
           bugs: { url: "https://github.com/backblaze-labs/b2-mcp/issues" },
           homepage: "https://github.com/backblaze-labs/b2-mcp#readme",
-          engines: { node: "^22.3.0 || ^24 || ^26" },
+          engines: { node: "^22.22.2 || ^24 || ^26" },
           bin: { "b2-mcp": "dist/index.js", "b2-mcp-server": "dist/index.js" },
           files: [
             "dist/**/*",
@@ -176,7 +176,7 @@ function withFixture(run: (fixtureRoot: string) => void): void {
     );
     writeFileSync(
       join(fixtureRoot, "runtime-policy.json"),
-      JSON.stringify({ engineRange: "^22.3.0 || ^24 || ^26" }, null, 2),
+      JSON.stringify({ engineRange: "^22.22.2 || ^24 || ^26" }, null, 2),
     );
     run(fixtureRoot);
   } finally {

--- a/tests/unit/runtime-policy.unit.test.ts
+++ b/tests/unit/runtime-policy.unit.test.ts
@@ -278,6 +278,63 @@ describe("runtime policy", () => {
     });
   });
 
+  it("rejects an engine floor that does not equal the engine range minimum", () => {
+    withRuntimePolicyFixture((fixtureRoot) => {
+      // Drop the engineRange 22 branch to a lower minor while leaving engineFloor
+      // (and the floor smoke) at 22.22.2: the floor must always equal the lowest
+      // Node the range advertises, so this mismatch must be rejected.
+      writeFixtureFile(
+        fixtureRoot,
+        "package.json",
+        JSON.stringify(
+          {
+            name: "@backblaze-labs/b2-mcp",
+            version: "0.1.0",
+            packageManager: "pnpm@11.20.0+sha256.test",
+            engines: { node: "^22.3.0 || ^24 || ^26" },
+            dependencies: { "@backblaze-labs/b2-sdk": "0.3.0" },
+            devDependencies: { "@types/node": "22.3.0" },
+          },
+          null,
+          2,
+        ),
+      );
+      writeFixtureFile(
+        fixtureRoot,
+        "runtime-policy.json",
+        JSON.stringify(
+          {
+            engineRange: "^22.3.0 || ^24 || ^26",
+            engineFloor: ">=22.22.2",
+            backblazeSdkEngineFloor: ">=22.3.0",
+            runtimeInstallNode: "22.23.1",
+            minimumEvidenceNode: "22.23.1",
+            node22LtsMinimum: "22.11.0",
+            node22Pinned: "22.23.1",
+            deterministicLinuxMatrix: ["22.23.1", "24", "26"],
+            crossPlatformNode: "22.23.1",
+            liveNodeMatrix: ["22.23.1", "24", "26"],
+            unsupportedMajors: [18, 20],
+            typesNodeVersion: "22.3.0",
+          },
+          null,
+          2,
+        ),
+      );
+
+      const result = spawnSync(process.execPath, ["scripts/check-runtime-policy.mjs"], {
+        cwd: root,
+        env: { ...process.env, B2_MCP_RUNTIME_POLICY_ROOT: fixtureRoot },
+        encoding: "utf8",
+      });
+
+      expect(result.status).not.toBe(0);
+      expect(result.stderr).toContain(
+        "runtime-policy engineFloor: expected >=22.3.0, got >=22.22.2",
+      );
+    });
+  });
+
   it("rejects Pages workflows without deploy and package hardening", () => {
     withRuntimePolicyFixture((fixtureRoot) => {
       writeFixtureFile(

--- a/tests/unit/runtime-policy.unit.test.ts
+++ b/tests/unit/runtime-policy.unit.test.ts
@@ -201,6 +201,83 @@ describe("runtime policy", () => {
     });
   });
 
+  it("rejects a project engine floor below the Backblaze SDK engine floor", () => {
+    withRuntimePolicyFixture((fixtureRoot) => {
+      // Raise the declared SDK floor above the project floor: the project floor
+      // may sit at or above the SDK floor, never below it. Rewriting only the
+      // SDK-facing fields keeps every other requireEqual pair aligned so this
+      // specific ordering diagnostic is the one under test.
+      writeFixtureFile(
+        fixtureRoot,
+        "runtime-policy.json",
+        JSON.stringify(
+          {
+            engineRange: "^22.22.2 || ^24 || ^26",
+            engineFloor: ">=22.22.2",
+            backblazeSdkEngineFloor: ">=24.15.0",
+            runtimeInstallNode: "22.23.1",
+            minimumEvidenceNode: "22.23.1",
+            node22LtsMinimum: "22.11.0",
+            node22Pinned: "22.23.1",
+            deterministicLinuxMatrix: ["22.23.1", "24", "26"],
+            crossPlatformNode: "22.23.1",
+            liveNodeMatrix: ["22.23.1", "24", "26"],
+            unsupportedMajors: [18, 20],
+            typesNodeVersion: "22.3.0",
+          },
+          null,
+          2,
+        ),
+      );
+      writeFixtureFile(
+        fixtureRoot,
+        "pnpm-lock.yaml",
+        [
+          "lockfileVersion: '9.0'",
+          "",
+          "importers:",
+          "",
+          "  .:",
+          "    dependencies:",
+          "      '@backblaze-labs/b2-sdk':",
+          "        specifier: 0.3.0",
+          "        version: 0.3.0",
+          "    devDependencies:",
+          "      '@types/node':",
+          "        specifier: 22.3.0",
+          "        version: 22.3.0",
+          "",
+          "packages:",
+          "",
+          "  '@backblaze-labs/b2-sdk@0.3.0':",
+          "    resolution: {integrity: sha512-test}",
+          "    engines: {node: '>=24.15.0'}",
+          "",
+          "  '@types/node@22.3.0':",
+          "    resolution: {integrity: sha512-test}",
+          "",
+          "snapshots:",
+          "",
+          "  '@backblaze-labs/b2-sdk@0.3.0': {}",
+          "",
+          "  '@types/node@22.3.0': {}",
+          "",
+        ].join("\n"),
+      );
+
+      const result = spawnSync(process.execPath, ["scripts/check-runtime-policy.mjs"], {
+        cwd: root,
+        env: { ...process.env, B2_MCP_RUNTIME_POLICY_ROOT: fixtureRoot },
+        encoding: "utf8",
+      });
+
+      expect(result.status).not.toBe(0);
+      expect(result.stderr).toContain(
+        "runtime-policy engineFloor >=22.22.2 must be >= the Backblaze SDK engine floor >=24.15.0",
+      );
+    });
+  });
+
   it("rejects Pages workflows without deploy and package hardening", () => {
     withRuntimePolicyFixture((fixtureRoot) => {
       writeFixtureFile(

--- a/tests/unit/runtime-policy.unit.test.ts
+++ b/tests/unit/runtime-policy.unit.test.ts
@@ -24,7 +24,7 @@ function withRuntimePolicyFixture(run: (fixtureRoot: string) => void): void {
           name: "@backblaze-labs/b2-mcp",
           version: "0.1.0",
           packageManager,
-          engines: { node: "^22.3.0 || ^24 || ^26" },
+          engines: { node: "^22.22.2 || ^24 || ^26" },
           dependencies: { "@backblaze-labs/b2-sdk": "0.3.0" },
           devDependencies: { "@types/node": "22.3.0" },
         },
@@ -37,8 +37,9 @@ function withRuntimePolicyFixture(run: (fixtureRoot: string) => void): void {
       "runtime-policy.json",
       JSON.stringify(
         {
-          engineRange: "^22.3.0 || ^24 || ^26",
-          engineFloor: ">=22.3.0",
+          engineRange: "^22.22.2 || ^24 || ^26",
+          engineFloor: ">=22.22.2",
+          backblazeSdkEngineFloor: ">=22.3.0",
           runtimeInstallNode: "22.23.1",
           minimumEvidenceNode: "22.23.1",
           node22LtsMinimum: "22.11.0",
@@ -112,7 +113,7 @@ function withRuntimePolicyFixture(run: (fixtureRoot: string) => void): void {
         "  runtime-engine-floor:",
         "    steps:",
         "      - with:",
-        "          node-version: 22.3.0",
+        "          node-version: 22.22.2",
         "  unit-coverage-matrix:",
         "    strategy:",
         "      matrix:",
@@ -160,21 +161,21 @@ function withRuntimePolicyFixture(run: (fixtureRoot: string) => void): void {
     writeFixtureFile(
       fixtureRoot,
       "README.md",
-      `^22.3.0 || ^24 || ^26\n22.23.1\n${packageManager}\n`,
+      `^22.22.2 || ^24 || ^26\n22.23.1\n${packageManager}\n`,
     );
     writeFixtureFile(
       fixtureRoot,
       "CONTRIBUTING.md",
-      `^22.3.0 || ^24 || ^26\n22.23.1\n${packageManager}\n`,
+      `^22.22.2 || ^24 || ^26\n22.23.1\n${packageManager}\n`,
     );
-    writeFixtureFile(fixtureRoot, "docs/V1_SCOPE.md", "^22.3.0 || ^24 || ^26\n>=22.3.0\n");
+    writeFixtureFile(fixtureRoot, "docs/V1_SCOPE.md", "^22.22.2 || ^24 || ^26\n>=22.22.2\n");
     writeFixtureFile(
       fixtureRoot,
       "docs/DEPLOY.md",
-      `^22.3.0 || ^24 || ^26\n22.23.1\n${packageManager}\n`,
+      `^22.22.2 || ^24 || ^26\n22.23.1\n${packageManager}\n`,
     );
-    writeFixtureFile(fixtureRoot, "docs/deployment/vercel.md", "^22.3.0 || ^24 || ^26\n");
-    writeFixtureFile(fixtureRoot, "deploy/vercel/README.md", "^22.3.0 || ^24 || ^26\n");
+    writeFixtureFile(fixtureRoot, "docs/deployment/vercel.md", "^22.22.2 || ^24 || ^26\n");
+    writeFixtureFile(fixtureRoot, "deploy/vercel/README.md", "^22.22.2 || ^24 || ^26\n");
     writeFixtureFile(fixtureRoot, "RELEASE.md", "22.23.1\n");
     writeFixtureFile(fixtureRoot, "CHANGELOG.md", "22.23.1\n");
 
@@ -196,7 +197,7 @@ describe("runtime policy", () => {
       expect(result.status).not.toBe(0);
       expect(result.stderr).toContain("unsupported Node 23 is present");
       expect(result.stderr).toContain("unsupported Node 25.9.0 is present");
-      expect(result.stderr).toContain("^22.3.0 || ^24 || ^26");
+      expect(result.stderr).toContain("^22.22.2 || ^24 || ^26");
     });
   });
 

--- a/tests/unit/supply-chain-policy.unit.test.ts
+++ b/tests/unit/supply-chain-policy.unit.test.ts
@@ -872,7 +872,7 @@ describe("supply-chain audit policy", () => {
     const unsupported = [...docLintPackages]
       .filter((path) => {
         const range = lock.packages[path].engines?.node;
-        return range && !semver.satisfies("22.3.0", range);
+        return range && !semver.satisfies("22.22.2", range);
       })
       .map((path) => {
         const pkg = lock.packages[path];


### PR DESCRIPTION
Supersedes #329 (dependabot's `eslint-plugin-jsdoc` 64.2.1 bump), which could not merge on the old `22.3.0` floor — 64.x requires Node `^22.22.2 || >=24.15.0` and the supply-chain 'doc-lint closure on the Node floor' gate rejected it.

## What changed
- **Raised the declared Node engine floor `22.3.0` → `22.22.2`** (`engines.node` = `^22.22.2 || ^24 || ^26`). The declared floor now matches what CI/`.nvmrc` already test and pin (22.23.1) — the old 22.3.0 floor was never actually exercised.
- **Bumped `eslint-plugin-jsdoc` 50.8.0 → 64.2.1**.
- Updated `runtime-policy.json` and the runtime-policy check: our floor may now sit **at or above** the B2 SDK's floor (SDK still declares `>=22.3.0`), never below — added an explicit `backblazeSdkEngineFloor` field so an SDK floor change is caught.
- `@types/node` stays pinned to its conservative `22.3.0` baseline (no 22.22.x release exists; lower type surface than the runtime is safe).
- Updated CI floor job, docs, badges, budget/perf node lists, and the policy contract/unit tests.

## Review fixes
Follow-up commits addressing Copilot review feedback:
- **`b9f6148` docs: correct SDK floor attribution and types baseline** — `docs/V1_SCOPE.md` no longer attributes the `>=22.22.2` floor to the B2 SDK; it now states the project raises its own floor above the SDK's `>=22.3.0` baseline for the JSDoc doc-lint toolchain. `CONTRIBUTING.md`'s typecheck row now describes the conservative `@types/node` 22.3.0 baseline instead of implying 22.22.2 types.
- **`01666ba` test: add SDK-floor ordering negative case** — added a runtime-policy unit case that sets the project floor below the SDK floor and asserts the specific ordering diagnostic, so reversing/removing the comparison cannot pass unnoticed.
- **`38cb901` fix: require engineFloor to equal engineRange minimum** — the runtime-policy check now derives the `engineRange` minimum and requires it to equal `engineFloor` before comparing with the SDK floor, so the range cannot drop to a lower minor (e.g. `^22.3.0`) while the floor and floor smoke stay at 22.22.2. Covered by a new negative unit case.

Deferred: narrowing the published `engines.node` Node 24 branch to `^24.15.0` was declined — it breaks the runtime-policy workflow validator (which requires bare-major caret ranges and rejects the bare `node-version: 24`/`26` entries CI uses) and conflates the runtime consumer contract with a dev-only toolchain constraint already mitigated by the pinned `.nvmrc`. A separate enforced development-toolchain range is tracked as follow-up.

## Verification (local, Node 22.19.0)
check:runtime-policy ✅ · lint:docs ✅ (64.2.1 runs) · typecheck ✅ · biome ✅ · spell/links ✅ · package-budget ✅ · contract ✅ · unit 1626 passed (only the known sandbox-only local-mcp-smoke egress test fails locally; passes in CI on 22.23.1). Runtime-policy unit suite (30 cases) passes with the added negative cases.

Close #329 as superseded once this merges.
