### PR TITLE
fix: stdio discovery mode for credential-less tool enumeration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+- The stdio server no longer exits when started without B2 credentials. It now
+  enters a credential-less discovery mode: the full tool surface is registered
+  so registry/directory services (mcp.so, Glama, LobeHub) can read `tools/list`
+  in a sandbox, a `server.stdio_discovery_mode` warning is logged, and every
+  tool call returns a clear `missing_credentials` error until
+  `B2_APPLICATION_KEY_ID` / `B2_APPLICATION_KEY` are set. The HTTP transport is
+  unchanged. (#356)
+
 ## [0.2.0] - 2026-09-01
 
 ### Added

--- a/scripts/check-vercel-bundle.mjs
+++ b/scripts/check-vercel-bundle.mjs
@@ -19,8 +19,8 @@ const VERCEL_SOURCE_BUDGET_BYTES = 1_500_000;
 // Headroom for the documented source tree plus production dependencies in the
 // Vercel function estimate; emitted build output is still checked separately.
 // Tracks the clean-consumer install footprint, which grew with the reviewed
-// aws-sdk 3.1119.0 and b2-sdk 0.4.0 bumps.
-const VERCEL_FUNCTION_BUNDLE_BUDGET_BYTES = 33_317_000;
+// aws-sdk 3.1119.0 and b2-sdk 0.4.0 bumps and the stdio discovery-mode source.
+const VERCEL_FUNCTION_BUNDLE_BUDGET_BYTES = 33_400_000;
 
 function readJson(relativePath) {
   return JSON.parse(readFileSync(path.join(root, relativePath), "utf8"));

--- a/scripts/lib/local-import-graph.cjs
+++ b/scripts/lib/local-import-graph.cjs
@@ -4,7 +4,7 @@ const { dirname, extname, resolve } = require("path");
 const WORKER_SOURCE_GRAPH_FILES_BUDGET = 75;
 // Headroom for the documented Worker source graph and dry-run output; emitted
 // budgets still guard the deployed artifact size explicitly.
-const WORKER_SOURCE_GRAPH_BYTES_BUDGET = 836_560;
+const WORKER_SOURCE_GRAPH_BYTES_BUDGET = 850_000;
 const WORKER_EMITTED_FILES_BUDGET = 8;
 const WORKER_EMITTED_TOTAL_BYTES_BUDGET = 9_605_000;
 const WORKER_UPLOAD_SCRIPT_BYTES_BUDGET = 3_000_000;

--- a/scripts/packed-consumer-smoke.mjs
+++ b/scripts/packed-consumer-smoke.mjs
@@ -763,12 +763,21 @@ try {
       },
       timeout: 10_000,
     });
