### PR TITLE
docs: add API-docs Pages badge and fill 0.2.0 changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- Publish the generated TypeDoc API reference to GitHub Pages from `main`
+  (<https://backblaze-labs.github.io/b2-mcp/>) and link it from the README badge
+  row and Documentation section. (#305)
+- `--host` CLI flag and `B2_HTTP_HOST` environment variable to bind the
+  Streamable HTTP transport to a chosen interface; the eval harness now
+  exercises Claude over both stdio and Streamable HTTP with a transport-parity
+  check. (#348)
 - Documented and exported public option/result helper types needed by the
   strict TypeDoc surface, including auth, OAuth, S3 peer, insight, serializer,
   and secret-sink contracts.
@@ -24,6 +31,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Enforce strict TypeDoc validation for public API docs: undocumented modules,
   exported members, and invalid links now fail `pnpm run docs` and the docs
   workflow. (#308)
+- Bumped the AWS SDK group (`@aws-sdk/client-s3`,
+  `@aws-sdk/s3-request-presigner`) `3.1103.0` → `3.1119.0` and realigned
+  `@smithy/types` `4.16.1` → `4.17.2` so the S3 peer adapter's command/type
+  boundary stays on a single version. (#349)
+- The scheduled/dispatch LLM eval workflow now fails loudly when
+  `ANTHROPIC_API_KEY` is missing instead of skipping, since it runs only on the
+  canonical `main` branch. (#347)
 
 ### Fixed
 - Publish GHCR cosign signatures to a sibling signature repository so the main
@@ -32,6 +46,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Bound stdio capability discovery with a tunable 10s bootstrap deadline; local
   deadline expiry now starts with a fail-closed tool surface instead of hanging
   the MCP client handshake. (#320)
+- Hardened Partner group-member creation recovery so a post-create
+  normalization or secret-sink failure ejects the created member instead of
+  leaking it, and aligned the empty-report degradation shape between
+  `b2_usage_growth` and `b2_egress_leaders`; added regression coverage closing
+  the QA F12–F20 error-classification and fault-injection detection gaps. (#345)
 
 ## [0.1.2] - 2026-08-23
 

--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@
 [![TypeScript](https://img.shields.io/badge/TypeScript-6.x-3178c6?logo=typescript&logoColor=white)](https://www.typescriptlang.org/)
 [![Node.js](https://img.shields.io/badge/Node.js-22.22%2B%20%7C%2024%20%7C%2026-339933?logo=nodedotjs&logoColor=white)](https://nodejs.org/)
 [![MCP](https://img.shields.io/badge/MCP-2026--07--28-5b5fc7)](https://modelcontextprotocol.io/specification/2026-07-28)
+[![API docs](https://img.shields.io/badge/API%20docs-TypeDoc-3178c6?logo=readthedocs&logoColor=white)](https://backblaze-labs.github.io/b2-mcp/)
 <!-- Directory badges point at deterministic per-server URLs derived from the locked
      name (io.github.backblaze-labs/b2-mcp) and repo path, so they activate automatically
      once the package is published to the MCP Registry and ingested by Glama/Smithery. -->
@@ -544,6 +545,7 @@ committed lockfile and a sanitized temporary environment.
 
 ## Documentation
 
+- [API reference](https://backblaze-labs.github.io/b2-mcp/) — generated TypeDoc for the public `src` surface, published to GitHub Pages from `main`
 - [`docs/CLIENTS.md`](docs/CLIENTS.md) — per-client setup + compatibility matrix
 - [`docs/AUTHENTICATION.md`](docs/AUTHENTICATION.md) — OAuth, credential custody, and auth boundary
 - [`docs/DEPLOY.md`](docs/DEPLOY.md) — deployment matrix and supported-host links


### PR DESCRIPTION
Release-readiness doc pass ahead of v0.2.0. Adds the requested API-docs page badge and brings the `[Unreleased]` changelog up to date with the work merged this cycle.

## Changes
- **API-docs GitHub Pages badge** in the README badge row, plus an **API reference** link in the Documentation section, both pointing at the TypeDoc site published from `main` by `docs.yml` (<https://backblaze-labs.github.io/b2-mcp/>, verified live — `build_type: workflow`).
- **CHANGELOG `[Unreleased]` filled for 0.2.0** with the merged PRs that were missing:
  - _Added_: API-docs Pages publishing (#305); `--host` flag + `B2_HTTP_HOST` + HTTP eval transport parity (#348)
  - _Changed_: aws-sdk group 3.1103.0 → 3.1119.0 and `@smithy/types` 4.16.1 → 4.17.2 (#349); scheduled eval workflow fails loudly on missing `ANTHROPIC_API_KEY` (#347)
  - _Fixed_: Partner group-member recovery + insights empty-scan alignment + QA F12–F20 detection coverage (#345)
  - Kept as `[Unreleased]` — the `## [0.2.0]` header is cut at bump time by `cut-changelog.mjs`, not here.

## Audit result (no other changes needed)
A full markdown sweep (README, CHANGELOG, RELEASE, CONTRIBUTING, SECURITY, AGENTS, all `docs/**`, `deploy/*/README`) found everything else already consistent: Node floor 22.22.2, tool counts (40 = 17 native / 19 S3 / 4 custom), all relative links resolve, MCP date 2026-07-28 uniform, credential-mode and destructive-policy defaults consistent, no placeholder/TODO text.

## Deliberately not touched
The 12 deployment "Verification Record" stamps (`0.1.1` / commit `89e911d` / verified `2026-08-23`) are re-verification attestations — left for the release-cut step to refresh after re-running deployment verification against the 0.2.0 build. Likewise, `package.json` version bump and the changelog promotion belong to the tag step.

## Verification
- `doc-links` unit test — pass
- `release-scripts` unit test (`[Unreleased]` discipline) — pass
