### PR TITLE
feat: build and attach reproducible MCPB bundle on release

### DIFF
--- a/.cspell/project-words.txt
+++ b/.cspell/project-words.txt
@@ -62,6 +62,7 @@ sophiecarreras
 # Cloud, network, storage, and security terms
 buildx
 creds
+EOCD
 EOPENBREAKER
 exfiltration
 Fleur

--- a/.cspell/project-words.txt
+++ b/.cspell/project-words.txt
@@ -71,6 +71,7 @@ MCPB
 mcpmarket
 noout
 paginators
+PKWARE
 punkpeye
 sessionful
 Smithery

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,16 @@
+# Normalize line endings so every OS checks out identical bytes.
+#
+# The MCPB desktop-extension bundle (dist-mcpb/b2-mcp.mcpb) packs
+# mcpb/manifest.json verbatim, and its release SHA-256 must be reproducible on
+# every build OS. Without this, a Windows checkout with core.autocrlf=true would
+# rewrite tracked text files to CRLF and change the packed manifest bytes, so a
+# Windows rebuild would not match the Linux release checksum. Forcing LF on
+# checkout removes that divergence at its source; see scripts/build-mcpb.mjs.
+* text=auto eol=lf
+
+# Binary assets git must never touch.
+*.mcpb binary
+*.png binary
+*.jpg binary
+*.gif binary
+*.ico binary

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -48,6 +48,8 @@ jobs:
       tarball-integrity: ${{ steps.pack.outputs.tarball_integrity }}
       sbom-name: ${{ steps.sbom.outputs.sbom_name }}
       sbom-sha256: ${{ steps.sbom.outputs.sbom_sha256 }}
+      mcpb-name: ${{ steps.mcpb.outputs.mcpb_name }}
+      mcpb-sha256: ${{ steps.mcpb.outputs.mcpb_sha256 }}
       checksums-name: ${{ steps.checksums.outputs.checksums_name }}
       checksums-sha256: ${{ steps.checksums.outputs.checksums_sha256 }}
       release-notes-name: ${{ steps.notes.outputs.release_notes_name }}
@@ -278,6 +280,21 @@ jobs:
             --access public \
             --ignore-scripts \
             --tag "${npm_tag}"
+      - name: Build MCPB desktop-extension bundle
+        id: mcpb
+        env:
+          ACTIONS_CACHE_URL: ""
+          ACTIONS_RESULTS_URL: ""
+          ACTIONS_RUNTIME_TOKEN: ""
+          ACTIONS_RUNTIME_URL: ""
+        run: |
+          set -euo pipefail
+          mkdir -p publish-package
+          pnpm run build:mcpb
+          cp dist-mcpb/b2-mcp.mcpb publish-package/b2-mcp.mcpb
+          mcpb_sha256="$(sha256sum publish-package/b2-mcp.mcpb | awk '{print $1}')"
+          echo "mcpb_name=b2-mcp.mcpb" >> "$GITHUB_OUTPUT"
+          echo "mcpb_sha256=${mcpb_sha256}" >> "$GITHUB_OUTPUT"
       - name: Write artifact checksums
         id: checksums
         env:
@@ -288,7 +305,7 @@ jobs:
         run: |
           set -euo pipefail
           cd publish-package
-          sha256sum *.tgz *.cdx.json release-notes.md npm-pack.json > SHA256SUMS
+          sha256sum *.tgz *.cdx.json *.mcpb release-notes.md npm-pack.json > SHA256SUMS
           checksums_sha256="$(sha256sum SHA256SUMS | awk '{print $1}')"
           echo "checksums_name=SHA256SUMS" >> "$GITHUB_OUTPUT"
           echo "checksums_sha256=${checksums_sha256}" >> "$GITHUB_OUTPUT"
