### PR TITLE
Fix GHCR package pull command

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -693,6 +693,7 @@ jobs:
           GHCR_TOKEN: ${{ github.token }}
           PUBLISH_TAG: ${{ needs.prepare.outputs.publish-tag }}
           REGISTRY_IMAGE: ghcr.io/${{ github.repository }}
+          COSIGN_REPOSITORY: ghcr.io/${{ github.repository }}-signatures
         run: |
           export PUBLISH_TAG="${PUBLISH_TAG#refs/tags/}"
           node scripts/publish-container-image.mjs

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   workflow. (#308)
 
 ### Fixed
+- Publish GHCR cosign signatures to a sibling signature repository so the main
+  package page keeps its default pull command pointed at a runnable image.
+  (#350)
 - Bound stdio capability discovery with a tunable 10s bootstrap deadline; local
   deadline expiry now starts with a fail-closed tool surface instead of hanging
   the MCP client handshake. (#320)

--- a/README.md
+++ b/README.md
@@ -152,7 +152,9 @@ guardrails enforced by the server.
 
 The published image defaults to the HTTP transport, reads configuration only
 from environment variables, and does not publish a mutable `latest` tag. Choose
-the version tag that matches the package release:
+the version tag that matches the package release. Cosign signatures are published
+to a sibling GHCR repository so the package page's default pull command stays on
+a runnable image tag:
 
 ```bash
 B2_MCP_VERSION=VERSION # replace with the release version you want

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -52,10 +52,13 @@ Before publishing `v0.1.0`:
 7. Confirm `@backblaze-labs/b2-mcp` is owned by Backblaze on npm and package
    provenance is enabled before publishing or advertising npm install commands.
 8. Confirm the GHCR package `ghcr.io/backblaze-labs/b2-mcp` is public before
-   advertising Docker run commands. On the first container release, if the
-   initial push creates a private package, set the package visibility to Public
-   in GitHub Packages and rerun the same publish tag. The workflow fails until
-   an anonymous manifest inspection succeeds.
+   advertising Docker run commands. Cosign signatures are stored in the sibling
+   `ghcr.io/backblaze-labs/b2-mcp-signatures` repository so signature tags do
+   not become the package page's default pull command. On the first container
+   release, if the initial push creates a private image or signature package,
+   set the package visibility to Public in GitHub Packages and rerun the same
+   publish tag. The workflow fails until anonymous image and signature checks
+   succeed.
 9. Confirm the `ghcr-publish` GitHub environment exists, requires trusted
    release approval, and restricts deployments to protected release refs.
 10. Confirm `live-b2-contract` has environment secrets `LIVE_B2_KEY_ID` and
@@ -188,9 +191,10 @@ exists. For the first public package only:
    package contents, records checksums and SBOM, repacks the staged package to
    prove it still matches the tarball, publishes the staged package directory
    with npm OIDC provenance, verifies registry metadata with bounded retry,
-   publishes and anonymously verifies the idempotent GHCR container image from
-   the same verified ref, and then creates or updates the GitHub Release. A
-   Docker/GHCR failure can be retried against the same tag; it must not sign an
+   publishes the idempotent GHCR container image from the same verified ref,
+   signs it in the sibling GHCR signature repository, verifies both anonymously,
+   and then creates or updates the GitHub Release. A Docker/GHCR failure can be
+   retried against the same tag; it must not sign an
    existing digest unless that digest already has this workflow's trusted
    signature plus provenance and SBOM attestations, and it must not overwrite an
    existing versioned image whose recorded revision differs from the verified

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -56,9 +56,10 @@ Before publishing `v0.1.0`:
    `ghcr.io/backblaze-labs/b2-mcp-signatures` repository so signature tags do
    not become the package page's default pull command. On the first container
    release, if the initial push creates a private image or signature package,
-   set the package visibility to Public in GitHub Packages and rerun the same
-   publish tag. The workflow fails until anonymous image and signature checks
-   succeed.
+   the publish job is expected to fail at the anonymous visibility gate after
+   the push/sign step. Set the package visibility to Public in GitHub Packages
+   and rerun the same publish tag. The workflow fails until anonymous image and
+   signature checks succeed.
 9. Confirm the `ghcr-publish` GitHub environment exists, requires trusted
    release approval, and restricts deployments to protected release refs.
 10. Confirm `live-b2-contract` has environment secrets `LIVE_B2_KEY_ID` and
@@ -193,8 +194,11 @@ exists. For the first public package only:
    with npm OIDC provenance, verifies registry metadata with bounded retry,
    publishes the idempotent GHCR container image from the same verified ref,
    signs it in the sibling GHCR signature repository, verifies both anonymously,
-   and then creates or updates the GitHub Release. A Docker/GHCR failure can be
-   retried against the same tag; it must not sign an
+   and then creates or updates the GitHub Release. Existing tags signed by the
+   old image-package `.sig` layout are first verified from that legacy location
+   and then re-signed into the sibling repository before the anonymous
+   signature check runs. A Docker/GHCR failure can be retried against the same
+   tag; it must not sign an
    existing digest unless that digest already has this workflow's trusted
    signature plus provenance and SBOM attestations, and it must not overwrite an
    existing versioned image whose recorded revision differs from the verified

--- a/docs/SUPPLY_CHAIN_SECURITY.md
+++ b/docs/SUPPLY_CHAIN_SECURITY.md
@@ -243,13 +243,16 @@ The only repository workflow allowed to publish npm packages is
   manifests for each required platform; tag-push and manual rerun paths both use
   the protected `main` workflow identity after the same tag-to-`ci-green`
   validation, so the workflow does not sign a digest based only on
-  caller-controlled OCI annotations; if a first publish dies after pushing tags
-  but before signing, delete the unsigned GHCR package version documented in
-  `RELEASE.md` and rerun the same tag;
+  caller-controlled OCI annotations; existing tags signed before the sibling
+  signature repository existed can still be verified through the legacy
+  image-package signature and are then re-signed into the sibling repository; if
+  a first publish dies after pushing tags but before signing, delete the
+  unsigned GHCR package version documented in `RELEASE.md` and rerun the same
+  tag;
 - verifies the pushed version tag and sibling cosign signature repository
   anonymously before the GitHub Release job can run, so a private first-publish
-  GHCR package fails the workflow until an owner sets the relevant package
-  visibility to Public and reruns the same tag;
+  GHCR package fails the workflow at the visibility gate until an owner sets the
+  relevant package visibility to Public and reruns the same tag;
 - publishes only immutable container tags: the package version without a leading
   `v` and the matching signed release tag; no mutable `latest` tag is produced;
 - uses npm trusted publishing with `id-token: write` and an OIDC preflight;

--- a/docs/SUPPLY_CHAIN_SECURITY.md
+++ b/docs/SUPPLY_CHAIN_SECURITY.md
@@ -232,9 +232,10 @@ The only repository workflow allowed to publish npm packages is
   keyless signing, behind the protected `ghcr-publish` environment;
 - publishes a multi-platform GHCR manifest for `linux/amd64` and `linux/arm64`,
   attaches BuildKit provenance and SBOM attestation manifests, signs the image
-  index digest that contains those manifests with cosign keyless signing, records
-  the image digest and pinned Node base digest in release metadata, and refuses
-  to overwrite an existing version tag whose manifest revision differs from the
+  index digest that contains those manifests with cosign keyless signing in the
+  sibling `ghcr.io/backblaze-labs/b2-mcp-signatures` repository, records the
+  image digest and pinned Node base digest in release metadata, and refuses to
+  overwrite an existing version tag whose manifest revision differs from the
   verified checkout SHA;
 - treats an already-published version tag as idempotent only after verifying the
   existing digest's prior cosign signature from this release workflow and
@@ -245,10 +246,10 @@ The only repository workflow allowed to publish npm packages is
   caller-controlled OCI annotations; if a first publish dies after pushing tags
   but before signing, delete the unsigned GHCR package version documented in
   `RELEASE.md` and rerun the same tag;
-- verifies the pushed version tag through an anonymous manifest inspection before
-  the GitHub Release job can run, so a private first-publish GHCR package fails
-  the workflow until an owner sets the package visibility to Public and reruns
-  the same tag;
+- verifies the pushed version tag and sibling cosign signature repository
+  anonymously before the GitHub Release job can run, so a private first-publish
+  GHCR package fails the workflow until an owner sets the relevant package
+  visibility to Public and reruns the same tag;
 - publishes only immutable container tags: the package version without a leading
   `v` and the matching signed release tag; no mutable `latest` tag is produced;
 - uses npm trusted publishing with `id-token: write` and an OIDC preflight;

--- a/scripts/publish-container-image.mjs
+++ b/scripts/publish-container-image.mjs
@@ -6,6 +6,7 @@ import { join } from "node:path";
 
 const REQUIRED_PLATFORMS = ["linux/amd64", "linux/arm64"];
 const BUILDKIT_ATTESTATION_TYPE = "attestation-manifest";
+const SIGNATURE_REPOSITORY_SUFFIX = "-signatures";
 const SPDX_PREDICATE_TYPE = "https://spdx.dev/Document";
 const SLSA_PREDICATE_PREFIX = "https://slsa.dev/provenance/";
 const RETRYABLE_OUTPUT =
@@ -197,17 +198,19 @@ function readDockerBaseImage() {
   return { name, digest, ref: `${name}@${digest}` };
 }
 
-function writeOutputs({ digest, imageRef, summaryRef }) {
+function writeOutputs({ digest, imageRef, summaryRef, signatureRepository }) {
   const outputPath = process.env.GITHUB_OUTPUT;
   if (outputPath) {
     appendFileSync(outputPath, `image-digest=${digest}\n`);
     appendFileSync(outputPath, `image-ref=${imageRef}\n`);
+    appendFileSync(outputPath, `signature-repository=${signatureRepository}\n`);
   }
   const summaryPath = process.env.GITHUB_STEP_SUMMARY;
   if (summaryPath) {
     appendFileSync(summaryPath, "\n## Container image\n\n");
     appendFileSync(summaryPath, `- Image: \`${summaryRef}\`\n`);
     appendFileSync(summaryPath, `- Digest: \`${digest}\`\n`);
+    appendFileSync(summaryPath, `- Signature repository: \`${signatureRepository}\`\n`);
     appendFileSync(summaryPath, `- Platforms: \`${REQUIRED_PLATFORMS.join("`, `")}\`\n`);
   }
 }
