### PR TITLE
docs: record Partner Groups CRUD coverage decision (#366)

### DIFF
--- a/docs/design-docs/sdk-adoption-contract.md
+++ b/docs/design-docs/sdk-adoption-contract.md
@@ -262,7 +262,7 @@ The reviewed `@backblaze-labs/b2-sdk/partner` client and its documented raw
 peer expose exactly these Group-related operations and nothing that mutates a
 Group's lifecycle:
 
-| SDK method                                   | B2 Partner endpoint       |
+| SDK method                                   | MCP tool                  |
 | -------------------------------------------- | ------------------------- |
 | `listGroups` / `paginateGroups`              | `b2_list_groups`          |
 | `listGroupMembers` / `paginateGroupMembers`  | `b2_list_group_members`   |

--- a/docs/design-docs/sdk-adoption-contract.md
+++ b/docs/design-docs/sdk-adoption-contract.md
@@ -248,6 +248,42 @@ Each retained row has exactly one reviewed implementation class:
 `s3_copy_object.acl` remains accepted as a no-op S3 compatibility hint; B2
 access follows the destination bucket policy.
 
+## Partner Groups Lifecycle Coverage Decision
+
+Glama's Server Coherence review ([#360](https://github.com/backblaze-labs/b2-mcp/issues/360),
+tracked by [#366](https://github.com/backblaze-labs/b2-mcp/issues/366)) flagged
+that the Partner Groups surface exposes membership operations
+(`b2_list_groups`, `b2_list_group_members`, `b2_create_group_member`,
+`b2_eject_group_member`) but no create/update/delete for the Group entities
+themselves. The finding is recorded here rather than answered with new tools.
+
+**Finding: the B2 Partner API exposes no Group create/update/delete endpoint.**
+The reviewed `@backblaze-labs/b2-sdk/partner` client and its documented raw
+peer expose exactly these Group-related operations and nothing that mutates a
+Group's lifecycle:
+
+| SDK method                                   | B2 Partner endpoint       |
+| -------------------------------------------- | ------------------------- |
+| `listGroups` / `paginateGroups`              | `b2_list_groups`          |
+| `listGroupMembers` / `paginateGroupMembers`  | `b2_list_group_members`   |
+| `createGroupMember`                          | `b2_create_group_member`  |
+| `ejectGroupMember`                           | `b2_eject_group_member`   |
+
+There is no `createGroup`, `updateGroup`, or `deleteGroup` on either the
+`partner` facade (`PartnerClient`) or the documented `partner/raw`
+(`PartnerRawClient`), and the B2 Partner API publishes no matching
+`b2_create_group` / `b2_update_group` / `b2_delete_group` endpoint. Group
+lifecycle (creating, renaming, or deleting a Group) is an **admin-console-only**
+operation with no public API or SDK surface to wrap.
+
+**Decision: no new Group tools.** Because the capability is not exposed by the
+Partner API/SDK, there is nothing to add — Group lifecycle is not an intentional
+omission of an available endpoint but the absence of one. Should Backblaze later
+publish Group create/update/delete endpoints, adding them would still be weighed
+against the deliberately lean 40-tool surface, and callers would be pointed at
+the admin console in the interim. The Groups membership rows above remain the
+complete Partner Groups tool coverage.
+
 ## Release Gate For #49
 
 [#49](https://github.com/backblaze-labs/b2-mcp/issues/49) must not freeze tool

--- a/docs/product-specs/v1-scope.md
+++ b/docs/product-specs/v1-scope.md
@@ -191,6 +191,12 @@ otherwise they register as non-secret compatibility stubs. That is an
 availability annotation; all three remain in the Native B2 SDK backing category. Partner/Groups read/eject/list
 tools are SDK-backed native B2 operations in the full profile.
 
+Partner Groups tool coverage stops at membership operations by design: the B2
+Partner API and `@backblaze-labs/b2-sdk/partner` expose no Group
+create/update/delete endpoint (Group lifecycle is admin-console-only), so no
+Group-lifecycle tools are added. The finding and decision are recorded in
+[`../design-docs/sdk-adoption-contract.md`](../design-docs/sdk-adoption-contract.md#partner-groups-lifecycle-coverage-decision).
+
 `b2_*` tools in `full`:
 
 - `b2_authorize_account`


### PR DESCRIPTION
## Summary

Addresses the **Partner Groups CRUD** coverage gap flagged in Glama's Server Coherence review as an investigation + documentation task — **no new tools**.

**Finding:** the B2 Partner API and `@backblaze-labs/b2-sdk/partner` expose **no** Group create/update/delete endpoint. The reviewed `PartnerClient`/`PartnerRawClient` only offer `listGroups`/`paginateGroups`, `listGroupMembers`/`paginateGroupMembers`, `createGroupMember`, and `ejectGroupMember`. Group lifecycle (create/rename/delete of the Group entity itself) is **admin-console-only** with no public API/SDK surface to wrap.

**Decision:** no new Group tools. There is nothing to add because the capability is not exposed; the existing membership tools are the complete Partner Groups coverage. Rationale is recorded so the coherence observation is answered by documentation, not surface growth.

### Changes
- `docs/design-docs/sdk-adoption-contract.md` — new "Partner Groups Lifecycle Coverage Decision" section with the SDK-method → MCP-tool table and the no-new-tools rationale.
- `docs/product-specs/v1-scope.md` — short note on the Partner Groups membership-only coverage decision, cross-linking the contract doc.

### Commits
- `docs: record Partner Groups CRUD coverage decision (#366)` — adds the coverage-decision section and v1-scope note.
- `docs: relabel Groups table column to MCP tool (#366)` — review fix: relabels the table's right-hand column header from "B2 Partner endpoint" to "MCP tool" so it accurately describes the `b2_*` tool names it lists.

## Linked issue

Closes #366

## Tests run
- `pnpm exec vitest run --project=contract sdk-adoption.contract.test.ts readme-drift.contract.test.ts` — 19 passed
- `pnpm exec vitest run --project=unit runtime-policy.unit.test.ts supply-chain-policy.unit.test.ts` — 91 passed

## Follow-up notes
- Docs-only change; no tool surface, schema, or fixture changes.
- If Backblaze later publishes Group create/update/delete endpoints, adding them would still be weighed against the deliberately lean 40-tool surface.
- Refs: #360 (Glama scorecard), #389 (S3 lifecycle read, split from this issue).
