### PR TITLE
fix: avoid streaming hash for test JWTs

### DIFF
--- a/tests/support/oauth-jwks.ts
+++ b/tests/support/oauth-jwks.ts
@@ -1,12 +1,13 @@
 /* cspell:disable */
 import {
   createPrivateKey,
-  createSign,
   generateKeyPairSync,
-  sign as nodeSign,
   type JsonWebKey,
+  sign as nodeSign,
 } from "node:crypto";
 import { introspectionClaims } from "./oauth-introspection";
+
+const textEncoder = new TextEncoder();
 
 const rsaPrivateJwk = {
   kty: "RSA",
@@ -78,7 +79,7 @@ export function signedJwt(
   };
   const signingInput = `${base64Url(JSON.stringify(header))}.${base64Url(JSON.stringify(claims))}`;
   const privateKey = createPrivateKey({ key: rsaPrivateJwk, format: "jwk" });
-  const signature = createSign("RSA-SHA256").update(signingInput).end().sign(privateKey);
+  const signature = nodeSign("RSA-SHA256", textEncoder.encode(signingInput), privateKey);
   return `${signingInput}.${base64Url(signature)}`;
 }
 
@@ -88,10 +89,10 @@ export function signedEs256Jwt(
 ): string {
   const header = { alg: "ES256", typ: "at+jwt", kid: ecPublicJwk.kid, ...headerOverrides };
   const signingInput = `${base64Url(JSON.stringify(header))}.${base64Url(JSON.stringify(claims))}`;
-  const signature = createSign("SHA256")
-    .update(signingInput)
-    .end()
-    .sign({ key: ecKeyPair.privateKey, dsaEncoding: "ieee-p1363" });
+  const signature = nodeSign("SHA256", textEncoder.encode(signingInput), {
+    key: ecKeyPair.privateKey,
+    dsaEncoding: "ieee-p1363",
+  });
   return `${signingInput}.${base64Url(signature)}`;
 }
 
@@ -101,11 +102,7 @@ export function signedEdDsaJwt(
 ): string {
   const header = { alg: "EdDSA", typ: "at+jwt", kid: ed25519PublicJwk.kid, ...headerOverrides };
   const signingInput = `${base64Url(JSON.stringify(header))}.${base64Url(JSON.stringify(claims))}`;
-  const signature = nodeSign(
-    null,
-    new TextEncoder().encode(signingInput),
-    ed25519KeyPair.privateKey,
-  );
+  const signature = nodeSign(null, textEncoder.encode(signingInput), ed25519KeyPair.privateKey);
   return `${signingInput}.${base64Url(signature)}`;
 }
 


### PR DESCRIPTION
## Summary
- Replaces streaming `createSign().update().sign()` usage in OAuth JWKS test JWT helpers with one-shot `crypto.sign()`.
- Reuses a shared `TextEncoder` for RSA, ES256, and EdDSA test JWT signing input.

## Linked alerts
- https://github.com/backblaze-labs/b2-mcp/security/code-scanning/45

## Tests run
- `mamba run -n b2-mcp-oauth-jwks-hash pnpm run typecheck`
- `mamba run -n b2-mcp-oauth-jwks-hash pnpm exec biome check tests/support/oauth-jwks.ts`
- `mamba run -n b2-mcp-oauth-jwks-hash pnpm exec vitest run tests/unit/oauth-resource-server.unit.test.ts tests/reliability/dependency-failures.reliability.test.ts tests/runtime-security/http.runtime-security.test.ts tests/unit/vercel-adapter.unit.test.ts tests/unit/cloudflare-worker-adapter.unit.test.ts`

## Follow-up notes
- No follow-up needed.