@@ -217,9 +220,25 @@ function createTagIfMissing(tagRef, sourceDigestRef) {
   run("docker", ["buildx", "imagetools", "create", "--tag", tagRef, sourceDigestRef]);
 }
 
-function signDigest(registryImage, digest) {
+function signatureRepository(registryImage) {
+  const expected = `${registryImage}${SIGNATURE_REPOSITORY_SUFFIX}`;
+  const configured = process.env.COSIGN_REPOSITORY?.toLowerCase();
+  if (configured && configured !== expected) {
+    throw new Error(
+      `COSIGN_REPOSITORY must be ${expected} so cosign signature tags do not land in ${registryImage}`,
+    );
+  }
+  return expected;
+}
+
+function cosignEnv(signatureRepo, env = {}) {
+  return { ...process.env, ...env, COSIGN_REPOSITORY: signatureRepo };
+}
+
+function signDigest(registryImage, digest, signatureRepo) {
   run("cosign", ["sign", "--yes", `${registryImage}@${digest}`], {
     attempts: 3,
+    env: cosignEnv(signatureRepo),
   });
 }
 
@@ -238,12 +257,48 @@ function trustArgs(githubServerUrl, githubRepository) {
   ];
 }
 
-function verifyTrustedExistingDigest(registryImage, digest, githubServerUrl, githubRepository) {
+function verifyTrustedExistingDigest(
+  registryImage,
+  digest,
+  githubServerUrl,
+  githubRepository,
+  signatureRepo,
+  env = {},
+) {
   const ref = `${registryImage}@${digest}`;
   const args = trustArgs(githubServerUrl, githubRepository);
   run("cosign", ["verify", ...args, ref], {
     attempts: 3,
+    env: cosignEnv(signatureRepo, env),
   });
+}
+
+function verifyAnonymousSignature(
+  registryImage,
+  digest,
+  githubServerUrl,
+  githubRepository,
+  signatureRepo,
+) {
+  const dockerConfig = mkdtempSync(join(tmpdir(), "b2-mcp-ghcr-signature-anonymous-"));
+  try {
+    verifyTrustedExistingDigest(
+      registryImage,
+      digest,
+      githubServerUrl,
+      githubRepository,
+      signatureRepo,
+      {
+        DOCKER_CONFIG: dockerConfig,
+      },
+    );
+  } catch (err) {
+    throw new Error(
+      `Anonymous GHCR signature verification failed for ${registryImage}@${digest} with COSIGN_REPOSITORY=${signatureRepo}. Make the ghcr.io signature package public in GitHub Packages, then rerun the publish workflow. ${err instanceof Error ? err.message : String(err)}`,
+    );
+  } finally {
+    rmSync(dockerConfig, { recursive: true, force: true });
+  }
 }
 
 function verifyAnonymousManifestPull(ref) {
@@ -270,6 +325,7 @@ function finishExistingImage({
   registryImage,
   githubServerUrl,
   githubRepository,
+  signatureRepo,
   summaryRef,
   message,
 }) {
@@ -279,11 +335,23 @@ function finishExistingImage({
   if (secondaryInfo && manifestDigest(secondaryInfo) !== digest) {
     throw new Error(`${secondaryRef} already exists with a different digest`);
   }
-  verifyTrustedExistingDigest(registryImage, digest, githubServerUrl, githubRepository);
+  verifyTrustedExistingDigest(
+    registryImage,
+    digest,
+    githubServerUrl,
+    githubRepository,
+    signatureRepo,
+  );
   requireBuildKitAttestations(primaryInfo, primaryRef, registryImage);
   createTagIfMissing(secondaryRef, `${registryImage}@${digest}`);
   verifyAnonymousManifestPull(summaryRef);
-  writeOutputs({ digest, imageRef: `${registryImage}@${digest}`, summaryRef });
+  verifyAnonymousSignature(registryImage, digest, githubServerUrl, githubRepository, signatureRepo);
+  writeOutputs({
+    digest,
+    imageRef: `${registryImage}@${digest}`,
+    summaryRef,
+    signatureRepository: signatureRepo,
+  });
   console.log(message);
   return true;
 }
@@ -299,6 +367,7 @@ function publish() {
   const version = publishTag.replace(/^v/, "");
   const versionRef = `${registryImage}:${version}`;
   const releaseRef = `${registryImage}:${publishTag}`;
+  const signatureRepo = signatureRepository(registryImage);
   const baseImage = readDockerBaseImage();
   // Stable releases stamp the runtime channel marker into the image; prereleases
   // stay on the `dev` channel by omitting the build arg.
@@ -324,6 +393,7 @@ function publish() {
       registryImage,
       githubServerUrl,
       githubRepository,
+      signatureRepo,
       summaryRef: versionRef,
       message: `${versionRef} already exists for ${checkoutSha}; treated as idempotent`,
     })
@@ -340,6 +410,7 @@ function publish() {
       registryImage,
       githubServerUrl,
       githubRepository,
+      signatureRepo,
       summaryRef: versionRef,
       message: `${releaseRef} already exists for ${checkoutSha}; restored missing version tag`,
     })
@@ -395,9 +466,15 @@ function publish() {
     throw new Error(`${versionRef} and ${releaseRef} resolved to different digests`);
   }
   requireBuildKitAttestations(publishedVersion, versionRef, registryImage);
-  signDigest(registryImage, digest);
+  signDigest(registryImage, digest, signatureRepo);
   verifyAnonymousManifestPull(versionRef);
-  writeOutputs({ digest, imageRef: `${registryImage}@${digest}`, summaryRef: versionRef });
+  verifyAnonymousSignature(registryImage, digest, githubServerUrl, githubRepository, signatureRepo);
+  writeOutputs({
+    digest,
+    imageRef: `${registryImage}@${digest}`,
+    summaryRef: versionRef,
+    signatureRepository: signatureRepo,
+  });
 }
 
 try {

--- a/scripts/publish-container-image.mjs
+++ b/scripts/publish-container-image.mjs
@@ -315,6 +315,7 @@ function verifyTrustedSignature({
   const args = trustArgs(githubServerUrl, githubRepository);
   run("cosign", ["verify", ...args, ref], {
     attempts: 3,
+    capture: true,
     env: cosignEnv({ signatureRepo, sourceEnv }),
   });
 }

--- a/scripts/publish-container-image.mjs
+++ b/scripts/publish-container-image.mjs
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
 import { spawnSync } from "node:child_process";
-import { appendFileSync, mkdtempSync, readFileSync, rmSync } from "node:fs";
+import { appendFileSync, mkdirSync, mkdtempSync, readFileSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 
@@ -9,6 +9,20 @@ const BUILDKIT_ATTESTATION_TYPE = "attestation-manifest";
 const SIGNATURE_REPOSITORY_SUFFIX = "-signatures";
 const SPDX_PREDICATE_TYPE = "https://spdx.dev/Document";
 const SLSA_PREDICATE_PREFIX = "https://slsa.dev/provenance/";
+const ANONYMOUS_ENV_PASSTHROUGH = [
+  "PATH",
+  "Path",
+  "PATHEXT",
+  "SystemRoot",
+  "SYSTEMROOT",
+  "WINDIR",
+  "TMPDIR",
+  "TMP",
+  "TEMP",
+  "SSL_CERT_FILE",
+  "SSL_CERT_DIR",
+  "NODE_EXTRA_CA_CERTS",
+];
 const RETRYABLE_OUTPUT =
   /(?:429|500|502|503|504|denied: retry|EOF|ECONNRESET|ETIMEDOUT|rate limit|timeout|temporary|temporarily|unavailable)/i;
 
@@ -198,19 +212,18 @@ function readDockerBaseImage() {
   return { name, digest, ref: `${name}@${digest}` };
 }
 
-function writeOutputs({ digest, imageRef, summaryRef, signatureRepository }) {
+function writeOutputs({ digest, imageRef, summaryRef, signatureRepo }) {
   const outputPath = process.env.GITHUB_OUTPUT;
   if (outputPath) {
     appendFileSync(outputPath, `image-digest=${digest}\n`);
     appendFileSync(outputPath, `image-ref=${imageRef}\n`);
-    appendFileSync(outputPath, `signature-repository=${signatureRepository}\n`);
   }
   const summaryPath = process.env.GITHUB_STEP_SUMMARY;
   if (summaryPath) {
     appendFileSync(summaryPath, "\n## Container image\n\n");
     appendFileSync(summaryPath, `- Image: \`${summaryRef}\`\n`);
     appendFileSync(summaryPath, `- Digest: \`${digest}\`\n`);
-    appendFileSync(summaryPath, `- Signature repository: \`${signatureRepository}\`\n`);
+    appendFileSync(summaryPath, `- Signature repository: \`${signatureRepo}\`\n`);
     appendFileSync(summaryPath, `- Platforms: \`${REQUIRED_PLATFORMS.join("`, `")}\`\n`);
   }
 }
@@ -220,7 +233,7 @@ function createTagIfMissing(tagRef, sourceDigestRef) {
   run("docker", ["buildx", "imagetools", "create", "--tag", tagRef, sourceDigestRef]);
 }
 
-function signatureRepository(registryImage) {
+function resolveSignatureRepository(registryImage) {
   const expected = `${registryImage}${SIGNATURE_REPOSITORY_SUFFIX}`;
   const configured = process.env.COSIGN_REPOSITORY?.toLowerCase();
   if (configured && configured !== expected) {
@@ -231,14 +244,47 @@ function signatureRepository(registryImage) {
   return expected;
 }
 
-function cosignEnv(signatureRepo, env = {}) {
-  return { ...process.env, ...env, COSIGN_REPOSITORY: signatureRepo };
+function cosignEnv({ signatureRepo, sourceEnv = process.env }) {
+  const childEnv = { ...sourceEnv };
+  if (signatureRepo) {
+    childEnv.COSIGN_REPOSITORY = signatureRepo;
+  } else {
+    delete childEnv.COSIGN_REPOSITORY;
+  }
+  return childEnv;
 }
 
-function signDigest(registryImage, digest, signatureRepo) {
+function anonymousEnv(env = {}) {
+  const childEnv = {};
+  for (const name of ANONYMOUS_ENV_PASSTHROUGH) {
+    if (process.env[name]) childEnv[name] = process.env[name];
+  }
+  return { ...childEnv, ...env };
+}
+
+function anonymousRegistryEnv({ signatureRepo }) {
+  const root = mkdtempSync(join(tmpdir(), "b2-mcp-ghcr-anonymous-"));
+  const dockerConfig = join(root, "docker");
+  const home = join(root, "home");
+  const xdgCache = join(root, "xdg-cache");
+  mkdirSync(dockerConfig, { recursive: true });
+  mkdirSync(home, { recursive: true });
+  mkdirSync(xdgCache, { recursive: true });
+  return {
+    root,
+    env: anonymousEnv({
+      DOCKER_CONFIG: dockerConfig,
+      HOME: home,
+      XDG_CACHE_HOME: xdgCache,
+      ...(signatureRepo ? { COSIGN_REPOSITORY: signatureRepo } : {}),
+    }),
+  };
+}
+
+function signDigest({ registryImage, digest, signatureRepo }) {
   run("cosign", ["sign", "--yes", `${registryImage}@${digest}`], {
     attempts: 3,
-    env: cosignEnv(signatureRepo),
+    env: cosignEnv({ signatureRepo }),
   });
 }
 
@@ -257,62 +303,102 @@ function trustArgs(githubServerUrl, githubRepository) {
   ];
 }
 
-function verifyTrustedExistingDigest(
+function verifyTrustedSignature({
   registryImage,
   digest,
   githubServerUrl,
   githubRepository,
   signatureRepo,
-  env = {},
-) {
+  sourceEnv = process.env,
+}) {
   const ref = `${registryImage}@${digest}`;
   const args = trustArgs(githubServerUrl, githubRepository);
   run("cosign", ["verify", ...args, ref], {
     attempts: 3,
-    env: cosignEnv(signatureRepo, env),
+    env: cosignEnv({ signatureRepo, sourceEnv }),
   });
 }
 
-function verifyAnonymousSignature(
+function verifyTrustedExistingDigest({
   registryImage,
   digest,
   githubServerUrl,
   githubRepository,
   signatureRepo,
-) {
-  const dockerConfig = mkdtempSync(join(tmpdir(), "b2-mcp-ghcr-signature-anonymous-"));
+  sourceEnv = process.env,
+}) {
   try {
-    verifyTrustedExistingDigest(
+    verifyTrustedSignature({
       registryImage,
       digest,
       githubServerUrl,
       githubRepository,
       signatureRepo,
-      {
-        DOCKER_CONFIG: dockerConfig,
-      },
-    );
+      sourceEnv,
+    });
+    return "sibling";
+  } catch (primaryErr) {
+    try {
+      verifyTrustedSignature({
+        registryImage,
+        digest,
+        githubServerUrl,
+        githubRepository,
+        signatureRepo: null,
+        sourceEnv,
+      });
+      console.warn(
+        `container-publish: verified ${registryImage}@${digest} through the legacy image-package cosign signature; migrating signature to ${signatureRepo}`,
+      );
+      return "legacy";
+    } catch (legacyErr) {
+      const primaryMessage = primaryErr instanceof Error ? primaryErr.message : String(primaryErr);
+      const legacyMessage = legacyErr instanceof Error ? legacyErr.message : String(legacyErr);
+      throw new Error(
+        `trusted cosign verification failed in both ${signatureRepo} and the legacy image package. sibling: ${primaryMessage}; legacy: ${legacyMessage}`,
+      );
+    }
+  }
+}
+
+function verifyAnonymousSignature({
+  registryImage,
+  digest,
+  githubServerUrl,
+  githubRepository,
+  signatureRepo,
+}) {
+  const anonymous = anonymousRegistryEnv({ signatureRepo });
+  try {
+    verifyTrustedSignature({
+      registryImage,
+      digest,
+      githubServerUrl,
+      githubRepository,
+      signatureRepo,
+      sourceEnv: anonymous.env,
+    });
   } catch (err) {
     throw new Error(
       `Anonymous GHCR signature verification failed for ${registryImage}@${digest} with COSIGN_REPOSITORY=${signatureRepo}. Make the ghcr.io signature package public in GitHub Packages, then rerun the publish workflow. ${err instanceof Error ? err.message : String(err)}`,
     );
   } finally {
-    rmSync(dockerConfig, { recursive: true, force: true });
+    rmSync(anonymous.root, { recursive: true, force: true });
   }
 }
 
 function verifyAnonymousManifestPull(ref) {
-  const dockerConfig = mkdtempSync(join(tmpdir(), "b2-mcp-ghcr-anonymous-"));
+  const anonymous = anonymousRegistryEnv({});
   try {
     inspectImage(ref, {
-      env: { ...process.env, DOCKER_CONFIG: dockerConfig },
+      env: anonymous.env,
     });
   } catch (err) {
     throw new Error(
       `Anonymous GHCR manifest pull failed for ${ref}. Make the ghcr.io package public in GitHub Packages, then rerun the publish workflow. ${err instanceof Error ? err.message : String(err)}`,
     );
   } finally {
-    rmSync(dockerConfig, { recursive: true, force: true });
+    rmSync(anonymous.root, { recursive: true, force: true });
   }
 }
 
@@ -335,22 +421,31 @@ function finishExistingImage({
   if (secondaryInfo && manifestDigest(secondaryInfo) !== digest) {
     throw new Error(`${secondaryRef} already exists with a different digest`);
   }
-  verifyTrustedExistingDigest(
+  const signatureLocation = verifyTrustedExistingDigest({
     registryImage,
     digest,
     githubServerUrl,
     githubRepository,
     signatureRepo,
-  );
+  });
   requireBuildKitAttestations(primaryInfo, primaryRef, registryImage);
+  if (signatureLocation === "legacy") {
+    signDigest({ registryImage, digest, signatureRepo });
+  }
   createTagIfMissing(secondaryRef, `${registryImage}@${digest}`);
   verifyAnonymousManifestPull(summaryRef);
-  verifyAnonymousSignature(registryImage, digest, githubServerUrl, githubRepository, signatureRepo);
+  verifyAnonymousSignature({
+    registryImage,
+    digest,
+    githubServerUrl,
+    githubRepository,
+    signatureRepo,
+  });
   writeOutputs({
     digest,
     imageRef: `${registryImage}@${digest}`,
     summaryRef,
-    signatureRepository: signatureRepo,
+    signatureRepo,
   });
   console.log(message);
   return true;
@@ -367,7 +462,7 @@ function publish() {
   const version = publishTag.replace(/^v/, "");
   const versionRef = `${registryImage}:${version}`;
   const releaseRef = `${registryImage}:${publishTag}`;
-  const signatureRepo = signatureRepository(registryImage);
+  const signatureRepo = resolveSignatureRepository(registryImage);
   const baseImage = readDockerBaseImage();
   // Stable releases stamp the runtime channel marker into the image; prereleases
   // stay on the `dev` channel by omitting the build arg.
@@ -466,14 +561,20 @@ function publish() {
     throw new Error(`${versionRef} and ${releaseRef} resolved to different digests`);
   }
   requireBuildKitAttestations(publishedVersion, versionRef, registryImage);
-  signDigest(registryImage, digest, signatureRepo);
+  signDigest({ registryImage, digest, signatureRepo });
   verifyAnonymousManifestPull(versionRef);
-  verifyAnonymousSignature(registryImage, digest, githubServerUrl, githubRepository, signatureRepo);
+  verifyAnonymousSignature({
+    registryImage,
+    digest,
+    githubServerUrl,
+    githubRepository,
+    signatureRepo,
+  });
   writeOutputs({
     digest,
     imageRef: `${registryImage}@${digest}`,
     summaryRef: versionRef,
-    signatureRepository: signatureRepo,
+    signatureRepo,
   });
 }
 

--- a/tests/unit/container-image.unit.test.ts
+++ b/tests/unit/container-image.unit.test.ts
@@ -23,6 +23,8 @@ type FakeState = {
   legacyOnly?: boolean;
   migrated?: boolean;
   signed?: boolean;
+  transientAnonymousSignatureFailures?: number;
+  transientSiblingVerifyFailures?: number;
   cosignCalls?: FakeCall[];
   dockerCalls?: FakeCall[];
 };
@@ -202,6 +204,26 @@ if (args[0] === "sign") {
   process.exit(0);
 }
 if (args[0] === "verify") {
+  if (
+    state.transientAnonymousSignatureFailures > 0 &&
+    isAnonymous &&
+    process.env.COSIGN_REPOSITORY === signatureRepo
+  ) {
+    state.transientAnonymousSignatureFailures -= 1;
+    saveState(state);
+    console.error("429 Too Many Requests");
+    process.exit(1);
+  }
+  if (
+    state.transientSiblingVerifyFailures > 0 &&
+    !isAnonymous &&
+    process.env.COSIGN_REPOSITORY === signatureRepo
+  ) {
+    state.transientSiblingVerifyFailures -= 1;
+    saveState(state);
+    console.error("429 Too Many Requests");
+    process.exit(1);
+  }
   if (state.failAnonymousSignature && isAnonymous) {
     saveState(state);
     console.error("denied: requested access to the resource is denied");
@@ -453,6 +475,38 @@ describe("container image policy", () => {
       ),
     ).toBe(true);
     expect(state.signed).toBe(true);
+  });
+
+  it("retries transient trusted sibling signature verification failures", () => {
+    const { result, state } = runPublishWithFakes({
+      existing: true,
+      transientSiblingVerifyFailures: 1,
+    });
+
+    expect(result.status).toBe(0);
+    expect(result.stderr).toContain("retrying cosign verify");
+    expect(state.transientSiblingVerifyFailures).toBe(0);
+    expect(
+      (state.cosignCalls ?? []).filter(
+        (call) =>
+          call.args[0] === "verify" &&
+          !call.env.DOCKER_CONFIG &&
+          call.env.COSIGN_REPOSITORY === signatureRepo,
+      ),
+    ).toHaveLength(2);
+  });
+
+  it("retries transient anonymous signature verification failures", () => {
+    const { result, state } = runPublishWithFakes({ transientAnonymousSignatureFailures: 1 });
+
+    expect(result.status).toBe(0);
+    expect(result.stderr).toContain("retrying cosign verify");
+    expect(state.transientAnonymousSignatureFailures).toBe(0);
+    expect(
+      anonymousCalls(state.cosignCalls).filter(
+        (call) => call.args[0] === "verify" && call.env.COSIGN_REPOSITORY === signatureRepo,
+      ),
+    ).toHaveLength(2);
   });
 
   it("fails when sibling signatures are not anonymously readable", () => {

--- a/tests/unit/container-image.unit.test.ts
+++ b/tests/unit/container-image.unit.test.ts
@@ -1,7 +1,273 @@
-import { readFileSync } from "fs";
-import { join } from "path";
+import { spawnSync } from "child_process";
+import { chmodSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "fs";
+import { tmpdir } from "os";
+import { delimiter, join } from "path";
 
 const root = join(__dirname, "../..");
+const publishScriptPath = join(root, "scripts/publish-container-image.mjs");
+const registryImage = "ghcr.io/backblaze-labs/b2-mcp";
+const signatureRepo = `${registryImage}-signatures`;
+const checkoutSha = "0123456789abcdef0123456789abcdef01234567";
+const publishTag = "v0.1.3";
+const imageDigest = `sha256:${"a".repeat(64)}`;
+
+type FakeCall = {
+  args: string[];
+  env: Record<string, string>;
+};
+
+type FakeState = {
+  built?: boolean;
+  existing?: boolean;
+  failAnonymousSignature?: boolean;
+  legacyOnly?: boolean;
+  migrated?: boolean;
+  signed?: boolean;
+  cosignCalls?: FakeCall[];
+  dockerCalls?: FakeCall[];
+};
+
+const credentialEnvNames = [
+  "GHCR_TOKEN",
+  "GITHUB_TOKEN",
+  "ACTIONS_ID_TOKEN_REQUEST_URL",
+  "ACTIONS_ID_TOKEN_REQUEST_TOKEN",
+  "DOCKER_AUTH_CONFIG",
+  "NPM_TOKEN",
+];
+
+function commandPath(binDir: string, name: string): string {
+  return join(binDir, process.platform === "win32" ? `${name}.cmd` : name);
+}
+
+function writeFakeCommand(binDir: string, name: string, script: string): void {
+  const scriptPath = join(binDir, `${name}.js`);
+  writeFileSync(scriptPath, script);
+  if (process.platform === "win32") {
+    writeFileSync(
+      commandPath(binDir, name),
+      `@echo off\r\n"${process.execPath}" "${scriptPath}" %*\r\n`,
+    );
+  } else {
+    writeFileSync(
+      commandPath(binDir, name),
+      `#!/bin/sh\nexec ${JSON.stringify(process.execPath)} ${JSON.stringify(scriptPath)} "$@"\n`,
+    );
+    chmodSync(commandPath(binDir, name), 0o755);
+  }
+}
+
+function fakeDockerScript(statePath: string): string {
+  return `
+const fs = require("node:fs");
+const statePath = ${JSON.stringify(statePath)};
+const imageDigest = ${JSON.stringify(imageDigest)};
+const checkoutSha = process.env.CHECKOUT_SHA;
+const platformAmd64 = "sha256:${"b".repeat(64)}";
+const platformArm64 = "sha256:${"c".repeat(64)}";
+const attestationAmd64 = "sha256:${"d".repeat(64)}";
+const attestationArm64 = "sha256:${"e".repeat(64)}";
+const envKeys = [
+  "COSIGN_REPOSITORY",
+  "DOCKER_CONFIG",
+  "HOME",
+  "XDG_CACHE_HOME",
+  "PATH",
+  "GHCR_TOKEN",
+  "GITHUB_TOKEN",
+  "ACTIONS_ID_TOKEN_REQUEST_URL",
+  "ACTIONS_ID_TOKEN_REQUEST_TOKEN",
+  "DOCKER_AUTH_CONFIG",
+  "NPM_TOKEN",
+];
+function readState() {
+  return JSON.parse(fs.readFileSync(statePath, "utf8"));
+}
+function saveState(state) {
+  fs.writeFileSync(statePath, JSON.stringify(state, null, 2));
+}
+function pickedEnv() {
+  return Object.fromEntries(envKeys.filter((key) => process.env[key]).map((key) => [key, process.env[key]]));
+}
+function imageInfo() {
+  return {
+    manifest: {
+      digest: imageDigest,
+      annotations: {
+        "org.opencontainers.image.revision": checkoutSha,
+      },
+      manifests: [
+        { digest: platformAmd64, platform: { os: "linux", architecture: "amd64" } },
+        { digest: platformArm64, platform: { os: "linux", architecture: "arm64" } },
+        {
+          digest: attestationAmd64,
+          annotations: {
+            "vnd.docker.reference.type": "attestation-manifest",
+            "vnd.docker.reference.digest": platformAmd64,
+          },
+        },
+        {
+          digest: attestationArm64,
+          annotations: {
+            "vnd.docker.reference.type": "attestation-manifest",
+            "vnd.docker.reference.digest": platformArm64,
+          },
+        },
+      ],
+    },
+  };
+}
+const args = process.argv.slice(2);
+const state = readState();
+state.dockerCalls = state.dockerCalls || [];
+state.dockerCalls.push({ args, env: pickedEnv() });
+saveState(state);
+if (args[0] === "login") process.exit(0);
+if (args[0] === "buildx" && args[1] === "build") {
+  state.built = true;
+  saveState(state);
+  process.exit(0);
+}
+if (args[0] === "buildx" && args[1] === "imagetools" && args[2] === "inspect") {
+  if (args.includes("--raw")) {
+    console.log(JSON.stringify({
+      layers: [
+        { annotations: { "in-toto.io/predicate-type": "https://slsa.dev/provenance/v1" } },
+        { annotations: { "in-toto.io/predicate-type": "https://spdx.dev/Document" } },
+      ],
+    }));
+    process.exit(0);
+  }
+  const ref = args[3];
+  const isReleaseTag = ref.endsWith(":0.1.3") || ref.endsWith(":v0.1.3");
+  if (isReleaseTag && !state.built && !state.existing) {
+    console.error("manifest unknown");
+    process.exit(1);
+  }
+  console.log(JSON.stringify(imageInfo()));
+  process.exit(0);
+}
+if (args[0] === "buildx" && args[1] === "imagetools" && args[2] === "create") {
+  state.createdTags = state.createdTags || [];
+  state.createdTags.push(args);
+  saveState(state);
+  process.exit(0);
+}
+console.error("unexpected docker " + args.join(" "));
+process.exit(1);
+`;
+}
+
+function fakeCosignScript(statePath: string): string {
+  return `
+const fs = require("node:fs");
+const statePath = ${JSON.stringify(statePath)};
+const signatureRepo = ${JSON.stringify(signatureRepo)};
+const envKeys = [
+  "COSIGN_REPOSITORY",
+  "DOCKER_CONFIG",
+  "HOME",
+  "XDG_CACHE_HOME",
+  "PATH",
+  "GHCR_TOKEN",
+  "GITHUB_TOKEN",
+  "ACTIONS_ID_TOKEN_REQUEST_URL",
+  "ACTIONS_ID_TOKEN_REQUEST_TOKEN",
+  "DOCKER_AUTH_CONFIG",
+  "NPM_TOKEN",
+];
+function readState() {
+  return JSON.parse(fs.readFileSync(statePath, "utf8"));
+}
+function saveState(state) {
+  fs.writeFileSync(statePath, JSON.stringify(state, null, 2));
+}
+function pickedEnv() {
+  return Object.fromEntries(envKeys.filter((key) => process.env[key]).map((key) => [key, process.env[key]]));
+}
+const args = process.argv.slice(2);
+const state = readState();
+state.cosignCalls = state.cosignCalls || [];
+state.cosignCalls.push({ args, env: pickedEnv() });
+const isAnonymous =
+  args[0] === "verify" &&
+  Boolean(process.env.DOCKER_CONFIG) &&
+  !process.env.GHCR_TOKEN &&
+  !process.env.GITHUB_TOKEN &&
+  !process.env.ACTIONS_ID_TOKEN_REQUEST_TOKEN;
+if (args[0] === "sign") {
+  state.signed = true;
+  state.migrated = true;
+  saveState(state);
+  process.exit(0);
+}
+if (args[0] === "verify") {
+  if (state.failAnonymousSignature && isAnonymous) {
+    saveState(state);
+    console.error("denied: requested access to the resource is denied");
+    process.exit(1);
+  }
+  if (state.legacyOnly && process.env.COSIGN_REPOSITORY === signatureRepo && !state.migrated) {
+    saveState(state);
+    console.error("no matching signatures");
+    process.exit(1);
+  }
+  saveState(state);
+  process.exit(0);
+}
+saveState(state);
+console.error("unexpected cosign " + args.join(" "));
+process.exit(1);
+`;
+}
+
+function runPublishWithFakes(
+  initialState: FakeState = {},
+  envOverrides: Record<string, string> = {},
+): { result: ReturnType<typeof spawnSync>; state: FakeState } {
+  const fixtureRoot = mkdtempSync(join(tmpdir(), "b2-mcp-container-publish-"));
+  try {
+    const binDir = join(fixtureRoot, "bin");
+    const statePath = join(fixtureRoot, "state.json");
+    mkdirSync(binDir, { recursive: true });
+    writeFileSync(statePath, JSON.stringify(initialState, null, 2));
+    writeFakeCommand(binDir, "docker", fakeDockerScript(statePath));
+    writeFakeCommand(binDir, "cosign", fakeCosignScript(statePath));
+
+    const env = {
+      ...process.env,
+      ACTIONS_ID_TOKEN_REQUEST_TOKEN: "oidc-request-token",
+      ACTIONS_ID_TOKEN_REQUEST_URL: "https://token.actions.githubusercontent.com",
+      COSIGN_REPOSITORY: signatureRepo,
+      DOCKER_AUTH_CONFIG: "registry-auth",
+      GHCR_TOKEN: "ghcr-token",
+      GITHUB_ACTOR: "goanpeca",
+      GITHUB_REPOSITORY: "backblaze-labs/b2-mcp",
+      GITHUB_SERVER_URL: "https://github.com",
+      GITHUB_TOKEN: "github-token",
+      NPM_TOKEN: "npm-token",
+      CHECKOUT_SHA: checkoutSha,
+      PATH: `${binDir}${delimiter}${process.env.PATH ?? ""}`,
+      PUBLISH_TAG: publishTag,
+      REGISTRY_IMAGE: registryImage,
+      ...envOverrides,
+    };
+
+    const result = spawnSync(process.execPath, [publishScriptPath], {
+      cwd: root,
+      encoding: "utf8",
+      env,
+    });
+    const state = JSON.parse(readFileSync(statePath, "utf8")) as FakeState;
+    return { result, state };
+  } finally {
+    rmSync(fixtureRoot, { recursive: true, force: true });
+  }
+}
+
+function anonymousCalls(calls: FakeCall[] = []): FakeCall[] {
+  return calls.filter((call) => call.env.DOCKER_CONFIG && !call.env.GHCR_TOKEN);
+}
 
 describe("container image policy", () => {
   const dockerfile = readFileSync(join(root, "Dockerfile"), "utf8");
@@ -116,19 +382,87 @@ describe("container image policy", () => {
     expect(publishScript).toContain("DOCKER_CONFIG");
     expect(publishScript).toContain("cosign");
     expect(publishScript).toContain("signDigest");
-    expect(publishScript).toContain('SIGNATURE_REPOSITORY_SUFFIX = "-signatures"');
-    expect(publishScript).toContain("COSIGN_REPOSITORY");
-    expect(publishScript).toContain("verifyAnonymousSignature");
-    expect(publishScript).toContain("signature-repository");
     expect(publishWorkflow).toContain(
       "COSIGN_REPOSITORY: ghcr.io/${{ github.repository }}-signatures",
     );
     expect(publishScript).toContain("refs/heads/main");
     expect(publishScript).not.toContain("refs/tags/v.*|refs/heads/main");
-    expect(publishScript.indexOf("signDigest(registryImage, digest, signatureRepo);")).toBeLessThan(
-      publishScript.indexOf("verifyAnonymousManifestPull(versionRef);"),
-    );
     expect(publishScript).not.toContain(":latest");
+  });
+
+  it("rejects a cosign repository outside the required sibling package", () => {
+    const { result, state } = runPublishWithFakes({}, { COSIGN_REPOSITORY: registryImage });
+
+    expect(result.status).toBe(1);
+    expect(result.stderr).toContain(`COSIGN_REPOSITORY must be ${signatureRepo}`);
+    expect(state.dockerCalls ?? []).toHaveLength(0);
+    expect(state.cosignCalls ?? []).toHaveLength(0);
+  });
+
+  it("signs and verifies new releases through the sibling signature repository", () => {
+    const { result, state } = runPublishWithFakes();
+
+    expect(result.status).toBe(0);
+    const cosignCalls = state.cosignCalls ?? [];
+    expect(cosignCalls).toContainEqual(
+      expect.objectContaining({
+        args: ["sign", "--yes", `${registryImage}@${imageDigest}`],
+        env: expect.objectContaining({ COSIGN_REPOSITORY: signatureRepo }),
+      }),
+    );
+    expect(cosignCalls).toContainEqual(
+      expect.objectContaining({
+        args: expect.arrayContaining(["verify", `${registryImage}@${imageDigest}`]),
+        env: expect.objectContaining({ COSIGN_REPOSITORY: signatureRepo }),
+      }),
+    );
+
+    const [anonymousSignature] = anonymousCalls(cosignCalls);
+    expect(anonymousSignature).toBeDefined();
+    expect(anonymousSignature.env.COSIGN_REPOSITORY).toBe(signatureRepo);
+    expect(anonymousSignature.env.DOCKER_CONFIG).toContain("b2-mcp-ghcr-anonymous-");
+    for (const name of credentialEnvNames) {
+      expect(anonymousSignature.env).not.toHaveProperty(name);
+    }
+
+    const [anonymousManifest] = anonymousCalls(state.dockerCalls);
+    expect(anonymousManifest).toBeDefined();
+    expect(anonymousManifest.env.DOCKER_CONFIG).toContain("b2-mcp-ghcr-anonymous-");
+    for (const name of credentialEnvNames) {
+      expect(anonymousManifest.env).not.toHaveProperty(name);
+    }
+  });
+
+  it("migrates idempotent reruns from legacy image-package signatures", () => {
+    const { result, state } = runPublishWithFakes({ existing: true, legacyOnly: true });
+
+    expect(result.status).toBe(0);
+    expect(result.stderr).toContain("legacy image-package cosign signature");
+    const cosignCalls = state.cosignCalls ?? [];
+    expect(
+      cosignCalls.some(
+        (call) => call.args[0] === "verify" && call.env.COSIGN_REPOSITORY === signatureRepo,
+      ),
+    ).toBe(true);
+    expect(
+      cosignCalls.some((call) => call.args[0] === "verify" && !call.env.COSIGN_REPOSITORY),
+    ).toBe(true);
+    expect(
+      cosignCalls.some(
+        (call) => call.args[0] === "sign" && call.env.COSIGN_REPOSITORY === signatureRepo,
+      ),
+    ).toBe(true);
+    expect(state.signed).toBe(true);
+  });
+
+  it("fails when sibling signatures are not anonymously readable", () => {
+    const { result, state } = runPublishWithFakes({ failAnonymousSignature: true });
+
+    expect(result.status).toBe(1);
+    expect(result.stderr).toContain("Anonymous GHCR signature verification failed");
+    expect(result.stderr).toContain("Make the ghcr.io signature package public");
+    expect(state.built).toBe(true);
+    expect(state.signed).toBe(true);
   });
 
   it("stamps the runtime release channel into stable images", () => {

--- a/tests/unit/container-image.unit.test.ts
+++ b/tests/unit/container-image.unit.test.ts
@@ -116,9 +116,16 @@ describe("container image policy", () => {
     expect(publishScript).toContain("DOCKER_CONFIG");
     expect(publishScript).toContain("cosign");
     expect(publishScript).toContain("signDigest");
+    expect(publishScript).toContain('SIGNATURE_REPOSITORY_SUFFIX = "-signatures"');
+    expect(publishScript).toContain("COSIGN_REPOSITORY");
+    expect(publishScript).toContain("verifyAnonymousSignature");
+    expect(publishScript).toContain("signature-repository");
+    expect(publishWorkflow).toContain(
+      "COSIGN_REPOSITORY: ghcr.io/${{ github.repository }}-signatures",
+    );
     expect(publishScript).toContain("refs/heads/main");
     expect(publishScript).not.toContain("refs/tags/v.*|refs/heads/main");
-    expect(publishScript.indexOf("signDigest(registryImage, digest);")).toBeLessThan(
+    expect(publishScript.indexOf("signDigest(registryImage, digest, signatureRepo);")).toBeLessThan(
       publishScript.indexOf("verifyAnonymousManifestPull(versionRef);"),
     );
     expect(publishScript).not.toContain(":latest");


### PR DESCRIPTION
## Summary
- Publish release cosign signatures with `COSIGN_REPOSITORY=ghcr.io/${{ github.repository }}-signatures` so `.sig` tags no longer land in the main GHCR image package.
- Keep idempotent reruns compatible with legacy image-package signatures by verifying the legacy location and re-signing trusted digests into the sibling repository.
- Run anonymous image and signature verification with isolated registry config and scrubbed child environments.
- Capture cosign verifier output so transient GHCR 429, timeout, and retryable failures use the configured retry loop before failing or falling back.
- Update release runbooks, supply-chain docs, README, changelog, and behavioral container-publish tests.

## Linked Issue
Closes #350

## Tests
- `node --check scripts/publish-container-image.mjs`
- `pnpm exec vitest run --config vitest.config.mts --project=unit tests/unit/container-image.unit.test.ts`
- `pnpm run typecheck`
- `pnpm run lint`
- `pnpm run lint:docs`
- `pnpm run format:check`
- `pnpm test`
- `pnpm run test:contract`
- `pnpm run spell`
- `pnpm run check:deployment-contracts`
- `pnpm run lint:links`
- `pnpm run build && pnpm run check:doc-examples`

## Follow-up Notes
- Existing `.sig` package versions already pushed to `ghcr.io/backblaze-labs/b2-mcp` may still need manual GHCR cleanup or the next release image publish to refresh the current package page default.
- The first run that creates the sibling signature package may fail at the anonymous visibility gate if GHCR creates it private. Set that package public and rerun the same tag.