### PR TITLE
docs: clarify s3_get_object saveToPath local-write (#378)

### DIFF
--- a/docs/generated/tool-profile-contract.json
+++ b/docs/generated/tool-profile-contract.json
@@ -204,7 +204,7 @@
         "s3_get_presigned_url",
         "s3_put_bucket_lifecycle"
       ],
-      "hash": "a15ea2576e84e590694e97556e5f08a23eb5b86a9077bc691d48954ecbcd10f2",
+      "hash": "c3325d9833b5798e58016f8d3776ed28d490584bd4c2c04abc7c5c0bdf187cd4",
       "fixtures": {
         "modern": "tests/fixtures/tool-contract/full.modern.json",
         "legacy": "tests/fixtures/tool-contract/full.legacy.json"
@@ -358,7 +358,7 @@
         "s3_get_presigned_url",
         "s3_put_bucket_lifecycle"
       ],
-      "hash": "91945963dc6b2b001bf97f93467deb52294691a101e10abc4987e88e6a85fc03",
+      "hash": "22f0627f1427f86eeb354c917cd6c009b26df85668c0e721da364fc4090e1aa5",
       "fixtures": {
         "modern": "tests/fixtures/tool-contract/live-b2-contract.modern.json",
         "legacy": "tests/fixtures/tool-contract/live-b2-contract.legacy.json"
@@ -502,7 +502,7 @@
         "s3_get_presigned_url",
         "s3_put_bucket_lifecycle"
       ],
-      "hash": "ed6cd7050149daa99e1097a594f2726f74a8344e715983c3378e6921222c0027",
+      "hash": "46962bdcd8be3556b49f0db8b722fd5f676173efcb8c70f0c5d16960af123ad4",
       "fixtures": {
         "modern": "tests/fixtures/tool-contract/phase1-default.modern.json",
         "legacy": "tests/fixtures/tool-contract/phase1-default.legacy.json"
@@ -582,7 +582,7 @@
         "b2_create_key",
         "b2_reserve_trial_create_account"
       ],