-    if (withoutCreds.status !== 1) {
-      throw new Error(`expected missing-credential startup to exit 1, got ${withoutCreds.status}`);
+    // Discovery mode: missing credentials no longer exit(1). The stdio server
+    // starts, logs the discovery warning, registers the full surface so
+    // registries can enumerate tools, and exits cleanly when stdin closes (EOF).
+    if (withoutCreds.status !== 0) {
+      throw new Error(
+        `expected credential-less discovery startup to exit 0, got ${withoutCreds.status}`,
+      );
     }
     assert(
-      withoutCreds.stderr.includes("B2_APPLICATION_KEY_ID and B2_APPLICATION_KEY are required"),
-      "missing credential error did not name required stdio variables",
+      !withoutCreds.stderr.includes("B2_APPLICATION_KEY_ID and B2_APPLICATION_KEY are required"),
+      "discovery-mode startup should not emit the missing-credential fatal",
+    );
+    assert(
+      withoutCreds.stderr.includes("server.stdio_discovery_mode"),
+      "discovery-mode startup should log the stdio discovery warning",
     );
 
     console.log(

--- a/src/b2/keys.ts
+++ b/src/b2/keys.ts
@@ -3,7 +3,7 @@
  *
  * @packageDocumentation
  */
-import type { ToolRegistrar } from "../mcp.js";
+import type { DurableSecretRegistrationOptions, ToolRegistrar } from "../mcp.js";
 import { z } from "zod";
 import { B2Client, type FullApplicationKeyResult, type ListKeysOptions } from "./client.js";
 import { B2AuthManager } from "../auth.js";
@@ -128,6 +128,9 @@ function normalizeCreateKeyBucketScope(args: { bucketId?: string; bucketIds?: st
  * @param client - Repository-owned B2 native client.
  * @param auth - Auth manager used for account-scoped key requests.
  * @param config - Server configuration for secret-sink and destructive policy.
+ * @param options - Registration controls; `registerDurableSecretSchemas` forces
+ * the full `b2_create_key` schema even without an active sink (discovery mode,
+ * where execution is guarded separately) so `tools/list` advertises real inputs.
  *
  * @example
  * ```ts
@@ -139,9 +142,14 @@ export function registerKeyTools(
   client: B2Client,
   auth: B2AuthManager,
   config: B2Config,
+  options: DurableSecretRegistrationOptions = {},
 ): void {
   // ── b2_create_key ─────────────────────────────────────────────────────────
-  if (config.secretSink?.mode === "file" || config.secretSink?.mode === "inline") {
+  if (
+    config.secretSink?.mode === "file" ||
+    config.secretSink?.mode === "inline" ||
+    options.registerDurableSecretSchemas === true
+  ) {
     server.registerTool(
       "b2_create_key",
       {

--- a/src/b2/partner.ts
+++ b/src/b2/partner.ts
@@ -3,7 +3,7 @@
  *
  * @packageDocumentation
  */
-import type { ToolRegistrar } from "../mcp.js";
+import type { DurableSecretRegistrationOptions, ToolRegistrar } from "../mcp.js";
 import type { Region } from "@backblaze-labs/b2-sdk/partner";
 import { z } from "zod";
 import { codedError, toolJson, toolError } from "../utils/errors.js";
@@ -242,6 +242,10 @@ function confirmedGroupMemberAccountIds(
  * compatibility.
  * @param config - Server configuration for destructive policy and secret-sink
  * behavior.
+ * @param options - Registration controls; `registerDurableSecretSchemas` forces
+ * the full `b2_create_group_member` / `b2_reserve_trial_create_account` schemas
+ * even without an active sink (discovery mode, where execution is guarded
+ * separately) so `tools/list` advertises real inputs.
  *
  * @example
  * ```ts
@@ -253,6 +257,7 @@ export function registerPartnerTools(
   client: B2Client,
   _auth: B2AuthManager,
   config: B2Config,
+  options: DurableSecretRegistrationOptions = {},
 ): void {
   // ── b2_list_groups ──────────────────────────────────────────────────────────
   server.registerTool(
@@ -299,7 +304,11 @@ export function registerPartnerTools(
   );
 
   // ── b2_create_group_member ────────────────────────────────────────────────
-  if (config.secretSink?.mode === "file" || config.secretSink?.mode === "inline") {
+  if (
+    config.secretSink?.mode === "file" ||
+    config.secretSink?.mode === "inline" ||
+    options.registerDurableSecretSchemas === true
+  ) {
     server.registerTool(
       "b2_create_group_member",
       {
@@ -540,7 +549,7 @@ export function registerPartnerTools(
   );
 
   // ── b2_reserve_trial_create_account ───────────────────────────────────────
-  if (config.secretSink?.mode === "inline") {
+  if (config.secretSink?.mode === "inline" || options.registerDurableSecretSchemas === true) {
     server.registerTool(
       "b2_reserve_trial_create_account",
       {

--- a/src/index.ts
+++ b/src/index.ts
@@ -106,13 +106,18 @@ const DISCOVERY_MODE_CREDENTIAL = "b2-mcp-discovery-mode";
  * off. The placeholder credentials are never used: `createServer` is told
  * credentials are missing and short-circuits every tool call with a clear error.
  *
+ * Discovery mode is entered only when **both** credential variables are absent.
+ * A partial or mistyped pair (exactly one set) is left untouched so it still
+ * fails fast as invalid, rather than overwriting the configured half and
+ * starting an unusable server.
+ *
  * @param env - Environment record to inspect and mutate; defaults to
  * `process.env`.
  *
  * @returns `true` when discovery mode was entered, otherwise `false`.
  */
 function enterStdioDiscoveryModeIfNeeded(env: NodeJS.ProcessEnv = process.env): boolean {
-  if (env.B2_APPLICATION_KEY_ID && env.B2_APPLICATION_KEY) return false;
+  if (env.B2_APPLICATION_KEY_ID || env.B2_APPLICATION_KEY) return false;
   env.B2_APPLICATION_KEY_ID = DISCOVERY_MODE_CREDENTIAL;
   env.B2_APPLICATION_KEY = DISCOVERY_MODE_CREDENTIAL;
   // Force the secret sink off unconditionally: an explicit `file` value would

--- a/src/index.ts
+++ b/src/index.ts
@@ -91,27 +91,6 @@ async function fetchStdioCapabilities(
   }
 }
 
-/**
- * Start the MCP server over stdio.
- *
- * @remarks
- * The stdio path reads credentials from the process environment, attempts
- * capability discovery once with a `B2_STDIO_CAPABILITY_TIMEOUT_MS` bootstrap
- * deadline (10s by default). A local deadline expiry starts with an empty
- * fail-closed capability set; a returned transient upstream outage degrades to
- * the full tool surface. Other credential errors remain fatal during bootstrap.
- *
- * @returns A promise that resolves after the stdio transport has been
- * registered with the MCP SDK.
- *
- * @throws CredentialResolutionError when credential resolution fails for a
- * reason other than transient capability lookup.
- *
- * @example
- * ```ts
- * await startStdio();
- * ```
- */
 const DISCOVERY_MODE_CREDENTIAL = "b2-mcp-discovery-mode";
 
 /**
@@ -145,6 +124,29 @@ function enterStdioDiscoveryModeIfNeeded(env: NodeJS.ProcessEnv = process.env): 
   return true;
 }
 
+/**
+ * Start the MCP server over stdio.
+ *
+ * @remarks
+ * The stdio path reads credentials from the process environment, attempts
+ * capability discovery once with a `B2_STDIO_CAPABILITY_TIMEOUT_MS` bootstrap
+ * deadline (10s by default). A local deadline expiry starts with an empty
+ * fail-closed capability set; a returned transient upstream outage degrades to
+ * the full tool surface. Other credential errors remain fatal during bootstrap.
+ * When no application key is present, the bootstrap starts a credential-less
+ * discovery server instead of exiting.
+ *
+ * @returns A promise that resolves after the stdio transport has been
+ * registered with the MCP SDK.
+ *
+ * @throws CredentialResolutionError when credential resolution fails for a
+ * reason other than transient capability lookup.
+ *
+ * @example
+ * ```ts
+ * await startStdio();
+ * ```
+ */
 export async function startStdio(): Promise<void> {
   initLogging();
   const discoveryMode = enterStdioDiscoveryModeIfNeeded();

--- a/src/index.ts
+++ b/src/index.ts
@@ -136,7 +136,11 @@ function enterStdioDiscoveryModeIfNeeded(env: NodeJS.ProcessEnv = process.env): 
   if (env.B2_APPLICATION_KEY_ID && env.B2_APPLICATION_KEY) return false;
   env.B2_APPLICATION_KEY_ID = DISCOVERY_MODE_CREDENTIAL;
   env.B2_APPLICATION_KEY = DISCOVERY_MODE_CREDENTIAL;
-  if (!env.B2_SECRET_SINK) env.B2_SECRET_SINK = "off";
+  // Force the secret sink off unconditionally: an explicit `file` value would
+  // make loadConfig preflight/create the sink file (and can fail before
+  // tools/list), and `inline` emits an unrelated durable-secret warning. Either
+  // contradicts the discovery-mode guarantee that the sink is off.
+  env.B2_SECRET_SINK = "off";
   env.B2_REGISTER_ALL_TOOLS = "true";
   return true;
 }
@@ -153,10 +157,7 @@ export async function startStdio(): Promise<void> {
     "capability.fetch.stdio_starting",
   );
   if (discoveryMode) {
-    logger.warn(
-      { transport: "stdio", reason: "no_credentials" },
-      "server.stdio_discovery_mode",
-    );
+    logger.warn({ transport: "stdio", reason: "no_credentials" }, "server.stdio_discovery_mode");
   }
   flushLogsSync();
   try {

--- a/src/index.ts
+++ b/src/index.ts
@@ -112,8 +112,38 @@ async function fetchStdioCapabilities(
  * await startStdio();
  * ```
  */
+const DISCOVERY_MODE_CREDENTIAL = "b2-mcp-discovery-mode";
+
+/**
+ * Enter credential-less stdio discovery mode when no B2 application key is set.
+ *
+ * @remarks
+ * `configFromMaterial` throws `missing_credentials` unless both
+ * `B2_APPLICATION_KEY_ID` and `B2_APPLICATION_KEY` are present, which made the
+ * stdio bootstrap exit before answering `tools/list`. Registry/directory
+ * services (mcp.so, Glama, LobeHub) spawn the server with no credentials just to
+ * enumerate tools, so instead of exiting we inject placeholder credentials,
+ * register the full surface (`B2_REGISTER_ALL_TOOLS`), and turn the secret sink
+ * off. The placeholder credentials are never used: `createServer` is told
+ * credentials are missing and short-circuits every tool call with a clear error.
+ *
+ * @param env - Environment record to inspect and mutate; defaults to
+ * `process.env`.
+ *
+ * @returns `true` when discovery mode was entered, otherwise `false`.
+ */
+function enterStdioDiscoveryModeIfNeeded(env: NodeJS.ProcessEnv = process.env): boolean {
+  if (env.B2_APPLICATION_KEY_ID && env.B2_APPLICATION_KEY) return false;
+  env.B2_APPLICATION_KEY_ID = DISCOVERY_MODE_CREDENTIAL;
+  env.B2_APPLICATION_KEY = DISCOVERY_MODE_CREDENTIAL;
+  if (!env.B2_SECRET_SINK) env.B2_SECRET_SINK = "off";
+  env.B2_REGISTER_ALL_TOOLS = "true";
+  return true;
+}
+
 export async function startStdio(): Promise<void> {
   initLogging();
+  const discoveryMode = enterStdioDiscoveryModeIfNeeded();
   const config = serverModule.loadConfig();
   const capabilityTimeoutMs = stdioCapabilityFetchTimeoutMs();
   let capabilities: string[] | null;
@@ -122,6 +152,12 @@ export async function startStdio(): Promise<void> {
     { transport: "stdio", timeoutMs: capabilityTimeoutMs },
     "capability.fetch.stdio_starting",
   );
+  if (discoveryMode) {
+    logger.warn(
+      { transport: "stdio", reason: "no_credentials" },
+      "server.stdio_discovery_mode",
+    );
+  }
   flushLogsSync();
   try {
     capabilities = await fetchStdioCapabilities(config, capabilityTimeoutMs);
@@ -152,6 +188,9 @@ export async function startStdio(): Promise<void> {
     } else {
       throw err;
     }
+  }
+  if (discoveryMode) {
+    createServerOptions = { ...createServerOptions, credentialsMissing: true };
   }
   stdioTransport.serveStdio(
     () =>

--- a/src/mcp.ts
+++ b/src/mcp.ts
@@ -29,6 +29,22 @@ export type McpServer = V2McpServer;
  */
 export type ToolCallback<TArgs = any> = (args: TArgs, extra: any) => any | Promise<any>;
 
+/**
+ * Registration controls for durable-secret-producing tool registrars.
+ *
+ * @remarks
+ * Durable-secret tools (`b2_create_key`, `b2_create_group_member`,
+ * `b2_reserve_trial_create_account`) register their full input schema only when
+ * an out-of-band secret sink is active. Credential-less discovery mode sets
+ * `registerDurableSecretSchemas` so those schemas are advertised in `tools/list`
+ * regardless of sink availability; execution is rejected by the discovery guard,
+ * so the real handlers never run.
+ */
+export interface DurableSecretRegistrationOptions {
+  /** Advertise the full durable-secret schemas even without an active sink. */
+  registerDurableSecretSchemas?: boolean;
+}
+
 /** Metadata used when registering a tool through {@link ToolRegistrar}. */
 export interface ToolRegistrationConfig {
   /** Optional human-readable title exposed to MCP clients. */

--- a/src/server.ts
+++ b/src/server.ts
@@ -929,9 +929,9 @@ function argKeysOf(args: unknown): string[] {
  * circuit returns the `missing_credentials` error without touching the real
  * handler, yet still emits the `tool.call` audit event (with the classified
  * code/status) so rejected attempts stay observable instead of leaving a gap.
- * It backstops {@link installDiscoveryModeToolCallHandler}: it runs only when a
- * call already cleared the SDK's schema validation (a no-required-argument tool)
- * and reached the per-tool callback.
+ * It backstops the low-level discovery-mode `tools/call` interceptor: it runs
+ * only when a call already cleared the SDK's schema validation (a
+ * no-required-argument tool) and reached the per-tool callback.
  *
  * @param name - Registered tool name recorded in the audit event.
  * @param config - Resolved B2 credentials and runtime policy.

--- a/src/server.ts
+++ b/src/server.ts
@@ -353,9 +353,16 @@ export function createServer(
     : auth;
   const masterClient = masterIsDistinct ? new B2Client(masterAuth) : b2Client;
 
+  // Discovery mode advertises the full durable-secret schemas (decoupled from
+  // sink availability) so registries learn real inputs like keyName/capabilities/
+  // email; the discovery guard still rejects every call before execution.
+  const durableSecretOptions = {
+    registerDurableSecretSchemas: options.credentialsMissing === true,
+  };
+
   // ── B2 Native API tools (control plane: buckets, keys, object lock) ──────
   registerBucketTools(registrar, b2Client, config);
-  registerKeyTools(registrar, b2Client, auth, config);
+  registerKeyTools(registrar, b2Client, auth, config, durableSecretOptions);
   registerObjectLockTools(registrar, b2Client, config);
 
   // ── Partner API tools (master key) ──────────────────────────────────────
@@ -364,7 +371,7 @@ export function createServer(
   // distinct master key is configured; otherwise (and in full-surface mode) keep
   // the prior behavior of always registering them.
   if (!filterActive || masterIsDistinct) {
-    registerPartnerTools(registrar, masterClient, masterAuth, config);
+    registerPartnerTools(registrar, masterClient, masterAuth, config, durableSecretOptions);
   }
 
   // ── S3-Compatible API tools (data plane: objects + multipart) ────────────
@@ -408,8 +415,12 @@ export function createServer(
       (name) => !registrar.hasTool(name) && isToolAllowedByOAuthScopes(name, oauthScopes),
     );
   } else if (config.secretSink?.mode !== "inline") {
-    registerDurableSecretCompatibilityStubs(registrar, config.secretSink, (name) =>
-      isToolAllowedByOAuthScopes(name, oauthScopes),
+    // Skip names already registered: discovery mode advertises the full
+    // durable-secret schemas above, so a stub would duplicate the registration.
+    registerDurableSecretCompatibilityStubs(
+      registrar,
+      config.secretSink,
+      (name) => !registrar.hasTool(name) && isToolAllowedByOAuthScopes(name, oauthScopes),
     );
   }
 

--- a/src/server.ts
+++ b/src/server.ts
@@ -315,7 +315,7 @@ export function createServer(
     shouldRegister: shouldRegisterForResolvedAuthz,
     wrapCallback: (name, callback) =>
       options.credentialsMissing === true
-        ? async () => toolError(MISSING_CREDENTIALS_TOOL_ERROR)
+        ? createMissingCredentialsToolCallback(name, config)
         : createAuditedToolCallback(name, callback, config, {
             getClientCapabilities: () => getMcpClientCapabilities(server),
             getProtocolVersion: () => getMcpNegotiatedProtocolVersion(server),
@@ -876,6 +876,53 @@ export function createAuditedToolCallback(
       );
       throw safeErr;
     }
+  };
+}
+
+/**
+ * Build an audit-only tool callback for discovery mode.
+ *
+ * @remarks
+ * Discovery mode registers the full surface with placeholder credentials but
+ * must reject every execution ahead of provider/destructive handling. This short
+ * circuit returns the `missing_credentials` error without touching the real
+ * handler, yet still emits the `tool.call` audit event (with the classified
+ * code/status) so rejected attempts stay observable instead of leaving a gap.
+ *
+ * @param name - Registered tool name recorded in the audit event.
+ * @param config - Resolved B2 credentials and runtime policy.
+ *
+ * @returns A tool callback that logs the attempt and returns `missing_credentials`.
+ *
+ * @example
+ * ```ts
+ * const callback = createMissingCredentialsToolCallback("b2_list_buckets", config);
+ * ```
+ */
+export function createMissingCredentialsToolCallback(name: string, config: B2Config): ToolCallback {
+  const keyFingerprint = config.credentialFingerprint ?? fingerprintConfig(config);
+  const outputFormat = config.outputFormat ?? DEFAULT_MCP_OUTPUT_FORMAT;
+
+  return async function missingCredentialsToolCallback(args: any) {
+    const start = Date.now();
+    const argKeys =
+      args && typeof args === "object" && !Array.isArray(args) ? Object.keys(args) : [];
+    const result = toolError(MISSING_CREDENTIALS_TOOL_ERROR);
+    logger.info(
+      {
+        tool: name,
+        credential: keyFingerprint,
+        outputFormat,
+        argKeys,
+        durationMs: Date.now() - start,
+        error: true,
+        resultType: "complete",
+        code: MISSING_CREDENTIALS_TOOL_ERROR.code,
+        status: MISSING_CREDENTIALS_TOOL_ERROR.status,
+      },
+      "tool.call",
+    );
+    return result;
   };
 }
 

--- a/src/server.ts
+++ b/src/server.ts
@@ -22,6 +22,7 @@ import {
   type ToolRegistrar,
 } from "./mcp.js";
 export { getRegisteredTools } from "./mcp.js";
+import type { CallToolResult } from "@modelcontextprotocol/server";
 import { z } from "zod";
 import type { B2Config, SecretSinkConfig } from "./utils/types.js";
 import { parseIntEnv } from "./utils/config.js";
@@ -414,6 +415,13 @@ export function createServer(
 
   const toolCount = registrar.commit();
   logger.info({ toolCount, version: VERSION, outputFormat }, "server.ready");
+
+  // Discovery mode: reject every tools/call ahead of the SDK's input-schema
+  // validation so required-argument tools also return missing_credentials, while
+  // tools/list keeps the real schemas registered above.
+  if (options.credentialsMissing === true) {
+    installDiscoveryModeToolCallHandler(server, config);
+  }
 
   const originalClose = server.close.bind(server);
   let cleanedUp = false;
@@ -880,6 +888,39 @@ export function createAuditedToolCallback(
 }
 
 /**
+ * Emit the discovery-mode `tool.call` audit event for a rejected attempt.
+ *
+ * @remarks
+ * Shared by the per-tool short circuit and the low-level `tools/call`
+ * interceptor so both paths log the same classified `missing_credentials`
+ * code/status and keep rejected attempts observable.
+ *
+ * @param name - Registered tool name recorded in the audit event.
+ * @param argKeys - Argument key names (never values) recorded in the event.
+ * @param config - Resolved B2 credentials and runtime policy.
+ */
+function logMissingCredentialsAudit(name: unknown, argKeys: string[], config: B2Config): void {
+  logger.info(
+    {
+      tool: name,
+      credential: config.credentialFingerprint ?? fingerprintConfig(config),
+      outputFormat: config.outputFormat ?? DEFAULT_MCP_OUTPUT_FORMAT,
+      argKeys,
+      durationMs: 0,
+      error: true,
+      resultType: "complete",
+      code: MISSING_CREDENTIALS_TOOL_ERROR.code,
+      status: MISSING_CREDENTIALS_TOOL_ERROR.status,
+    },
+    "tool.call",
+  );
+}
+
+function argKeysOf(args: unknown): string[] {
+  return args && typeof args === "object" && !Array.isArray(args) ? Object.keys(args) : [];
+}
+
+/**
  * Build an audit-only tool callback for discovery mode.
  *
  * @remarks
@@ -888,6 +929,9 @@ export function createAuditedToolCallback(
  * circuit returns the `missing_credentials` error without touching the real
  * handler, yet still emits the `tool.call` audit event (with the classified
  * code/status) so rejected attempts stay observable instead of leaving a gap.
+ * It backstops {@link installDiscoveryModeToolCallHandler}: it runs only when a
+ * call already cleared the SDK's schema validation (a no-required-argument tool)
+ * and reached the per-tool callback.
  *
  * @param name - Registered tool name recorded in the audit event.
  * @param config - Resolved B2 credentials and runtime policy.
@@ -900,30 +944,34 @@ export function createAuditedToolCallback(
  * ```
  */
 export function createMissingCredentialsToolCallback(name: string, config: B2Config): ToolCallback {
-  const keyFingerprint = config.credentialFingerprint ?? fingerprintConfig(config);
-  const outputFormat = config.outputFormat ?? DEFAULT_MCP_OUTPUT_FORMAT;
-
   return async function missingCredentialsToolCallback(args: any) {
-    const start = Date.now();
-    const argKeys =
-      args && typeof args === "object" && !Array.isArray(args) ? Object.keys(args) : [];
-    const result = toolError(MISSING_CREDENTIALS_TOOL_ERROR);
-    logger.info(
-      {
-        tool: name,
-        credential: keyFingerprint,
-        outputFormat,
-        argKeys,
-        durationMs: Date.now() - start,
-        error: true,
-        resultType: "complete",
-        code: MISSING_CREDENTIALS_TOOL_ERROR.code,
-        status: MISSING_CREDENTIALS_TOOL_ERROR.status,
-      },
-      "tool.call",
-    );
-    return result;
+    logMissingCredentialsAudit(name, argKeysOf(args), config);
+    return toolError(MISSING_CREDENTIALS_TOOL_ERROR);
   };
+}
+
+/**
+ * Intercept every discovery-mode `tools/call` ahead of input-schema validation.
+ *
+ * @remarks
+ * The MCP SDK validates a tool's registered input schema before it invokes the
+ * tool callback, so the per-callback short circuit alone does not reject calls
+ * that fail schema validation first (for example a required-argument tool such
+ * as `s3_head_bucket` called with `{}`, which would otherwise return a schema
+ * validation error rather than `missing_credentials`). Overriding the low-level
+ * `tools/call` handler after registration rejects *every* call with
+ * `missing_credentials` regardless of arguments while `tools/list` keeps the
+ * real schemas, so registries still enumerate the full, accurate surface.
+ *
+ * @param server - MCP server whose tool-call dispatch is being overridden.
+ * @param config - Resolved B2 credentials and runtime policy for audit logging.
+ */
+function installDiscoveryModeToolCallHandler(server: McpServer, config: B2Config): void {
+  server.server.setRequestHandler("tools/call", async (request) => {
+    const params = (request as { params?: { name?: unknown; arguments?: unknown } }).params;
+    logMissingCredentialsAudit(params?.name, argKeysOf(params?.arguments), config);
+    return toolError(MISSING_CREDENTIALS_TOOL_ERROR) as CallToolResult;
+  });
 }
 
 function destructiveAuditLogFields(

--- a/src/server.ts
+++ b/src/server.ts
@@ -183,7 +183,33 @@ export interface CreateServerOptions {
    * @internal
    */
   failClosedUnknownCapabilities?: boolean;
+  /**
+   * Register the full tool surface for discovery while no B2 credentials are
+   * configured, and answer every tool call with a clear `missing_credentials`
+   * error instead of attempting a doomed provider call.
+   *
+   * @remarks
+   * Set by the stdio bootstrap when it starts without
+   * `B2_APPLICATION_KEY_ID` / `B2_APPLICATION_KEY` so registry/directory
+   * services (mcp.so, Glama, LobeHub) can still enumerate `tools/list` in a
+   * credential-less sandbox. Tool *calls* fail with an actionable message; the
+   * placeholder credentials the bootstrap injects are never used because this
+   * short-circuits before the handler runs.
+   *
+   * @internal
+   */
+  credentialsMissing?: boolean;
 }
+
+/** Tool-call error returned in credential-less stdio discovery mode. */
+const MISSING_CREDENTIALS_TOOL_ERROR = Object.freeze({
+  status: 401,
+  code: "missing_credentials",
+  message:
+    "B2 credentials are not configured. Set B2_APPLICATION_KEY_ID and B2_APPLICATION_KEY " +
+    "(stdio) or send the credential headers (HTTP) before calling B2 tools. The server is " +
+    "running in discovery mode, so tools are listed but cannot execute.",
+});
 
 /**
  * Build the MCP server and register the B2 tool surface.
@@ -288,11 +314,13 @@ export function createServer(
   const registrar = new ToolRegistrationAdapter(server, {
     shouldRegister: shouldRegisterForResolvedAuthz,
     wrapCallback: (name, callback) =>
-      createAuditedToolCallback(name, callback, config, {
-        getClientCapabilities: () => getMcpClientCapabilities(server),
-        getProtocolVersion: () => getMcpNegotiatedProtocolVersion(server),
-        requestStateCodec,
-      }),
+      options.credentialsMissing === true
+        ? async () => toolError(MISSING_CREDENTIALS_TOOL_ERROR)
+        : createAuditedToolCallback(name, callback, config, {
+            getClientCapabilities: () => getMcpClientCapabilities(server),
+            getProtocolVersion: () => getMcpNegotiatedProtocolVersion(server),
+            requestStateCodec,
+          }),
   });
 
   // Initialize clients. The application (workhorse) key drives the B2 native

--- a/tests/protocol/stdio.modern-protocol.test.ts
+++ b/tests/protocol/stdio.modern-protocol.test.ts
@@ -88,17 +88,18 @@ describe("startStdio", () => {
     expect(serveStdio).not.toHaveBeenCalled();
   });
 
-  it("exits the process when required credentials are missing", async () => {
+  it("starts in credential-less discovery mode instead of exiting when credentials are missing", async () => {
     delete process.env.B2_APPLICATION_KEY_ID;
     delete process.env.B2_APPLICATION_KEY;
-    // loadConfig() calls process.exit(1) on missing creds — stub it so the
-    // test doesn't actually exit, and assert it was triggered.
+    // Discovery mode replaces the old exit(1): the server starts and registers
+    // the full surface so directories can enumerate tools without credentials.
     const exit = vi.spyOn(process, "exit").mockImplementation((() => {
       throw new Error("exit");
     }) as never);
 
-    await expect(startStdio()).rejects.toThrow("exit");
-    expect(exit).toHaveBeenCalledWith(1);
+    await expect(startStdio()).resolves.toBeUndefined();
+    expect(exit).not.toHaveBeenCalled();
+    expect(serveStdio).toHaveBeenCalledTimes(1);
     exit.mockRestore();
   });
 });

--- a/tests/protocol/stdio.transport.legacy-protocol.test.ts
+++ b/tests/protocol/stdio.transport.legacy-protocol.test.ts
@@ -98,4 +98,46 @@ describe("stdio transport legacy protocol fallback (2025 era)", () => {
     expect(JSON.stringify(s3Call)).toContain("objects");
     expect(raw.stdoutLines.join("\n")).not.toMatch(/Mcp-Session-Id/i);
   });
+
+  it("rejects every discovery-mode call with missing_credentials before schema validation", async () => {
+    raw = new RawStdioSession();
+    // No credentials: the stdio bootstrap enters discovery mode and registers the
+    // full surface, but every tools/call must short-circuit with missing_credentials.
+    raw.start({}, { omitCredentials: true });
+
+    resultOf(
+      await raw.request("initialize", {
+        protocolVersion: LEGACY_PROTOCOL_VERSION,
+        capabilities: {},
+        clientInfo: { name: "b2-mcp-discovery", version: "1.0.0" },
+      }),
+    );
+    raw.send({ jsonrpc: "2.0", method: "notifications/initialized", params: {} });
+
+    // tools/list keeps the real schemas, so s3_head_bucket still advertises its
+    // required `bucket` argument that would otherwise fail validation first.
+    const listed = resultOf(await raw.request("tools/list"));
+    const headBucket = listed.tools.find(
+      (tool: { name: string }) => tool.name === "s3_head_bucket",
+    );
+    expect(headBucket).toBeDefined();
+    expect(headBucket.inputSchema.required).toContain("bucket");
+
+    // Called with {} a required-argument tool would normally return a schema
+    // validation error; discovery mode must return missing_credentials instead,
+    // proving the interception runs ahead of the SDK's input-schema validation.
+    const headCall = resultOf(
+      await raw.request("tools/call", { name: "s3_head_bucket", arguments: {} }),
+    );
+    expect(headCall.isError).toBe(true);
+    const headText = JSON.stringify(headCall);
+    expect(headText).toContain("missing_credentials");
+    expect(headText).not.toContain("validation");
+
+    const listCall = resultOf(
+      await raw.request("tools/call", { name: "b2_list_buckets", arguments: {} }),
+    );
+    expect(listCall.isError).toBe(true);
+    expect(JSON.stringify(listCall)).toContain("missing_credentials");
+  });
 });

--- a/tests/support/protocol.ts
+++ b/tests/support/protocol.ts
@@ -48,11 +48,18 @@ export class RawStdioSession {
   readonly stderrChunks: string[] = [];
   readonly frames: JSONRPCMessage[] = [];
 
-  start(extraEnv: NodeJS.ProcessEnv = {}): void {
+  start(extraEnv: NodeJS.ProcessEnv = {}, options: { omitCredentials?: boolean } = {}): void {
     requireBuiltEntrypoints();
+    const env = protocolEnv(extraEnv);
+    if (options.omitCredentials) {
+      // Force credential-less startup so the stdio bootstrap enters discovery
+      // mode (the entrypoint injects its own placeholders and B2_REGISTER_ALL_TOOLS).
+      delete env.B2_APPLICATION_KEY_ID;
+      delete env.B2_APPLICATION_KEY;
+    }
     this.child = spawn(process.execPath, [SIMULATOR_ENTRYPOINT, "stdio"], {
       cwd: ROOT,
-      env: protocolEnv(extraEnv),
+      env,
       stdio: ["pipe", "pipe", "pipe"],
     });
     this.child.stdout.on("data", (chunk) => this.captureStdout(chunk.toString()));

--- a/tests/unit/discovery-mode.unit.test.ts
+++ b/tests/unit/discovery-mode.unit.test.ts
@@ -1,9 +1,13 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
-import { createServer } from "../../src/server";
+import { createServer, getRegisteredTools } from "../../src/server";
 import { logger } from "../../src/utils/logger";
 import { callTool, testConfig } from "../support/deterministic-fakes";
 
 afterEach(() => vi.restoreAllMocks());
+
+function schemaKeys(server: ReturnType<typeof createServer>, name: string): string[] {
+  return Object.keys(getRegisteredTools(server)?.[name]?.inputSchema?.shape ?? {});
+}
 
 // createServer(config, null, { credentialsMissing: true }) is the credential-less
 // stdio discovery mode: the full tool surface is registered so directory services
@@ -38,6 +42,45 @@ describe("credential-less discovery mode", () => {
       }),
       "tool.call",
     );
+  });
+
+  it("advertises the full durable-secret schemas, not confirm-only stubs", () => {
+    // testConfig has no secret sink, so outside discovery mode these tools would
+    // register confirm-only compatibility stubs. Discovery mode must decouple
+    // schema advertisement from sink availability so registries learn real inputs.
+    const server = createServer(testConfig, null, { credentialsMissing: true });
+
+    expect(schemaKeys(server, "b2_create_key")).toEqual(
+      expect.arrayContaining(["keyName", "capabilities", "idempotencyKey"]),
+    );
+    expect(schemaKeys(server, "b2_create_group_member")).toEqual(
+      expect.arrayContaining(["adminAccountId", "groupId", "memberEmail"]),
+    );
+    expect(schemaKeys(server, "b2_reserve_trial_create_account")).toEqual(
+      expect.arrayContaining(["email", "term", "storage"]),
+    );
+  });
+
+  it("still refuses the durable-secret tools with missing_credentials", async () => {
+    const server = createServer(testConfig, null, { credentialsMissing: true });
+
+    for (const name of [
+      "b2_create_key",
+      "b2_create_group_member",
+      "b2_reserve_trial_create_account",
+    ]) {
+      const result = await callTool(server, name, {});
+      expect(result.isError).toBe(true);
+      expect(result.content[0].text).toContain("missing_credentials");
+    }
+  });
+
+  it("keeps confirm-only stubs when credentials are present without a sink", () => {
+    // Without the discovery flag and no active sink, the durable-secret tools stay
+    // compatibility stubs (confirm-only), confirming the schemas are decoupled
+    // from sink availability only under discovery mode.
+    const server = createServer(testConfig, null);
+    expect(schemaKeys(server, "b2_create_key")).toEqual(["confirm"]);
   });
 
   it("guards even the bootstrap authorize tool", async () => {

--- a/tests/unit/discovery-mode.unit.test.ts
+++ b/tests/unit/discovery-mode.unit.test.ts
@@ -1,6 +1,9 @@
-import { describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import { createServer } from "../../src/server";
+import { logger } from "../../src/utils/logger";
 import { callTool, testConfig } from "../support/deterministic-fakes";
+
+afterEach(() => vi.restoreAllMocks());
 
 // createServer(config, null, { credentialsMissing: true }) is the credential-less
 // stdio discovery mode: the full tool surface is registered so directory services
@@ -18,6 +21,23 @@ describe("credential-less discovery mode", () => {
       expect(text).toContain("HTTP 401");
       expect(text).toContain("B2_APPLICATION_KEY_ID");
     }
+  });
+
+  it("emits a tool.call audit event for the rejected attempt", async () => {
+    const infoSpy = vi.spyOn(logger, "info").mockImplementation(() => undefined as never);
+    const server = createServer(testConfig, null, { credentialsMissing: true });
+
+    await callTool(server, "b2_list_buckets", {});
+
+    expect(infoSpy).toHaveBeenCalledWith(
+      expect.objectContaining({
+        tool: "b2_list_buckets",
+        error: true,
+        code: "missing_credentials",
+        status: 401,
+      }),
+      "tool.call",
+    );
   });
 
   it("guards even the bootstrap authorize tool", async () => {

--- a/tests/unit/discovery-mode.unit.test.ts
+++ b/tests/unit/discovery-mode.unit.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it } from "vitest";
+import { createServer } from "../../src/server";
+import { callTool, testConfig } from "../support/deterministic-fakes";
+
+// createServer(config, null, { credentialsMissing: true }) is the credential-less
+// stdio discovery mode: the full tool surface is registered so directory services
+// can read tools/list, but every tool call short-circuits with a clear
+// missing_credentials error instead of attempting a doomed provider call.
+describe("credential-less discovery mode", () => {
+  it("registers the full surface but refuses tool calls with missing_credentials", async () => {
+    const server = createServer(testConfig, null, { credentialsMissing: true });
+
+    for (const name of ["b2_list_buckets", "s3_head_bucket", "b2_usage_growth"]) {
+      const result = await callTool(server, name, {});
+      expect(result.isError).toBe(true);
+      const text = result.content[0].text;
+      expect(text).toContain("missing_credentials");
+      expect(text).toContain("HTTP 401");
+      expect(text).toContain("B2_APPLICATION_KEY_ID");
+    }
+  });
+
+  it("guards even the bootstrap authorize tool", async () => {
+    const server = createServer(testConfig, null, { credentialsMissing: true });
+
+    const result = await callTool(server, "b2_authorize_account", {});
+    expect(result.isError).toBe(true);
+    expect(result.content[0].text).toContain("missing_credentials");
+  });
+
+  it("does not guard tool calls when credentials are present", async () => {
+    const server = createServer(testConfig, null);
+    // Without the discovery flag the real handler runs; b2_list_buckets does not
+    // reach the missing_credentials short-circuit (it fails or succeeds through
+    // the normal client path, never returning this discovery-only code).
+    const result = await callTool(server, "b2_list_buckets", {});
+    const text = result?.content?.[0]?.text ?? "";
+    expect(text).not.toContain("missing_credentials");
+  });
+});

--- a/tests/unit/index.unit.test.ts
+++ b/tests/unit/index.unit.test.ts
@@ -204,6 +204,33 @@ describe("stdio entry point", () => {
     });
   });
 
+  it("does not enter discovery mode with a partial credential pair", async () => {
+    // Only the key id is set: a partial/mistyped pair must still fail fast as
+    // invalid instead of overwriting the configured half and starting an unusable
+    // discovery server.
+    process.env.B2_APPLICATION_KEY_ID = "test-key-id";
+    delete process.env.B2_APPLICATION_KEY;
+    const config = testConfig();
+    const server = { close: vi.fn(async () => undefined) };
+    const createServer = vi.spyOn(serverModule, "createServer").mockReturnValue(server as never);
+    vi.spyOn(serverModule, "loadConfig").mockReturnValue(config);
+    vi.spyOn(serverModule, "fetchCapabilities").mockResolvedValue(["listBuckets"]);
+    vi.mocked(stdioTransport.serveStdio).mockImplementation(
+      () =>
+        ({ close: vi.fn(async () => undefined) }) as ReturnType<typeof stdioTransport.serveStdio>,
+    );
+
+    await startStdio();
+
+    // The configured half is left untouched (never overwritten with the
+    // placeholder) and discovery mode is not activated.
+    expect(process.env.B2_APPLICATION_KEY_ID).toBe("test-key-id");
+    expect(process.env.B2_APPLICATION_KEY).toBeUndefined();
+    expect(createServer).not.toHaveBeenCalledWith(config, expect.anything(), {
+      credentialsMissing: true,
+    });
+  });
+
   it("falls back to the full stdio surface when capability lookup is unavailable", async () => {
     const config = testConfig();
     const server = { close: vi.fn(async () => undefined) };

--- a/tests/unit/index.unit.test.ts
+++ b/tests/unit/index.unit.test.ts
@@ -29,7 +29,11 @@ const credentialEnvKeys = [
 ] as const;
 
 const transportEnvKeys = ["B2_MCP_TRANSPORT"] as const;
-const bootstrapEnvKeys = ["B2_STDIO_CAPABILITY_TIMEOUT_MS"] as const;
+const bootstrapEnvKeys = [
+  "B2_STDIO_CAPABILITY_TIMEOUT_MS",
+  "B2_REGISTER_ALL_TOOLS",
+  "B2_SECRET_SINK",
+] as const;
 const executableEnvKeys = [...credentialEnvKeys, ...transportEnvKeys, ...bootstrapEnvKeys] as const;
 const { startStdio } = packageRoot;
 
@@ -102,6 +106,10 @@ describe("stdio entry point", () => {
     savedEnv = Object.fromEntries(
       [...credentialEnvKeys, ...bootstrapEnvKeys].map((key) => [key, process.env[key]]),
     );
+    // Default to the credentialed path; discovery-mode cases delete these.
+    process.env.B2_APPLICATION_KEY_ID = "test-key-id";
+    process.env.B2_APPLICATION_KEY = "test-key-secret";
+    delete process.env.B2_REGISTER_ALL_TOOLS;
   });
 
   afterEach(() => {
@@ -136,6 +144,58 @@ describe("stdio entry point", () => {
     options?.onerror(new Error("stdio failed"));
     expect(createServer).toHaveBeenCalledWith(config, ["listBuckets"]);
     expect(warn).toHaveBeenCalledWith({ err: "stdio failed" }, "mcp.stdio.error");
+  });
+
+  it("enters credential-less discovery mode and enumerates the full surface", async () => {
+    delete process.env.B2_APPLICATION_KEY_ID;
+    delete process.env.B2_APPLICATION_KEY;
+    const config = testConfig();
+    const server = { close: vi.fn(async () => undefined) };
+    const createServer = vi.spyOn(serverModule, "createServer").mockReturnValue(server as never);
+    vi.spyOn(serverModule, "loadConfig").mockReturnValue(config);
+    // B2_REGISTER_ALL_TOOLS=true makes the real fetchCapabilities resolve null;
+    // the mock stands in for that full-surface result.
+    const fetchCapabilities = vi.spyOn(serverModule, "fetchCapabilities").mockResolvedValue(null);
+    const serveStdio = vi.mocked(stdioTransport.serveStdio).mockImplementation(
+      () => ({ close: vi.fn(async () => undefined) }) as ReturnType<typeof stdioTransport.serveStdio>,
+    );
+    const warn = vi.spyOn(loggerModule.logger, "warn").mockImplementation(() => undefined);
+
+    await startStdio();
+    (serveStdio.mock.calls[0]?.[0] as (() => unknown) | undefined)?.();
+
+    expect(process.env.B2_APPLICATION_KEY_ID).toBe("b2-mcp-discovery-mode");
+    expect(process.env.B2_APPLICATION_KEY).toBe("b2-mcp-discovery-mode");
+    expect(process.env.B2_REGISTER_ALL_TOOLS).toBe("true");
+    expect(process.env.B2_SECRET_SINK).toBe("off");
+    expect(fetchCapabilities).toHaveBeenCalled();
+    expect(createServer).toHaveBeenCalledWith(config, null, { credentialsMissing: true });
+    expect(warn).toHaveBeenCalledWith(
+      { transport: "stdio", reason: "no_credentials" },
+      "server.stdio_discovery_mode",
+    );
+  });
+
+  it("does not enter discovery mode when credentials are present", async () => {
+    process.env.B2_APPLICATION_KEY_ID = "test-key-id";
+    process.env.B2_APPLICATION_KEY = "test-key-secret";
+    const config = testConfig();
+    const server = { close: vi.fn(async () => undefined) };
+    const createServer = vi.spyOn(serverModule, "createServer").mockReturnValue(server as never);
+    vi.spyOn(serverModule, "loadConfig").mockReturnValue(config);
+    vi.spyOn(serverModule, "fetchCapabilities").mockResolvedValue(["listBuckets"]);
+    const serveStdio = vi.mocked(stdioTransport.serveStdio).mockImplementation(
+      () => ({ close: vi.fn(async () => undefined) }) as ReturnType<typeof stdioTransport.serveStdio>,
+    );
+
+    await startStdio();
+    (serveStdio.mock.calls[0]?.[0] as (() => unknown) | undefined)?.();
+
+    expect(process.env.B2_APPLICATION_KEY_ID).toBe("test-key-id");
+    expect(createServer).toHaveBeenCalledWith(config, ["listBuckets"]);
+    expect(createServer).not.toHaveBeenCalledWith(config, expect.anything(), {
+      credentialsMissing: true,
+    });
   });
 
   it("falls back to the full stdio surface when capability lookup is unavailable", async () => {
@@ -234,17 +294,23 @@ describe("stdio entry point", () => {
     expect(stdioTransport.serveStdio).not.toHaveBeenCalled();
   });
 
-  it("writes the missing-credential message and exits non-zero", async () => {
+  it("starts in discovery mode instead of exiting when credentials are missing", async () => {
     for (const key of credentialEnvKeys) delete process.env[key];
-    const stderr = vi.spyOn(process.stderr, "write").mockImplementation(() => true);
-    vi.spyOn(process, "exit").mockImplementation(((code) => {
+    const exit = vi.spyOn(process, "exit").mockImplementation(((code) => {
       throw Object.assign(new Error(`process.exit(${code})`), { exitCode: code });
     }) as typeof process.exit);
-
-    await expect(startStdio()).rejects.toMatchObject({ exitCode: 1 });
-    expect(stderr).toHaveBeenCalledWith(
-      "b2-mcp: B2_APPLICATION_KEY_ID and B2_APPLICATION_KEY are required for stdio\n",
+    const config = testConfig();
+    vi.spyOn(serverModule, "createServer").mockReturnValue({
+      close: vi.fn(async () => undefined),
+    } as never);
+    vi.spyOn(serverModule, "loadConfig").mockReturnValue(config);
+    vi.spyOn(serverModule, "fetchCapabilities").mockResolvedValue(null);
+    vi.mocked(stdioTransport.serveStdio).mockImplementation(
+      () => ({ close: vi.fn(async () => undefined) }) as ReturnType<typeof stdioTransport.serveStdio>,
     );
+
+    await expect(startStdio()).resolves.toBeUndefined();
+    expect(exit).not.toHaveBeenCalled();
   });
 });
 
@@ -376,12 +442,24 @@ describe("executable CLI entry point", () => {
     expect(result.stderr).toContain("Usage: b2-mcp");
   });
 
-  it("selects stdio by default and reports missing credentials with exit code 1", () => {
-    const result = runEntrypoint([]);
+  it("starts the stdio server in discovery mode when credentials are missing", () => {
+    // Empty stdin makes the MCP stdio transport close promptly on EOF instead of
+    // blocking; the discovery warning is flushed synchronously at startup.
+    const result = spawnSync(tsxBin, ["src/index.ts"], {
+      cwd: process.cwd(),
+      encoding: "utf8",
+      env: executableEnv({}),
+      input: "",
+      timeout: 10_000,
+    });
 
-    expect(result.status).toBe(1);
-    expect(result.stderr).toContain(
-      "b2-mcp: B2_APPLICATION_KEY_ID and B2_APPLICATION_KEY are required for stdio",
+    // No longer exits with the missing-credential fatal (previously status 1);
+    // the server starts in discovery mode and closes on stdin EOF instead. The
+    // discovery warning itself is asserted in the mocked stdio-entry test above.
+    expect(result.status).not.toBe(1);
+    const output = `${result.stdout}${result.stderr}`;
+    expect(output).not.toContain(
+      "B2_APPLICATION_KEY_ID and B2_APPLICATION_KEY are required for stdio",
     );
   });
 

--- a/tests/unit/index.unit.test.ts
+++ b/tests/unit/index.unit.test.ts
@@ -156,9 +156,12 @@ describe("stdio entry point", () => {
     // B2_REGISTER_ALL_TOOLS=true makes the real fetchCapabilities resolve null;
     // the mock stands in for that full-surface result.
     const fetchCapabilities = vi.spyOn(serverModule, "fetchCapabilities").mockResolvedValue(null);
-    const serveStdio = vi.mocked(stdioTransport.serveStdio).mockImplementation(
-      () => ({ close: vi.fn(async () => undefined) }) as ReturnType<typeof stdioTransport.serveStdio>,
-    );
+    const serveStdio = vi
+      .mocked(stdioTransport.serveStdio)
+      .mockImplementation(
+        () =>
+          ({ close: vi.fn(async () => undefined) }) as ReturnType<typeof stdioTransport.serveStdio>,
+      );
     const warn = vi.spyOn(loggerModule.logger, "warn").mockImplementation(() => undefined);
 
     await startStdio();
@@ -184,9 +187,12 @@ describe("stdio entry point", () => {
     const createServer = vi.spyOn(serverModule, "createServer").mockReturnValue(server as never);
     vi.spyOn(serverModule, "loadConfig").mockReturnValue(config);
     vi.spyOn(serverModule, "fetchCapabilities").mockResolvedValue(["listBuckets"]);
-    const serveStdio = vi.mocked(stdioTransport.serveStdio).mockImplementation(
-      () => ({ close: vi.fn(async () => undefined) }) as ReturnType<typeof stdioTransport.serveStdio>,
-    );
+    const serveStdio = vi
+      .mocked(stdioTransport.serveStdio)
+      .mockImplementation(
+        () =>
+          ({ close: vi.fn(async () => undefined) }) as ReturnType<typeof stdioTransport.serveStdio>,
+      );
 
     await startStdio();
     (serveStdio.mock.calls[0]?.[0] as (() => unknown) | undefined)?.();
@@ -306,7 +312,8 @@ describe("stdio entry point", () => {
     vi.spyOn(serverModule, "loadConfig").mockReturnValue(config);
     vi.spyOn(serverModule, "fetchCapabilities").mockResolvedValue(null);
     vi.mocked(stdioTransport.serveStdio).mockImplementation(
-      () => ({ close: vi.fn(async () => undefined) }) as ReturnType<typeof stdioTransport.serveStdio>,
+      () =>
+        ({ close: vi.fn(async () => undefined) }) as ReturnType<typeof stdioTransport.serveStdio>,
     );
 
     await expect(startStdio()).resolves.toBeUndefined();
@@ -454,9 +461,13 @@ describe("executable CLI entry point", () => {
     });
 
     // No longer exits with the missing-credential fatal (previously status 1);
-    // the server starts in discovery mode and closes on stdin EOF instead. The
-    // discovery warning itself is asserted in the mocked stdio-entry test above.
-    expect(result.status).not.toBe(1);
+    // the server starts in discovery mode and closes cleanly on stdin EOF. Assert
+    // an exact clean exit so a timeout (status null + error set) or any alternate
+    // startup crash cannot pass. The discovery warning itself is asserted in the
+    // mocked stdio-entry test above.
+    expect(result.error).toBeUndefined();
+    expect(result.signal).toBeNull();
+    expect(result.status).toBe(0);
     const output = `${result.stdout}${result.stderr}`;
     expect(output).not.toContain(
       "B2_APPLICATION_KEY_ID and B2_APPLICATION_KEY are required for stdio",


### PR DESCRIPTION
Closes #356.

## Problem
Registry/directory services (mcp.so, Glama build tests, LobeHub `plugin init`) launch the **stdio** server with no B2 credentials just to read `tools/list`. Today `loadConfig()` throws `missing_credentials` and the process exits:

```
MCP error -32000: Connection closed ({"err":"Credential or capability resolution failed","msg":"server.fatal"})
```

so directories show "No tools detected". The only workaround (placeholder creds + `B2_REGISTER_ALL_TOOLS=true`) can't be set by a live-fetch sandbox.

## Fix — auto discovery mode (stdio only)
When the stdio bootstrap starts with **both** `B2_APPLICATION_KEY_ID` and `B2_APPLICATION_KEY` absent:
- It **no longer exits.** It injects placeholder credentials, registers the **full 40-tool surface** (`B2_REGISTER_ALL_TOOLS`), and forces the secret sink **off unconditionally** (an explicit `file`/`inline` value can no longer preflight the sink or emit a durable-secret warning).
- Logs a clear `server.stdio_discovery_mode` warning.
- `createServer` is told `credentialsMissing: true` and **short-circuits every tool call** with an actionable `missing_credentials` (HTTP 401) error naming the env vars. The placeholder credentials are never used.

A **partial or mistyped pair** (exactly one variable set) is left untouched, so it still fails fast as invalid rather than overwriting the configured half and starting an unusable server.

The **HTTP transport is unchanged** — it already boots without credentials and resolves them per request.

### Rejection happens before schema validation
The MCP SDK validates a tool's registered input schema before invoking its callback, so a per-callback short circuit alone would let a required-argument tool (e.g. `s3_head_bucket` called with `{}`) return a schema-validation error instead of `missing_credentials`. Discovery mode therefore also overrides the low-level `tools/call` handler after registration, so **every** call is rejected with `missing_credentials` regardless of arguments, while `tools/list` keeps the real schemas so registries still enumerate the full, accurate surface. A per-tool audit-only callback backstops the validation-clearing path.

### Full schemas even for durable-secret tools
Durable-secret-producing tools (`b2_create_key`, `b2_create_group_member`, `b2_reserve_trial_create_account`) normally register their full input schema only when an out-of-band secret sink is active. Since discovery forces the sink off, schema advertisement is **decoupled from sink availability** (`registerDurableSecretSchemas`): discovery registers the real schemas (so registries learn required inputs like `keyName`, `capabilities`, `memberEmail`, `email`) instead of `confirm`-only compatibility stubs, and the stubs are skipped for those already-registered names. Execution is still rejected by the discovery guard, so the real handlers never run.

### Observability
Rejected discovery-mode calls still emit a `tool.call` audit event carrying the classified `missing_credentials` code / 401 status, so the attempts remain visible instead of leaving a gap.

### Behavior change
Previously, a human who forgot their keys saw an immediate `exit(1)` with a stderr message. Now they see the server start, a discovery warning, and a clear per-call error — the signal the user asked for. This is intentional (the exit-on-missing-creds tests were reworked to assert discovery).

## Verification
- `tests/unit/discovery-mode.unit.test.ts`: full surface registers; `b2_list_buckets` / `s3_head_bucket` / `b2_usage_growth` / `b2_authorize_account` all return `missing_credentials`; a rejected call emits the `tool.call` audit event; durable-secret tools advertise their real schemas (not confirm-only stubs) yet still refuse; credentialed path is unaffected.
- `tests/unit/index.unit.test.ts`: discovery mode entered only when both creds absent (a partial pair does not enter discovery and is not overwritten); env placeholders + warning asserted; binary no longer exits(1) on missing creds and now exits cleanly (status 0) on stdin EOF.
- `tests/protocol/stdio.transport.legacy-protocol.test.ts`: raw stdio protocol path lists `s3_head_bucket` with its required `bucket` arg, then calls it with `{}` and asserts `missing_credentials` rather than a validation error.
- `tests/protocol/stdio.modern-protocol.test.ts`: reworked to assert discovery start instead of exit.
- End-to-end: `node dist/index.js` with no B2 env now reports `server.ready { toolCount: 40 }` (was `server.fatal`).
- Full unit, contract, and protocol suites pass; typecheck / lint / format / spell / links / docs clean. Bumped the Cloudflare Worker source-graph byte budget for the added src bytes.

## Review & CI follow-ups
- **Review hardening:** secret sink forced off unconditionally; missing-credential rejection routed through an audit-only path so `tool.call` stays observable; low-level `tools/call` interception added so rejection precedes schema validation, covered by a raw stdio protocol test; discovery scoped to fully credential-less startup so a partial pair still fails fast; durable-secret schema advertisement decoupled from sink availability so `tools/list` exposes real inputs.
- **CI:** restored strict TypeDoc (moved the detached `startStdio` doc back onto the function; removed a link to a non-exported symbol); updated the packed-consumer smoke to assert credential-less discovery startup (exit 0 + discovery warning) instead of the old `exit(1)`; raised the Vercel function-bundle byte budget for the added discovery-mode source.

Part of the v0.2.1 discoverability work (#297).
