### PR TITLE
ci: fail evals when Anthropic secret is missing

### DIFF
--- a/.github/workflows/evals.yml
+++ b/.github/workflows/evals.yml
@@ -63,7 +63,6 @@ jobs:
   evals:
     name: Claude pass rates
     needs: guard
-    if: needs.guard.result == 'success'
     runs-on: ubuntu-latest
     timeout-minutes: 20
     steps:

--- a/.github/workflows/evals.yml
+++ b/.github/workflows/evals.yml
@@ -25,9 +25,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 5
     outputs:
-      should-run: ${{ steps.ref.outputs.should_run }}
       checkout-sha: ${{ steps.ref.outputs.checkout_sha }}
-      skip-reason: ${{ steps.ref.outputs.skip_reason }}
     steps:
       - name: Resolve trusted eval ref and provider secrets
         id: ref
@@ -36,9 +34,7 @@ jobs:
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
         run: |
           set -euo pipefail
-          should_run=true
           checkout_sha="${GITHUB_SHA}"
-          skip_reason=""
 
           case "${EVENT_NAME}" in
             workflow_dispatch|schedule)
@@ -57,35 +53,17 @@ jobs:
             if [[ -n "$value" ]]; then echo "::add-mask::$value"; fi
           done
 
-          missing=()
-          if [[ -z "${ANTHROPIC_API_KEY:-}" ]]; then missing+=("ANTHROPIC_API_KEY"); fi
-          if [[ "${#missing[@]}" -gt 0 ]]; then
-            should_run=false
-            checkout_sha=""
-            skip_reason="missing provider secret(s): ${missing[*]}"
+          if [[ -z "${ANTHROPIC_API_KEY:-}" ]]; then
+            echo "::error::ANTHROPIC_API_KEY is required for canonical scheduled/dispatch LLM evals; configure it with gh secret set ANTHROPIC_API_KEY"
+            exit 1
           fi
 
-          echo "should_run=${should_run}" >> "$GITHUB_OUTPUT"
           echo "checkout_sha=${checkout_sha}" >> "$GITHUB_OUTPUT"
-          echo "skip_reason=${skip_reason}" >> "$GITHUB_OUTPUT"
-
-  skipped:
-    name: LLM evals skipped
-    needs: guard
-    if: ${{ always() && needs.guard.result == 'success' && needs.guard.outputs.should-run != 'true' }}
-    runs-on: ubuntu-latest
-    timeout-minutes: 2
-    steps:
-      - name: Report skipped evals
-        env:
-          SKIP_REASON: ${{ needs.guard.outputs.skip-reason }}
-        run: |
-          echo "LLM evals skipped: ${SKIP_REASON}" >> "$GITHUB_STEP_SUMMARY"
 
   evals:
     name: Claude pass rates
     needs: guard
-    if: needs.guard.outputs.should-run == 'true'
+    if: needs.guard.result == 'success'
     runs-on: ubuntu-latest
     timeout-minutes: 20
     steps:

--- a/docs/EVALS.md
+++ b/docs/EVALS.md
@@ -156,7 +156,10 @@ must not run against unreviewed code. It runs only on:
 
 The guard job checks that the repository is `backblaze-labs/b2-mcp`, the ref is
 `refs/heads/main`, and the `ANTHROPIC_API_KEY` repository secret is present.
-Missing provider secrets produce a skipped summary instead of a failed eval job.
+Because scheduled and manual CI evals are canonical-main only, a missing
+`ANTHROPIC_API_KEY` is treated as repository misconfiguration: the guard emits a
+GitHub Actions error and fails the workflow. `OPENAI_API_KEY` is not required by
+CI while OpenAI evals are disabled.
 
 The eval job installs with the pinned package manager, builds once, then runs:
 

--- a/tests/contract/ci-workflow-policy.contract.test.ts
+++ b/tests/contract/ci-workflow-policy.contract.test.ts
@@ -425,7 +425,8 @@ describe("CI workflow policy", () => {
 
     expect(workflowJobBlock(evals, "skipped")).toBeNull();
     expect(evals).not.toContain("LLM evals skipped");
-    expect(evalJob).toContain("needs.guard.result == 'success'");
+    expect(evalJob).not.toContain("needs.guard.result");
+    expect(evalJob).not.toContain("needs.guard.outputs.should-run");
     expect(evalJob).toContain("ref: ${{ needs.guard.outputs.checkout-sha }}");
     expect(evalJob).toContain("persist-credentials: false");
   });