@@ -327,6 +344,7 @@ jobs:
           path: |
             publish-package/*.tgz
             publish-package/*.cdx.json
+            publish-package/*.mcpb
             publish-package/SHA256SUMS
             publish-package/release-notes.md
             publish-package/npm-pack.json
@@ -722,12 +740,15 @@ jobs:
           EXPECTED_CHECKSUMS_SHA256: ${{ needs.prepare.outputs.checksums-sha256 }}
           EXPECTED_RELEASE_NOTES_NAME: ${{ needs.prepare.outputs.release-notes-name }}
           EXPECTED_RELEASE_NOTES_SHA256: ${{ needs.prepare.outputs.release-notes-sha256 }}
+          EXPECTED_MCPB_NAME: ${{ needs.prepare.outputs.mcpb-name }}
+          EXPECTED_MCPB_SHA256: ${{ needs.prepare.outputs.mcpb-sha256 }}
         run: |
           set -euo pipefail
           tarball="./publish-package/${EXPECTED_TARBALL_NAME}"
           sbom="publish-package/${EXPECTED_SBOM_NAME}"
           checksums="publish-package/${EXPECTED_CHECKSUMS_NAME}"
           notes="publish-package/${EXPECTED_RELEASE_NOTES_NAME}"
+          mcpb="publish-package/${EXPECTED_MCPB_NAME}"
           if [[ ! -f "$tarball" ]]; then
             echo "::error::Expected release tarball ${tarball} is missing"
             exit 1
@@ -742,6 +763,10 @@ jobs:
           fi
           if [[ ! -f "$notes" ]]; then
             echo "::error::Expected release notes ${notes} are missing"
+            exit 1
+          fi
+          if [[ ! -f "$mcpb" ]]; then
+            echo "::error::Expected MCPB bundle ${mcpb} is missing"
             exit 1
           fi
           actual_tarball_sha="$(sha256sum "$tarball" | awk '{print $1}')"
@@ -766,6 +791,13 @@ jobs:
             echo "::error::Release notes SHA-256 mismatch"
             exit 1
           fi
+          actual_mcpb_sha="$(sha256sum "$mcpb" | awk '{print $1}')"
+          if [[ "$actual_mcpb_sha" != "$EXPECTED_MCPB_SHA256" ]]; then
+            echo "::error::MCPB bundle SHA-256 mismatch"
+            echo "expected=${EXPECTED_MCPB_SHA256}"
+            echo "actual=${actual_mcpb_sha}"
+            exit 1
+          fi
           (cd publish-package && sha256sum --check "${EXPECTED_CHECKSUMS_NAME}")
       - name: Create GitHub release from verified artifact
         env:
@@ -774,6 +806,7 @@ jobs:
           EXPECTED_SBOM_NAME: ${{ needs.prepare.outputs.sbom-name }}
           EXPECTED_CHECKSUMS_NAME: ${{ needs.prepare.outputs.checksums-name }}
           EXPECTED_RELEASE_NOTES_NAME: ${{ needs.prepare.outputs.release-notes-name }}
+          EXPECTED_MCPB_NAME: ${{ needs.prepare.outputs.mcpb-name }}
           PUBLISH_TAG: ${{ needs.prepare.outputs.publish-tag }}
         run: |
           set -euo pipefail
@@ -801,6 +834,7 @@ jobs:
           gh release upload "${PUBLISH_TAG}" \
             "publish-package/${EXPECTED_TARBALL_NAME}" \
             "publish-package/${EXPECTED_SBOM_NAME}" \
+            "publish-package/${EXPECTED_MCPB_NAME}" \
             "publish-package/${EXPECTED_RELEASE_NOTES_NAME}" \
             "publish-package/npm-pack.json" \
             "publish-package/${EXPECTED_CHECKSUMS_NAME}" \

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -677,6 +677,22 @@ jobs:
       - run: pnpm install --frozen-lockfile
       - run: pnpm run build
       - run: pnpm run test:cross-platform
+      # Record this OS's MCPB bundle digest so the aggregation job can prove the
+      # bytes match across operating systems, not just across repeated builds on
+      # one runner. Compute it in Node (not a shell redirect) so no OS-specific
+      # shell encoding (e.g. pwsh UTF-16 `>`) corrupts the recorded digest.
+      - name: Record MCPB bundle digest
+        run: |
+          pnpm run build:mcpb
+          node -e "const{createHash}=require('node:crypto');const{readFileSync,writeFileSync}=require('node:fs');writeFileSync('mcpb-digest.txt',createHash('sha256').update(readFileSync('dist-mcpb/b2-mcp.mcpb')).digest('hex')+'\n')"
+      # actions/upload-artifact v7, reviewed 2026-08-25.
+      - name: Upload MCPB bundle digest
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
+        with:
+          name: mcpb-digest-${{ matrix.os }}
+          path: mcpb-digest.txt
+          if-no-files-found: error
+          retention-days: 7
 
   cross-platform-minimum:
     name: cross-platform minimum
@@ -691,6 +707,28 @@ jobs:
             echo "::error::cross-platform minimum matrix result was ${{ needs.cross-platform-minimum-matrix.result }}"
             exit 1
           fi
+      # actions/download-artifact v6, reviewed 2026-08-25.
+      - name: Download per-OS MCPB bundle digests
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c
+        with:
+          pattern: mcpb-digest-*
+          path: mcpb-digests
+      # The matrix proves each OS reproduces its own bytes; this proves all three
+      # OSes produce the SAME bytes, so the release SHA-256 is OS-independent.
+      - name: Compare MCPB bundle digests across operating systems
+        run: |
+          mapfile -t files < <(find mcpb-digests -name mcpb-digest.txt | sort)
+          if [[ "${#files[@]}" -ne 3 ]]; then
+            echo "::error::expected 3 per-OS MCPB digests, found ${#files[@]}"
+            exit 1
+          fi
+          for f in "${files[@]}"; do printf '%s: %s\n' "$f" "$(cat "$f")"; done
+          unique=$(cat "${files[@]}" | sort -u | wc -l | tr -d ' ')
+          if [[ "$unique" -ne 1 ]]; then
+            echo "::error::MCPB bundle digests differ across operating systems (not byte-reproducible)"
+            exit 1
+          fi
+          echo "MCPB bundle is byte-identical across ubuntu, windows, and macos."
 
   conformance-summary:
     name: conformance summary

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -89,8 +89,11 @@ Before publishing `v0.1.0`:
     the protected live B2 contract workflow as a pre-release gate, verify the
     tarball SHA-256, publish the staged package directory only after its
     repacked tarball matches the scanned artifact, verify registry metadata with
-    bounded retry, publish and verify the GHCR image, and attach the SBOM to the
-    GitHub Release only after npm publish and GHCR publishing succeed.
+    bounded retry, publish and verify the GHCR image, and attach the SBOM and
+    the reproducible MCPB desktop-extension bundle (`b2-mcp.mcpb`) to the GitHub
+    Release only after npm publish and GHCR publishing succeed. The `.mcpb` is
+    built with `pnpm run build:mcpb`, its SHA-256 is recorded in `SHA256SUMS`,
+    and the release job re-verifies the bundle digest before upload.
 13. Confirm the release tag ruleset only allows release owners to create
     `v*` tags and does not allow force-updating or deleting release tags.
 14. Confirm `refs/heads/ci-green` is treated as an owned protected marker:
@@ -238,10 +241,11 @@ exists. For the first public package only:
    ```
 7. After npm/GHCR/GitHub Release succeed, run the per-release directory actions
    in [`docs/references/discoverability.md`](docs/references/discoverability.md) ("On every release"):
-   build and upload the `.mcpb` bundle (`pnpm run build:mcpb`) through Smithery's
-   Local publish tab, refresh the LobeHub listing (`lhm plugin update`), and cut
-   a new Glama release. These are manual and are not part of `Publish Package`,
-   so skipping them leaves the directory listings advertising the prior version.
+   submit the `.mcpb` bundle — already built and attached to the GitHub Release
+   by `Publish Package` — through Smithery's Local publish tab, refresh the
+   LobeHub listing (`lhm plugin update`), and cut a new Glama release. These are
+   manual and are not part of `Publish Package`, so skipping them leaves the
+   directory listings advertising the prior version.
 
 ## Build Version and Release Channel
 

--- a/docs/references/discoverability.md
+++ b/docs/references/discoverability.md
@@ -30,7 +30,7 @@ directories de-duplicate community forks under the official entry.
 | `smithery.yaml` | Smithery | stdio one-click config; credential fields masked as `password`. |
 | `glama.json` | Glama | `maintainers` list gates the org claim. Read from the default branch. |
 | `lhm.plugin.json` | LobeHub | Owner declaration used by `lhm plugin update`; regenerate on release. |
-| `mcpb/manifest.json` | Smithery (Local/MCPB) | MCPB 0.3 manifest with `privacy_policies`; packed to a `.mcpb` bundle (`pnpm run build:mcpb`) and uploaded via Smithery's Local publish tab. |
+| `mcpb/manifest.json` | Smithery (Local/MCPB) | MCPB 0.3 manifest with `privacy_policies`; packed to a reproducible `.mcpb` bundle (`pnpm run build:mcpb`), attached to every GitHub Release (checksummed in `SHA256SUMS`), and uploaded via Smithery's Local publish tab. |
 
 The canonical registry description lives in
 `scripts/lib/mcp-registry-manifest.mjs` (`mcpRegistryDescription`) and is
@@ -177,11 +177,16 @@ tabs. The **URL** tab is for a remote server you host at a public HTTPS endpoint
 (Streamable HTTP + OAuth) — not us, since b2-mcp runs locally per user with the
 user's own B2 keys. Use the **Local (MCPB Bundle)** tab instead.
 
-1. Build the bundle: `pnpm run build:mcpb` → `dist-mcpb/b2-mcp.mcpb` (packs
-   `mcpb/manifest.json`, which runs `npx -y @backblaze-labs/b2-mcp@<version>`
-   and prompts for the B2 credentials). Both the manifest version and the pinned
-   npx launcher version are kept in lockstep with `package.json` by
-   `scripts/update-server-json-version.mjs`, so the advertised bundle is
+1. Grab the bundle from the GitHub Release. `Publish Package` builds
+   `dist-mcpb/b2-mcp.mcpb` (`pnpm run build:mcpb`), records its SHA-256 in the
+   release `SHA256SUMS`, and attaches it to the release assets on every release,
+   so no manual build is needed — download `b2-mcp.mcpb` from the release. (To
+   rebuild locally for inspection, run `pnpm run build:mcpb`.) The bundle packs
+   `mcpb/manifest.json`, which runs `npx -y @backblaze-labs/b2-mcp@<version>` and
+   prompts for the B2 credentials. Both the manifest version and the pinned npx
+   launcher version are kept in lockstep with `package.json` by
+   `scripts/update-server-json-version.mjs`, and `scripts/build-mcpb.mjs`
+   normalizes the archive timestamps, so the advertised bundle is byte-for-byte
    reproducible.
 2. On [smithery.ai/new](https://smithery.ai/new), pick the **Local (MCPB
    Bundle)** tab, namespace `backblaze-labs`, server id `b2-mcp`, and upload the
@@ -191,7 +196,9 @@ user's own B2 keys. Use the **Local (MCPB Bundle)** tab instead.
 
 1. Bump + `scripts/update-server-json-version.mjs` (syncs `server.json`,
    `lhm.plugin.json`, and `mcpb/manifest.json` versions).
-2. `pnpm run build:mcpb` and upload/publish the `.mcpb` to Smithery.
+2. `Publish Package` builds `b2-mcp.mcpb`, checksums it into `SHA256SUMS`, and
+   attaches it to the GitHub Release automatically. Download that asset and
+   upload/publish it to Smithery (no local `pnpm run build:mcpb` required).
 3. Regenerate `lhm.plugin.json` and `lhm plugin update`.
 4. Cut a new Glama release (rerun the Dockerfile deploy → Make Release).
 5. Confirm the registry badge shows the new version.

--- a/docs/references/discoverability.md
+++ b/docs/references/discoverability.md
@@ -188,6 +188,14 @@ user's own B2 keys. Use the **Local (MCPB Bundle)** tab instead.
    `scripts/update-server-json-version.mjs`, and `scripts/build-mcpb.mjs`
    normalizes the archive timestamps, so the advertised bundle is byte-for-byte
    reproducible.
+
+   > **Scope of the `.mcpb` checksum.** The bundle contains only
+   > `mcpb/manifest.json` — a launcher that runs `npx -y @backblaze-labs/b2-mcp@<version>`.
+   > The reproducible SHA-256 therefore attests to the *launcher manifest*, not
+   > to the server code, which npx resolves from npm at runtime by version tag
+   > (no integrity/provenance pin). It is not an end-to-end supply-chain
+   > guarantee over the executed code; assurance for the npm package itself comes
+   > from the npm publish pipeline (`publish.yml`), not from this digest.
 2. On [smithery.ai/new](https://smithery.ai/new), pick the **Local (MCPB
    Bundle)** tab, namespace `backblaze-labs`, server id `b2-mcp`, and upload the
    `.mcpb`. (The legacy `smithery.yaml` is retained for older tooling.)

--- a/scripts/build-mcpb.mjs
+++ b/scripts/build-mcpb.mjs
@@ -27,21 +27,51 @@ const outFile = path.join(outDir, "b2-mcp.mcpb");
 const FIXED_DOS_TIME = 0x0000;
 const FIXED_DOS_DATE = 0x0021;
 
+// Named byte offsets into the ZIP records we touch, per the PKWARE APPNOTE
+// (.ZIP File Format Specification). Naming each field keeps the offset→field
+// mapping readable without holding the spec open, and makes a mistranscribed
+// addend obvious at the read site instead of silently corrupting the archive.
+const ZIP = {
+  EOCD_SIGNATURE: 0x06054b50,
+  CENTRAL_SIGNATURE: 0x02014b50,
+  LOCAL_SIGNATURE: 0x04034b50,
+  ZIP64_SENTINEL: 0xffffffff,
+  // End Of Central Directory record.
+  EOCD_MIN_SIZE: 22,
+  EOCD_ENTRY_COUNT: 10, // total central-directory records (2 bytes)
+  EOCD_CENTRAL_OFFSET: 16, // offset of first central-directory header (4 bytes)
+  EOCD_COMMENT_LENGTH: 20, // archive comment length (2 bytes)
+  // Central-directory file header.
+  CENTRAL_HEADER_SIZE: 46, // fixed-size prefix before name/extra/comment
+  CENTRAL_MODTIME: 12, // last-mod file time (2 bytes)
+  CENTRAL_MODDATE: 14, // last-mod file date (2 bytes)
+  CENTRAL_NAME_LENGTH: 28, // file-name length (2 bytes)
+  CENTRAL_EXTRA_LENGTH: 30, // extra-field length (2 bytes)
+  CENTRAL_COMMENT_LENGTH: 32, // file-comment length (2 bytes)
+  CENTRAL_LOCAL_OFFSET: 42, // offset of matching local header (4 bytes)
+  // Local file header.
+  LOCAL_MODTIME: 10, // last-mod file time (2 bytes)
+  LOCAL_MODDATE: 12, // last-mod file date (2 bytes)
+};
+
 /**
  * Rewrite every local-file-header and central-directory-header timestamp in a
  * zip buffer to a fixed value, so packing identical inputs yields identical
  * bytes. Parses the archive from its End Of Central Directory record rather than
  * scanning for signatures, so byte sequences inside compressed data are never
  * mistaken for headers.
+ *
+ * The mcpb packer emits a plain, single-disk, comment-less zip well under the
+ * 4 GiB ZIP64 threshold, so this normalizer assumes that shape and fails loud if
+ * an input ever violates it — a non-zero archive comment (which could contain a
+ * spurious EOCD signature and defeat the backward scan) or a ZIP64 sentinel
+ * central-directory offset (which would make the offset field unreadable as a
+ * plain 32-bit value). It never silently corrupts bytes.
  */
 function normalizeZipTimestamps(buffer) {
-  const EOCD_SIGNATURE = 0x06054b50;
-  const CENTRAL_SIGNATURE = 0x02014b50;
-  const LOCAL_SIGNATURE = 0x04034b50;
-
   let eocd = -1;
-  for (let offset = buffer.length - 22; offset >= 0; offset -= 1) {
-    if (buffer.readUInt32LE(offset) === EOCD_SIGNATURE) {
+  for (let offset = buffer.length - ZIP.EOCD_MIN_SIZE; offset >= 0; offset -= 1) {
+    if (buffer.readUInt32LE(offset) === ZIP.EOCD_SIGNATURE) {
       eocd = offset;
       break;
     }
@@ -49,27 +79,35 @@ function normalizeZipTimestamps(buffer) {
   if (eocd < 0) {
     throw new Error("build-mcpb: could not locate zip End Of Central Directory record");
   }
+  if (buffer.readUInt16LE(eocd + ZIP.EOCD_COMMENT_LENGTH) !== 0) {
+    throw new Error(
+      "build-mcpb: refusing to normalize a zip with an archive comment (EOCD scan is ambiguous)",
+    );
+  }
 
-  const entryCount = buffer.readUInt16LE(eocd + 10);
-  let central = buffer.readUInt32LE(eocd + 16);
+  const entryCount = buffer.readUInt16LE(eocd + ZIP.EOCD_ENTRY_COUNT);
+  let central = buffer.readUInt32LE(eocd + ZIP.EOCD_CENTRAL_OFFSET);
+  if (central === ZIP.ZIP64_SENTINEL) {
+    throw new Error("build-mcpb: ZIP64 archives are not supported by the timestamp normalizer");
+  }
   for (let index = 0; index < entryCount; index += 1) {
-    if (buffer.readUInt32LE(central) !== CENTRAL_SIGNATURE) {
+    if (buffer.readUInt32LE(central) !== ZIP.CENTRAL_SIGNATURE) {
       throw new Error(`build-mcpb: malformed central directory header at offset ${central}`);
     }
-    buffer.writeUInt16LE(FIXED_DOS_TIME, central + 12);
-    buffer.writeUInt16LE(FIXED_DOS_DATE, central + 14);
+    buffer.writeUInt16LE(FIXED_DOS_TIME, central + ZIP.CENTRAL_MODTIME);
+    buffer.writeUInt16LE(FIXED_DOS_DATE, central + ZIP.CENTRAL_MODDATE);
 
-    const localOffset = buffer.readUInt32LE(central + 42);
-    if (buffer.readUInt32LE(localOffset) !== LOCAL_SIGNATURE) {
+    const localOffset = buffer.readUInt32LE(central + ZIP.CENTRAL_LOCAL_OFFSET);
+    if (buffer.readUInt32LE(localOffset) !== ZIP.LOCAL_SIGNATURE) {
       throw new Error(`build-mcpb: malformed local file header at offset ${localOffset}`);
     }
-    buffer.writeUInt16LE(FIXED_DOS_TIME, localOffset + 10);
-    buffer.writeUInt16LE(FIXED_DOS_DATE, localOffset + 12);
+    buffer.writeUInt16LE(FIXED_DOS_TIME, localOffset + ZIP.LOCAL_MODTIME);
+    buffer.writeUInt16LE(FIXED_DOS_DATE, localOffset + ZIP.LOCAL_MODDATE);
 
-    const fileNameLength = buffer.readUInt16LE(central + 28);
-    const extraLength = buffer.readUInt16LE(central + 30);
-    const commentLength = buffer.readUInt16LE(central + 32);
-    central += 46 + fileNameLength + extraLength + commentLength;
+    const fileNameLength = buffer.readUInt16LE(central + ZIP.CENTRAL_NAME_LENGTH);
+    const extraLength = buffer.readUInt16LE(central + ZIP.CENTRAL_EXTRA_LENGTH);
+    const commentLength = buffer.readUInt16LE(central + ZIP.CENTRAL_COMMENT_LENGTH);
+    central += ZIP.CENTRAL_HEADER_SIZE + fileNameLength + extraLength + commentLength;
   }
 
   return buffer;

--- a/scripts/build-mcpb.mjs
+++ b/scripts/build-mcpb.mjs
@@ -1,20 +1,79 @@
 #!/usr/bin/env node
 /**
- * Pack the MCPB (MCP Bundle) for Smithery's Local publish path.
+ * Pack the MCPB (MCP Bundle) desktop-extension artifact.
  *
  * The bundle is a versioned release artifact — its `version` must match
  * `package.json` (kept in lockstep by `scripts/update-server-json-version.mjs`).
- * The output `.mcpb` is not committed and is not produced by `publish.yml`; a
- * maintainer runs this on release and uploads the bundle by hand through
- * Smithery's Local (MCPB Bundle) publish tab. See docs/references/discoverability.md.
+ * The output `.mcpb` is produced on every release by `publish.yml`, attached to
+ * the GitHub Release, and recorded in the release `SHA256SUMS`. It is also the
+ * artifact a maintainer uploads through Smithery's Local (MCPB Bundle) publish
+ * tab. See docs/references/discoverability.md.
+ *
+ * The packer stamps each zip entry with the current wall-clock time, which would
+ * make the `.mcpb` bytes differ on every build and defeat a meaningful release
+ * checksum. After packing we normalize every entry timestamp to a fixed epoch so
+ * the artifact is byte-for-byte reproducible from identical inputs.
  */
 import { execFileSync } from "node:child_process";
-import { mkdirSync, readFileSync, rmSync } from "node:fs";
+import { mkdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import path from "node:path";
 
 const root = process.cwd();
 const outDir = path.join(root, "dist-mcpb");
 const outFile = path.join(outDir, "b2-mcp.mcpb");
+
+// Fixed DOS date/time stamped into every zip entry for reproducibility:
+// 1980-01-01 00:00:00 (the earliest value the DOS timestamp format can encode).
+const FIXED_DOS_TIME = 0x0000;
+const FIXED_DOS_DATE = 0x0021;
+
+/**
+ * Rewrite every local-file-header and central-directory-header timestamp in a
+ * zip buffer to a fixed value, so packing identical inputs yields identical
+ * bytes. Parses the archive from its End Of Central Directory record rather than
+ * scanning for signatures, so byte sequences inside compressed data are never
+ * mistaken for headers.
+ */
+function normalizeZipTimestamps(buffer) {
+  const EOCD_SIGNATURE = 0x06054b50;
+  const CENTRAL_SIGNATURE = 0x02014b50;
+  const LOCAL_SIGNATURE = 0x04034b50;
+
+  let eocd = -1;
+  for (let offset = buffer.length - 22; offset >= 0; offset -= 1) {
+    if (buffer.readUInt32LE(offset) === EOCD_SIGNATURE) {
+      eocd = offset;
+      break;
+    }
+  }
+  if (eocd < 0) {
+    throw new Error("build-mcpb: could not locate zip End Of Central Directory record");
+  }
+
+  const entryCount = buffer.readUInt16LE(eocd + 10);
+  let central = buffer.readUInt32LE(eocd + 16);
+  for (let index = 0; index < entryCount; index += 1) {
+    if (buffer.readUInt32LE(central) !== CENTRAL_SIGNATURE) {
+      throw new Error(`build-mcpb: malformed central directory header at offset ${central}`);
+    }
+    buffer.writeUInt16LE(FIXED_DOS_TIME, central + 12);
+    buffer.writeUInt16LE(FIXED_DOS_DATE, central + 14);
+
+    const localOffset = buffer.readUInt32LE(central + 42);
+    if (buffer.readUInt32LE(localOffset) !== LOCAL_SIGNATURE) {
+      throw new Error(`build-mcpb: malformed local file header at offset ${localOffset}`);
+    }
+    buffer.writeUInt16LE(FIXED_DOS_TIME, localOffset + 10);
+    buffer.writeUInt16LE(FIXED_DOS_DATE, localOffset + 12);
+
+    const fileNameLength = buffer.readUInt16LE(central + 28);
+    const extraLength = buffer.readUInt16LE(central + 30);
+    const commentLength = buffer.readUInt16LE(central + 32);
+    central += 46 + fileNameLength + extraLength + commentLength;
+  }
+
+  return buffer;
+}
 
 // Drop any prior artifact up front so a later validation/pack failure can never
 // leave a stale `.mcpb` (from an earlier version) sitting in the documented
@@ -41,4 +100,8 @@ execFileSync("pnpm", ["exec", "mcpb", "pack", "mcpb", outFile], {
   cwd: root,
   stdio: "inherit",
 });
+
+// Normalize entry timestamps in place so the release artifact is reproducible.
+writeFileSync(outFile, normalizeZipTimestamps(readFileSync(outFile)));
+
 console.log(`build-mcpb: packed ${outFile} (b2-mcp@${packageVersion})`);

--- a/scripts/build-mcpb.mjs
+++ b/scripts/build-mcpb.mjs
@@ -17,7 +17,8 @@
  */
 import { execFileSync } from "node:child_process";
 import { createHash } from "node:crypto";
-import { mkdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { existsSync, mkdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { createRequire } from "node:module";
 import path from "node:path";
 
 const root = process.cwd();
@@ -167,10 +168,43 @@ if (manifestVersion !== packageVersion) {
   process.exit(2);
 }
 
-// Invoke the lockfile-resolved mcpb binary (pinned as an exact dev dependency)
-// so the packer's full dependency graph is frozen with the rest of the repo,
-// rather than re-resolving transitive deps via `npx -y` on each release.
+// Resolve the lockfile-installed mcpb CLI (pinned as an exact dev dependency)
+// and run its JavaScript entry point directly through the current Node binary,
+// so the packer's full dependency graph is frozen with the rest of the repo
+// rather than re-resolving transitive deps via `npx -y` on each release. Running
+// the CLI's JS entry point through `process.execPath` (instead of invoking the
+// `pnpm`/`mcpb` shims via `execFileSync`) is Windows-safe: on Windows those
+// shims are `.cmd` files that `execFileSync` cannot launch without a shell, which
+// would break the cross-platform reproducible build this script promises.
 //
+// Resolve the package's main entry (its `exports` map does not expose
+// package.json), then walk up to the package root so the bin path is read from
+// the installed manifest rather than hard-coded.
+const require = createRequire(import.meta.url);
+function mcpbPackageRoot() {
+  let dir = path.dirname(require.resolve("@anthropic-ai/mcpb"));
+  while (true) {
+    const manifest = path.join(dir, "package.json");
+    if (
+      existsSync(manifest) &&
+      JSON.parse(readFileSync(manifest, "utf8")).name === "@anthropic-ai/mcpb"
+    ) {
+      return dir;
+    }
+    const parent = path.dirname(dir);
+    if (parent === dir)
+      throw new Error("build-mcpb: could not locate the @anthropic-ai/mcpb package root");
+    dir = parent;
+  }
+}
+const mcpbRoot = mcpbPackageRoot();
+const mcpbBin = JSON.parse(readFileSync(path.join(mcpbRoot, "package.json"), "utf8")).bin;
+const mcpbBinRelative = typeof mcpbBin === "string" ? mcpbBin : mcpbBin?.mcpb;
+if (!mcpbBinRelative) {
+  throw new Error("build-mcpb: could not resolve the mcpb CLI entry point from its package.json");
+}
+const mcpbCli = path.join(mcpbRoot, mcpbBinRelative);
+
 // The packer prints its own SHA-1 of the bytes it writes, but we mutate those
 // bytes below to normalize metadata, so that digest never matches the final
 // artifact. Capture (rather than inherit) the packer's chatty output so its
@@ -183,7 +217,7 @@ if (manifestVersion !== packageVersion) {
 const packFile = path.join(outDir, "b2-mcp.unnormalized.mcpb");
 rmSync(packFile, { force: true });
 try {
-  execFileSync("pnpm", ["exec", "mcpb", "pack", "mcpb", packFile], {
+  execFileSync(process.execPath, [mcpbCli, "pack", "mcpb", packFile], {
     cwd: root,
     stdio: ["ignore", "pipe", "pipe"],
   });

--- a/scripts/build-mcpb.mjs
+++ b/scripts/build-mcpb.mjs
@@ -176,22 +176,39 @@ if (manifestVersion !== packageVersion) {
 // artifact. Capture (rather than inherit) the packer's chatty output so its
 // misleading digest cannot be mistaken for the release checksum, and surface it
 // only if the pack fails.
+// Pack to a temporary file rather than the documented `outFile`, so the
+// non-normalized packer output never occupies the published path. `outFile` is
+// written only from the normalized bytes below, keeping the `.mcpb` extension
+// the packer expects on its output argument.
+const packFile = path.join(outDir, "b2-mcp.unnormalized.mcpb");
+rmSync(packFile, { force: true });
 try {
-  execFileSync("pnpm", ["exec", "mcpb", "pack", "mcpb", outFile], {
+  execFileSync("pnpm", ["exec", "mcpb", "pack", "mcpb", packFile], {
     cwd: root,
     stdio: ["ignore", "pipe", "pipe"],
   });
 } catch (error) {
   if (error.stdout) process.stderr.write(error.stdout);
   if (error.stderr) process.stderr.write(error.stderr);
+  rmSync(packFile, { force: true });
   throw error;
 }
 
-// Normalize host/time metadata in place so the release artifact is reproducible,
-// then emit the authoritative post-normalization SHA-256 that the release
-// `SHA256SUMS` records.
-const normalized = normalizeZipMetadata(readFileSync(outFile));
-writeFileSync(outFile, normalized);
+// Normalize host/time metadata so the release artifact is reproducible, then
+// emit the authoritative post-normalization SHA-256 that the release
+// `SHA256SUMS` records. If normalization or the write fails, remove any partial
+// `outFile` so a stale, unverified bundle can never be left at the documented
+// path for an accidental upload — matching the stale-artifact guard above.
+let normalized;
+try {
+  normalized = normalizeZipMetadata(readFileSync(packFile));
+  writeFileSync(outFile, normalized);
+} catch (error) {
+  rmSync(outFile, { force: true });
+  throw error;
+} finally {
+  rmSync(packFile, { force: true });
+}
 const sha256 = createHash("sha256").update(normalized).digest("hex");
 
 console.log(`build-mcpb: packed ${outFile} (b2-mcp@${packageVersion})`);

--- a/scripts/build-mcpb.mjs
+++ b/scripts/build-mcpb.mjs
@@ -9,12 +9,14 @@
  * artifact a maintainer uploads through Smithery's Local (MCPB Bundle) publish
  * tab. See docs/references/discoverability.md.
  *
- * The packer stamps each zip entry with the current wall-clock time, which would
- * make the `.mcpb` bytes differ on every build and defeat a meaningful release
- * checksum. After packing we normalize every entry timestamp to a fixed epoch so
- * the artifact is byte-for-byte reproducible from identical inputs.
+ * The packer stamps each zip entry with the current wall-clock time and the
+ * build host's system/permission metadata, which would make the `.mcpb` bytes
+ * differ across builds and OSes and defeat a meaningful release checksum. After
+ * packing we normalize those fields (see `normalizeZipMetadata`) so the artifact
+ * is byte-for-byte reproducible from identical inputs on any supported build OS.
  */
 import { execFileSync } from "node:child_process";
+import { createHash } from "node:crypto";
 import { mkdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import path from "node:path";
 
@@ -26,6 +28,17 @@ const outFile = path.join(outDir, "b2-mcp.mcpb");
 // 1980-01-01 00:00:00 (the earliest value the DOS timestamp format can encode).
 const FIXED_DOS_TIME = 0x0000;
 const FIXED_DOS_DATE = 0x0021;
+
+// Fixed host/permission metadata so the artifact is byte-identical regardless of
+// the build OS. The mcpb packer records the host system in `version made by`
+// (Unix `0x03..` on macOS/Linux vs FAT `0x00..` on Windows) and the file mode in
+// the central-directory `external attributes` (Unix mode in the high bytes vs
+// DOS attribute bits on Windows). Left untouched, a Windows rebuild of the same
+// manifest would not match the Linux release checksum. We pin both to the values
+// the Linux CI packer already emits — Unix host, zip spec 2.0, regular file 0644
+// — so every platform produces the exact release bytes.
+const FIXED_VERSION_MADE_BY = 0x0314;
+const FIXED_EXTERNAL_ATTRS = 0x01a40000;
 
 // Named byte offsets into the ZIP records we touch, per the PKWARE APPNOTE
 // (.ZIP File Format Specification). Naming each field keeps the offset→field
@@ -43,32 +56,41 @@ const ZIP = {
   EOCD_COMMENT_LENGTH: 20, // archive comment length (2 bytes)
   // Central-directory file header.
   CENTRAL_HEADER_SIZE: 46, // fixed-size prefix before name/extra/comment
+  CENTRAL_VERSION_MADE_BY: 4, // host system + zip spec version (2 bytes)
   CENTRAL_MODTIME: 12, // last-mod file time (2 bytes)
   CENTRAL_MODDATE: 14, // last-mod file date (2 bytes)
   CENTRAL_NAME_LENGTH: 28, // file-name length (2 bytes)
   CENTRAL_EXTRA_LENGTH: 30, // extra-field length (2 bytes)
   CENTRAL_COMMENT_LENGTH: 32, // file-comment length (2 bytes)
+  CENTRAL_EXTERNAL_ATTRS: 38, // external file attributes / Unix mode (4 bytes)
   CENTRAL_LOCAL_OFFSET: 42, // offset of matching local header (4 bytes)
   // Local file header.
   LOCAL_MODTIME: 10, // last-mod file time (2 bytes)
   LOCAL_MODDATE: 12, // last-mod file date (2 bytes)
+  LOCAL_NAME_LENGTH: 26, // file-name length (2 bytes)
+  LOCAL_EXTRA_LENGTH: 28, // extra-field length (2 bytes)
 };
 
 /**
- * Rewrite every local-file-header and central-directory-header timestamp in a
- * zip buffer to a fixed value, so packing identical inputs yields identical
- * bytes. Parses the archive from its End Of Central Directory record rather than
- * scanning for signatures, so byte sequences inside compressed data are never
- * mistaken for headers.
+ * Rewrite every host- and time-dependent field in a zip buffer to a fixed value,
+ * so packing identical inputs yields identical bytes on any build OS. Normalizes
+ * each entry's DOS mod time/date, the central-directory `version made by` (which
+ * encodes the packing host) and `external attributes` (which encode the Unix
+ * mode on macOS/Linux vs DOS attribute bits on Windows). Parses the archive from
+ * its End Of Central Directory record rather than scanning for signatures, so
+ * byte sequences inside compressed data are never mistaken for headers.
  *
- * The mcpb packer emits a plain, single-disk, comment-less zip well under the
- * 4 GiB ZIP64 threshold, so this normalizer assumes that shape and fails loud if
- * an input ever violates it — a non-zero archive comment (which could contain a
- * spurious EOCD signature and defeat the backward scan) or a ZIP64 sentinel
- * central-directory offset (which would make the offset field unreadable as a
- * plain 32-bit value). It never silently corrupts bytes.
+ * The mcpb packer emits a plain, single-disk, comment-less, extra-field-less zip
+ * well under the 4 GiB ZIP64 threshold, so this normalizer assumes that shape
+ * and fails loud if an input ever violates it — a non-zero archive comment
+ * (which could contain a spurious EOCD signature and defeat the backward scan),
+ * a ZIP64 sentinel central-directory offset (which would make the offset field
+ * unreadable as a plain 32-bit value), or any extra/comment field (which could
+ * carry host-dependent uid/gid or extended-timestamp bytes this normalizer does
+ * not touch, silently breaking cross-platform reproducibility). It never
+ * silently corrupts bytes and never leaves an unnormalized field behind.
  */
-function normalizeZipTimestamps(buffer) {
+function normalizeZipMetadata(buffer) {
   let eocd = -1;
   for (let offset = buffer.length - ZIP.EOCD_MIN_SIZE; offset >= 0; offset -= 1) {
     if (buffer.readUInt32LE(offset) === ZIP.EOCD_SIGNATURE) {
@@ -88,14 +110,16 @@ function normalizeZipTimestamps(buffer) {
   const entryCount = buffer.readUInt16LE(eocd + ZIP.EOCD_ENTRY_COUNT);
   let central = buffer.readUInt32LE(eocd + ZIP.EOCD_CENTRAL_OFFSET);
   if (central === ZIP.ZIP64_SENTINEL) {
-    throw new Error("build-mcpb: ZIP64 archives are not supported by the timestamp normalizer");
+    throw new Error("build-mcpb: ZIP64 archives are not supported by the metadata normalizer");
   }
   for (let index = 0; index < entryCount; index += 1) {
     if (buffer.readUInt32LE(central) !== ZIP.CENTRAL_SIGNATURE) {
       throw new Error(`build-mcpb: malformed central directory header at offset ${central}`);
     }
+    buffer.writeUInt16LE(FIXED_VERSION_MADE_BY, central + ZIP.CENTRAL_VERSION_MADE_BY);
     buffer.writeUInt16LE(FIXED_DOS_TIME, central + ZIP.CENTRAL_MODTIME);
     buffer.writeUInt16LE(FIXED_DOS_DATE, central + ZIP.CENTRAL_MODDATE);
+    buffer.writeUInt32LE(FIXED_EXTERNAL_ATTRS, central + ZIP.CENTRAL_EXTERNAL_ATTRS);
 
     const localOffset = buffer.readUInt32LE(central + ZIP.CENTRAL_LOCAL_OFFSET);
     if (buffer.readUInt32LE(localOffset) !== ZIP.LOCAL_SIGNATURE) {
@@ -103,10 +127,22 @@ function normalizeZipTimestamps(buffer) {
     }
     buffer.writeUInt16LE(FIXED_DOS_TIME, localOffset + ZIP.LOCAL_MODTIME);
     buffer.writeUInt16LE(FIXED_DOS_DATE, localOffset + ZIP.LOCAL_MODDATE);
+    if (buffer.readUInt16LE(localOffset + ZIP.LOCAL_EXTRA_LENGTH) !== 0) {
+      throw new Error(
+        "build-mcpb: refusing to normalize a zip whose local header carries extra fields " +
+          "(possible host-dependent uid/gid or timestamp bytes)",
+      );
+    }
 
     const fileNameLength = buffer.readUInt16LE(central + ZIP.CENTRAL_NAME_LENGTH);
     const extraLength = buffer.readUInt16LE(central + ZIP.CENTRAL_EXTRA_LENGTH);
     const commentLength = buffer.readUInt16LE(central + ZIP.CENTRAL_COMMENT_LENGTH);
+    if (extraLength !== 0 || commentLength !== 0) {
+      throw new Error(
+        "build-mcpb: refusing to normalize a zip whose central header carries extra/comment " +
+          "fields (possible host-dependent uid/gid or timestamp bytes)",
+      );
+    }
     central += ZIP.CENTRAL_HEADER_SIZE + fileNameLength + extraLength + commentLength;
   }
 
@@ -134,12 +170,29 @@ if (manifestVersion !== packageVersion) {
 // Invoke the lockfile-resolved mcpb binary (pinned as an exact dev dependency)
 // so the packer's full dependency graph is frozen with the rest of the repo,
 // rather than re-resolving transitive deps via `npx -y` on each release.
-execFileSync("pnpm", ["exec", "mcpb", "pack", "mcpb", outFile], {
-  cwd: root,
-  stdio: "inherit",
-});
+//
+// The packer prints its own SHA-1 of the bytes it writes, but we mutate those
+// bytes below to normalize metadata, so that digest never matches the final
+// artifact. Capture (rather than inherit) the packer's chatty output so its
+// misleading digest cannot be mistaken for the release checksum, and surface it
+// only if the pack fails.
+try {
+  execFileSync("pnpm", ["exec", "mcpb", "pack", "mcpb", outFile], {
+    cwd: root,
+    stdio: ["ignore", "pipe", "pipe"],
+  });
+} catch (error) {
+  if (error.stdout) process.stderr.write(error.stdout);
+  if (error.stderr) process.stderr.write(error.stderr);
+  throw error;
+}
 
-// Normalize entry timestamps in place so the release artifact is reproducible.
-writeFileSync(outFile, normalizeZipTimestamps(readFileSync(outFile)));
+// Normalize host/time metadata in place so the release artifact is reproducible,
+// then emit the authoritative post-normalization SHA-256 that the release
+// `SHA256SUMS` records.
+const normalized = normalizeZipMetadata(readFileSync(outFile));
+writeFileSync(outFile, normalized);
+const sha256 = createHash("sha256").update(normalized).digest("hex");
 
 console.log(`build-mcpb: packed ${outFile} (b2-mcp@${packageVersion})`);
+console.log(`build-mcpb: sha256 ${sha256}  ${path.basename(outFile)}`);

--- a/scripts/run-cross-platform-tests.mjs
+++ b/scripts/run-cross-platform-tests.mjs
@@ -11,6 +11,10 @@ const testFiles = [
   "tests/unit/http-server.unit.test.ts",
   "tests/unit/http-transport.unit.test.ts",
   "tests/contract/tools-schema.contract.test.ts",
+  // Packs and parses the MCPB bundle so host-specific launcher/ZIP-metadata
+  // regressions (the `.cmd`-shim launch path, the byte-reproducibility
+  // normalization) are caught on the Windows/macOS matrix, not just Linux.
+  "tests/contract/mcpb-bundle.contract.test.ts",
   "tests/protocol/stdio.modern-protocol.test.ts",
   "tests/protocol/stdio.transport.modern-protocol.test.ts",
   "tests/protocol/stdio.transport.legacy-protocol.test.ts",

--- a/scripts/verify-release-input.mjs
+++ b/scripts/verify-release-input.mjs
@@ -69,8 +69,6 @@ function readJson(root, relativePath) {
 const NPX_VALUE_FLAGS = new Set([
   "-p",
   "--package",
-  "-c",
-  "--call",
   "--registry",
   "--userconfig",
   "--cache",
@@ -79,6 +77,10 @@ const NPX_VALUE_FLAGS = new Set([
   "--node-options",
   "--npm",
 ]);
+
+// npx call-mode flags: the following token is a shell command, not a package, so
+// the positional scan cannot interpret it. The launcher must not use call mode.
+const NPX_CALL_FLAGS = new Set(["-c", "--call"]);
 
 /**
  * Return the package spec npx would actually execute: the first positional
@@ -132,6 +134,15 @@ export function verifyReleaseInput(root, tag) {
   );
   const mcpbArgs = (mcpbConfig.args ?? []).map(String);
   const pinnedSpec = `${canonicalPackageName}@${pkg.version}`;
+  // Reject npx call mode outright: it runs the following token as a shell command
+  // rather than the pinned package, so the positional scan below cannot reason
+  // about it. The launcher must be the direct `npx -y <pinnedSpec>` form.
+  for (const arg of mcpbArgs) {
+    assert(
+      !NPX_CALL_FLAGS.has(arg),
+      `mcpb/manifest.json npx launcher must not use call mode (${arg})`,
+    );
+  }
   // The spec npx actually launches must be exactly the pinned version, not just
   // present somewhere in args (an earlier `@latest` positional would win).
   assert(

--- a/scripts/verify-release-input.mjs
+++ b/scripts/verify-release-input.mjs
@@ -83,6 +83,17 @@ export function verifyReleaseInput(root, tag) {
     packageJsonPath: path.join(root, "package.json"),
     expectedVersion: pkg.version,
   });
+  const mcpbManifest = readJson(root, "mcpb/manifest.json");
+  assert(
+    mcpbManifest.version === pkg.version,
+    `mcpb/manifest.json version ${mcpbManifest.version} does not match package version ${pkg.version}`,
+  );
+  assert(mcpbManifest.name === "b2-mcp", `unexpected mcpb/manifest.json name ${mcpbManifest.name}`);
+  const mcpbArgs = mcpbManifest.server?.mcp_config?.args ?? [];
+  assert(
+    mcpbArgs.includes(`${canonicalPackageName}@${pkg.version}`),
+    `mcpb/manifest.json npx launcher is not pinned to ${canonicalPackageName}@${pkg.version}`,
+  );
   assert(
     pkg.engines?.node === runtimePolicy.engineRange,
     `package engine range must be ${runtimePolicy.engineRange}`,

--- a/scripts/verify-release-input.mjs
+++ b/scripts/verify-release-input.mjs
@@ -63,44 +63,6 @@ function readJson(root, relativePath) {
   return JSON.parse(readFileSync(path.join(root, relativePath), "utf8"));
 }
 
-// npx option flags that consume the following argument as their value, so the
-// package-to-execute scan must skip both. Boolean flags (e.g. -y/--yes/--no) are
-// handled generically by the leading-dash check.
-const NPX_VALUE_FLAGS = new Set([
-  "-p",
-  "--package",
-  "--registry",
-  "--userconfig",
-  "--cache",
-  "--shell",
-  "--node-arg",
-  "--node-options",
-  "--npm",
-]);
-
-// npx call-mode flags: the following token is a shell command, not a package, so
-// the positional scan cannot interpret it. The launcher must not use call mode.
-const NPX_CALL_FLAGS = new Set(["-c", "--call"]);
-
-/**
- * Return the package spec npx would actually execute: the first positional
- * argument after skipping option flags (and the values of value-taking options).
- * `--` forces the next token to be the executable. Returns undefined if none.
- */
-function npxExecutableSpec(args) {
-  for (let index = 0; index < args.length; index += 1) {
-    const arg = args[index];
-    if (arg === "--") return args[index + 1];
-    if (NPX_VALUE_FLAGS.has(arg)) {
-      index += 1;
-      continue;
-    }
-    if (arg.startsWith("-")) continue;
-    return arg;
-  }
-  return undefined;
-}
-
 export function verifyReleaseInput(root, tag) {
   const pkg = readJson(root, "package.json");
   const runtimePolicy = readJson(root, "runtime-policy.json");
@@ -132,32 +94,19 @@ export function verifyReleaseInput(root, tag) {
     mcpbConfig.command === "npx",
     `mcpb/manifest.json launcher command must be npx, got ${mcpbConfig.command}`,
   );
-  const mcpbArgs = (mcpbConfig.args ?? []).map(String);
+  // Fail closed with an exact allowlist rather than parsing arbitrary npx options:
+  // the only supported launcher is `npx -y <pinnedSpec>`. Any extra flag (e.g.
+  // --package=, --call=, --registry) could change what npx executes or where it
+  // resolves it, so require the exact argument array.
   const pinnedSpec = `${canonicalPackageName}@${pkg.version}`;
-  // Reject npx call mode outright: it runs the following token as a shell command
-  // rather than the pinned package, so the positional scan below cannot reason
-  // about it. The launcher must be the direct `npx -y <pinnedSpec>` form.
-  for (const arg of mcpbArgs) {
-    assert(
-      !NPX_CALL_FLAGS.has(arg),
-      `mcpb/manifest.json npx launcher must not use call mode (${arg})`,
-    );
-  }
-  // The spec npx actually launches must be exactly the pinned version, not just
-  // present somewhere in args (an earlier `@latest` positional would win).
+  const expectedArgs = ["-y", pinnedSpec];
+  const mcpbArgs = mcpbConfig.args ?? [];
   assert(
-    npxExecutableSpec(mcpbArgs) === pinnedSpec,
-    `mcpb/manifest.json npx launcher must execute ${pinnedSpec} in the executable argument position, got ${npxExecutableSpec(mcpbArgs) ?? "(none)"}`,
+    Array.isArray(mcpbArgs) &&
+      mcpbArgs.length === expectedArgs.length &&
+      mcpbArgs.every((arg, index) => arg === expectedArgs[index]),
+    `mcpb/manifest.json npx launcher args must be exactly ${JSON.stringify(expectedArgs)}, got ${JSON.stringify(mcpbArgs)}`,
   );
-  // Fail closed on any other reference to our package (e.g. an `@latest` decoy or
-  // a `-p <pkg>` injection) that could resolve to unpinned code at launch.
-  for (const arg of mcpbArgs) {
-    if (arg === pinnedSpec) continue;
-    assert(
-      arg !== canonicalPackageName && !arg.startsWith(`${canonicalPackageName}@`),
-      `mcpb/manifest.json references ${canonicalPackageName} outside the pinned ${pinnedSpec}`,
-    );
-  }
   assert(
     pkg.engines?.node === runtimePolicy.engineRange,
     `package engine range must be ${runtimePolicy.engineRange}`,

--- a/scripts/verify-release-input.mjs
+++ b/scripts/verify-release-input.mjs
@@ -63,6 +63,42 @@ function readJson(root, relativePath) {
   return JSON.parse(readFileSync(path.join(root, relativePath), "utf8"));
 }
 
+// npx option flags that consume the following argument as their value, so the
+// package-to-execute scan must skip both. Boolean flags (e.g. -y/--yes/--no) are
+// handled generically by the leading-dash check.
+const NPX_VALUE_FLAGS = new Set([
+  "-p",
+  "--package",
+  "-c",
+  "--call",
+  "--registry",
+  "--userconfig",
+  "--cache",
+  "--shell",
+  "--node-arg",
+  "--node-options",
+  "--npm",
+]);
+
+/**
+ * Return the package spec npx would actually execute: the first positional
+ * argument after skipping option flags (and the values of value-taking options).
+ * `--` forces the next token to be the executable. Returns undefined if none.
+ */
+function npxExecutableSpec(args) {
+  for (let index = 0; index < args.length; index += 1) {
+    const arg = args[index];
+    if (arg === "--") return args[index + 1];
+    if (NPX_VALUE_FLAGS.has(arg)) {
+      index += 1;
+      continue;
+    }
+    if (arg.startsWith("-")) continue;
+    return arg;
+  }
+  return undefined;
+}
+
 export function verifyReleaseInput(root, tag) {
   const pkg = readJson(root, "package.json");
   const runtimePolicy = readJson(root, "runtime-policy.json");
@@ -89,11 +125,28 @@ export function verifyReleaseInput(root, tag) {
     `mcpb/manifest.json version ${mcpbManifest.version} does not match package version ${pkg.version}`,
   );
   assert(mcpbManifest.name === "b2-mcp", `unexpected mcpb/manifest.json name ${mcpbManifest.name}`);
-  const mcpbArgs = mcpbManifest.server?.mcp_config?.args ?? [];
+  const mcpbConfig = mcpbManifest.server?.mcp_config ?? {};
   assert(
-    mcpbArgs.includes(`${canonicalPackageName}@${pkg.version}`),
-    `mcpb/manifest.json npx launcher is not pinned to ${canonicalPackageName}@${pkg.version}`,
+    mcpbConfig.command === "npx",
+    `mcpb/manifest.json launcher command must be npx, got ${mcpbConfig.command}`,
   );
+  const mcpbArgs = (mcpbConfig.args ?? []).map(String);
+  const pinnedSpec = `${canonicalPackageName}@${pkg.version}`;
+  // The spec npx actually launches must be exactly the pinned version, not just
+  // present somewhere in args (an earlier `@latest` positional would win).
+  assert(
+    npxExecutableSpec(mcpbArgs) === pinnedSpec,
+    `mcpb/manifest.json npx launcher must execute ${pinnedSpec} in the executable argument position, got ${npxExecutableSpec(mcpbArgs) ?? "(none)"}`,
+  );
+  // Fail closed on any other reference to our package (e.g. an `@latest` decoy or
+  // a `-p <pkg>` injection) that could resolve to unpinned code at launch.
+  for (const arg of mcpbArgs) {
+    if (arg === pinnedSpec) continue;
+    assert(
+      arg !== canonicalPackageName && !arg.startsWith(`${canonicalPackageName}@`),
+      `mcpb/manifest.json references ${canonicalPackageName} outside the pinned ${pinnedSpec}`,
+    );
+  }
   assert(
     pkg.engines?.node === runtimePolicy.engineRange,
     `package engine range must be ${runtimePolicy.engineRange}`,

--- a/tests/contract/mcpb-bundle.contract.test.ts
+++ b/tests/contract/mcpb-bundle.contract.test.ts
@@ -164,6 +164,10 @@ describe("MCPB desktop-extension bundle", () => {
   it("produces byte-reproducible output across repeated builds", () => {
     // A second pack of the same inputs must reproduce the shared build's digest;
     // this is what lets a third party rebuild and confirm the release SHA-256.
+    // This proves intra-host reproducibility; the cross-OS comparison (that every
+    // supported build OS emits the SAME bytes) is enforced by the
+    // `cross-platform-minimum` job in .github/workflows/test.yml, which compares
+    // this bundle's digest across the ubuntu/windows/macos matrix legs.
     expect(sha256(Uint8Array.from(buildBundle()))).toBe(digest);
   }, 60_000);
 

--- a/tests/contract/mcpb-bundle.contract.test.ts
+++ b/tests/contract/mcpb-bundle.contract.test.ts
@@ -6,8 +6,13 @@
  * or `scripts/build-mcpb.mjs` before release, so a manifest schema break, a
  * version drift, or a regression in the reproducibility normalization would
  * otherwise only surface at release time. This test packs the bundle in CI and
- * asserts it is a valid, version-aligned, byte-reproducible archive, and that
- * the release workflow actually builds, checksums, and uploads it.
+ * asserts it is a valid, version-aligned, byte-reproducible archive whose
+ * checksum detects tampering, and that the release workflow actually builds,
+ * checksums, and uploads it.
+ *
+ * The bundle is packed once in `beforeAll` and reused across assertions, so the
+ * otherwise fast/deterministic contract layer pays for at most two `mcpb pack`
+ * subprocesses (the shared build plus one rebuild that proves reproducibility).
  */
 
 import { execFileSync } from "node:child_process";
@@ -23,8 +28,8 @@ function buildBundle(): Buffer {
   return readFileSync(mcpbPath);
 }
 
-function sha256(buffer: Buffer): string {
-  return createHash("sha256").update(Uint8Array.from(buffer)).digest("hex");
+function sha256(buffer: Uint8Array): string {
+  return createHash("sha256").update(buffer).digest("hex");
 }
 
 const pkg = readJson<{ version: string; name: string }>("package.json");
@@ -36,6 +41,14 @@ const manifest = readJson<{
 }>("mcpb/manifest.json");
 
 describe("MCPB desktop-extension bundle", () => {
+  let bundle: Buffer;
+  let digest: string;
+
+  beforeAll(() => {
+    bundle = buildBundle();
+    digest = sha256(Uint8Array.from(bundle));
+  }, 60_000);
+
   it("keeps the manifest version in lockstep with package.json", () => {
     expect(manifest.version).toBe(pkg.version);
     expect(manifest.name).toBe("b2-mcp");
@@ -44,26 +57,23 @@ describe("MCPB desktop-extension bundle", () => {
   });
 
   it("packs a valid zip archive containing the manifest", () => {
-    const bundle = buildBundle();
     // Local file header magic (PK\x03\x04) marks a well-formed zip.
     expect(bundle.subarray(0, 4)).toEqual(Buffer.from([0x50, 0x4b, 0x03, 0x04]));
     expect(bundle.includes(Buffer.from("manifest.json"))).toBe(true);
     expect(bundle.length).toBeGreaterThan(0);
-  }, 60_000);
+  });
 
   it("produces byte-reproducible output across repeated builds", () => {
-    const first = sha256(buildBundle());
-    const second = sha256(buildBundle());
-    expect(second).toBe(first);
+    // A second pack of the same inputs must reproduce the shared build's digest;
+    // this is what lets a third party rebuild and confirm the release SHA-256.
+    expect(sha256(Uint8Array.from(buildBundle()))).toBe(digest);
   }, 60_000);
 
-  it("normalizes every entry timestamp to the fixed 1980-01-01 epoch", () => {
-    const bundle = buildBundle();
-    // Local file header: mod time at +10, mod date at +12 (little-endian).
-    // Fixed to 0x0000 / 0x0021 (1980-01-01 00:00:00) for reproducibility.
-    expect(bundle.readUInt16LE(10)).toBe(0x0000);
-    expect(bundle.readUInt16LE(12)).toBe(0x0021);
-  }, 60_000);
+  it("yields a checksum that detects a tampered bundle", () => {
+    const tampered = Uint8Array.from(bundle);
+    tampered[tampered.length - 1] ^= 0xff;
+    expect(sha256(tampered)).not.toBe(digest);
+  });
 
   it("is built, checksummed, and attached by the release workflow", () => {
     const publish = readFileSync(join(root, ".github/workflows/publish.yml"), "utf8");

--- a/tests/contract/mcpb-bundle.contract.test.ts
+++ b/tests/contract/mcpb-bundle.contract.test.ts
@@ -1,0 +1,82 @@
+/**
+ * Contract test for the MCPB desktop-extension bundle (`dist-mcpb/b2-mcp.mcpb`).
+ *
+ * The bundle is built and attached to every GitHub Release by `publish.yml` and
+ * recorded in the release `SHA256SUMS`. Nothing else exercises `mcpb/manifest.json`
+ * or `scripts/build-mcpb.mjs` before release, so a manifest schema break, a
+ * version drift, or a regression in the reproducibility normalization would
+ * otherwise only surface at release time. This test packs the bundle in CI and
+ * asserts it is a valid, version-aligned, byte-reproducible archive, and that
+ * the release workflow actually builds, checksums, and uploads it.
+ */
+
+import { execFileSync } from "node:child_process";
+import { createHash } from "node:crypto";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { readJson, root } from "./support";
+
+const mcpbPath = join(root, "dist-mcpb", "b2-mcp.mcpb");
+
+function buildBundle(): Buffer {
+  execFileSync("node", ["scripts/build-mcpb.mjs"], { cwd: root, stdio: "pipe" });
+  return readFileSync(mcpbPath);
+}
+
+function sha256(buffer: Buffer): string {
+  return createHash("sha256").update(Uint8Array.from(buffer)).digest("hex");
+}
+
+const pkg = readJson<{ version: string; name: string }>("package.json");
+const manifest = readJson<{
+  version: string;
+  name: string;
+  manifest_version: string;
+  server?: { mcp_config?: { args?: string[] } };
+}>("mcpb/manifest.json");
+
+describe("MCPB desktop-extension bundle", () => {
+  it("keeps the manifest version in lockstep with package.json", () => {
+    expect(manifest.version).toBe(pkg.version);
+    expect(manifest.name).toBe("b2-mcp");
+    expect(manifest.manifest_version).toBe("0.3");
+    expect(manifest.server?.mcp_config?.args).toContain(`${pkg.name}@${pkg.version}`);
+  });
+
+  it("packs a valid zip archive containing the manifest", () => {
+    const bundle = buildBundle();
+    // Local file header magic (PK\x03\x04) marks a well-formed zip.
+    expect(bundle.subarray(0, 4)).toEqual(Buffer.from([0x50, 0x4b, 0x03, 0x04]));
+    expect(bundle.includes(Buffer.from("manifest.json"))).toBe(true);
+    expect(bundle.length).toBeGreaterThan(0);
+  }, 60_000);
+
+  it("produces byte-reproducible output across repeated builds", () => {
+    const first = sha256(buildBundle());
+    const second = sha256(buildBundle());
+    expect(second).toBe(first);
+  }, 60_000);
+
+  it("normalizes every entry timestamp to the fixed 1980-01-01 epoch", () => {
+    const bundle = buildBundle();
+    // Local file header: mod time at +10, mod date at +12 (little-endian).
+    // Fixed to 0x0000 / 0x0021 (1980-01-01 00:00:00) for reproducibility.
+    expect(bundle.readUInt16LE(10)).toBe(0x0000);
+    expect(bundle.readUInt16LE(12)).toBe(0x0021);
+  }, 60_000);
+
+  it("is built, checksummed, and attached by the release workflow", () => {
+    const publish = readFileSync(join(root, ".github/workflows/publish.yml"), "utf8");
+    expect(publish).toContain("pnpm run build:mcpb");
+    expect(publish).toContain("cp dist-mcpb/b2-mcp.mcpb publish-package/b2-mcp.mcpb");
+    // The checksums manifest and release upload both cover the bundle.
+    expect(publish).toContain("sha256sum *.tgz *.cdx.json *.mcpb release-notes.md npm-pack.json");
+    expect(publish).toContain("EXPECTED_MCPB_NAME");
+    expect(publish).toContain('"publish-package/${EXPECTED_MCPB_NAME}"');
+  });
+
+  it("keeps the build artifact directory out of version control", () => {
+    const gitignore = readFileSync(join(root, ".gitignore"), "utf8");
+    expect(gitignore.split(/\r?\n/)).toContain("dist-mcpb/");
+  });
+});

--- a/tests/contract/mcpb-bundle.contract.test.ts
+++ b/tests/contract/mcpb-bundle.contract.test.ts
@@ -5,10 +5,12 @@
  * recorded in the release `SHA256SUMS`. Nothing else exercises `mcpb/manifest.json`
  * or `scripts/build-mcpb.mjs` before release, so a manifest schema break, a
  * version drift, or a regression in the reproducibility normalization would
- * otherwise only surface at release time. This test packs the bundle in CI and
- * asserts it is a valid, version-aligned, byte-reproducible archive whose
- * checksum detects tampering, and that the release workflow actually builds,
- * checksums, and uploads it.
+ * otherwise only surface at release time. This test packs the bundle in CI,
+ * parses and inflates it with a real ZIP reader, and asserts it is a readable,
+ * version-aligned archive whose entries are normalized to fixed timestamps and
+ * host metadata (so it is byte-reproducible across build OSes) and whose checksum
+ * detects tampering, and that the release workflow actually builds, checksums,
+ * and uploads it.
  *
  * The bundle is packed once in `beforeAll` and reused across assertions, so the
  * otherwise fast/deterministic contract layer pays for at most two `mcpb pack`
@@ -19,9 +21,85 @@ import { execFileSync } from "node:child_process";
 import { createHash } from "node:crypto";
 import { readFileSync } from "node:fs";
 import { join } from "node:path";
+import { inflateRawSync } from "node:zlib";
 import { readJson, root } from "./support";
 
 const mcpbPath = join(root, "dist-mcpb", "b2-mcp.mcpb");
+
+// The Unix host + regular-file 0644 metadata the normalizer pins on every OS so
+// a Windows rebuild reproduces the Linux release bytes (see build-mcpb.mjs).
+const FIXED_VERSION_MADE_BY = 0x0314;
+const FIXED_EXTERNAL_ATTRS = 0x01a40000;
+
+interface ZipEntry {
+  name: string;
+  content: Buffer;
+  versionMadeBy: number;
+  externalAttrs: number;
+  central: { time: number; date: number };
+  local: { time: number; date: number };
+}
+
+/**
+ * Minimal but real ZIP reader: walks the central directory, follows each entry
+ * to its local header, and inflates the stored bytes. Unlike a magic-byte check
+ * this fails if the hand-rolled record rewriting in build-mcpb.mjs corrupts the
+ * central directory, an offset, or the compressed payload, and it exposes the
+ * exact header fields the normalizer is responsible for pinning.
+ */
+function readZipEntries(buffer: Buffer): ZipEntry[] {
+  const EOCD = 0x06054b50;
+  const CENTRAL = 0x02014b50;
+  const LOCAL = 0x04034b50;
+  let eocd = -1;
+  for (let offset = buffer.length - 22; offset >= 0; offset -= 1) {
+    if (buffer.readUInt32LE(offset) === EOCD) {
+      eocd = offset;
+      break;
+    }
+  }
+  if (eocd < 0) throw new Error("no End Of Central Directory record");
+  const count = buffer.readUInt16LE(eocd + 10);
+  let cursor = buffer.readUInt32LE(eocd + 16);
+  const entries: ZipEntry[] = [];
+  for (let index = 0; index < count; index += 1) {
+    if (buffer.readUInt32LE(cursor) !== CENTRAL) {
+      throw new Error(`corrupt central directory header at ${cursor}`);
+    }
+    const versionMadeBy = buffer.readUInt16LE(cursor + 4);
+    const method = buffer.readUInt16LE(cursor + 10);
+    const time = buffer.readUInt16LE(cursor + 12);
+    const date = buffer.readUInt16LE(cursor + 14);
+    const compressedSize = buffer.readUInt32LE(cursor + 20);
+    const nameLength = buffer.readUInt16LE(cursor + 28);
+    const extraLength = buffer.readUInt16LE(cursor + 30);
+    const commentLength = buffer.readUInt16LE(cursor + 32);
+    const externalAttrs = buffer.readUInt32LE(cursor + 38);
+    const localOffset = buffer.readUInt32LE(cursor + 42);
+    const name = buffer.toString("utf8", cursor + 46, cursor + 46 + nameLength);
+    if (buffer.readUInt32LE(localOffset) !== LOCAL) {
+      throw new Error(`corrupt local file header for ${name}`);
+    }
+    const localTime = buffer.readUInt16LE(localOffset + 10);
+    const localDate = buffer.readUInt16LE(localOffset + 12);
+    const localNameLength = buffer.readUInt16LE(localOffset + 26);
+    const localExtraLength = buffer.readUInt16LE(localOffset + 28);
+    const dataStart = localOffset + 30 + localNameLength + localExtraLength;
+    const raw = buffer.subarray(dataStart, dataStart + compressedSize);
+    const content =
+      method === 0 ? Buffer.from(Uint8Array.from(raw)) : inflateRawSync(Uint8Array.from(raw));
+    entries.push({
+      name,
+      content,
+      versionMadeBy,
+      externalAttrs,
+      central: { time, date },
+      local: { time: localTime, date: localDate },
+    });
+    cursor += 46 + nameLength + extraLength + commentLength;
+  }
+  return entries;
+}
 
 function buildBundle(): Buffer {
   execFileSync("node", ["scripts/build-mcpb.mjs"], { cwd: root, stdio: "pipe" });
@@ -56,11 +134,31 @@ describe("MCPB desktop-extension bundle", () => {
     expect(manifest.server?.mcp_config?.args).toContain(`${pkg.name}@${pkg.version}`);
   });
 
-  it("packs a valid zip archive containing the manifest", () => {
-    // Local file header magic (PK\x03\x04) marks a well-formed zip.
-    expect(bundle.subarray(0, 4)).toEqual(Buffer.from([0x50, 0x4b, 0x03, 0x04]));
-    expect(bundle.includes(Buffer.from("manifest.json"))).toBe(true);
-    expect(bundle.length).toBeGreaterThan(0);
+  it("packs a real, readable zip whose manifest round-trips", () => {
+    // Parse and inflate the archive with a real reader (not a magic-byte check),
+    // so any corruption of the central directory or payload from the hand-rolled
+    // record rewriting fails here rather than shipping a broken bundle.
+    const entries = readZipEntries(bundle);
+    expect(entries.map((entry) => entry.name)).toEqual(["manifest.json"]);
+    expect(JSON.parse(entries[0].content.toString("utf8"))).toEqual(readJson("mcpb/manifest.json"));
+  });
+
+  it("normalizes every entry's timestamp and host metadata to fixed values", () => {
+    // Assert the observable normalized state rather than relying on two
+    // back-to-back builds matching: DOS timestamps have two-second granularity,
+    // so a same-second unnormalized pack could coincide, but no real build dates
+    // to 1980-01-01, so this fails the moment normalization is removed.
+    for (const entry of readZipEntries(bundle)) {
+      for (const stamp of [entry.central, entry.local]) {
+        expect(stamp.time).toBe(0); // 00:00:00
+        expect(stamp.date & 0x1f).toBe(1); // day 1
+        expect((stamp.date >> 5) & 0x0f).toBe(1); // month 1
+        expect(1980 + (stamp.date >> 9)).toBe(1980); // year 1980
+      }
+      // Host-independent so a Windows rebuild reproduces the Linux release bytes.
+      expect(entry.versionMadeBy).toBe(FIXED_VERSION_MADE_BY);
+      expect(entry.externalAttrs).toBe(FIXED_EXTERNAL_ATTRS);
+    }
   });
 
   it("produces byte-reproducible output across repeated builds", () => {

--- a/tests/unit/release-scripts.unit.test.ts
+++ b/tests/unit/release-scripts.unit.test.ts
@@ -234,6 +234,17 @@ function writeFixtureServerJson(fixtureRoot: string, manifest: Record<string, an
   writeFileSync(join(fixtureRoot, "server.json"), JSON.stringify(manifest, null, 2));
 }
 
+function readFixtureMcpbManifest(fixtureRoot: string): Record<string, any> {
+  return JSON.parse(readFileSync(join(fixtureRoot, "mcpb", "manifest.json"), "utf8"));
+}
+
+function writeFixtureMcpbManifest(fixtureRoot: string, manifest: Record<string, any>): void {
+  writeFileSync(
+    join(fixtureRoot, "mcpb", "manifest.json"),
+    `${JSON.stringify(manifest, null, 2)}\n`,
+  );
+}
+
 async function withTempManifest(
   mutate: (manifest: McpRegistryManifest) => void,
   run: (manifestPath: string, manifest: McpRegistryManifest) => Promise<void>,
@@ -601,6 +612,92 @@ describe("release scripts", () => {
         const manifest = readFixtureServerJson(fixtureRoot);
         testCase.mutate(manifest);
         writeFixtureServerJson(fixtureRoot, manifest);
+
+        const result = spawnSync(
+          process.execPath,
+          ["scripts/verify-release-input.mjs", "--tag", "v0.1.0"],
+          { cwd: root, env: scriptEnv(fixtureRoot), encoding: "utf8" },
+        );
+
+        expect(result.status).not.toBe(0);
+        expect(result.stderr).toContain(testCase.message);
+      });
+    });
+  }
+
+  // The MCPB launcher is a fail-closed release check: the only supported form is
+  // `npx -y @backblaze-labs/b2-mcp@<version>`. Assert rejection of drift and of
+  // any extra/equals-form npx option or unpinned spec that could change what npx
+  // executes or where it resolves the package.
+  for (const testCase of [
+    {
+      name: "mcpb version drift",
+      message: "mcpb/manifest.json version 0.9.9 does not match package version 0.1.0",
+      mutate: (manifest: Record<string, any>) => {
+        manifest.version = "0.9.9";
+      },
+    },
+    {
+      name: "an unexpected mcpb name",
+      message: "unexpected mcpb/manifest.json name not-b2-mcp",
+      mutate: (manifest: Record<string, any>) => {
+        manifest.name = "not-b2-mcp";
+      },
+    },
+    {
+      name: "a non-npx launcher command",
+      message: "mcpb/manifest.json launcher command must be npx, got node",
+      mutate: (manifest: Record<string, any>) => {
+        manifest.server.mcp_config.command = "node";
+      },
+    },
+    {
+      name: "an extra npx option",
+      message: "mcpb/manifest.json npx launcher args must be exactly",
+      mutate: (manifest: Record<string, any>) => {
+        manifest.server.mcp_config.args = [
+          "-y",
+          "--registry",
+          "https://attacker.example",
+          "@backblaze-labs/b2-mcp@0.1.0",
+        ];
+      },
+    },
+    {
+      name: "an equals-form npx option",
+      message: "mcpb/manifest.json npx launcher args must be exactly",
+      mutate: (manifest: Record<string, any>) => {
+        manifest.server.mcp_config.args = [
+          "-y",
+          "--package=@backblaze-labs/b2-mcp@latest",
+          "@backblaze-labs/b2-mcp@0.1.0",
+        ];
+      },
+    },
+    {
+      name: "an unpinned package spec",
+      message: "mcpb/manifest.json npx launcher args must be exactly",
+      mutate: (manifest: Record<string, any>) => {
+        manifest.server.mcp_config.args = ["-y", "@backblaze-labs/b2-mcp"];
+      },
+    },
+    {
+      name: "a decoy package before the pinned spec",
+      message: "mcpb/manifest.json npx launcher args must be exactly",
+      mutate: (manifest: Record<string, any>) => {
+        manifest.server.mcp_config.args = [
+          "-y",
+          "@backblaze-labs/b2-mcp@latest",
+          "@backblaze-labs/b2-mcp@0.1.0",
+        ];
+      },
+    },
+  ]) {
+    it(`rejects ${testCase.name} in mcpb/manifest.json`, () => {
+      withFixture((fixtureRoot) => {
+        const manifest = readFixtureMcpbManifest(fixtureRoot);
+        testCase.mutate(manifest);
+        writeFixtureMcpbManifest(fixtureRoot, manifest);
 
         const result = spawnSync(
           process.execPath,

--- a/tests/unit/release-scripts.unit.test.ts
+++ b/tests/unit/release-scripts.unit.test.ts
@@ -209,7 +209,7 @@ function withFixture(run: (fixtureRoot: string) => void): void {
           server: {
             type: "node",
             entry_point: "npx",
-            mcp_config: { command: "npx", args: ["-y", "@backblaze-labs/b2-mcp"] },
+            mcp_config: { command: "npx", args: ["-y", "@backblaze-labs/b2-mcp@0.1.0"] },
           },
         },
         null,


### PR DESCRIPTION
## Summary

Produces the MCPB desktop-extension bundle (`b2-mcp.mcpb`) on every release and attaches it to the GitHub Release assets, closing the release-automation gaps in #358 (part of discoverability epic #297).

### Release automation
- **Built + attached in the release workflow.** `publish.yml`'s `prepare` job builds the bundle (`pnpm run build:mcpb`), copies it into `publish-package/`, and exposes `mcpb-name` / `mcpb-sha256` outputs. The `github-release` job re-verifies the bundle exists and its digest matches before uploading it as a release asset.
- **Included in release checksums.** The `.mcpb` is added to the `SHA256SUMS` manifest and to the `npm-package` upload-artifact paths.

### Reproducible, cross-platform build
- **Byte-reproducible on any build OS.** The MCPB packer stamps each zip entry with wall-clock time and the build host's system/permission metadata. `scripts/build-mcpb.mjs` normalizes those fields after packing: every entry's DOS mod time/date is pinned to a fixed 1980-01-01 epoch, and the central-directory `version made by` (host system) and `external attributes` (Unix mode vs DOS bits) are pinned to fixed Unix values, so a Windows rebuild reproduces the exact Linux release bytes. It parses the archive from its End Of Central Directory record (named ZIP field offsets, not magic numbers) and fails loud on ZIP64, an archive comment, or any extra/comment field rather than silently producing non-reproducible output.
- **Windows-safe packer invocation.** The build resolves the lockfile-installed mcpb CLI and runs its JavaScript entry point through the current Node binary (`process.execPath`) instead of the `pnpm` / `mcpb` shims, so `pnpm run build:mcpb` does not depend on a shell to launch a Windows `.cmd` shim and reproduces the release artifact on every supported build OS.
- **No stale artifact left behind.** The packer writes to a temporary path; `outFile` is written only from the normalized bytes, and any normalization/write failure removes a partial `.mcpb` so an unverified bundle can never sit at the documented upload path.
- **Authoritative digest.** The packer's own pre-normalization SHA-1 is suppressed; the script recomputes and prints the post-normalization SHA-256 (the value recorded in `SHA256SUMS`) so build output cannot be mistaken for the artifact checksum.

### CI gating
- **Contract test** `tests/contract/mcpb-bundle.contract.test.ts` packs the bundle, parses and inflates it with a real ZIP reader (so central-directory or payload corruption fails in CI), asserts the manifest round-trips, asserts every local/central header is normalized to the fixed 1980-01-01 epoch and fixed host metadata, proves byte-reproducibility across rebuilds, confirms the checksum detects a tampered bundle, and checks that `publish.yml` builds/checksums/uploads it. Surfaces manifest or build breaks in CI instead of at release time.
- **Runs on the cross-platform matrix.** The bundle contract is included in the `test:cross-platform` runner, so the pack/parse, byte-reproducible digest, and ZIP-metadata normalization are verified on the Windows and macOS legs (not just Ubuntu). Host-specific launcher or ZIP-metadata regressions fail that matrix.

### Fail-closed release verification
- **`scripts/verify-release-input.mjs`** asserts `mcpb/manifest.json` version and name match the release, and that the launcher is exactly `command: npx` with `args` equal to `["-y", "@backblaze-labs/b2-mcp@<version>"]`. This strict exact-array allowlist rejects any extra or equals-form npx option (`--package=`, `--call=`, `--registry`, an `@latest` decoy, `-p` injection) that could change what npx executes or where it resolves the package.
- **Negative unit coverage.** `tests/unit/release-scripts.unit.test.ts` parameterizes rejection cases that mutate `mcpb/manifest.json` (version drift, wrong name, non-npx command, an extra option, an equals-form option, an unpinned spec, and a decoy package before the pinned spec), so a regression that again accepts extra npx options or an unpinned package fails CI.

### Docs
- `docs/references/discoverability.md` and `RELEASE.md` describe the automated build/attach/checksum flow (download the `.mcpb` from the release instead of building by hand for Smithery), and explicitly scope the `.mcpb` checksum to the launcher manifest, not the code npx fetches from npm at runtime.

The Claude Connectors Directory submission that consumes this artifact remains tracked separately in #385.

## Linked issue

Closes #358

## Commits

- `feat:` build and attach reproducible MCPB bundle on release
- `refactor:` name ZIP field offsets and assert mcpb preconditions
- `test:` pack mcpb once and add tamper-detection assertion
- `docs:` clarify mcpb checksum covers launcher, not npm code
- `fix:` normalize mcpb host metadata and emit real sha256
- `test:` read mcpb with real zip parser, assert normalization
- `fix:` verify mcpb npx launcher executes pinned spec
- `fix:` reject npx call mode in mcpb launcher check
- `fix:` require exact npx launcher args in mcpb check
- `fix:` never leave an unnormalized mcpb bundle at the output path
- `fix:` run mcpb CLI via node for Windows-safe build
- `test:` assert mcpb launcher rejects drift and npx options
- `test:` run mcpb bundle contract on cross-platform matrix

## Tests run

- `pnpm run typecheck` - pass
- `pnpm run lint` - pass
- `pnpm run test:contract` (incl. `mcpb-bundle`, `ci-workflow-policy`, `spelling-policy`) - pass
- `pnpm run test:cross-platform` (incl. `mcpb-bundle` contract) - pass
- `release-scripts` (incl. new mcpb launcher rejection cases) / `package-budget-policy` / `supply-chain-policy` unit tests - pass
- `pnpm run lint:docs`, `pnpm run lint:links`, `pnpm run spell`, `pnpm run format:check` - pass
- `node scripts/verify-release-input.mjs --tag v0.2.0` - pass
- Reproducibility spot-check: repeated `pnpm run build:mcpb` runs produce identical SHA-256; `unzip -t` / `mcpb info` validate the archive.

## Follow-up notes

- `EOCD` and `PKWARE` were added to `.cspell/project-words.txt` for the new zip-parsing code.
- The bundle stays gitignored (`dist-mcpb/`); it is a build artifact produced at release time.
