### PR TITLE
fix: update test JWT signing helper

### DIFF
--- a/tests/support/oauth-jwks.ts
+++ b/tests/support/oauth-jwks.ts
@@ -3,8 +3,8 @@ import {
   createPrivateKey,
   createSign,
   generateKeyPairSync,
-  sign as nodeSign,
   type JsonWebKey,
+  sign as nodeSign,
 } from "node:crypto";
 import { introspectionClaims } from "./oauth-introspection";
 
@@ -78,7 +78,7 @@ export function signedJwt(
   };
   const signingInput = `${base64Url(JSON.stringify(header))}.${base64Url(JSON.stringify(claims))}`;
   const privateKey = createPrivateKey({ key: rsaPrivateJwk, format: "jwk" });
-  const signature = createSign("RSA-SHA256").update(signingInput).end().sign(privateKey);
+  const signature = nodeSign("RSA-SHA256", new TextEncoder().encode(signingInput), privateKey);
   return `${signingInput}.${base64Url(signature)}`;
 }
 


### PR DESCRIPTION
## Summary
- Replace the RSA JWT test helper's streaming `createSign("RSA-SHA256")` call with one-shot `crypto.sign`.
- Preserve RS256 JWT fixture behavior while avoiding the CodeQL password-hash false-positive pattern in test support code.

## Linked alerts
- https://github.com/backblaze-labs/b2-mcp/security/code-scanning/45

## Tests run
- `/Users/gpenacastellanos/miniforge3/condabin/mamba run -n b2-mcp-password-hash pnpm run typecheck`
- `/Users/gpenacastellanos/miniforge3/condabin/mamba run -n b2-mcp-password-hash pnpm exec biome check tests/support/oauth-jwks.ts`
- `/Users/gpenacastellanos/miniforge3/condabin/mamba run -n b2-mcp-password-hash pnpm exec vitest run tests/unit/oauth-resource-server.unit.test.ts tests/unit/auth.unit.test.ts`

## Follow-up notes
- No follow-up required.