--- a/tests/contract/ci-workflow-policy.contract.test.ts
+++ b/tests/contract/ci-workflow-policy.contract.test.ts
@@ -392,7 +392,6 @@ describe("CI workflow policy", () => {
 
   it("runs provider evals only from trusted scheduled or manual main refs", () => {
     const guard = workflowJobBlock(evals, "guard") ?? "";
-    const skipped = workflowJobBlock(evals, "skipped") ?? "";
     const evalJob = workflowJobBlock(evals, "evals") ?? "";
 
     expect(evals).toMatch(topLevelMappingEntry("permissions", "contents", "read"));
@@ -408,7 +407,6 @@ describe("CI workflow policy", () => {
 
     expect(guard).toContain("if: github.repository == 'backblaze-labs/b2-mcp'");
     expect(guard).toContain("checkout-sha: ${{ steps.ref.outputs.checkout_sha }}");
-    expect(guard).toContain("skip-reason: ${{ steps.ref.outputs.skip_reason }}");
     expect(guard).toContain("timeout-minutes: 5");
     expect(guard).toContain("workflow_dispatch|schedule");
     expect(guard).toContain('[[ "$GITHUB_REF" != "refs/heads/main" ]]');
@@ -417,16 +415,17 @@ describe("CI workflow policy", () => {
     // Anthropic only and must not reference the OpenAI secret.
     expect(guard).not.toContain("OPENAI_API_KEY");
     expect(guard).toContain("::add-mask::");
-    expect(guard).toContain("should_run=false");
-    expect(guard).toContain("missing provider secret(s)");
+    expect(guard).toContain('[[ -z "${ANTHROPIC_API_KEY:-}" ]]');
+    expect(guard).toContain("::error::ANTHROPIC_API_KEY is required");
+    expect(guard).toContain("gh secret set ANTHROPIC_API_KEY");
+    expect(guard).toContain("exit 1");
+    expect(guard).not.toContain("should_run=false");
+    expect(guard).not.toContain("missing provider secret(s)");
     expect(guard).not.toContain("environment:");
 
-    expect(skipped).toContain("needs.guard.outputs.should-run != 'true'");
-    expect(skipped).toContain("LLM evals skipped");
-    expect(skipped).toContain("SKIP_REASON: ${{ needs.guard.outputs.skip-reason }}");
-    expect(skipped).toContain('echo "LLM evals skipped: ${SKIP_REASON}"');
-    expect(skipped).not.toContain("LLM evals skipped: ${{");
-    expect(evalJob).toContain("needs.guard.outputs.should-run == 'true'");
+    expect(workflowJobBlock(evals, "skipped")).toBeNull();
+    expect(evals).not.toContain("LLM evals skipped");
+    expect(evalJob).toContain("needs.guard.result == 'success'");
     expect(evalJob).toContain("ref: ${{ needs.guard.outputs.checkout-sha }}");
     expect(evalJob).toContain("persist-credentials: false");
   });


### PR DESCRIPTION
## Summary

Make the scheduled/manual LLM eval guard fail loudly when `ANTHROPIC_API_KEY` is missing, since the workflow now runs only on the canonical main branch. OpenAI remains deferred and is not required by the guard.

## Changes

- Replace the missing Anthropic secret skip path with a masked `::error::` and `exit 1`.
- Remove the `skipped` evals job and rely on the guard dependency to gate eval execution.
- Update the CI workflow policy contract and eval runbook to assert the fail-loud Anthropic-only behavior.

## Linked Issue

Closes #271

## Tests Run

- `pnpm install --frozen-lockfile`
- `pnpm run build`
- `pnpm run lint:docs`
- `pnpm run test:contract`

## Follow-up Notes

- Verified `ANTHROPIC_API_KEY` is configured in `backblaze-labs/b2-mcp` repo secrets; `gh secret list` shows it was updated at `2026-08-25T00:12:17Z`.
- Re-add `OPENAI_API_KEY` to the guard when OpenAI evals are re-enabled under epic #252.
