### PR TITLE
feat: expose read-only B2 resources

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -107,6 +107,35 @@ Each register function receives the server + client(s) and calls `server.tool(na
 
 **Capability-aware registration.** When `createServer` is given a `capabilities` array (the entry points fetch it via `fetchCapabilities`), it wraps `server.tool` so only tools the key can use are registered — the surface auto-right-sizes to the credential (a read-only key drops every write/delete/admin tool; full ~9,719 tokens → read-only ~2,867). The map is `src/utils/tool-capabilities.ts` (any-of semantics; unmapped tools always register; Partner tools register only with a distinct master key). When `capabilities` is `null`/omitted — all unit tests, or `B2_REGISTER_ALL_TOOLS=true` — the full surface registers, so there's no behavior change. The key decides what's _possible_; the destructive gate decides what's _permitted_.
 
+### Resource registration flow
+
+`src/resources.ts` registers the read-only MCP resource surface after tools are
+committed, so `b2://capabilities` can report the active tool profile. Resources
+are JSON only:
+
+- `b2://server-config` - non-secret process configuration: transport,
+  credential mode, destructive policy, secret-sink mode, public URL, and server
+  version. It is intentionally not B2-capability-gated because it contains no
+  account identifiers or credential values and supports credential-less stdio
+  discovery.
+- `b2://capabilities` - the current credential capability set plus active tool
+  profile; omitted in credential-less discovery mode and reduced by OAuth scope
+  policy when OAuth is active.
+- `b2://bucket/{bucketName}` - capability/OAuth-gated on the same central
+  `isToolEnabled` / `isToolAllowedByOAuthScopes` policy as `b2_list_buckets`.
+  `resources/list` advertises at most the first 100 concrete bucket resources
+  because B2 has no bucket-list pagination; `resources/read` can still target a
+  known bucket name directly. Bucket reads include type/visibility, lifecycle,
+  Object Lock, retention, encryption, CORS, replication, and notification rules
+  when the caller is also allowed to use `b2_get_bucket_notification_rules`.
+
+Bucket notification rules use the same redaction helper as the bucket tools.
+Webhook URL host/path/query, HMAC signing secrets, and custom-header values are
+redacted before reaching the MCP response, and successful resource payloads pass
+through the central MCP-output sanitizer. Bucket resource reads are not given a
+client cache hint because visibility and notification targets are
+security-relevant after writes.
+
 ### Three backing categories, two client types
 
 The public tool surface is described by backing category, with availability

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   and per-release steps (Glama, Smithery, LobeHub, mcp.so). (#300)
 - README "official server" note and an `Official …` MCP Registry manifest
   description to distinguish `backblaze-labs/b2-mcp` from community forks. (#301)
+- Read-only MCP resources for non-secret server config, credential
+  capability/tool profile, and a capability-gated `b2://bucket/{bucketName}`
+  template with notification webhook secrets redacted. The server now advertises
+  the MCP `resources` capability. (#165)
 
 ### Changed
 - The stdio server no longer exits when started without B2 credentials. It now

--- a/README.md
+++ b/README.md
@@ -41,6 +41,14 @@ configured.
 
 Destructive actions are gated, durable B2 secrets stay out of the model's context in the default/file/off modes, and the unsafe `B2_SECRET_SINK=inline` escape hatch is explicit. The tool surface is deliberately lean (registration is capability-aware, so a key only ever sees tools it can use).
 
+The server also exposes read-only MCP resources for cacheable control-plane
+context: `b2://server-config`, `b2://capabilities`, and the
+`b2://bucket/{bucketName}` template. Resource visibility follows the same
+capability-aware and OAuth-scope policy as the corresponding tools. Bucket
+resource reads redact notification webhook hosts, paths, HMAC secrets, and
+custom-header values; `resources/list` caps advertised bucket resources at 100,
+while `resources/read` can target a known permitted bucket name directly.
+
 ---
 
 ## Quick start
@@ -388,6 +396,27 @@ with mixed `B2_MCP_OUTPUT_FORMAT` values can return either text shape.
 
 ---
 
+## Resources
+
+Read-only MCP resources expose stable control-plane state without requiring a
+tool call:
+
+- `b2://server-config` - non-secret server configuration, including transport,
+  credential mode, destructive policy, secret-sink mode, public URL, and version.
+- `b2://capabilities` - the current credential's B2 capability set and active
+  MCP tool profile.
+- `b2://bucket/{bucketName}` - bucket type/visibility, lifecycle rules, Object
+  Lock, default retention, encryption, CORS, replication, and notification
+  rules when the caller can read them. Notification webhook secrets are redacted.
+
+Bucket resource reads intentionally omit a client cache hint because visibility
+and notification targets are security-relevant after writes. Bucket
+`resources/list` is capped at 100 concrete bucket resources; use the template
+URI directly when you already know an authorized bucket name outside that
+advertised list.
+
+---
+
 ## Tools
 
 The server exposes **40 tools** (registration is capability-aware, so a given key sees only the subset it can use).
@@ -533,7 +562,7 @@ Scope follows the caller's key — a partner key sees its sub-accounts; a custom
 
 ## Security & self-hosting
 
-Built-in safeguards (on by default): destructive-action gating (`B2_DESTRUCTIVE_POLICY`), MCP form elicitation for destructive tools on clients that advertise it for the 2026 protocol, sink-backed durable-secret creation for local stdio with hosted HTTP fail-closed defaults, central recursive response sanitization, explicit credential-provider modes, capability-aware tool registration that fails closed, rate limiting, and a values-redacted audit log (non-secret credential fingerprints only — never secrets, values, or file contents). The server never phones home.
+Built-in safeguards (on by default): destructive-action gating (`B2_DESTRUCTIVE_POLICY`), MCP form elicitation for destructive tools on clients that advertise it for the 2026 protocol, sink-backed durable-secret creation for local stdio with hosted HTTP fail-closed defaults, central recursive response sanitization, explicit credential-provider modes, capability-aware tool and resource registration that fails closed, rate limiting, and a values-redacted audit log (non-secret credential fingerprints only — never secrets, values, or file contents). The server never phones home.
 
 Destructive actions have two layers. `B2_DESTRUCTIVE_POLICY=block` is the hard refusal and remains the required wall for internet-facing or untrusted-client HTTP deployments. Under `confirm`, capable 2026 MCP clients are asked for form elicitation first; clients without compatible elicitation, or servers with `B2_DESTRUCTIVE_ELICITATION=off`, fall back to the existing `confirm: true` retry. `elicit` is the stricter middle ground between `confirm` and `block`: it requires an accepted MCP form-elicitation response from a form-capable client and refuses (rather than falling back to a model `confirm: true`) whenever no such response can be obtained, for deployments that want human-in-the-loop friction on every destructive action without giving up the operation entirely. Because the response is relayed by the client, this is friction, not an independent authorization boundary. Under `allow`, both the confirm gate and elicitation are skipped for trusted single-user sessions. Elicitation responses are relayed by the MCP client, so they are useful human-in-the-loop friction but not an independent security boundary against a malicious or compromised internet-facing client.
 

--- a/docs/DEPLOY.md
+++ b/docs/DEPLOY.md
@@ -84,6 +84,12 @@ or pull request code. Record deployed commit, artifact digest, Node version,
 MCP revision, platform region/runtime, tool-contract hash, and result. A failed
 provider smoke downgrades that recipe's support claim until repaired.
 
+Rolling deploy note: MCP resources are an additive advertised capability.
+During a mixed-version stateless HTTP rollout, a client that initialized against
+a new replica can briefly send `resources/list` or `resources/read` to an old
+replica and receive method-not-found. Treat that as expected, bounded rollout
+skew; it self-heals once all replicas run the same version.
+
 The supported container operator runbook is
 [`deploy/customer-hosted/README.md`](../deploy/customer-hosted/README.md).
 Treat that README as the canonical source for build/run steps, secret injection,

--- a/scripts/check-vercel-bundle.mjs
+++ b/scripts/check-vercel-bundle.mjs
@@ -21,10 +21,10 @@ const VERCEL_SOURCE_BUDGET_BYTES = 1_500_000;
 // The estimate is all source bytes + the full clean-consumer production install
 // (see below), which grew with the reviewed aws-sdk 3.1119.0 and b2-sdk 0.4.0
 // bumps and the stdio discovery-mode source. The whole function estimate lands
-// near 33.32 MB on Linux — of which the dependency install itself is ~32.11 MB
+// near 33.44 MB on Linux — of which the dependency install itself is ~32.11 MB
 // (reports/package-budget/metrics.json), not b2-sdk alone — so the budget
 // carries modest headroom above the full estimate.
-const VERCEL_FUNCTION_BUNDLE_BUDGET_BYTES = 33_400_000;
+const VERCEL_FUNCTION_BUNDLE_BUDGET_BYTES = 33_450_000;
 
 function readJson(relativePath) {
   return JSON.parse(readFileSync(path.join(root, relativePath), "utf8"));

--- a/scripts/lib/local-import-graph.cjs
+++ b/scripts/lib/local-import-graph.cjs
@@ -4,7 +4,7 @@ const { dirname, extname, resolve } = require("path");
 const WORKER_SOURCE_GRAPH_FILES_BUDGET = 75;
 // Headroom for the documented Worker source graph and dry-run output; emitted
 // budgets still guard the deployed artifact size explicitly.
-const WORKER_SOURCE_GRAPH_BYTES_BUDGET = 850_000;
+const WORKER_SOURCE_GRAPH_BYTES_BUDGET = 865_000;
 const WORKER_EMITTED_FILES_BUDGET = 8;
 const WORKER_EMITTED_TOTAL_BYTES_BUDGET = 9_605_000;
 const WORKER_UPLOAD_SCRIPT_BYTES_BUDGET = 3_000_000;

--- a/scripts/lib/local-import-graph.cjs
+++ b/scripts/lib/local-import-graph.cjs
@@ -4,7 +4,7 @@ const { dirname, extname, resolve } = require("path");
 const WORKER_SOURCE_GRAPH_FILES_BUDGET = 75;
 // Headroom for the documented Worker source graph and dry-run output; emitted
 // budgets still guard the deployed artifact size explicitly.
-const WORKER_SOURCE_GRAPH_BYTES_BUDGET = 866_000;
+const WORKER_SOURCE_GRAPH_BYTES_BUDGET = 870_000;
 const WORKER_EMITTED_FILES_BUDGET = 8;
 const WORKER_EMITTED_TOTAL_BYTES_BUDGET = 9_605_000;
 const WORKER_UPLOAD_SCRIPT_BYTES_BUDGET = 3_000_000;

--- a/scripts/lib/local-import-graph.cjs
+++ b/scripts/lib/local-import-graph.cjs
@@ -4,7 +4,7 @@ const { dirname, extname, resolve } = require("path");
 const WORKER_SOURCE_GRAPH_FILES_BUDGET = 75;
 // Headroom for the documented Worker source graph and dry-run output; emitted
 // budgets still guard the deployed artifact size explicitly.
-const WORKER_SOURCE_GRAPH_BYTES_BUDGET = 865_000;
+const WORKER_SOURCE_GRAPH_BYTES_BUDGET = 866_000;
 const WORKER_EMITTED_FILES_BUDGET = 8;
 const WORKER_EMITTED_TOTAL_BYTES_BUDGET = 9_605_000;
 const WORKER_UPLOAD_SCRIPT_BYTES_BUDGET = 3_000_000;

--- a/src/b2/buckets.ts
+++ b/src/b2/buckets.ts
@@ -21,37 +21,65 @@ import { badRequest, badRequestError, toolJson, toolError } from "../utils/error
 import { checkDestructive } from "../utils/destructive-gate.js";
 import { isTestRuntime } from "../utils/runtime.js";
 
+type NotificationCustomHeaders = EventNotificationRuleInput["targetConfiguration"]["customHeaders"];
+
 /**
  * Redact webhook secrets from a notification-rules API response before it reaches
- * the model — B2 echoes back hmacSha256SigningSecret and custom-header values on
+ * the model. B2 echoes back hmacSha256SigningSecret and custom-header values on
  * get/set, and a prompt-injected model should not be able to read them.
  */
 function redactWebhookUrl(raw: string | undefined): string | undefined {
   if (raw === undefined) return undefined;
   try {
     const u = new URL(raw);
-    return `${u.protocol}//${u.host}/[redacted]`;
+    return `${u.protocol}//[redacted]/[redacted]`;
   } catch {
     return "[redacted]";
   }
 }
 
-function redactNotificationSecrets(result: NotificationRulesResult): NotificationRulesResult {
-  for (const rule of result.eventNotificationRules) {
-    const tc = rule.targetConfiguration;
-    tc.url = redactWebhookUrl(tc.url) ?? tc.url;
-    if (tc.hmacSha256SigningSecret) tc.hmacSha256SigningSecret = "[redacted]";
-    if (Array.isArray(tc.customHeaders)) {
-      tc.customHeaders = tc.customHeaders.map((h) =>
-        h && typeof h === "object" ? { ...h, value: "[redacted]" } : h,
-      );
-    } else if (tc.customHeaders && typeof tc.customHeaders === "object") {
-      tc.customHeaders = Object.fromEntries(
-        Object.keys(tc.customHeaders).map((k) => [k, "[redacted]"]),
-      );
-    }
+function redactCustomHeaders(customHeaders: NotificationCustomHeaders): NotificationCustomHeaders {
+  if (Array.isArray(customHeaders)) {
+    return customHeaders.map((header) => ({ ...header, value: "[redacted]" }));
   }
-  return result;
+  if (customHeaders && typeof customHeaders === "object") {
+    return Object.fromEntries(Object.keys(customHeaders).map((name) => [name, "[redacted]"]));
+  }
+  return customHeaders;
+}
+
+/**
+ * Redact notification-rule response secrets while preserving the normalized shape.
+ *
+ * @param result - Notification-rule response to redact.
+ *
+ * @returns Redacted notification-rule response.
+ *
+ * @internal
+ */
+export function redactNotificationSecrets(
+  result: NotificationRulesResult,
+): NotificationRulesResult {
+  return {
+    ...(result.bucketId !== undefined ? { bucketId: result.bucketId } : {}),
+    eventNotificationRules: result.eventNotificationRules.map((rule) => {
+      const tc = rule.targetConfiguration;
+      return {
+        ...rule,
+        eventTypes: [...rule.eventTypes],
+        targetConfiguration: {
+          ...tc,
+          ...(tc.url !== undefined ? { url: redactWebhookUrl(tc.url) } : {}),
+          ...(tc.hmacSha256SigningSecret !== undefined
+            ? { hmacSha256SigningSecret: "[redacted]" }
+            : {}),
+          ...(tc.customHeaders !== undefined
+            ? { customHeaders: redactCustomHeaders(tc.customHeaders) }
+            : {}),
+        },
+      };
+    }),
+  };
 }
 
 const NON_GLOBAL_IPV4_CIDRS: Array<[string, number]> = [

--- a/src/resources.ts
+++ b/src/resources.ts
@@ -6,6 +6,7 @@
 
 import {
   ProtocolError,
+  ProtocolErrorCode,
   ResourceNotFoundError,
   ResourceTemplate,
   type ListResourcesResult,
@@ -210,6 +211,39 @@ function isRequestAborted(err: unknown): boolean {
   return parseB2Error(err).code === "request_aborted";
 }
 
+/**
+ * Classify a JSON-RPC {@link ProtocolError} for the resource audit log.
+ *
+ * @remarks
+ * Protocol errors cross the wire with a numeric JSON-RPC code, so routing them
+ * through {@link parseB2Error} (which only understands provider/HTTP shapes)
+ * collapses them to `internal_error`/500. That would record routine outcomes —
+ * a missing-bucket `resources/read`, which surfaces as {@link
+ * ResourceNotFoundError} (`-32602` with `data.uri`) — as server failures and
+ * skew resource error-rate alerting. Classify them here instead.
+ */
+function protocolErrorAuditFields(err: ProtocolError): { code: string; status: number } {
+  // A resources/read miss is a routine not-found, not a bad request; classify
+  // it distinctly even though its wire code is Invalid Params (`-32602`).
+  if (err instanceof ResourceNotFoundError) return { code: "resource_not_found", status: 404 };
+  switch (err.code) {
+    case ProtocolErrorCode.ParseError:
+      return { code: "parse_error", status: 400 };
+    case ProtocolErrorCode.InvalidRequest:
+      return { code: "invalid_request", status: 400 };
+    case ProtocolErrorCode.MethodNotFound:
+      return { code: "method_not_found", status: 404 };
+    case ProtocolErrorCode.InvalidParams:
+      return { code: "invalid_params", status: 400 };
+    case ProtocolErrorCode.ResourceNotFound:
+      return { code: "resource_not_found", status: 404 };
+    case ProtocolErrorCode.InternalError:
+      return { code: "internal_error", status: 500 };
+    default:
+      return { code: "protocol_error", status: 400 };
+  }
+}
+
 async function withResourceGuards<T>(
   config: B2Config,
   ctx: ServerContext,
@@ -247,7 +281,9 @@ async function withResourceGuards<T>(
         credential: credentialFingerprint(config),
         durationMs: Date.now() - start,
         error: true,
-        ...providerErrorFields(err, sanitizerOptions),
+        ...(err instanceof ProtocolError
+          ? protocolErrorAuditFields(err)
+          : providerErrorFields(err, sanitizerOptions)),
         err: safeErr.message,
       },
       "resource.error",

--- a/src/resources.ts
+++ b/src/resources.ts
@@ -5,6 +5,7 @@
  */
 
 import {
+  ProtocolError,
   ResourceNotFoundError,
   ResourceTemplate,
   type ListResourcesResult,
@@ -233,6 +234,7 @@ async function withResourceGuards<T>(
       },
       "resource.error",
     );
+    if (err instanceof ProtocolError) throw err;
     throw safeErr;
   }
 }

--- a/src/resources.ts
+++ b/src/resources.ts
@@ -184,6 +184,29 @@ function credentialFingerprint(config: B2Config): string {
   return config.credentialFingerprint ?? fingerprintConfig(config);
 }
 
+/**
+ * Build sanitizer options that also redact the config's B2 key IDs.
+ *
+ * @remarks
+ * Header/principal credential IDs never reach `process.env`, and
+ * {@link sanitizerOptionsFromConfig} contributes only key secrets. Without the
+ * key IDs a request-controlled URI such as `b2://bucket/<applicationKeyId>`
+ * would write the credential handle verbatim into the resource audit log, so
+ * fold the configured key IDs into the redaction set alongside key secrets.
+ *
+ * @param config - Resolved runtime configuration.
+ *
+ * @returns Sanitizer options redacting configured key secrets and key IDs.
+ */
+function resourceSanitizerOptions(config: B2Config): SanitizerOptions {
+  const base = sanitizerOptionsFromConfig(config);
+  const keyIds = [config.applicationKeyId, config.appKeyId, config.masterKeyId].filter(
+    (id): id is string => typeof id === "string" && id.length >= 8,
+  );
+  if (keyIds.length === 0) return base;
+  return { ...base, secrets: [...(base.secrets ?? []), ...keyIds] };
+}
+
 function providerErrorFields(
   err: unknown,
   sanitizerOptions: SanitizerOptions,
@@ -256,7 +279,7 @@ async function withResourceGuards<T>(
 ): Promise<T> {
   const start = Date.now();
   const signal = (ctx as { mcpReq?: { signal?: AbortSignal } } | undefined)?.mcpReq?.signal;
-  const sanitizerOptions = sanitizerOptionsFromConfig(config);
+  const sanitizerOptions = resourceSanitizerOptions(config);
   const safeUri = sanitizeText(audit.uri, sanitizerOptions);
   try {
     const result = await runWithMcpRequestSignal(signal ?? currentMcpRequestSignal(), () =>
@@ -418,7 +441,7 @@ async function bucketEventNotifications(
   }
 
   const start = Date.now();
-  const sanitizerOptions = sanitizerOptionsFromConfig(options.config);
+  const sanitizerOptions = resourceSanitizerOptions(options.config);
   const safeUri = sanitizeText(uri, sanitizerOptions);
   try {
     const value = redactNotificationSecrets(

--- a/src/resources.ts
+++ b/src/resources.ts
@@ -221,6 +221,10 @@ function isRequestAborted(err: unknown): boolean {
  * a missing-bucket `resources/read`, which surfaces as {@link
  * ResourceNotFoundError} (`-32602` with `data.uri`) — as server failures and
  * skew resource error-rate alerting. Classify them here instead.
+ *
+ * @param err - JSON-RPC protocol error raised while serving a resource.
+ *
+ * @returns Stable audit `code` and HTTP-equivalent `status` for the error.
  */
 export function protocolErrorAuditFields(err: ProtocolError): { code: string; status: number } {
   // A resources/read miss is a routine not-found, not a bad request; classify

--- a/src/resources.ts
+++ b/src/resources.ts
@@ -193,6 +193,20 @@ function providerErrorFields(
   };
 }
 
+function sanitizeProtocolErrorForRethrow(
+  err: ProtocolError,
+  sanitizerOptions: SanitizerOptions,
+): ProtocolError {
+  const safeErr = sanitizeError(err, sanitizerOptions);
+  const safeData =
+    err.data === undefined ? undefined : sanitizeForMcpOutput(err.data, sanitizerOptions);
+  return ProtocolError.fromError(err.code, safeErr.message, safeData);
+}
+
+function isRequestAborted(err: unknown): boolean {
+  return parseB2Error(err).code === "request_aborted";
+}
+
 async function withResourceGuards<T>(
   config: B2Config,
   ctx: ServerContext,
@@ -234,7 +248,7 @@ async function withResourceGuards<T>(
       },
       "resource.error",
     );
-    if (err instanceof ProtocolError) throw err;
+    if (err instanceof ProtocolError) throw sanitizeProtocolErrorForRethrow(err, sanitizerOptions);
     throw safeErr;
   }
 }
@@ -367,8 +381,9 @@ async function bucketEventNotifications(
     );
     return { isClientAuthorizedToRead: true, value };
   } catch (err) {
-    const safeErr = sanitizeError(err, sanitizerOptions);
     const error = providerErrorFields(err, sanitizerOptions);
+    if (isRequestAborted(err)) throw err;
+    const safeErr = sanitizeError(err, sanitizerOptions);
     logger.warn(
       {
         resource: "b2_bucket",

--- a/src/resources.ts
+++ b/src/resources.ts
@@ -13,16 +13,25 @@ import {
   type Variables,
 } from "@modelcontextprotocol/server";
 import type { B2Client, BucketInfoResult, NotificationRulesResult } from "./b2/client.js";
+import { redactNotificationSecrets } from "./b2/buckets.js";
+import { fingerprintConfig } from "./credentials.js";
 import type { McpServer } from "./mcp.js";
 import { getRegisteredTools } from "./mcp.js";
 import { currentMcpRequestSignal, runWithMcpRequestSignal } from "./request-context.js";
 import { getDestructivePolicy } from "./utils/destructive-gate.js";
+import { parseB2Error } from "./utils/errors.js";
+import { logger } from "./utils/logger.js";
 import {
+  currentSanitizerOptions,
+  sanitizeForMcpOutput,
   sanitizeError,
-  sanitizerOptionsFromConfig,
+  sanitizeProviderCode,
+  sanitizeProviderRequestId,
   runWithSanitizerOptions,
+  sanitizerOptionsFromConfig,
+  type SanitizerOptions,
 } from "./utils/secret-sanitizer.js";
-import { isToolAllowedByOAuthScopes } from "./utils/tool-capabilities.js";
+import { isToolAllowedByOAuthScopes, isToolEnabled } from "./utils/tool-capabilities.js";
 import type { B2Config } from "./utils/types.js";
 import { VERSION } from "./version.js";
 
@@ -32,76 +41,214 @@ export const SERVER_CONFIG_RESOURCE_URI = "b2://server-config";
 export const CAPABILITIES_RESOURCE_URI = "b2://capabilities";
 /** URI template for per-bucket read-only control-plane state. */
 export const BUCKET_RESOURCE_TEMPLATE_URI = "b2://bucket/{bucketName}";
+/** Maximum concrete bucket resources advertised by one resources/list response. */
+export const BUCKET_RESOURCE_LIST_LIMIT = 100;
 
 const JSON_MIME_TYPE = "application/json";
-const RESOURCE_CACHE_HINT = { ttlMs: 30_000, cacheScope: "private" as const };
+const STATIC_RESOURCE_CACHE_HINT = { ttlMs: 30_000, cacheScope: "private" as const };
 
 interface RegisterControlPlaneResourcesOptions {
-  /** MCP SDK server instance receiving resource registrations. */
-  server: McpServer;
-  /** Resolved runtime configuration. */
-  config: B2Config;
-  /** Capability set for the current credential; `null` means full surface. */
-  capabilities?: readonly string[] | null;
-  /** Native B2 client used for bucket control-plane reads. */
-  b2Client: B2Client;
   /** Verified OAuth scopes for the current caller, when OAuth is active. */
   oauthScopes?: ReadonlySet<string> | null;
   /** Whether the stdio entry is advertising schemas without real credentials. */
   credentialsMissing?: boolean;
 }
 
-type ResourceJson = Record<string, unknown>;
+type ResourceOperation = "resources/list" | "resources/read" | "b2_get_bucket_notification_rules";
 
-function jsonResource(uri: string, value: ResourceJson): ReadResourceResult {
+interface ResourceAuditMetadata {
+  name: string;
+  uri: string;
+  operation: ResourceOperation;
+}
+
+/** Sanitized provider error metadata embedded in degraded resource payloads. */
+export interface ResourceProviderErrorPayload {
+  /** Stable provider or local error code. */
+  code: string;
+  /** HTTP status associated with the provider or local error. */
+  status: number;
+  /** Provider request id, when available. */
+  requestId?: string;
+}
+
+/** JSON payload returned by `b2://server-config`. */
+export interface ServerConfigResourcePayload {
+  /** Resource payload schema revision. */
+  schemaVersion: 1;
+  /** Resource URI. */
+  uri: typeof SERVER_CONFIG_RESOURCE_URI;
+  /** MCP server version. */
+  version: string;
+  /** Active MCP transport. */
+  transport: string;
+  /** Credential-provider mode visible to this server instance. */
+  credentialMode: string;
+  /** Effective destructive-operation policy. */
+  destructivePolicy: string;
+  /** Effective durable-secret sink mode. */
+  secretSinkMode: string;
+  /** Public MCP/OAuth resource URL, when configured. */
+  publicUrl: string | null;
+}
+
+/** Summary of the active MCP tool profile returned by `b2://capabilities`. */
+export interface ActiveToolProfileResourcePayload {
+  /** Whether the server is using the full or capability-filtered tool surface. */
+  mode: "full" | "capability-filtered";
+  /** Number of registered tools. */
+  toolCount: number;
+  /** Number of registered tools annotated read-only. */
+  readOnlyToolCount: number;
+  /** Number of registered tools annotated destructive. */
+  destructiveToolCount: number;
+  /** Registered MCP tool names. */
+  toolNames: string[];
+}
+
+/** JSON payload returned by `b2://capabilities`. */
+export interface CapabilitiesResourcePayload {
+  /** Resource payload schema revision. */
+  schemaVersion: 1;
+  /** Resource URI. */
+  uri: typeof CAPABILITIES_RESOURCE_URI;
+  /** Whether B2 capability filtering is active for this server instance. */
+  capabilityFiltering: "enabled" | "disabled";
+  /** Current credential's B2 capabilities, or null in full-surface mode. */
+  capabilities: string[] | null;
+  /** Capability-filtered MCP tool profile. */
+  activeToolProfile: ActiveToolProfileResourcePayload;
+}
+
+/** Notification-rule section returned by the bucket resource. */
+export interface BucketEventNotificationsResourcePayload {
+  /** Whether this credential is authorized to read bucket notification rules. */
+  isClientAuthorizedToRead: boolean;
+  /** Redacted notification-rule value, or null when unreadable/unavailable. */
+  value: NotificationRulesResult | null;
+  /** True when a secondary notification-rule read failed but bucket config succeeded. */
+  unavailable?: true;
+  /** Sanitized provider error metadata for an unavailable secondary read. */
+  error?: ResourceProviderErrorPayload;
+}
+
+/** JSON payload returned by `b2://bucket/{bucketName}`. */
+export interface BucketResourcePayload {
+  /** Resource payload schema revision. */
+  schemaVersion: 1;
+  /** Concrete bucket resource URI. */
+  uri: string;
+  /** B2 bucket name. */
+  bucketName: string;
+  /** B2 bucket ID. */
+  bucketId: string;
+  /** Raw B2 bucket type. */
+  bucketType: string;
+  /** Derived visibility label. */
+  visibility: "public" | "private" | "restricted" | "snapshot" | "unknown";
+  /** Configured CORS rules. */
+  corsRules: NonNullable<BucketInfoResult["corsRules"]>;
+  /** Configured lifecycle rules. */
+  lifecycleRules: NonNullable<BucketInfoResult["lifecycleRules"]>;
+  /** Default server-side encryption configuration. */
+  defaultServerSideEncryption: BucketInfoResult["defaultServerSideEncryption"] | null;
+  /** Object Lock configuration. */
+  objectLock: BucketInfoResult["fileLockConfiguration"] | null;
+  /** Default Object Lock retention policy. */
+  defaultRetention: BucketInfoResult["defaultRetention"] | null;
+  /** B2 replication configuration. */
+  replicationConfiguration: BucketInfoResult["replicationConfiguration"] | null;
+  /** Redacted bucket notification-rule state. */
+  eventNotifications: BucketEventNotificationsResourcePayload;
+}
+
+function jsonResource(uri: string, value: unknown): ReadResourceResult {
+  const safeValue = sanitizeForMcpOutput(value, currentSanitizerOptions());
   return {
     contents: [
       {
         uri,
         mimeType: JSON_MIME_TYPE,
-        text: `${JSON.stringify(value, null, 2)}\n`,
+        text: `${JSON.stringify(safeValue, null, 2)}\n`,
       },
     ],
+  };
+}
+
+function credentialFingerprint(config: B2Config): string {
+  return config.credentialFingerprint ?? fingerprintConfig(config);
+}
+
+function providerErrorFields(
+  err: unknown,
+  sanitizerOptions: SanitizerOptions,
+): ResourceProviderErrorPayload {
+  const parsed = parseB2Error(err);
+  const requestId = sanitizeProviderRequestId(parsed.requestId, sanitizerOptions);
+  return {
+    code: sanitizeProviderCode(parsed.code, sanitizerOptions),
+    status: parsed.status,
+    ...(requestId ? { requestId } : {}),
   };
 }
 
 async function withResourceGuards<T>(
   config: B2Config,
   ctx: ServerContext,
+  audit: ResourceAuditMetadata,
   callback: () => Promise<T> | T,
 ): Promise<T> {
+  const start = Date.now();
   const signal = (ctx as { mcpReq?: { signal?: AbortSignal } } | undefined)?.mcpReq?.signal;
   const sanitizerOptions = sanitizerOptionsFromConfig(config);
   try {
-    return await runWithMcpRequestSignal(signal ?? currentMcpRequestSignal(), () =>
+    const result = await runWithMcpRequestSignal(signal ?? currentMcpRequestSignal(), () =>
       runWithSanitizerOptions(sanitizerOptions, callback),
     );
+    const safeResult = sanitizeForMcpOutput(result, sanitizerOptions) as T;
+    logger.info(
+      {
+        resource: audit.name,
+        uri: audit.uri,
+        operation: audit.operation,
+        credential: credentialFingerprint(config),
+        durationMs: Date.now() - start,
+        error: false,
+      },
+      "resource.call",
+    );
+    return safeResult;
   } catch (err) {
-    throw sanitizeError(err, sanitizerOptions);
+    const safeErr = sanitizeError(err, sanitizerOptions);
+    logger.warn(
+      {
+        resource: audit.name,
+        uri: audit.uri,
+        operation: audit.operation,
+        credential: credentialFingerprint(config),
+        durationMs: Date.now() - start,
+        error: true,
+        ...providerErrorFields(err, sanitizerOptions),
+        err: safeErr.message,
+      },
+      "resource.error",
+    );
+    throw safeErr;
   }
 }
 
-function hasCapability(
+function capabilitySet(
   capabilities: readonly string[] | null | undefined,
-  capability: string,
-): boolean {
-  return capabilities == null || capabilities.includes(capability);
+): ReadonlySet<string> | null {
+  return capabilities == null ? null : new Set(capabilities);
 }
 
 function canUseTool(
   name: string,
-  capabilities: readonly string[] | null | undefined,
+  caps: ReadonlySet<string> | null,
   oauthScopes: ReadonlySet<string> | null | undefined,
 ): boolean {
-  if (!isToolAllowedByOAuthScopes(name, oauthScopes ?? null)) return false;
-  if (name === "b2_list_buckets") return hasCapability(capabilities, "listBuckets");
-  if (name === "b2_get_bucket_notification_rules") {
-    return (
-      hasCapability(capabilities, "readBucketNotifications") ||
-      hasCapability(capabilities, "writeBucketNotifications")
-    );
-  }
-  return true;
+  return isToolAllowedByOAuthScopes(name, oauthScopes ?? null) && isToolEnabled(name, caps);
 }
 
 function resolveHttpCredentialMode(): "headers" | "principal" | "server" {
@@ -117,7 +264,7 @@ function publicUrl(): string | null {
   return process.env.B2_MCP_PUBLIC_URL?.trim() || process.env.B2_OAUTH_RESOURCE?.trim() || null;
 }
 
-function serverConfigPayload(config: B2Config): ResourceJson {
+function serverConfigPayload(config: B2Config): ServerConfigResourcePayload {
   return {
     schemaVersion: 1,
     uri: SERVER_CONFIG_RESOURCE_URI,
@@ -130,7 +277,10 @@ function serverConfigPayload(config: B2Config): ResourceJson {
   };
 }
 
-function activeToolProfile(server: McpServer, capabilities: readonly string[] | null | undefined) {
+function activeToolProfile(
+  server: McpServer,
+  capabilities: readonly string[] | null | undefined,
+): ActiveToolProfileResourcePayload {
   const tools = getRegisteredTools(server) ?? {};
   const records = Object.values(tools);
   return {
@@ -145,57 +295,13 @@ function activeToolProfile(server: McpServer, capabilities: readonly string[] | 
 function capabilitiesPayload(
   server: McpServer,
   capabilities: readonly string[] | null | undefined,
-): ResourceJson {
+): CapabilitiesResourcePayload {
   return {
     schemaVersion: 1,
     uri: CAPABILITIES_RESOURCE_URI,
     capabilityFiltering: capabilities == null ? "disabled" : "enabled",
     capabilities: capabilities == null ? null : [...capabilities].sort(),
     activeToolProfile: activeToolProfile(server, capabilities),
-  };
-}
-
-function redactWebhookUrl(raw: string | undefined): string | undefined {
-  if (raw === undefined) return undefined;
-  try {
-    const u = new URL(raw);
-    return `${u.protocol}//${u.host}/[redacted]`;
-  } catch {
-    return "[redacted]";
-  }
-}
-
-function redactCustomHeaders(
-  customHeaders: NotificationRulesResult["eventNotificationRules"][number]["targetConfiguration"]["customHeaders"],
-): Record<string, string> | undefined {
-  if (customHeaders === undefined) return undefined;
-  if (Array.isArray(customHeaders)) {
-    return Object.fromEntries(customHeaders.map((header) => [header.name, "[redacted]"]));
-  }
-  return Object.fromEntries(Object.keys(customHeaders).map((name) => [name, "[redacted]"]));
-}
-
-function redactNotificationRules(result: NotificationRulesResult): NotificationRulesResult {
-  return {
-    ...(result.bucketId !== undefined ? { bucketId: result.bucketId } : {}),
-    eventNotificationRules: result.eventNotificationRules.map((rule) => ({
-      name: rule.name,
-      eventTypes: [...rule.eventTypes],
-      isEnabled: rule.isEnabled,
-      ...(rule.objectNamePrefix !== undefined ? { objectNamePrefix: rule.objectNamePrefix } : {}),
-      ...(rule.isSuspended !== undefined ? { isSuspended: rule.isSuspended } : {}),
-      ...(rule.suspensionReason !== undefined ? { suspensionReason: rule.suspensionReason } : {}),
-      targetConfiguration: {
-        targetType: rule.targetConfiguration.targetType,
-        url: redactWebhookUrl(rule.targetConfiguration.url) ?? "[redacted]",
-        ...(rule.targetConfiguration.hmacSha256SigningSecret !== undefined
-          ? { hmacSha256SigningSecret: "[redacted]" }
-          : {}),
-        ...(rule.targetConfiguration.customHeaders !== undefined
-          ? { customHeaders: redactCustomHeaders(rule.targetConfiguration.customHeaders) }
-          : {}),
-      },
-    })),
   };
 }
 
@@ -214,12 +320,11 @@ async function bucketPayload(
   bucket: BucketInfoResult,
   options: {
     b2Client: B2Client;
+    config: B2Config;
     canReadNotificationRules: boolean;
   },
-): Promise<ResourceJson> {
-  const notificationRules = options.canReadNotificationRules
-    ? redactNotificationRules(await options.b2Client.getBucketNotificationRules(bucket.bucketId))
-    : null;
+): Promise<BucketResourcePayload> {
+  const eventNotifications = await bucketEventNotifications(uri, bucket.bucketId, options);
 
   return {
     schemaVersion: 1,
@@ -235,11 +340,53 @@ async function bucketPayload(
     defaultRetention:
       bucket.defaultRetention ?? bucket.fileLockConfiguration?.value?.defaultRetention ?? null,
     replicationConfiguration: bucket.replicationConfiguration ?? null,
-    eventNotifications: {
-      isClientAuthorizedToRead: options.canReadNotificationRules,
-      value: notificationRules,
-    },
+    eventNotifications,
   };
+}
+
+async function bucketEventNotifications(
+  uri: string,
+  bucketId: string,
+  options: {
+    b2Client: B2Client;
+    config: B2Config;
+    canReadNotificationRules: boolean;
+  },
+): Promise<BucketEventNotificationsResourcePayload> {
+  if (!options.canReadNotificationRules) {
+    return { isClientAuthorizedToRead: false, value: null };
+  }
+
+  const start = Date.now();
+  const sanitizerOptions = sanitizerOptionsFromConfig(options.config);
+  try {
+    const value = redactNotificationSecrets(
+      await options.b2Client.getBucketNotificationRules(bucketId),
+    );
+    return { isClientAuthorizedToRead: true, value };
+  } catch (err) {
+    const safeErr = sanitizeError(err, sanitizerOptions);
+    const error = providerErrorFields(err, sanitizerOptions);
+    logger.warn(
+      {
+        resource: "b2_bucket",
+        uri,
+        operation: "b2_get_bucket_notification_rules",
+        credential: credentialFingerprint(options.config),
+        durationMs: Date.now() - start,
+        error: true,
+        ...error,
+        err: safeErr.message,
+      },
+      "resource.dependency_error",
+    );
+    return {
+      isClientAuthorizedToRead: true,
+      value: null,
+      unavailable: true,
+      error,
+    };
+  }
 }
 
 function bucketResourceUri(bucketName: string): string {
@@ -252,6 +399,34 @@ function bucketNameFromVariables(variables: Variables): string | null {
   return typeof value === "string" && value.length > 0 ? value : null;
 }
 
+function listedBucketResources(config: B2Config, buckets: BucketInfoResult[]): ListResourcesResult {
+  const visibleBuckets = buckets.slice(0, BUCKET_RESOURCE_LIST_LIMIT);
+  if (buckets.length > BUCKET_RESOURCE_LIST_LIMIT) {
+    logger.warn(
+      {
+        resource: "b2_bucket",
+        uri: BUCKET_RESOURCE_TEMPLATE_URI,
+        operation: "resources/list",
+        credential: credentialFingerprint(config),
+        bucketCount: buckets.length,
+        returnedBucketCount: visibleBuckets.length,
+        limit: BUCKET_RESOURCE_LIST_LIMIT,
+      },
+      "resource.list.truncated",
+    );
+  }
+  return {
+    resources: visibleBuckets.map((bucket) => ({
+      uri: bucketResourceUri(bucket.bucketName),
+      name: `b2_bucket_${bucket.bucketName}`,
+      title: `B2 Bucket: ${bucket.bucketName}`,
+      description:
+        "Read-only B2 bucket control-plane configuration. resources/list advertises at most the first 100 bucket resources; use this template URI directly for a known bucket name beyond that cap.",
+      mimeType: JSON_MIME_TYPE,
+    })),
+  };
+}
+
 /**
  * Register the first read-only B2 control-plane MCP resources.
  *
@@ -262,22 +437,34 @@ function bucketNameFromVariables(variables: Variables): string | null {
  * control-plane state; notification rules are included only when separately
  * readable and are always returned with webhook secrets redacted.
  *
- * @param options - Resource registration dependencies and authorization state.
+ * @param server - MCP SDK server instance receiving resource registrations.
+ * @param b2Client - Native B2 client used for bucket control-plane reads.
+ * @param config - Resolved runtime configuration.
+ * @param capabilities - Capability set for the current credential; `null` means full surface.
+ * @param options - Optional caller-scoped authorization state.
  */
-export function registerControlPlaneResources(options: RegisterControlPlaneResourcesOptions): void {
-  const { server, config, capabilities, b2Client } = options;
+export function registerControlPlaneResources(
+  server: McpServer,
+  b2Client: B2Client,
+  config: B2Config,
+  capabilities?: readonly string[] | null,
+  options: RegisterControlPlaneResourcesOptions = {},
+): void {
   const oauthScopes = options.oauthScopes ?? null;
+  const caps = capabilitySet(capabilities);
   const canReadBuckets =
-    options.credentialsMissing !== true && canUseTool("b2_list_buckets", capabilities, oauthScopes);
+    options.credentialsMissing !== true && canUseTool("b2_list_buckets", caps, oauthScopes);
   const canReadCapabilities =
-    options.credentialsMissing !== true &&
-    (oauthScopes === null || isToolAllowedByOAuthScopes("b2_authorize_account", oauthScopes));
+    options.credentialsMissing !== true && canUseTool("b2_authorize_account", caps, oauthScopes);
   const canReadNotificationRules = canUseTool(
     "b2_get_bucket_notification_rules",
-    capabilities,
+    caps,
     oauthScopes,
   );
 
+  // Intentionally not gated by B2 capabilities: this process-level resource
+  // contains no account identifiers or credential values, and it remains useful
+  // during credential-less stdio discovery.
   server.registerResource(
     "b2_server_config",
     SERVER_CONFIG_RESOURCE_URI,
@@ -285,10 +472,15 @@ export function registerControlPlaneResources(options: RegisterControlPlaneResou
       title: "B2 MCP Server Config",
       description: "Non-secret Backblaze B2 MCP server configuration.",
       mimeType: JSON_MIME_TYPE,
-      cacheHint: RESOURCE_CACHE_HINT,
+      cacheHint: STATIC_RESOURCE_CACHE_HINT,
     },
     async (uri, ctx) =>
-      withResourceGuards(config, ctx, () => jsonResource(uri.href, serverConfigPayload(config))),
+      withResourceGuards(
+        config,
+        ctx,
+        { name: "b2_server_config", uri: uri.href, operation: "resources/read" },
+        () => jsonResource(uri.href, serverConfigPayload(config)),
+      ),
   );
 
   if (canReadCapabilities) {
@@ -299,11 +491,14 @@ export function registerControlPlaneResources(options: RegisterControlPlaneResou
         title: "B2 Credential Capabilities",
         description: "Current B2 credential capability set and active MCP tool profile.",
         mimeType: JSON_MIME_TYPE,
-        cacheHint: RESOURCE_CACHE_HINT,
+        cacheHint: STATIC_RESOURCE_CACHE_HINT,
       },
       async (uri, ctx) =>
-        withResourceGuards(config, ctx, () =>
-          jsonResource(uri.href, capabilitiesPayload(server, capabilities)),
+        withResourceGuards(
+          config,
+          ctx,
+          { name: "b2_capabilities", uri: uri.href, operation: "resources/read" },
+          () => jsonResource(uri.href, capabilitiesPayload(server, capabilities)),
         ),
     );
   }
@@ -314,39 +509,45 @@ export function registerControlPlaneResources(options: RegisterControlPlaneResou
     "b2_bucket",
     new ResourceTemplate(BUCKET_RESOURCE_TEMPLATE_URI, {
       list: async (ctx): Promise<ListResourcesResult> =>
-        withResourceGuards(config, ctx, async () => {
-          const result = await b2Client.listBuckets();
-          return {
-            resources: result.buckets.map((bucket) => ({
-              uri: bucketResourceUri(bucket.bucketName),
-              name: `b2_bucket_${bucket.bucketName}`,
-              title: `B2 Bucket: ${bucket.bucketName}`,
-              description: "Read-only B2 bucket control-plane configuration.",
-              mimeType: JSON_MIME_TYPE,
-            })),
-          };
-        }),
+        withResourceGuards(
+          config,
+          ctx,
+          { name: "b2_bucket", uri: BUCKET_RESOURCE_TEMPLATE_URI, operation: "resources/list" },
+          async () => {
+            const result = await b2Client.listBuckets();
+            return listedBucketResources(
+              config,
+              Array.isArray(result.buckets) ? result.buckets : [],
+            );
+          },
+        ),
     }),
     {
       title: "B2 Bucket",
-      description: "Read-only B2 bucket control-plane configuration by bucket name.",
+      description:
+        "Read-only B2 bucket control-plane configuration by bucket name. resources/list is capped at 100 concrete bucket resources; resources/read can still target any known bucket name permitted by the credential.",
       mimeType: JSON_MIME_TYPE,
-      cacheHint: RESOURCE_CACHE_HINT,
     },
     async (uri, variables, ctx) =>
-      withResourceGuards(config, ctx, async () => {
-        const bucketName = bucketNameFromVariables(variables);
-        if (!bucketName) throw new ResourceNotFoundError(uri.href);
-        const result = await b2Client.listBuckets({ bucketName });
-        const bucket = result.buckets.find((candidate) => candidate.bucketName === bucketName);
-        if (!bucket) throw new ResourceNotFoundError(uri.href);
-        return jsonResource(
-          uri.href,
-          await bucketPayload(uri.href, bucket, {
-            b2Client,
-            canReadNotificationRules,
-          }),
-        );
-      }),
+      withResourceGuards(
+        config,
+        ctx,
+        { name: "b2_bucket", uri: uri.href, operation: "resources/read" },
+        async () => {
+          const bucketName = bucketNameFromVariables(variables);
+          if (!bucketName) throw new ResourceNotFoundError(uri.href);
+          const result = await b2Client.listBuckets({ bucketName });
+          const bucket = result.buckets.find((candidate) => candidate.bucketName === bucketName);
+          if (!bucket) throw new ResourceNotFoundError(uri.href);
+          return jsonResource(
+            uri.href,
+            await bucketPayload(uri.href, bucket, {
+              b2Client,
+              config,
+              canReadNotificationRules,
+            }),
+          );
+        },
+      ),
   );
 }

--- a/src/resources.ts
+++ b/src/resources.ts
@@ -54,6 +54,8 @@ interface RegisterControlPlaneResourcesOptions {
   oauthScopes?: ReadonlySet<string> | null;
   /** Whether the stdio entry is advertising schemas without real credentials. */
   credentialsMissing?: boolean;
+  /** Whether capability discovery failed locally and the tool surface is fail-closed. */
+  failClosedUnknownCapabilities?: boolean;
 }
 
 type ResourceOperation = "resources/list" | "resources/read" | "b2_get_bucket_notification_rules";
@@ -475,7 +477,9 @@ export function registerControlPlaneResources(
   const canReadBuckets =
     options.credentialsMissing !== true && canUseTool("b2_list_buckets", caps, oauthScopes);
   const canReadCapabilities =
-    options.credentialsMissing !== true && canUseTool("b2_authorize_account", caps, oauthScopes);
+    options.credentialsMissing !== true &&
+    options.failClosedUnknownCapabilities !== true &&
+    canUseTool("b2_authorize_account", caps, oauthScopes);
   const canReadNotificationRules = canUseTool(
     "b2_get_bucket_notification_rules",
     caps,

--- a/src/resources.ts
+++ b/src/resources.ts
@@ -1,0 +1,352 @@
+/**
+ * Read-only MCP resource registration for B2 control-plane state.
+ *
+ * @packageDocumentation
+ */
+
+import {
+  ResourceNotFoundError,
+  ResourceTemplate,
+  type ListResourcesResult,
+  type ReadResourceResult,
+  type ServerContext,
+  type Variables,
+} from "@modelcontextprotocol/server";
+import type { B2Client, BucketInfoResult, NotificationRulesResult } from "./b2/client.js";
+import type { McpServer } from "./mcp.js";
+import { getRegisteredTools } from "./mcp.js";
+import { currentMcpRequestSignal, runWithMcpRequestSignal } from "./request-context.js";
+import { getDestructivePolicy } from "./utils/destructive-gate.js";
+import {
+  sanitizeError,
+  sanitizerOptionsFromConfig,
+  runWithSanitizerOptions,
+} from "./utils/secret-sanitizer.js";
+import { isToolAllowedByOAuthScopes } from "./utils/tool-capabilities.js";
+import type { B2Config } from "./utils/types.js";
+import { VERSION } from "./version.js";
+
+/** Stable URI for non-secret server configuration. */
+export const SERVER_CONFIG_RESOURCE_URI = "b2://server-config";
+/** Stable URI for the current credential capability profile. */
+export const CAPABILITIES_RESOURCE_URI = "b2://capabilities";
+/** URI template for per-bucket read-only control-plane state. */
+export const BUCKET_RESOURCE_TEMPLATE_URI = "b2://bucket/{bucketName}";
+
+const JSON_MIME_TYPE = "application/json";
+const RESOURCE_CACHE_HINT = { ttlMs: 30_000, cacheScope: "private" as const };
+
+interface RegisterControlPlaneResourcesOptions {
+  /** MCP SDK server instance receiving resource registrations. */
+  server: McpServer;
+  /** Resolved runtime configuration. */
+  config: B2Config;
+  /** Capability set for the current credential; `null` means full surface. */
+  capabilities?: readonly string[] | null;
+  /** Native B2 client used for bucket control-plane reads. */
+  b2Client: B2Client;
+  /** Verified OAuth scopes for the current caller, when OAuth is active. */
+  oauthScopes?: ReadonlySet<string> | null;
+  /** Whether the stdio entry is advertising schemas without real credentials. */
+  credentialsMissing?: boolean;
+}
+
+type ResourceJson = Record<string, unknown>;
+
+function jsonResource(uri: string, value: ResourceJson): ReadResourceResult {
+  return {
+    contents: [
+      {
+        uri,
+        mimeType: JSON_MIME_TYPE,
+        text: `${JSON.stringify(value, null, 2)}\n`,
+      },
+    ],
+  };
+}
+
+async function withResourceGuards<T>(
+  config: B2Config,
+  ctx: ServerContext,
+  callback: () => Promise<T> | T,
+): Promise<T> {
+  const signal = (ctx as { mcpReq?: { signal?: AbortSignal } } | undefined)?.mcpReq?.signal;
+  const sanitizerOptions = sanitizerOptionsFromConfig(config);
+  try {
+    return await runWithMcpRequestSignal(signal ?? currentMcpRequestSignal(), () =>
+      runWithSanitizerOptions(sanitizerOptions, callback),
+    );
+  } catch (err) {
+    throw sanitizeError(err, sanitizerOptions);
+  }
+}
+
+function hasCapability(
+  capabilities: readonly string[] | null | undefined,
+  capability: string,
+): boolean {
+  return capabilities == null || capabilities.includes(capability);
+}
+
+function canUseTool(
+  name: string,
+  capabilities: readonly string[] | null | undefined,
+  oauthScopes: ReadonlySet<string> | null | undefined,
+): boolean {
+  if (!isToolAllowedByOAuthScopes(name, oauthScopes ?? null)) return false;
+  if (name === "b2_list_buckets") return hasCapability(capabilities, "listBuckets");
+  if (name === "b2_get_bucket_notification_rules") {
+    return (
+      hasCapability(capabilities, "readBucketNotifications") ||
+      hasCapability(capabilities, "writeBucketNotifications")
+    );
+  }
+  return true;
+}
+
+function resolveHttpCredentialMode(): "headers" | "principal" | "server" {
+  const raw = (process.env.B2_HTTP_CREDENTIAL_MODE ?? "headers").trim().toLowerCase();
+  return raw === "headers" || raw === "principal" || raw === "server" ? raw : "headers";
+}
+
+function credentialMode(config: B2Config): string {
+  return (config.transport ?? "stdio") === "http" ? resolveHttpCredentialMode() : "stdio";
+}
+
+function publicUrl(): string | null {
+  return process.env.B2_MCP_PUBLIC_URL?.trim() || process.env.B2_OAUTH_RESOURCE?.trim() || null;
+}
+
+function serverConfigPayload(config: B2Config): ResourceJson {
+  return {
+    schemaVersion: 1,
+    uri: SERVER_CONFIG_RESOURCE_URI,
+    version: VERSION,
+    transport: config.transport ?? "stdio",
+    credentialMode: credentialMode(config),
+    destructivePolicy: getDestructivePolicy(config),
+    secretSinkMode: config.secretSink?.mode ?? "off",
+    publicUrl: publicUrl(),
+  };
+}
+
+function activeToolProfile(server: McpServer, capabilities: readonly string[] | null | undefined) {
+  const tools = getRegisteredTools(server) ?? {};
+  const records = Object.values(tools);
+  return {
+    mode: capabilities == null ? "full" : "capability-filtered",
+    toolCount: records.length,
+    readOnlyToolCount: records.filter((tool) => tool.annotations.readOnlyHint).length,
+    destructiveToolCount: records.filter((tool) => tool.annotations.destructiveHint).length,
+    toolNames: records.map((tool) => tool.name).sort(),
+  };
+}
+
+function capabilitiesPayload(
+  server: McpServer,
+  capabilities: readonly string[] | null | undefined,
+): ResourceJson {
+  return {
+    schemaVersion: 1,
+    uri: CAPABILITIES_RESOURCE_URI,
+    capabilityFiltering: capabilities == null ? "disabled" : "enabled",
+    capabilities: capabilities == null ? null : [...capabilities].sort(),
+    activeToolProfile: activeToolProfile(server, capabilities),
+  };
+}
+
+function redactWebhookUrl(raw: string | undefined): string | undefined {
+  if (raw === undefined) return undefined;
+  try {
+    const u = new URL(raw);
+    return `${u.protocol}//${u.host}/[redacted]`;
+  } catch {
+    return "[redacted]";
+  }
+}
+
+function redactCustomHeaders(
+  customHeaders: NotificationRulesResult["eventNotificationRules"][number]["targetConfiguration"]["customHeaders"],
+): Record<string, string> | undefined {
+  if (customHeaders === undefined) return undefined;
+  if (Array.isArray(customHeaders)) {
+    return Object.fromEntries(customHeaders.map((header) => [header.name, "[redacted]"]));
+  }
+  return Object.fromEntries(Object.keys(customHeaders).map((name) => [name, "[redacted]"]));
+}
+
+function redactNotificationRules(result: NotificationRulesResult): NotificationRulesResult {
+  return {
+    ...(result.bucketId !== undefined ? { bucketId: result.bucketId } : {}),
+    eventNotificationRules: result.eventNotificationRules.map((rule) => ({
+      name: rule.name,
+      eventTypes: [...rule.eventTypes],
+      isEnabled: rule.isEnabled,
+      ...(rule.objectNamePrefix !== undefined ? { objectNamePrefix: rule.objectNamePrefix } : {}),
+      ...(rule.isSuspended !== undefined ? { isSuspended: rule.isSuspended } : {}),
+      ...(rule.suspensionReason !== undefined ? { suspensionReason: rule.suspensionReason } : {}),
+      targetConfiguration: {
+        targetType: rule.targetConfiguration.targetType,
+        url: redactWebhookUrl(rule.targetConfiguration.url) ?? "[redacted]",
+        ...(rule.targetConfiguration.hmacSha256SigningSecret !== undefined
+          ? { hmacSha256SigningSecret: "[redacted]" }
+          : {}),
+        ...(rule.targetConfiguration.customHeaders !== undefined
+          ? { customHeaders: redactCustomHeaders(rule.targetConfiguration.customHeaders) }
+          : {}),
+      },
+    })),
+  };
+}
+
+function bucketVisibility(
+  bucketType: string,
+): "public" | "private" | "restricted" | "snapshot" | "unknown" {
+  if (bucketType === "allPublic") return "public";
+  if (bucketType === "allPrivate") return "private";
+  if (bucketType === "restricted") return "restricted";
+  if (bucketType === "snapshot") return "snapshot";
+  return "unknown";
+}
+
+async function bucketPayload(
+  uri: string,
+  bucket: BucketInfoResult,
+  options: {
+    b2Client: B2Client;
+    canReadNotificationRules: boolean;
+  },
+): Promise<ResourceJson> {
+  const notificationRules = options.canReadNotificationRules
+    ? redactNotificationRules(await options.b2Client.getBucketNotificationRules(bucket.bucketId))
+    : null;
+
+  return {
+    schemaVersion: 1,
+    uri,
+    bucketName: bucket.bucketName,
+    bucketId: bucket.bucketId,
+    bucketType: bucket.bucketType,
+    visibility: bucketVisibility(bucket.bucketType),
+    corsRules: bucket.corsRules ?? [],
+    lifecycleRules: bucket.lifecycleRules ?? [],
+    defaultServerSideEncryption: bucket.defaultServerSideEncryption ?? null,
+    objectLock: bucket.fileLockConfiguration ?? null,
+    defaultRetention:
+      bucket.defaultRetention ?? bucket.fileLockConfiguration?.value?.defaultRetention ?? null,
+    replicationConfiguration: bucket.replicationConfiguration ?? null,
+    eventNotifications: {
+      isClientAuthorizedToRead: options.canReadNotificationRules,
+      value: notificationRules,
+    },
+  };
+}
+
+function bucketResourceUri(bucketName: string): string {
+  return `b2://bucket/${encodeURIComponent(bucketName)}`;
+}
+
+function bucketNameFromVariables(variables: Variables): string | null {
+  const value = variables.bucketName;
+  if (Array.isArray(value)) return value.length === 1 ? value[0] : null;
+  return typeof value === "string" && value.length > 0 ? value : null;
+}
+
+/**
+ * Register the first read-only B2 control-plane MCP resources.
+ *
+ * @remarks
+ * Static resources expose non-secret server configuration and the current
+ * credential's capability-filtered tool profile. The bucket template is
+ * registered only when the current credential and OAuth caller can list bucket
+ * control-plane state; notification rules are included only when separately
+ * readable and are always returned with webhook secrets redacted.
+ *
+ * @param options - Resource registration dependencies and authorization state.
+ */
+export function registerControlPlaneResources(options: RegisterControlPlaneResourcesOptions): void {
+  const { server, config, capabilities, b2Client } = options;
+  const oauthScopes = options.oauthScopes ?? null;
+  const canReadBuckets =
+    options.credentialsMissing !== true && canUseTool("b2_list_buckets", capabilities, oauthScopes);
+  const canReadCapabilities =
+    options.credentialsMissing !== true &&
+    (oauthScopes === null || isToolAllowedByOAuthScopes("b2_authorize_account", oauthScopes));
+  const canReadNotificationRules = canUseTool(
+    "b2_get_bucket_notification_rules",
+    capabilities,
+    oauthScopes,
+  );
+
+  server.registerResource(
+    "b2_server_config",
+    SERVER_CONFIG_RESOURCE_URI,
+    {
+      title: "B2 MCP Server Config",
+      description: "Non-secret Backblaze B2 MCP server configuration.",
+      mimeType: JSON_MIME_TYPE,
+      cacheHint: RESOURCE_CACHE_HINT,
+    },
+    async (uri, ctx) =>
+      withResourceGuards(config, ctx, () => jsonResource(uri.href, serverConfigPayload(config))),
+  );
+
+  if (canReadCapabilities) {
+    server.registerResource(
+      "b2_capabilities",
+      CAPABILITIES_RESOURCE_URI,
+      {
+        title: "B2 Credential Capabilities",
+        description: "Current B2 credential capability set and active MCP tool profile.",
+        mimeType: JSON_MIME_TYPE,
+        cacheHint: RESOURCE_CACHE_HINT,
+      },
+      async (uri, ctx) =>
+        withResourceGuards(config, ctx, () =>
+          jsonResource(uri.href, capabilitiesPayload(server, capabilities)),
+        ),
+    );
+  }
+
+  if (!canReadBuckets) return;
+
+  server.registerResource(
+    "b2_bucket",
+    new ResourceTemplate(BUCKET_RESOURCE_TEMPLATE_URI, {
+      list: async (ctx): Promise<ListResourcesResult> =>
+        withResourceGuards(config, ctx, async () => {
+          const result = await b2Client.listBuckets();
+          return {
+            resources: result.buckets.map((bucket) => ({
+              uri: bucketResourceUri(bucket.bucketName),
+              name: `b2_bucket_${bucket.bucketName}`,
+              title: `B2 Bucket: ${bucket.bucketName}`,
+              description: "Read-only B2 bucket control-plane configuration.",
+              mimeType: JSON_MIME_TYPE,
+            })),
+          };
+        }),
+    }),
+    {
+      title: "B2 Bucket",
+      description: "Read-only B2 bucket control-plane configuration by bucket name.",
+      mimeType: JSON_MIME_TYPE,
+      cacheHint: RESOURCE_CACHE_HINT,
+    },
+    async (uri, variables, ctx) =>
+      withResourceGuards(config, ctx, async () => {
+        const bucketName = bucketNameFromVariables(variables);
+        if (!bucketName) throw new ResourceNotFoundError(uri.href);
+        const result = await b2Client.listBuckets({ bucketName });
+        const bucket = result.buckets.find((candidate) => candidate.bucketName === bucketName);
+        if (!bucket) throw new ResourceNotFoundError(uri.href);
+        return jsonResource(
+          uri.href,
+          await bucketPayload(uri.href, bucket, {
+            b2Client,
+            canReadNotificationRules,
+          }),
+        );
+      }),
+  );
+}

--- a/src/resources.ts
+++ b/src/resources.ts
@@ -28,6 +28,7 @@ import {
   sanitizeError,
   sanitizeProviderCode,
   sanitizeProviderRequestId,
+  sanitizeText,
   runWithSanitizerOptions,
   sanitizerOptionsFromConfig,
   type SanitizerOptions,
@@ -216,6 +217,7 @@ async function withResourceGuards<T>(
   const start = Date.now();
   const signal = (ctx as { mcpReq?: { signal?: AbortSignal } } | undefined)?.mcpReq?.signal;
   const sanitizerOptions = sanitizerOptionsFromConfig(config);
+  const safeUri = sanitizeText(audit.uri, sanitizerOptions);
   try {
     const result = await runWithMcpRequestSignal(signal ?? currentMcpRequestSignal(), () =>
       runWithSanitizerOptions(sanitizerOptions, callback),
@@ -224,7 +226,7 @@ async function withResourceGuards<T>(
     logger.info(
       {
         resource: audit.name,
-        uri: audit.uri,
+        uri: safeUri,
         operation: audit.operation,
         credential: credentialFingerprint(config),
         durationMs: Date.now() - start,
@@ -238,7 +240,7 @@ async function withResourceGuards<T>(
     logger.warn(
       {
         resource: audit.name,
-        uri: audit.uri,
+        uri: safeUri,
         operation: audit.operation,
         credential: credentialFingerprint(config),
         durationMs: Date.now() - start,
@@ -375,6 +377,7 @@ async function bucketEventNotifications(
 
   const start = Date.now();
   const sanitizerOptions = sanitizerOptionsFromConfig(options.config);
+  const safeUri = sanitizeText(uri, sanitizerOptions);
   try {
     const value = redactNotificationSecrets(
       await options.b2Client.getBucketNotificationRules(bucketId),
@@ -387,7 +390,7 @@ async function bucketEventNotifications(
     logger.warn(
       {
         resource: "b2_bucket",
-        uri,
+        uri: safeUri,
         operation: "b2_get_bucket_notification_rules",
         credential: credentialFingerprint(options.config),
         durationMs: Date.now() - start,

--- a/src/resources.ts
+++ b/src/resources.ts
@@ -222,7 +222,7 @@ function isRequestAborted(err: unknown): boolean {
  * ResourceNotFoundError} (`-32602` with `data.uri`) — as server failures and
  * skew resource error-rate alerting. Classify them here instead.
  */
-function protocolErrorAuditFields(err: ProtocolError): { code: string; status: number } {
+export function protocolErrorAuditFields(err: ProtocolError): { code: string; status: number } {
   // A resources/read miss is a routine not-found, not a bad request; classify
   // it distinctly even though its wire code is Invalid Params (`-32602`).
   if (err instanceof ResourceNotFoundError) return { code: "resource_not_found", status: 404 };

--- a/src/server.ts
+++ b/src/server.ts
@@ -429,6 +429,7 @@ export function createServer(
   registerControlPlaneResources(server, b2Client, config, capabilities, {
     oauthScopes,
     credentialsMissing: options.credentialsMissing,
+    failClosedUnknownCapabilities,
   });
   logger.info({ toolCount, version: VERSION, outputFormat }, "server.ready");
 

--- a/src/server.ts
+++ b/src/server.ts
@@ -74,6 +74,7 @@ import { registerKeyTools } from "./b2/keys.js";
 import { registerObjectLockTools } from "./b2/object-lock.js";
 import { registerPartnerTools } from "./b2/partner.js";
 import { registerInsightTools } from "./b2/insights.js";
+import { registerControlPlaneResources } from "./resources.js";
 
 import { registerS3BucketTools } from "./s3/buckets.js";
 import { registerS3ObjectTools } from "./s3/objects.js";
@@ -425,6 +426,14 @@ export function createServer(
   }
 
   const toolCount = registrar.commit();
+  registerControlPlaneResources({
+    server,
+    config,
+    capabilities,
+    b2Client,
+    oauthScopes,
+    credentialsMissing: options.credentialsMissing,
+  });
   logger.info({ toolCount, version: VERSION, outputFormat }, "server.ready");
 
   // Discovery mode: reject every tools/call ahead of the SDK's input-schema

--- a/src/server.ts
+++ b/src/server.ts
@@ -426,11 +426,7 @@ export function createServer(
   }
 
   const toolCount = registrar.commit();
-  registerControlPlaneResources({
-    server,
-    config,
-    capabilities,
-    b2Client,
+  registerControlPlaneResources(server, b2Client, config, capabilities, {
     oauthScopes,
     credentialsMissing: options.credentialsMissing,
   });

--- a/tests/contract/tool-profile-contract.contract.test.ts
+++ b/tests/contract/tool-profile-contract.contract.test.ts
@@ -425,8 +425,14 @@ describe("MCP advertised capability contract", () => {
       expect(fixture.modern?.discover.ttlMs).toBe(contract.approvedCacheHint.ttlMs);
       expect(fixture.modern?.discover.cacheScope).toBe(contract.approvedCacheHint.cacheScope);
       expect(fixture.modern?.discover.supportedVersions).toEqual([contract.mcpRevision]);
-      expect(fixture.modern?.discover.capabilities).toEqual({ tools: { listChanged: true } });
-      expect(Object.keys(fixture.modern?.discover.capabilities ?? {}).sort()).toEqual(["tools"]);
+      expect(fixture.modern?.discover.capabilities).toEqual({
+        resources: { listChanged: true },
+        tools: { listChanged: true },
+      });
+      expect(Object.keys(fixture.modern?.discover.capabilities ?? {}).sort()).toEqual([
+        "resources",
+        "tools",
+      ]);
     },
   );
 

--- a/tests/fixtures/tool-contract/full.modern.json
+++ b/tests/fixtures/tool-contract/full.modern.json
@@ -2035,6 +2035,9 @@
     "discover": {
       "supportedVersions": ["2026-07-28"],
       "capabilities": {
+        "resources": {
+          "listChanged": true
+        },
         "tools": {
           "listChanged": true
         }

--- a/tests/fixtures/tool-contract/live-b2-contract.modern.json
+++ b/tests/fixtures/tool-contract/live-b2-contract.modern.json
@@ -2027,6 +2027,9 @@
     "discover": {
       "supportedVersions": ["2026-07-28"],
       "capabilities": {
+        "resources": {
+          "listChanged": true
+        },
         "tools": {
           "listChanged": true
         }

--- a/tests/fixtures/tool-contract/phase1-default.modern.json
+++ b/tests/fixtures/tool-contract/phase1-default.modern.json
@@ -1929,6 +1929,9 @@
     "discover": {
       "supportedVersions": ["2026-07-28"],
       "capabilities": {
+        "resources": {
+          "listChanged": true
+        },
         "tools": {
           "listChanged": true
         }

--- a/tests/fixtures/tool-contract/read-only.modern.json
+++ b/tests/fixtures/tool-contract/read-only.modern.json
@@ -703,6 +703,9 @@
     "discover": {
       "supportedVersions": ["2026-07-28"],
       "capabilities": {
+        "resources": {
+          "listChanged": true
+        },
         "tools": {
           "listChanged": true
         }

--- a/tests/unit/b2-buckets-fixtures.unit.test.ts
+++ b/tests/unit/b2-buckets-fixtures.unit.test.ts
@@ -132,7 +132,7 @@ describe("B2 bucket tools with deterministic native fake", () => {
       await tools.call("b2_get_bucket_notification_rules", { bucketId: "bucket-1" }),
     );
     expect(getResult.eventNotificationRules[0].targetConfiguration).toMatchObject({
-      url: "https://hooks.example.test/[redacted]",
+      url: "https://[redacted]/[redacted]",
       hmacSha256SigningSecret: "[redacted]",
       customHeaders: [{ name: "Authorization", value: "[redacted]" }],
     });
@@ -175,7 +175,7 @@ describe("B2 bucket tools with deterministic native fake", () => {
       ],
     });
     expect(setResult.eventNotificationRules[0].targetConfiguration).toMatchObject({
-      url: "https://hooks.example.test/[redacted]",
+      url: "https://[redacted]/[redacted]",
       hmacSha256SigningSecret: "[redacted]",
     });
   });

--- a/tests/unit/b2-tools.unit.test.ts
+++ b/tests/unit/b2-tools.unit.test.ts
@@ -1900,7 +1900,7 @@ describe("bucket notification rules", () => {
     );
     expect(set.eventNotificationRules[0].objectNamePrefix).toBe("");
     expect(set.eventNotificationRules[0].targetConfiguration.url).toBe(
-      "https://hooks.slack.com/[redacted]",
+      "https://[redacted]/[redacted]",
     );
     expect(JSON.stringify(set)).not.toContain("webhook-token");
     expect(JSON.stringify(set)).not.toContain("slack-path-token");
@@ -1915,7 +1915,7 @@ describe("bucket notification rules", () => {
     );
     const tc = get.eventNotificationRules[0].targetConfiguration;
     expect(tc.hmacSha256SigningSecret).toBe("[redacted]");
-    expect(tc.url).toBe("https://hooks.slack.com/[redacted]");
+    expect(tc.url).toBe("https://[redacted]/[redacted]");
     expect(tc.customHeaders).toEqual({ Authorization: "[redacted]" });
     expect(JSON.stringify(get)).not.toContain("supersecret");
     expect(JSON.stringify(get)).not.toContain("webhook-token");
@@ -1977,7 +1977,7 @@ describe("bucket notification rules", () => {
     expect(json).not.toContain("rule-secret");
     expect(json).not.toContain("notification-secret");
     expect(get.eventNotificationRules[0].targetConfiguration.url).toBe(
-      "https://hooks.example.com/[redacted]",
+      "https://[redacted]/[redacted]",
     );
     expect(get.eventNotificationRules[0].targetConfiguration.customHeaders).toEqual({
       Authorization: "[redacted]",

--- a/tests/unit/resources.unit.test.ts
+++ b/tests/unit/resources.unit.test.ts
@@ -1,0 +1,345 @@
+import { Client, InMemoryTransport } from "@modelcontextprotocol/client";
+import type { ReadResourceResult } from "@modelcontextprotocol/server";
+import {
+  BUCKET_RESOURCE_TEMPLATE_URI,
+  CAPABILITIES_RESOURCE_URI,
+  SERVER_CONFIG_RESOURCE_URI,
+} from "../../src/resources";
+import {
+  createServer,
+  invalidateAuthManagerCache,
+  type CreateServerOptions,
+} from "../../src/server";
+import type { B2Config } from "../../src/utils/types";
+import { DeterministicB2NativeFake, testConfig } from "../support/deterministic-fakes";
+import { installSdkTransport, StaticHttpResponse } from "../support/sdk-test-helpers";
+
+const CANARY_SECRET = "B2_MCP_CANARY_SECRET_resource_do_not_leak";
+
+function bucketInfoFixture(bucketId: string, bucketName: string) {
+  return {
+    accountId: "account-123",
+    bucketId,
+    bucketName,
+    bucketType: "allPrivate",
+    bucketInfo: {},
+    corsRules: [
+      {
+        corsRuleName: "browser-read",
+        allowedOrigins: ["https://app.example.com"],
+        allowedHeaders: ["authorization"],
+        allowedOperations: ["s3_get"],
+        exposeHeaders: ["x-bz-content-sha1"],
+        maxAgeSeconds: 600,
+      },
+    ],
+    defaultServerSideEncryption: {
+      isClientAuthorizedToRead: true,
+      value: { mode: "SSE-B2", algorithm: "AES256" },
+    },
+    fileLockConfiguration: {
+      isClientAuthorizedToRead: true,
+      value: {
+        isFileLockEnabled: true,
+        defaultRetention: {
+          mode: "governance",
+          period: { duration: 7, unit: "days" },
+        },
+      },
+    },
+    lifecycleRules: [
+      {
+        fileNamePrefix: "logs/",
+        daysFromHidingToDeleting: 30,
+      },
+    ],
+    options: ["s3"],
+    revision: 3,
+    replicationConfiguration: {
+      isClientAuthorizedToRead: true,
+      value: {
+        asReplicationSource: {
+          sourceApplicationKeyId: "replication-key-id",
+          replicationRules: [
+            {
+              replicationRuleName: "replicate-logs",
+              destinationBucketId: "dest-bucket-id",
+              fileNamePrefix: "logs/",
+              includeExistingFiles: false,
+              isEnabled: true,
+              priority: 1,
+            },
+          ],
+        },
+        asReplicationDestination: null,
+      },
+    },
+  };
+}
+
+function notificationRulesFixture(bucketId: string) {
+  return {
+    bucketId,
+    eventNotificationRules: [
+      {
+        name: "object-created",
+        eventTypes: ["b2:ObjectCreated:*"],
+        isEnabled: true,
+        objectNamePrefix: "logs/",
+        targetConfiguration: {
+          targetType: "webhook",
+          url: `https://hooks.example.com/${CANARY_SECRET}`,
+          hmacSha256SigningSecret: CANARY_SECRET,
+          customHeaders: [{ name: "Authorization", value: CANARY_SECRET }],
+        },
+      },
+    ],
+  };
+}
+
+async function connectResourceClient(
+  options: {
+    capabilities?: string[] | null;
+    config?: B2Config;
+    serverOptions?: CreateServerOptions;
+    fake?: DeterministicB2NativeFake;
+  } = {},
+) {
+  const fake =
+    options.fake ??
+    new DeterministicB2NativeFake({
+      capabilities: options.capabilities ?? undefined,
+    });
+  installSdkTransport(fake);
+  const server = createServer(
+    options.config ?? testConfig,
+    options.capabilities,
+    options.serverOptions,
+  );
+  const client = new Client(
+    { name: "b2-mcp-resource-test", version: "1.0.0" },
+    { defaultCacheTtlMs: 0 },
+  );
+  const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
+  await server.connect(serverTransport);
+  await client.connect(clientTransport);
+  return {
+    client,
+    fake,
+    async close() {
+      await client.close().catch(() => undefined);
+      await server.close().catch(() => undefined);
+    },
+  };
+}
+
+function parseJsonResource(result: ReadResourceResult): any {
+  expect(result.contents).toHaveLength(1);
+  const [content] = result.contents;
+  expect(content.mimeType).toBe("application/json");
+  expect("text" in content).toBe(true);
+  return JSON.parse(String("text" in content ? content.text : ""));
+}
+
+describe("MCP control-plane resources", () => {
+  const previousEnv = {
+    B2_HTTP_CREDENTIAL_MODE: process.env.B2_HTTP_CREDENTIAL_MODE,
+    B2_MCP_PUBLIC_URL: process.env.B2_MCP_PUBLIC_URL,
+    B2_OAUTH_RESOURCE: process.env.B2_OAUTH_RESOURCE,
+  };
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    invalidateAuthManagerCache();
+    for (const [key, value] of Object.entries(previousEnv)) {
+      if (value === undefined) delete process.env[key];
+      else process.env[key] = value;
+    }
+  });
+
+  it("lists and reads static server and capability resources without secrets", async () => {
+    process.env.B2_HTTP_CREDENTIAL_MODE = "principal";
+    process.env.B2_MCP_PUBLIC_URL = "https://mcp.example.com/mcp";
+    const config = {
+      ...testConfig,
+      transport: "http",
+      destructivePolicy: "block",
+      secretSink: { mode: "off" },
+    } satisfies B2Config;
+    const { client, close } = await connectResourceClient({ capabilities: [], config });
+
+    try {
+      const listed = await client.listResources(undefined, { cacheMode: "refresh" });
+      const uris = listed.resources.map((resource) => resource.uri).sort();
+      expect(uris).toEqual([CAPABILITIES_RESOURCE_URI, SERVER_CONFIG_RESOURCE_URI]);
+
+      const serverConfig = parseJsonResource(
+        await client.readResource({ uri: SERVER_CONFIG_RESOURCE_URI }, { cacheMode: "refresh" }),
+      );
+      expect(serverConfig).toMatchObject({
+        version: expect.any(String),
+        transport: "http",
+        credentialMode: "principal",
+        destructivePolicy: "block",
+        secretSinkMode: "off",
+        publicUrl: "https://mcp.example.com/mcp",
+      });
+      expect(JSON.stringify(serverConfig)).not.toContain(testConfig.applicationKey);
+
+      const capabilities = parseJsonResource(
+        await client.readResource({ uri: CAPABILITIES_RESOURCE_URI }, { cacheMode: "refresh" }),
+      );
+      expect(capabilities).toMatchObject({
+        capabilityFiltering: "enabled",
+        capabilities: [],
+        activeToolProfile: {
+          mode: "capability-filtered",
+          toolCount: expect.any(Number),
+          toolNames: expect.arrayContaining(["b2_authorize_account"]),
+        },
+      });
+      expect(JSON.stringify(capabilities)).not.toContain(testConfig.applicationKey);
+    } finally {
+      await close();
+    }
+  });
+
+  it("lists bucket resources and reads bucket config with notification secrets redacted", async () => {
+    const bucket = bucketInfoFixture("bucket-id-1", "resource-bucket");
+    const fake = new DeterministicB2NativeFake({
+      capabilities: ["listBuckets", "readBucketNotifications"],
+    })
+      .respond("b2_list_buckets", new StaticHttpResponse(200, { buckets: [bucket] }))
+      .respond("b2_list_buckets", new StaticHttpResponse(200, { buckets: [bucket] }))
+      .respond(
+        "b2_get_bucket_notification_rules",
+        new StaticHttpResponse(200, notificationRulesFixture("bucket-id-1")),
+      );
+    const {
+      client,
+      fake: transport,
+      close,
+    } = await connectResourceClient({
+      capabilities: ["listBuckets", "readBucketNotifications"],
+      fake,
+    });
+
+    try {
+      const listed = await client.listResources(undefined, { cacheMode: "refresh" });
+      expect(listed.resources.map((resource) => resource.uri).sort()).toEqual([
+        "b2://bucket/resource-bucket",
+        CAPABILITIES_RESOURCE_URI,
+        SERVER_CONFIG_RESOURCE_URI,
+      ]);
+
+      const templates = await client.listResourceTemplates(undefined, { cacheMode: "refresh" });
+      expect(templates.resourceTemplates.map((template) => template.uriTemplate)).toContain(
+        BUCKET_RESOURCE_TEMPLATE_URI,
+      );
+
+      const raw = await client.readResource(
+        { uri: "b2://bucket/resource-bucket" },
+        { cacheMode: "refresh" },
+      );
+      const content = raw.contents[0];
+      const text = content && "text" in content ? content.text : "";
+      expect(text).not.toContain(CANARY_SECRET);
+
+      const resource = parseJsonResource(raw);
+      expect(resource).toMatchObject({
+        bucketName: "resource-bucket",
+        bucketId: "bucket-id-1",
+        bucketType: "allPrivate",
+        visibility: "private",
+        defaultServerSideEncryption: { mode: "SSE-B2", algorithm: "AES256" },
+        objectLock: {
+          isClientAuthorizedToRead: true,
+          value: { isFileLockEnabled: true },
+        },
+        eventNotifications: {
+          isClientAuthorizedToRead: true,
+          value: {
+            eventNotificationRules: [
+              {
+                targetConfiguration: {
+                  url: "https://hooks.example.com/[redacted]",
+                  hmacSha256SigningSecret: "[redacted]",
+                  customHeaders: { Authorization: "[redacted]" },
+                },
+              },
+            ],
+          },
+        },
+      });
+
+      const endpoints = transport.requests.map((request) => request.endpoint);
+      expect(endpoints).toEqual([
+        "b2_authorize_account",
+        "b2_list_buckets",
+        "b2_list_buckets",
+        "b2_get_bucket_notification_rules",
+      ]);
+      expect(endpoints.some((endpoint) => /create|update|set|delete/i.test(endpoint))).toBe(false);
+    } finally {
+      await close();
+    }
+  });
+
+  it("omits notification rules when the credential cannot read them", async () => {
+    const bucket = bucketInfoFixture("bucket-id-2", "bucket-without-notification-cap");
+    const fake = new DeterministicB2NativeFake({ capabilities: ["listBuckets"] }).respond(
+      "b2_list_buckets",
+      new StaticHttpResponse(200, { buckets: [bucket] }),
+    );
+    const {
+      client,
+      fake: transport,
+      close,
+    } = await connectResourceClient({
+      capabilities: ["listBuckets"],
+      fake,
+    });
+
+    try {
+      const resource = parseJsonResource(
+        await client.readResource(
+          { uri: "b2://bucket/bucket-without-notification-cap" },
+          { cacheMode: "refresh" },
+        ),
+      );
+      expect(resource.eventNotifications).toEqual({
+        isClientAuthorizedToRead: false,
+        value: null,
+      });
+      expect(transport.requests.map((request) => request.endpoint)).toEqual([
+        "b2_authorize_account",
+        "b2_list_buckets",
+      ]);
+    } finally {
+      await close();
+    }
+  });
+
+  it("does not list or read bucket resources without bucket-read authorization", async () => {
+    const { client, fake, close } = await connectResourceClient({ capabilities: ["readFiles"] });
+
+    try {
+      const listed = await client.listResources(undefined, { cacheMode: "refresh" });
+      expect(listed.resources.map((resource) => resource.uri).sort()).toEqual([
+        CAPABILITIES_RESOURCE_URI,
+        SERVER_CONFIG_RESOURCE_URI,
+      ]);
+
+      const templates = await client.listResourceTemplates(undefined, { cacheMode: "refresh" });
+      expect(templates.resourceTemplates.map((template) => template.uriTemplate)).not.toContain(
+        BUCKET_RESOURCE_TEMPLATE_URI,
+      );
+      await expect(
+        client.readResource({ uri: "b2://bucket/not-readable" }, { cacheMode: "refresh" }),
+      ).rejects.toThrow(/not.*found/i);
+      expect(fake.requests).toEqual([]);
+    } finally {
+      await close();
+    }
+  });
+});

--- a/tests/unit/resources.unit.test.ts
+++ b/tests/unit/resources.unit.test.ts
@@ -1,17 +1,28 @@
 import { Client, InMemoryTransport } from "@modelcontextprotocol/client";
 import type { ReadResourceResult } from "@modelcontextprotocol/server";
 import {
+  BUCKET_RESOURCE_LIST_LIMIT,
   BUCKET_RESOURCE_TEMPLATE_URI,
   CAPABILITIES_RESOURCE_URI,
+  type BucketResourcePayload,
+  type CapabilitiesResourcePayload,
   SERVER_CONFIG_RESOURCE_URI,
+  type ServerConfigResourcePayload,
 } from "../../src/resources";
 import {
   createServer,
   invalidateAuthManagerCache,
   type CreateServerOptions,
 } from "../../src/server";
+import { logger } from "../../src/utils/logger";
+import { annotationsForTool } from "../../src/utils/tool-capabilities";
 import type { B2Config } from "../../src/utils/types";
-import { DeterministicB2NativeFake, testConfig } from "../support/deterministic-fakes";
+import type { MockInstance } from "vitest";
+import {
+  b2ErrorResponse,
+  DeterministicB2NativeFake,
+  testConfig,
+} from "../support/deterministic-fakes";
 import { installSdkTransport, StaticHttpResponse } from "../support/sdk-test-helpers";
 
 const CANARY_SECRET = "B2_MCP_CANARY_SECRET_resource_do_not_leak";
@@ -88,7 +99,7 @@ function notificationRulesFixture(bucketId: string) {
         objectNamePrefix: "logs/",
         targetConfiguration: {
           targetType: "webhook",
-          url: `https://hooks.example.com/${CANARY_SECRET}`,
+          url: `https://${CANARY_SECRET}.hooks.example.com/${CANARY_SECRET}`,
           hmacSha256SigningSecret: CANARY_SECRET,
           customHeaders: [{ name: "Authorization", value: CANARY_SECRET }],
         },
@@ -133,13 +144,64 @@ async function connectResourceClient(
   };
 }
 
-function parseJsonResource(result: ReadResourceResult): any {
+function resourceText(result: ReadResourceResult): string {
   expect(result.contents).toHaveLength(1);
   const [content] = result.contents;
   expect(content.mimeType).toBe("application/json");
   expect("text" in content).toBe(true);
-  return JSON.parse(String("text" in content ? content.text : ""));
+  return String("text" in content ? content.text : "");
 }
+
+function parseJsonResource<T extends object>(result: ReadResourceResult): T {
+  return JSON.parse(resourceText(result)) as T;
+}
+
+function sortedKeys(value: object): string[] {
+  return Object.keys(value).sort();
+}
+
+const SERVER_CONFIG_KEYS = [
+  "credentialMode",
+  "destructivePolicy",
+  "publicUrl",
+  "schemaVersion",
+  "secretSinkMode",
+  "transport",
+  "uri",
+  "version",
+] as const;
+
+const CAPABILITIES_KEYS = [
+  "activeToolProfile",
+  "capabilities",
+  "capabilityFiltering",
+  "schemaVersion",
+  "uri",
+] as const;
+
+const ACTIVE_TOOL_PROFILE_KEYS = [
+  "destructiveToolCount",
+  "mode",
+  "readOnlyToolCount",
+  "toolCount",
+  "toolNames",
+] as const;
+
+const BUCKET_RESOURCE_KEYS = [
+  "bucketId",
+  "bucketName",
+  "bucketType",
+  "corsRules",
+  "defaultRetention",
+  "defaultServerSideEncryption",
+  "eventNotifications",
+  "lifecycleRules",
+  "objectLock",
+  "replicationConfiguration",
+  "schemaVersion",
+  "uri",
+  "visibility",
+] as const;
 
 describe("MCP control-plane resources", () => {
   const previousEnv = {
@@ -147,6 +209,13 @@ describe("MCP control-plane resources", () => {
     B2_MCP_PUBLIC_URL: process.env.B2_MCP_PUBLIC_URL,
     B2_OAUTH_RESOURCE: process.env.B2_OAUTH_RESOURCE,
   };
+  let infoSpy: MockInstance;
+  let warnSpy: MockInstance;
+
+  beforeEach(() => {
+    infoSpy = vi.spyOn(logger, "info").mockImplementation(() => undefined as never);
+    warnSpy = vi.spyOn(logger, "warn").mockImplementation(() => undefined as never);
+  });
 
   afterEach(() => {
     vi.restoreAllMocks();
@@ -173,10 +242,13 @@ describe("MCP control-plane resources", () => {
       const uris = listed.resources.map((resource) => resource.uri).sort();
       expect(uris).toEqual([CAPABILITIES_RESOURCE_URI, SERVER_CONFIG_RESOURCE_URI]);
 
-      const serverConfig = parseJsonResource(
+      const serverConfig = parseJsonResource<ServerConfigResourcePayload>(
         await client.readResource({ uri: SERVER_CONFIG_RESOURCE_URI }, { cacheMode: "refresh" }),
       );
+      expect(sortedKeys(serverConfig)).toEqual([...SERVER_CONFIG_KEYS]);
       expect(serverConfig).toMatchObject({
+        schemaVersion: 1,
+        uri: SERVER_CONFIG_RESOURCE_URI,
         version: expect.any(String),
         transport: "http",
         credentialMode: "principal",
@@ -186,10 +258,14 @@ describe("MCP control-plane resources", () => {
       });
       expect(JSON.stringify(serverConfig)).not.toContain(testConfig.applicationKey);
 
-      const capabilities = parseJsonResource(
+      const capabilities = parseJsonResource<CapabilitiesResourcePayload>(
         await client.readResource({ uri: CAPABILITIES_RESOURCE_URI }, { cacheMode: "refresh" }),
       );
+      expect(sortedKeys(capabilities)).toEqual([...CAPABILITIES_KEYS]);
+      expect(sortedKeys(capabilities.activeToolProfile)).toEqual([...ACTIVE_TOOL_PROFILE_KEYS]);
       expect(capabilities).toMatchObject({
+        schemaVersion: 1,
+        uri: CAPABILITIES_RESOURCE_URI,
         capabilityFiltering: "enabled",
         capabilities: [],
         activeToolProfile: {
@@ -198,7 +274,37 @@ describe("MCP control-plane resources", () => {
           toolNames: expect.arrayContaining(["b2_authorize_account"]),
         },
       });
+      const expectedReadOnlyCount = capabilities.activeToolProfile.toolNames.filter(
+        (name) => annotationsForTool(name).readOnlyHint,
+      ).length;
+      const expectedDestructiveCount = capabilities.activeToolProfile.toolNames.filter(
+        (name) => annotationsForTool(name).destructiveHint,
+      ).length;
+      expect(capabilities.activeToolProfile.readOnlyToolCount).toBe(expectedReadOnlyCount);
+      expect(capabilities.activeToolProfile.destructiveToolCount).toBe(expectedDestructiveCount);
       expect(JSON.stringify(capabilities)).not.toContain(testConfig.applicationKey);
+      expect(infoSpy).toHaveBeenCalledWith(
+        expect.objectContaining({
+          resource: "b2_server_config",
+          uri: SERVER_CONFIG_RESOURCE_URI,
+          operation: "resources/read",
+          credential: expect.any(String),
+          durationMs: expect.any(Number),
+          error: false,
+        }),
+        "resource.call",
+      );
+      expect(infoSpy).toHaveBeenCalledWith(
+        expect.objectContaining({
+          resource: "b2_capabilities",
+          uri: CAPABILITIES_RESOURCE_URI,
+          operation: "resources/read",
+          credential: expect.any(String),
+          durationMs: expect.any(Number),
+          error: false,
+        }),
+        "resource.call",
+      );
     } finally {
       await close();
     }
@@ -206,6 +312,7 @@ describe("MCP control-plane resources", () => {
 
   it("lists bucket resources and reads bucket config with notification secrets redacted", async () => {
     const bucket = bucketInfoFixture("bucket-id-1", "resource-bucket");
+    bucket.corsRules[0].allowedOrigins = [testConfig.applicationKey];
     const fake = new DeterministicB2NativeFake({
       capabilities: ["listBuckets", "readBucketNotifications"],
     })
@@ -241,16 +348,22 @@ describe("MCP control-plane resources", () => {
         { uri: "b2://bucket/resource-bucket" },
         { cacheMode: "refresh" },
       );
-      const content = raw.contents[0];
-      const text = content && "text" in content ? content.text : "";
+      const text = resourceText(raw);
       expect(text).not.toContain(CANARY_SECRET);
+      expect(text).not.toContain(testConfig.applicationKey);
 
-      const resource = parseJsonResource(raw);
+      const resource = parseJsonResource<BucketResourcePayload>(raw);
+      expect(sortedKeys(resource)).toEqual([...BUCKET_RESOURCE_KEYS]);
+      expect(sortedKeys(resource.eventNotifications)).toEqual([
+        "isClientAuthorizedToRead",
+        "value",
+      ]);
       expect(resource).toMatchObject({
         bucketName: "resource-bucket",
         bucketId: "bucket-id-1",
         bucketType: "allPrivate",
         visibility: "private",
+        corsRules: [{ allowedOrigins: ["[redacted]"] }],
         defaultServerSideEncryption: { mode: "SSE-B2", algorithm: "AES256" },
         objectLock: {
           isClientAuthorizedToRead: true,
@@ -262,7 +375,7 @@ describe("MCP control-plane resources", () => {
             eventNotificationRules: [
               {
                 targetConfiguration: {
-                  url: "https://hooks.example.com/[redacted]",
+                  url: "https://[redacted]/[redacted]",
                   hmacSha256SigningSecret: "[redacted]",
                   customHeaders: { Authorization: "[redacted]" },
                 },
@@ -280,6 +393,28 @@ describe("MCP control-plane resources", () => {
         "b2_get_bucket_notification_rules",
       ]);
       expect(endpoints.some((endpoint) => /create|update|set|delete/i.test(endpoint))).toBe(false);
+      expect(infoSpy).toHaveBeenCalledWith(
+        expect.objectContaining({
+          resource: "b2_bucket",
+          uri: BUCKET_RESOURCE_TEMPLATE_URI,
+          operation: "resources/list",
+          credential: expect.any(String),
+          durationMs: expect.any(Number),
+          error: false,
+        }),
+        "resource.call",
+      );
+      expect(infoSpy).toHaveBeenCalledWith(
+        expect.objectContaining({
+          resource: "b2_bucket",
+          uri: "b2://bucket/resource-bucket",
+          operation: "resources/read",
+          credential: expect.any(String),
+          durationMs: expect.any(Number),
+          error: false,
+        }),
+        "resource.call",
+      );
     } finally {
       await close();
     }
@@ -301,12 +436,13 @@ describe("MCP control-plane resources", () => {
     });
 
     try {
-      const resource = parseJsonResource(
+      const resource = parseJsonResource<BucketResourcePayload>(
         await client.readResource(
           { uri: "b2://bucket/bucket-without-notification-cap" },
           { cacheMode: "refresh" },
         ),
       );
+      expect(sortedKeys(resource)).toEqual([...BUCKET_RESOURCE_KEYS]);
       expect(resource.eventNotifications).toEqual({
         isClientAuthorizedToRead: false,
         value: null,
@@ -315,6 +451,156 @@ describe("MCP control-plane resources", () => {
         "b2_authorize_account",
         "b2_list_buckets",
       ]);
+    } finally {
+      await close();
+    }
+  });
+
+  it("returns bucket config when the secondary notification lookup fails", async () => {
+    const bucket = bucketInfoFixture("bucket-id-3", "bucket-with-notification-outage");
+    const fake = new DeterministicB2NativeFake({
+      capabilities: ["listBuckets", "readBucketNotifications"],
+    })
+      .respond("b2_list_buckets", new StaticHttpResponse(200, { buckets: [bucket] }))
+      .respond(
+        "b2_get_bucket_notification_rules",
+        b2ErrorResponse(
+          503,
+          "notification_rules_unavailable",
+          `temporary ${testConfig.applicationKey}`,
+          { "x-bz-request-id": "notify-req-7" },
+        ),
+      );
+    const { client, close } = await connectResourceClient({
+      capabilities: ["listBuckets", "readBucketNotifications"],
+      fake,
+    });
+
+    try {
+      const raw = await client.readResource(
+        { uri: "b2://bucket/bucket-with-notification-outage" },
+        { cacheMode: "refresh" },
+      );
+      const text = resourceText(raw);
+      expect(text).not.toContain(testConfig.applicationKey);
+      const resource = parseJsonResource<BucketResourcePayload>(raw);
+
+      expect(resource.bucketName).toBe("bucket-with-notification-outage");
+      expect(resource.eventNotifications).toEqual({
+        isClientAuthorizedToRead: true,
+        value: null,
+        unavailable: true,
+        error: {
+          code: "notification_rules_unavailable",
+          status: 503,
+          requestId: "notify-req-7",
+        },
+      });
+      expect(warnSpy).toHaveBeenCalledWith(
+        expect.objectContaining({
+          resource: "b2_bucket",
+          uri: "b2://bucket/bucket-with-notification-outage",
+          operation: "b2_get_bucket_notification_rules",
+          credential: expect.any(String),
+          durationMs: expect.any(Number),
+          error: true,
+          code: "notification_rules_unavailable",
+          status: 503,
+          requestId: "notify-req-7",
+          err: expect.stringContaining("[redacted]"),
+        }),
+        "resource.dependency_error",
+      );
+      expect(infoSpy).toHaveBeenCalledWith(
+        expect.objectContaining({
+          resource: "b2_bucket",
+          uri: "b2://bucket/bucket-with-notification-outage",
+          operation: "resources/read",
+          error: false,
+        }),
+        "resource.call",
+      );
+    } finally {
+      await close();
+    }
+  });
+
+  it("logs provider metadata when a bucket resource read fails", async () => {
+    const fake = new DeterministicB2NativeFake({ capabilities: ["listBuckets"] }).respond(
+      "b2_list_buckets",
+      b2ErrorResponse(503, "bucket_list_down", `failed ${testConfig.applicationKey}`, {
+        "x-bz-request-id": "bucket-read-req-9",
+      }),
+    );
+    const { client, close } = await connectResourceClient({
+      capabilities: ["listBuckets"],
+      fake,
+    });
+
+    try {
+      await expect(
+        client.readResource({ uri: "b2://bucket/unavailable" }, { cacheMode: "refresh" }),
+      ).rejects.toThrow(/failed \[redacted\]/);
+      expect(warnSpy).toHaveBeenCalledWith(
+        expect.objectContaining({
+          resource: "b2_bucket",
+          uri: "b2://bucket/unavailable",
+          operation: "resources/read",
+          credential: expect.any(String),
+          durationMs: expect.any(Number),
+          error: true,
+          code: "bucket_list_down",
+          status: 503,
+          requestId: "bucket-read-req-9",
+          err: expect.stringContaining("[redacted]"),
+        }),
+        "resource.error",
+      );
+      expect(JSON.stringify(warnSpy.mock.calls)).not.toContain(testConfig.applicationKey);
+    } finally {
+      await close();
+    }
+  });
+
+  it("caps bucket resources/list for large bucket namespaces", async () => {
+    const buckets = Array.from({ length: BUCKET_RESOURCE_LIST_LIMIT + 25 }, (_, index) =>
+      bucketInfoFixture(
+        `bucket-id-${index}`,
+        `resource-bucket-${index.toString().padStart(3, "0")}`,
+      ),
+    );
+    const fake = new DeterministicB2NativeFake({ capabilities: ["listBuckets"] }).respond(
+      "b2_list_buckets",
+      new StaticHttpResponse(200, { buckets }),
+    );
+    const { client, close } = await connectResourceClient({
+      capabilities: ["listBuckets"],
+      fake,
+    });
+
+    try {
+      const listed = await client.listResources(undefined, { cacheMode: "refresh" });
+      const bucketUris = listed.resources
+        .map((resource) => resource.uri)
+        .filter((uri) => uri.startsWith("b2://bucket/"));
+
+      expect(bucketUris).toHaveLength(BUCKET_RESOURCE_LIST_LIMIT);
+      expect(bucketUris).toContain("b2://bucket/resource-bucket-000");
+      expect(bucketUris).not.toContain(
+        `b2://bucket/resource-bucket-${BUCKET_RESOURCE_LIST_LIMIT.toString().padStart(3, "0")}`,
+      );
+      expect(warnSpy).toHaveBeenCalledWith(
+        expect.objectContaining({
+          resource: "b2_bucket",
+          uri: BUCKET_RESOURCE_TEMPLATE_URI,
+          operation: "resources/list",
+          credential: expect.any(String),
+          bucketCount: BUCKET_RESOURCE_LIST_LIMIT + 25,
+          returnedBucketCount: BUCKET_RESOURCE_LIST_LIMIT,
+          limit: BUCKET_RESOURCE_LIST_LIMIT,
+        }),
+        "resource.list.truncated",
+      );
     } finally {
       await close();
     }
@@ -337,6 +623,29 @@ describe("MCP control-plane resources", () => {
       await expect(
         client.readResource({ uri: "b2://bucket/not-readable" }, { cacheMode: "refresh" }),
       ).rejects.toThrow(/not.*found/i);
+      expect(fake.requests).toEqual([]);
+    } finally {
+      await close();
+    }
+  });
+
+  it("keeps non-secret server config visible in credential-less discovery mode", async () => {
+    const { client, fake, close } = await connectResourceClient({
+      capabilities: null,
+      serverOptions: { credentialsMissing: true },
+    });
+
+    try {
+      const listed = await client.listResources(undefined, { cacheMode: "refresh" });
+      expect(listed.resources.map((resource) => resource.uri).sort()).toEqual([
+        SERVER_CONFIG_RESOURCE_URI,
+      ]);
+
+      const serverConfig = parseJsonResource<ServerConfigResourcePayload>(
+        await client.readResource({ uri: SERVER_CONFIG_RESOURCE_URI }, { cacheMode: "refresh" }),
+      );
+      expect(sortedKeys(serverConfig)).toEqual([...SERVER_CONFIG_KEYS]);
+      expect(JSON.stringify(serverConfig)).not.toContain(testConfig.applicationKey);
       expect(fake.requests).toEqual([]);
     } finally {
       await close();

--- a/tests/unit/resources.unit.test.ts
+++ b/tests/unit/resources.unit.test.ts
@@ -1,5 +1,9 @@
 import { Client, InMemoryTransport } from "@modelcontextprotocol/client";
-import type { ReadResourceResult } from "@modelcontextprotocol/server";
+import {
+  ProtocolErrorCode,
+  ResourceNotFoundError,
+  type ReadResourceResult,
+} from "@modelcontextprotocol/server";
 import {
   BUCKET_RESOURCE_LIST_LIMIT,
   BUCKET_RESOURCE_TEMPLATE_URI,
@@ -557,6 +561,44 @@ describe("MCP control-plane resources", () => {
         "resource.error",
       );
       expect(JSON.stringify(warnSpy.mock.calls)).not.toContain(testConfig.applicationKey);
+    } finally {
+      await close();
+    }
+  });
+
+  it("preserves SDK resource-not-found errors for missing buckets", async () => {
+    const fake = new DeterministicB2NativeFake({ capabilities: ["listBuckets"] }).respond(
+      "b2_list_buckets",
+      new StaticHttpResponse(200, { buckets: [] }),
+    );
+    const { client, close } = await connectResourceClient({
+      capabilities: ["listBuckets"],
+      fake,
+    });
+
+    try {
+      const uri = "b2://bucket/missing-bucket";
+      let error: unknown;
+      try {
+        await client.readResource({ uri }, { cacheMode: "refresh" });
+      } catch (err) {
+        error = err;
+      }
+
+      expect(error).toBeInstanceOf(ResourceNotFoundError);
+      expect(error).toMatchObject({
+        code: ProtocolErrorCode.InvalidParams,
+        data: { uri },
+      });
+      expect(warnSpy).toHaveBeenCalledWith(
+        expect.objectContaining({
+          resource: "b2_bucket",
+          uri,
+          operation: "resources/read",
+          error: true,
+        }),
+        "resource.error",
+      );
     } finally {
       await close();
     }

--- a/tests/unit/resources.unit.test.ts
+++ b/tests/unit/resources.unit.test.ts
@@ -658,6 +658,77 @@ describe("MCP control-plane resources", () => {
     }
   });
 
+  it("sanitizes request-controlled bucket resource URIs in audit logs", async () => {
+    const bucket = bucketInfoFixture("bucket-id-secret", testConfig.applicationKey);
+    const fake = new DeterministicB2NativeFake({ capabilities: ["listBuckets"] }).respond(
+      "b2_list_buckets",
+      new StaticHttpResponse(200, { buckets: [bucket] }),
+    );
+    const { client, close } = await connectResourceClient({
+      capabilities: ["listBuckets"],
+      fake,
+    });
+
+    try {
+      const uri = `b2://bucket/${testConfig.applicationKey}`;
+      const resource = parseJsonResource<BucketResourcePayload>(
+        await client.readResource({ uri }, { cacheMode: "refresh" }),
+      );
+      expect(resource.uri).toBe("b2://bucket/[redacted]");
+      expect(infoSpy).toHaveBeenCalledWith(
+        expect.objectContaining({
+          resource: "b2_bucket",
+          uri: "b2://bucket/[redacted]",
+          operation: "resources/read",
+          error: false,
+        }),
+        "resource.call",
+      );
+      expect(JSON.stringify(infoSpy.mock.calls)).not.toContain(testConfig.applicationKey);
+    } finally {
+      await close();
+    }
+  });
+
+  it("sanitizes request-controlled bucket resource URIs in protocol errors", async () => {
+    const fake = new DeterministicB2NativeFake({ capabilities: ["listBuckets"] }).respond(
+      "b2_list_buckets",
+      new StaticHttpResponse(200, { buckets: [] }),
+    );
+    const { client, close } = await connectResourceClient({
+      capabilities: ["listBuckets"],
+      fake,
+    });
+
+    try {
+      const uri = `b2://bucket/${testConfig.applicationKey}`;
+      let error: unknown;
+      try {
+        await client.readResource({ uri }, { cacheMode: "refresh" });
+      } catch (err) {
+        error = err;
+      }
+
+      expect(error).toBeInstanceOf(ResourceNotFoundError);
+      expect(error).toMatchObject({
+        code: ProtocolErrorCode.InvalidParams,
+        data: { uri: "b2://bucket/[redacted]" },
+      });
+      expect(warnSpy).toHaveBeenCalledWith(
+        expect.objectContaining({
+          resource: "b2_bucket",
+          uri: "b2://bucket/[redacted]",
+          operation: "resources/read",
+          error: true,
+        }),
+        "resource.error",
+      );
+      expect(JSON.stringify(warnSpy.mock.calls)).not.toContain(testConfig.applicationKey);
+    } finally {
+      await close();
+    }
+  });
+
   it("caps bucket resources/list for large bucket namespaces", async () => {
     const buckets = Array.from({ length: BUCKET_RESOURCE_LIST_LIMIT + 25 }, (_, index) =>
       bucketInfoFixture(

--- a/tests/unit/resources.unit.test.ts
+++ b/tests/unit/resources.unit.test.ts
@@ -818,4 +818,24 @@ describe("MCP control-plane resources", () => {
       await close();
     }
   });
+
+  it("omits capability summaries while capabilities are fail-closed unknown", async () => {
+    const { client, fake, close } = await connectResourceClient({
+      capabilities: [],
+      serverOptions: { failClosedUnknownCapabilities: true },
+    });
+
+    try {
+      const listed = await client.listResources(undefined, { cacheMode: "refresh" });
+      expect(listed.resources.map((resource) => resource.uri).sort()).toEqual([
+        SERVER_CONFIG_RESOURCE_URI,
+      ]);
+      await expect(
+        client.readResource({ uri: CAPABILITIES_RESOURCE_URI }, { cacheMode: "refresh" }),
+      ).rejects.toThrow(/not.*found/i);
+      expect(fake.requests).toEqual([]);
+    } finally {
+      await close();
+    }
+  });
 });

--- a/tests/unit/resources.unit.test.ts
+++ b/tests/unit/resources.unit.test.ts
@@ -529,6 +529,60 @@ describe("MCP control-plane resources", () => {
     }
   });
 
+  it("does not turn caller-aborted notification reads into successful bucket reads", async () => {
+    const bucket = bucketInfoFixture("bucket-id-4", "bucket-with-aborted-notification-read");
+    const fake = new DeterministicB2NativeFake({
+      capabilities: ["listBuckets", "readBucketNotifications"],
+    })
+      .respond("b2_list_buckets", new StaticHttpResponse(200, { buckets: [bucket] }))
+      .respond(
+        "b2_get_bucket_notification_rules",
+        b2ErrorResponse(499, "request_aborted", `caller ${testConfig.applicationKey}`, {
+          "x-bz-request-id": "notify-abort-1",
+        }),
+      );
+    const { client, close } = await connectResourceClient({
+      capabilities: ["listBuckets", "readBucketNotifications"],
+      fake,
+    });
+
+    try {
+      const uri = "b2://bucket/bucket-with-aborted-notification-read";
+      await expect(client.readResource({ uri }, { cacheMode: "refresh" })).rejects.toThrow(
+        /caller \[redacted\]/,
+      );
+      expect(
+        warnSpy.mock.calls.some(([, message]) => message === "resource.dependency_error"),
+      ).toBe(false);
+      expect(infoSpy).not.toHaveBeenCalledWith(
+        expect.objectContaining({
+          resource: "b2_bucket",
+          uri,
+          operation: "resources/read",
+          error: false,
+        }),
+        "resource.call",
+      );
+      expect(warnSpy).toHaveBeenCalledWith(
+        expect.objectContaining({
+          resource: "b2_bucket",
+          uri,
+          operation: "resources/read",
+          credential: expect.any(String),
+          durationMs: expect.any(Number),
+          error: true,
+          code: "request_aborted",
+          status: 499,
+          requestId: "notify-abort-1",
+          err: expect.stringContaining("[redacted]"),
+        }),
+        "resource.error",
+      );
+    } finally {
+      await close();
+    }
+  });
+
   it("logs provider metadata when a bucket resource read fails", async () => {
     const fake = new DeterministicB2NativeFake({ capabilities: ["listBuckets"] }).respond(
       "b2_list_buckets",

--- a/tests/unit/resources.unit.test.ts
+++ b/tests/unit/resources.unit.test.ts
@@ -644,12 +644,18 @@ describe("MCP control-plane resources", () => {
         code: ProtocolErrorCode.InvalidParams,
         data: { uri },
       });
+      // The audit log must classify a routine missing-bucket read as a
+      // resource-not-found (404), not collapse the JSON-RPC protocol error
+      // through the provider parser into internal_error/500, which would skew
+      // resource error-rate alerting.
       expect(warnSpy).toHaveBeenCalledWith(
         expect.objectContaining({
           resource: "b2_bucket",
           uri,
           operation: "resources/read",
           error: true,
+          code: "resource_not_found",
+          status: 404,
         }),
         "resource.error",
       );

--- a/tests/unit/resources.unit.test.ts
+++ b/tests/unit/resources.unit.test.ts
@@ -846,6 +846,93 @@ describe("MCP control-plane resources", () => {
       await close();
     }
   });
+
+  it("hides bucket and capability resources for non-B2 OAuth scopes", async () => {
+    const { client, fake, close } = await connectResourceClient({
+      capabilities: ["listBuckets", "readBucketNotifications"],
+      serverOptions: { oauthScopes: ["openid"] },
+    });
+
+    try {
+      const listed = await client.listResources(undefined, { cacheMode: "refresh" });
+      expect(listed.resources.map((resource) => resource.uri).sort()).toEqual([
+        SERVER_CONFIG_RESOURCE_URI,
+      ]);
+      await expect(
+        client.readResource({ uri: "b2://bucket/any" }, { cacheMode: "refresh" }),
+      ).rejects.toThrow(/not.*found/i);
+      expect(fake.requests).toEqual([]);
+    } finally {
+      await close();
+    }
+  });
+
+  it("suppresses the admin-gated notification sub-read for a b2:read scope", async () => {
+    const bucket = bucketInfoFixture("bucket-id-read", "read-scope-bucket");
+    const fake = new DeterministicB2NativeFake({
+      capabilities: ["listBuckets", "readBucketNotifications"],
+    }).respond("b2_list_buckets", new StaticHttpResponse(200, { buckets: [bucket] }));
+    const {
+      client,
+      fake: transport,
+      close,
+    } = await connectResourceClient({
+      capabilities: ["listBuckets", "readBucketNotifications"],
+      serverOptions: { oauthScopes: ["b2:read"] },
+      fake,
+    });
+
+    try {
+      const resource = parseJsonResource<BucketResourcePayload>(
+        await client.readResource(
+          { uri: "b2://bucket/read-scope-bucket" },
+          { cacheMode: "refresh" },
+        ),
+      );
+      expect(resource.eventNotifications).toEqual({
+        isClientAuthorizedToRead: false,
+        value: null,
+      });
+      expect(transport.requests.map((request) => request.endpoint)).toEqual([
+        "b2_authorize_account",
+        "b2_list_buckets",
+      ]);
+    } finally {
+      await close();
+    }
+  });
+
+  it("redacts request-controlled key IDs from resource audit URIs", async () => {
+    const bucket = bucketInfoFixture("bucket-id-keyid", testConfig.applicationKeyId);
+    const fake = new DeterministicB2NativeFake({ capabilities: ["listBuckets"] }).respond(
+      "b2_list_buckets",
+      new StaticHttpResponse(200, { buckets: [bucket] }),
+    );
+    const { client, close } = await connectResourceClient({
+      capabilities: ["listBuckets"],
+      fake,
+    });
+
+    try {
+      const uri = `b2://bucket/${testConfig.applicationKeyId}`;
+      const resource = parseJsonResource<BucketResourcePayload>(
+        await client.readResource({ uri }, { cacheMode: "refresh" }),
+      );
+      expect(resource.uri).toBe("b2://bucket/[redacted]");
+      expect(infoSpy).toHaveBeenCalledWith(
+        expect.objectContaining({
+          resource: "b2_bucket",
+          uri: "b2://bucket/[redacted]",
+          operation: "resources/read",
+          error: false,
+        }),
+        "resource.call",
+      );
+      expect(JSON.stringify(infoSpy.mock.calls)).not.toContain(testConfig.applicationKeyId);
+    } finally {
+      await close();
+    }
+  });
 });
 
 describe("protocolErrorAuditFields", () => {

--- a/tests/unit/resources.unit.test.ts
+++ b/tests/unit/resources.unit.test.ts
@@ -903,7 +903,7 @@ describe("MCP control-plane resources", () => {
   });
 
   it("redacts request-controlled key IDs from resource audit URIs", async () => {
-    const bucket = bucketInfoFixture("bucket-id-keyid", testConfig.applicationKeyId);
+    const bucket = bucketInfoFixture("bucket-key-id", testConfig.applicationKeyId);
     const fake = new DeterministicB2NativeFake({ capabilities: ["listBuckets"] }).respond(
       "b2_list_buckets",
       new StaticHttpResponse(200, { buckets: [bucket] }),

--- a/tests/unit/resources.unit.test.ts
+++ b/tests/unit/resources.unit.test.ts
@@ -1,5 +1,6 @@
 import { Client, InMemoryTransport } from "@modelcontextprotocol/client";
 import {
+  ProtocolError,
   ProtocolErrorCode,
   ResourceNotFoundError,
   type ReadResourceResult,
@@ -10,6 +11,7 @@ import {
   CAPABILITIES_RESOURCE_URI,
   type BucketResourcePayload,
   type CapabilitiesResourcePayload,
+  protocolErrorAuditFields,
   SERVER_CONFIG_RESOURCE_URI,
   type ServerConfigResourcePayload,
 } from "../../src/resources";
@@ -843,5 +845,35 @@ describe("MCP control-plane resources", () => {
     } finally {
       await close();
     }
+  });
+});
+
+describe("protocolErrorAuditFields", () => {
+  it("classifies a resources/read miss as resource_not_found (404), not internal_error/500", () => {
+    expect(protocolErrorAuditFields(new ResourceNotFoundError("b2://bucket/missing"))).toEqual({
+      code: "resource_not_found",
+      status: 404,
+    });
+  });
+
+  it.each([
+    [ProtocolErrorCode.ParseError, "parse_error", 400],
+    [ProtocolErrorCode.InvalidRequest, "invalid_request", 400],
+    [ProtocolErrorCode.MethodNotFound, "method_not_found", 404],
+    [ProtocolErrorCode.InvalidParams, "invalid_params", 400],
+    [ProtocolErrorCode.ResourceNotFound, "resource_not_found", 404],
+    [ProtocolErrorCode.InternalError, "internal_error", 500],
+  ] as const)("maps protocol code %d to %s/%d", (code, expectedCode, expectedStatus) => {
+    expect(protocolErrorAuditFields(new ProtocolError(code, "boom"))).toEqual({
+      code: expectedCode,
+      status: expectedStatus,
+    });
+  });
+
+  it("maps an unrecognized protocol code to a generic protocol_error (400)", () => {
+    expect(protocolErrorAuditFields(new ProtocolError(-31999, "unknown"))).toEqual({
+      code: "protocol_error",
+      status: 400,
+    });
   });
 });


### PR DESCRIPTION
## Summary
- Registers MCP resources for non-secret server config and credential capabilities/tool profile, while omitting capability summaries when credential capabilities are fail-closed unknown.
- Adds a capability/OAuth-gated B2 bucket resource template with capped `resources/list`, uncached `resources/read`, sanitized payloads, preserved resource-not-found protocol errors, cancellation-safe reads, graceful notification-read degradation, redacted notification webhook secrets, and structured resource audit logs.
- Classifies JSON-RPC `ProtocolError`s in the resource audit log so a routine missing-bucket `resources/read` records as `resource_not_found`/404 instead of collapsing to `internal_error`/500, with unit tests covering every classification branch.
- Redacts the configured application/app/master key IDs from resource audit URIs so a request-controlled URI such as `b2://bucket/<applicationKeyId>` logs as `b2://bucket/[redacted]` in header/principal credential modes, and adds OAuth-scope tests proving a non-B2 scope set hides bucket and capability resources and a `b2:read` scope suppresses the admin-gated notification sub-read.
- Reuses the central tool capability policy and shared notification-redaction helper, and documents resources in README, AGENTS, CHANGELOG, and the deployment rollout note.
- Raises the Worker source-graph byte budget minimally from 850,000 to 870,000 and the Vercel function estimate budget to 33,450,000 so the added `src/resources.ts` module remains covered by size guards.

## Linked Issue
Closes #165

## Tests
- mamba run -n b2-mcp-issue-165 pnpm exec vitest run --config vitest.config.mts --project=unit tests/unit/resources.unit.test.ts tests/unit/b2-buckets-fixtures.unit.test.ts tests/unit/b2-tools.unit.test.ts
- mamba run -n b2-mcp-issue-165 pnpm run test:contract
- mamba run -n b2-mcp-issue-165 pnpm run check:package-budget && mamba run -n b2-mcp-issue-165 pnpm run check:vercel-bundle
- mamba run -n b2-mcp-issue-165 pnpm run test:coverage
- mamba run -n b2-mcp-issue-165 pnpm run lint:docs
- mamba run -n b2-mcp-issue-165 pnpm run spell
- mamba run -n b2-mcp-issue-165 pnpm run verify

## Follow-Up Notes
- None.
