### PR TITLE
test: deterministically freeze time in rate-limiter burst drain

### DIFF
--- a/tests/unit/http-server.unit.test.ts
+++ b/tests/unit/http-server.unit.test.ts
@@ -1186,11 +1186,21 @@ describe("health and readiness endpoints", () => {
   });
 
   it("does not rate-limit health probes with the data-plane MCP bucket", async () => {
-    const sourceRateKey = deriveRateKey("http:127.0.0.1");
-    for (let index = 0; index < rateLimiterConfig.burst; index += 1) {
-      expect(allowRequest(sourceRateKey)).toBe(true);
+    // Freeze time while draining the bucket: the token-bucket refills against
+    // Date.now(), so on a slow runner real wall-clock elapsed during the loop
+    // would replenish a token and the post-burst request would be allowed,
+    // flaking this assertion. Fake timers keep elapsed at 0 so the drain is
+    // deterministic; real timers are restored before the async server probe.
+    vi.useFakeTimers();
+    try {
+      const sourceRateKey = deriveRateKey("http:127.0.0.1");
+      for (let index = 0; index < rateLimiterConfig.burst; index += 1) {
+        expect(allowRequest(sourceRateKey)).toBe(true);
+      }
+      expect(allowRequest(sourceRateKey)).toBe(false);
+    } finally {
+      vi.useRealTimers();
     }
-    expect(allowRequest(sourceRateKey)).toBe(false);
 
     const handle = buildHttpServer({
       credentialProvider: {


### PR DESCRIPTION
## Problem
`main` is red on the cross-platform CI (`CI / cross-platform minimum`, notably `windows-latest`). Failing assertion:

```
tests/unit/http-server.unit.test.ts:1193
  expected true to be false
  "does not rate-limit health probes with the data-plane MCP bucket"
```

## Root cause (timing flake, not a code regression)
The per-key token bucket in `src/utils/rate-limiter.ts` refills against `Date.now()` at `refillPerMs = rps/1000 = 60/1000 = 0.06` tokens/ms — one token every ~16.7ms of real wall-clock time.

The test consumed exactly `burst` (120) tokens in a loop, then asserted the next request is denied. On a slow/loaded runner (Windows CI), enough real time elapses **during** the drain loop that the bucket refills ≥1 token, so the post-burst request is (correctly, per the limiter) allowed — and the assertion flakes. It passes on fast machines and fails on slow ones; nothing in the recent merges changed the limiter.

## Fix
Freeze time with `vi.useFakeTimers()` around **only** the synchronous burst-drain assertions, so `Date.now()` doesn't advance and `elapsed` stays 0 → no refill → the drain is deterministic (121st request denied every time). Real timers are restored in a `finally` before the async server/health-probe part of the same test, which needs real timers.

No production code changed — this is a test-determinism fix.

## Verification
- Targeted test — pass
- Full `tests/unit/http-server.unit.test.ts` (68 tests) — pass (fake-timer scope doesn't leak)
- `pnpm run test:cross-platform` (the exact failing CI target) — **192 passed**