-      "hash": "5fefc07c6182565e9da2c08cea05496affa651a848404b97915168ae16a747a5",
+      "hash": "3c4ba900d7221865c067815fb307a229dca789422270aca2ba8480a1b651a6b2",
       "fixtures": {
         "modern": "tests/fixtures/tool-contract/read-only.modern.json",
         "legacy": "tests/fixtures/tool-contract/read-only.legacy.json"

--- a/docs/generated/tool-profiles.md
+++ b/docs/generated/tool-profiles.md
@@ -8,16 +8,16 @@ Approved modern cache hint: `ttlMs=30000`, `cacheScope=private`
 
 | Profile | Total | `b2_*` | `s3_*` | `bz_*` | Hash prefix |
 | --- | ---: | ---: | ---: | ---: | --- |
-| `full` | 40 | 21 | 19 | 0 | `a15ea2576e84` |
-| `live-b2-contract` | 39 | 20 | 19 | 0 | `91945963dc6b` |
-| `phase1-default` | 37 | 18 | 19 | 0 | `ed6cd7050149` |
-| `read-only` | 20 | 11 | 9 | 0 | `5fefc07c6182` |
+| `full` | 40 | 21 | 19 | 0 | `c3325d9833b5` |
+| `live-b2-contract` | 39 | 20 | 19 | 0 | `22f0627f1427` |
+| `phase1-default` | 37 | 18 | 19 | 0 | `46962bdcd8be` |
+| `read-only` | 20 | 11 | 9 | 0 | `3c4ba900d722` |
 
 ## `full`
 
 Complete tool superset for contract review and regression detection across all backing categories; durable-secret producers are sink-backed when a secret sink is active and otherwise remain availability-annotated stubs.
 
-Profile hash: `a15ea2576e84e590694e97556e5f08a23eb5b86a9077bc691d48954ecbcd10f2`
+Profile hash: `c3325d9833b5798e58016f8d3776ed28d490584bd4c2c04abc7c5c0bdf187cd4`
 
 ### Capability Input
 
@@ -79,7 +79,7 @@ Profile hash: `a15ea2576e84e590694e97556e5f08a23eb5b86a9077bc691d48954ecbcd10f2`
 
 Protected live B2 contract profile: non-master application key with release-evidence capabilities, no key-management grants, and a distinct master key only for Partner/Groups API surface discovery.
 
-Profile hash: `91945963dc6b2b001bf97f93467deb52294691a101e10abc4987e88e6a85fc03`
+Profile hash: `22f0627f1427f86eeb354c917cd6c009b26df85668c0e721da364fc4090e1aa5`
 
 ### Capability Input
 
@@ -158,7 +158,7 @@ Profile hash: `91945963dc6b2b001bf97f93467deb52294691a101e10abc4987e88e6a85fc03`
 
 Default customer-hosted Phase 1 profile: standard B2 application key, no distinct Partner/master credential, and durable-secret producers exposed as sink-backed tools on local stdio or unavailable stubs when the sink is off.
 
-Profile hash: `ed6cd7050149daa99e1097a594f2726f74a8344e715983c3378e6921222c0027`
+Profile hash: `46962bdcd8be3556b49f0db8b722fd5f676173efcb8c70f0c5d16960af123ad4`
 
 ### Capability Input
 
@@ -229,7 +229,7 @@ Profile hash: `ed6cd7050149daa99e1097a594f2726f74a8344e715983c3378e6921222c0027`
 
 Deterministic read/list profile for safe production use and contract tests; write/delete/admin handlers are omitted while durable-secret producer names remain unavailable stubs unless a sink-backed admin profile is configured.
 
-Profile hash: `5fefc07c6182565e9da2c08cea05496affa651a848404b97915168ae16a747a5`
+Profile hash: `3c4ba900d7221865c067815fb307a229dca789422270aca2ba8480a1b651a6b2`
 
 ### Capability Input
 

--- a/lhm.plugin.json
+++ b/lhm.plugin.json
@@ -1532,7 +1532,7 @@
     },
     {
       "name": "s3_get_object",
-      "description": "Read a SMALL object inline (≤1 MiB, returned base64) — for manifests, sidecars, and configs the agent must inspect — or stream any size to a local path with saveToPath. For real object data, generate a GetObject URL with s3_get_presigned_url and download directly from B2 (bytes never pass through the server or the model context).",
+      "description": "Read a SMALL object inline (≤1 MiB, returned base64) — for manifests, sidecars, and configs the agent must inspect — or stream any size to a local path with saveToPath. saveToPath writes the fetched bytes to the local filesystem (creating parent directories), removes the partial file if the stream fails (cleanup of its own output only), and performs no mutation of B2 or any remote data. For real object data, generate a GetObject URL with s3_get_presigned_url and download directly from B2 (bytes never pass through the server or the model context).",
       "inputSchema": {
         "$schema": "https://json-schema.org/draft/2020-12/schema",
         "type": "object",

--- a/src/s3/objects.ts
+++ b/src/s3/objects.ts
@@ -567,7 +567,7 @@ export function registerS3ObjectTools(
     "s3_get_object",
     {
       description:
-        "Read a SMALL object inline (≤1 MiB, returned base64) — for manifests, sidecars, and configs the agent must inspect — or stream any size to a local path with saveToPath. For real object data, generate a GetObject URL with s3_get_presigned_url and download directly from B2 (bytes never pass through the server or the model context).",
+        "Read a SMALL object inline (≤1 MiB, returned base64) — for manifests, sidecars, and configs the agent must inspect — or stream any size to a local path with saveToPath. saveToPath writes the fetched bytes to the local filesystem (creating parent directories), removes the partial file if the stream fails (cleanup of its own output only), and performs no mutation of B2 or any remote data. For real object data, generate a GetObject URL with s3_get_presigned_url and download directly from B2 (bytes never pass through the server or the model context).",
       inputSchema: {
         bucket: z.string().describe("The bucket name."),
         key: z.string().describe("The object key."),

--- a/tests/fixtures/tool-contract/full.legacy.json
+++ b/tests/fixtures/tool-contract/full.legacy.json
@@ -1511,7 +1511,7 @@
     },
     {
       "name": "s3_get_object",
-      "descriptionSha256": "372860e08b930d6f3a8a153a0a6ea99015de17cbd7067a56cc5ccef70db07856",
+      "descriptionSha256": "1f105cb19c32513a49545dbf7e12bc5193dabccf736f0869104d8194b80046d0",
       "inputSchema": {
         "$schema": "https://json-schema.org/draft/2020-12/schema",
         "properties": {
@@ -2067,5 +2067,5 @@
     "toolsListCacheHint": null,
     "discover": null
   },
-  "hash": "a15ea2576e84e590694e97556e5f08a23eb5b86a9077bc691d48954ecbcd10f2"
+  "hash": "c3325d9833b5798e58016f8d3776ed28d490584bd4c2c04abc7c5c0bdf187cd4"
 }

--- a/tests/fixtures/tool-contract/full.modern.json
+++ b/tests/fixtures/tool-contract/full.modern.json
@@ -1511,7 +1511,7 @@
     },
     {
       "name": "s3_get_object",
-      "descriptionSha256": "372860e08b930d6f3a8a153a0a6ea99015de17cbd7067a56cc5ccef70db07856",
+      "descriptionSha256": "1f105cb19c32513a49545dbf7e12bc5193dabccf736f0869104d8194b80046d0",
       "inputSchema": {
         "$schema": "https://json-schema.org/draft/2020-12/schema",
         "properties": {
@@ -2086,5 +2086,5 @@
       "resultType": "complete"
     }
   },
-  "hash": "a15ea2576e84e590694e97556e5f08a23eb5b86a9077bc691d48954ecbcd10f2"
+  "hash": "c3325d9833b5798e58016f8d3776ed28d490584bd4c2c04abc7c5c0bdf187cd4"
 }

--- a/tests/fixtures/tool-contract/live-b2-contract.legacy.json
+++ b/tests/fixtures/tool-contract/live-b2-contract.legacy.json
@@ -1503,7 +1503,7 @@
     },
     {
       "name": "s3_get_object",
-      "descriptionSha256": "372860e08b930d6f3a8a153a0a6ea99015de17cbd7067a56cc5ccef70db07856",
+      "descriptionSha256": "1f105cb19c32513a49545dbf7e12bc5193dabccf736f0869104d8194b80046d0",
       "inputSchema": {
         "$schema": "https://json-schema.org/draft/2020-12/schema",
         "properties": {
@@ -2059,5 +2059,5 @@
     "toolsListCacheHint": null,
     "discover": null
   },
-  "hash": "91945963dc6b2b001bf97f93467deb52294691a101e10abc4987e88e6a85fc03"
+  "hash": "22f0627f1427f86eeb354c917cd6c009b26df85668c0e721da364fc4090e1aa5"
 }

--- a/tests/fixtures/tool-contract/live-b2-contract.modern.json
+++ b/tests/fixtures/tool-contract/live-b2-contract.modern.json
@@ -1503,7 +1503,7 @@
     },
     {
       "name": "s3_get_object",
-      "descriptionSha256": "372860e08b930d6f3a8a153a0a6ea99015de17cbd7067a56cc5ccef70db07856",
+      "descriptionSha256": "1f105cb19c32513a49545dbf7e12bc5193dabccf736f0869104d8194b80046d0",
       "inputSchema": {
         "$schema": "https://json-schema.org/draft/2020-12/schema",
         "properties": {
@@ -2078,5 +2078,5 @@
       "resultType": "complete"
     }
   },
-  "hash": "91945963dc6b2b001bf97f93467deb52294691a101e10abc4987e88e6a85fc03"
+  "hash": "22f0627f1427f86eeb354c917cd6c009b26df85668c0e721da364fc4090e1aa5"
 }

--- a/tests/fixtures/tool-contract/phase1-default.legacy.json
+++ b/tests/fixtures/tool-contract/phase1-default.legacy.json
@@ -1405,7 +1405,7 @@
     },
     {
       "name": "s3_get_object",
-      "descriptionSha256": "372860e08b930d6f3a8a153a0a6ea99015de17cbd7067a56cc5ccef70db07856",
+      "descriptionSha256": "1f105cb19c32513a49545dbf7e12bc5193dabccf736f0869104d8194b80046d0",
       "inputSchema": {
         "$schema": "https://json-schema.org/draft/2020-12/schema",
         "properties": {
@@ -1961,5 +1961,5 @@
     "toolsListCacheHint": null,
     "discover": null
   },
-  "hash": "ed6cd7050149daa99e1097a594f2726f74a8344e715983c3378e6921222c0027"
+  "hash": "46962bdcd8be3556b49f0db8b722fd5f676173efcb8c70f0c5d16960af123ad4"
 }

--- a/tests/fixtures/tool-contract/phase1-default.modern.json
+++ b/tests/fixtures/tool-contract/phase1-default.modern.json
@@ -1405,7 +1405,7 @@
     },
     {
       "name": "s3_get_object",
-      "descriptionSha256": "372860e08b930d6f3a8a153a0a6ea99015de17cbd7067a56cc5ccef70db07856",
+      "descriptionSha256": "1f105cb19c32513a49545dbf7e12bc5193dabccf736f0869104d8194b80046d0",
       "inputSchema": {
         "$schema": "https://json-schema.org/draft/2020-12/schema",
         "properties": {
@@ -1980,5 +1980,5 @@
       "resultType": "complete"
     }
   },
-  "hash": "ed6cd7050149daa99e1097a594f2726f74a8344e715983c3378e6921222c0027"
+  "hash": "46962bdcd8be3556b49f0db8b722fd5f676173efcb8c70f0c5d16960af123ad4"
 }

--- a/tests/fixtures/tool-contract/read-only.legacy.json
+++ b/tests/fixtures/tool-contract/read-only.legacy.json
@@ -400,7 +400,7 @@
     },
     {
       "name": "s3_get_object",
-      "descriptionSha256": "372860e08b930d6f3a8a153a0a6ea99015de17cbd7067a56cc5ccef70db07856",
+      "descriptionSha256": "1f105cb19c32513a49545dbf7e12bc5193dabccf736f0869104d8194b80046d0",
       "inputSchema": {
         "$schema": "https://json-schema.org/draft/2020-12/schema",
         "properties": {
@@ -703,5 +703,5 @@
     "toolsListCacheHint": null,
     "discover": null
   },
-  "hash": "5fefc07c6182565e9da2c08cea05496affa651a848404b97915168ae16a747a5"
+  "hash": "3c4ba900d7221865c067815fb307a229dca789422270aca2ba8480a1b651a6b2"
 }

--- a/tests/fixtures/tool-contract/read-only.modern.json
+++ b/tests/fixtures/tool-contract/read-only.modern.json
@@ -400,7 +400,7 @@
     },
     {
       "name": "s3_get_object",
-      "descriptionSha256": "372860e08b930d6f3a8a153a0a6ea99015de17cbd7067a56cc5ccef70db07856",
+      "descriptionSha256": "1f105cb19c32513a49545dbf7e12bc5193dabccf736f0869104d8194b80046d0",
       "inputSchema": {
         "$schema": "https://json-schema.org/draft/2020-12/schema",
         "properties": {
@@ -722,5 +722,5 @@
       "resultType": "complete"
     }
   },
-  "hash": "5fefc07c6182565e9da2c08cea05496affa651a848404b97915168ae16a747a5"
+  "hash": "3c4ba900d7221865c067815fb307a229dca789422270aca2ba8480a1b651a6b2"
 }


### PR DESCRIPTION
Closes #378.

## What

Makes `s3_get_object`'s description explicit about the `saveToPath` local-write path. The description now states that `saveToPath`:

- writes the fetched bytes to the **local filesystem**, creating parent directories,
- removes the partial file if the stream fails (cleanup of its **own** output only), and
- performs **no** mutation of B2 or any remote data.

This closes the "description matches behaviour" static heuristic honestly so static scanners stop re-flagging it. No annotation or `destructiveHint` change — `s3_get_object` is not destructive (the `unlink` only cleans up its own partial download).

## Where

- `src/s3/objects.ts` — the `s3_get_object` registration description (source of truth).
- Regenerated artifacts via `pnpm run generate:tool-contract`: `docs/generated/tool-profiles.md`, `docs/generated/tool-profile-contract.json`, and the `tests/fixtures/tool-contract/*` fixtures.
- `lhm.plugin.json` synced in lockstep (drift test enforces parity).

## Verification

- `pnpm run typecheck` — clean
- `pnpm run build` — clean
- `pnpm run test:contract` — 338 passed (incl. `lhm-manifest`, `tool-profile-contract`)
- `node scripts/check-doc-links.mjs` — clean