### PR TITLE
test: make skills-pack and mcp-smoke unit tests hermetic

### DIFF
--- a/tests/unit/local-mcp-smoke.unit.test.ts
+++ b/tests/unit/local-mcp-smoke.unit.test.ts
@@ -1,6 +1,15 @@
-import * as http from "http";
+import { createRequire } from "module";
 import { join } from "path";
 import { pathToFileURL } from "url";
+
+// The guard mutates the CJS `http` singleton via `require("node:http")`. Observe
+// that exact object here rather than the ESM `import * as http from "http"`
+// namespace: whether the ESM namespace reflects a CJS property reassignment is
+// environment-dependent (it does not under raw Node, and only happens to under
+// some test-runner module loaders). When it does not reflect, `http.get(...)`
+// runs the real implementation, makes an actual outbound request, and the
+// assertion fails — passing in CI but flaking on developer machines.
+const http = createRequire(__filename)("node:http") as typeof import("http");
 
 interface LocalSmokeModule {
   NETWORK_GUARD_SIGNAL: string;

--- a/tests/unit/skills-pack-validator.unit.test.ts
+++ b/tests/unit/skills-pack-validator.unit.test.ts
@@ -1,15 +1,28 @@
 import { cpSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "fs";
 import { tmpdir } from "os";
-import { join } from "path";
+import { dirname, join } from "path";
 import { spawnSync } from "child_process";
 
 const root = join(__dirname, "../..");
 const validator = join(root, "scripts", "validate-pack.mjs");
 
+// Copy only the files declared in skills/pack.json rather than the entire
+// skills/ tree. A recursive copy picks up whatever ambient junk the working
+// tree happens to hold (macOS `.DS_Store`, editor swap files, etc.), which the
+// validator then flags as an "unexpected" packaged file. That made this suite
+// pass on a fresh CI checkout but fail on developer machines. Copying the exact
+// manifest set reproduces the clean-checkout state deterministically; the
+// individual cases below add their own extra files when they need them.
 function copyValidatorFixture(): string {
   const fixtureRoot = mkdtempSync(join(tmpdir(), "b2-mcp-skills-pack-"));
   mkdirSync(join(fixtureRoot, "docs", "generated"), { recursive: true });
-  cpSync(join(root, "skills"), join(fixtureRoot, "skills"), { recursive: true });
+  const packManifest = JSON.parse(readFileSync(join(root, "skills", "pack.json"), "utf8"));
+  const packagedFiles: string[] = packManifest.packageFiles;
+  for (const relativePath of packagedFiles) {
+    const destination = join(fixtureRoot, relativePath);
+    mkdirSync(dirname(destination), { recursive: true });
+    cpSync(join(root, relativePath), destination);
+  }
   cpSync(
     join(root, "docs", "generated", "tool-profile-contract.json"),
     join(fixtureRoot, "docs", "generated", "tool-profile-contract.json"),

--- a/tests/unit/skills-pack-validator.unit.test.ts
+++ b/tests/unit/skills-pack-validator.unit.test.ts
@@ -17,8 +17,8 @@ function copyValidatorFixture(): string {
   const fixtureRoot = mkdtempSync(join(tmpdir(), "b2-mcp-skills-pack-"));
   mkdirSync(join(fixtureRoot, "docs", "generated"), { recursive: true });
   const packManifest = JSON.parse(readFileSync(join(root, "skills", "pack.json"), "utf8"));
-  const packagedFiles: string[] = packManifest.packageFiles;
-  for (const relativePath of packagedFiles) {
+  const packageFiles: string[] = packManifest.packageFiles;
+  for (const relativePath of packageFiles) {
     const destination = join(fixtureRoot, relativePath);
     mkdirSync(dirname(destination), { recursive: true });
     cpSync(join(root, relativePath), destination);


### PR DESCRIPTION
## Summary

Makes the two non-hermetic unit suites deterministic across dev machines and CI.

**`skills-pack-validator.unit.test.ts`** — the fixture did a recursive `cpSync` of the whole `skills/` tree, so any ambient junk in a developer's working tree (macOS `.DS_Store`, editor swap files, …) was copied in and then flagged by the validator as an "unexpected" packaged file. It now copies only the files declared in `skills/pack.json`, reproducing the clean-checkout state regardless of local junk. Confirmed: with a stray `skills/.DS_Store` present, the suite failed before and passes after.

**`local-mcp-smoke.unit.test.ts`** — the egress-guard test observed `http` via `import * as http from "http"`, but the guard mutates the CJS `require("node:http")` singleton. Whether the ESM namespace reflects a CJS property reassignment is environment-dependent (it does not under raw Node; it only happens to under some test-runner loaders). When it doesn't reflect, `http.get("http://example.com/mcp")` runs the real implementation and makes an actual outbound request instead of throwing — passing in CI but flaking locally. The test now references the same object the guard mutates via `createRequire`.

## Linked issue

Closes #401

## Commits

- `test: make skills-pack and mcp-smoke unit tests hermetic` — the two fixes above.
- `test: rename local to match manifest packageFiles field` — review nit: renamed the fixture's local variable to match the manifest field name (`packageFiles`) for readability; no behavior change.

## Tests run

- `pnpm exec vitest run --project=unit tests/unit/skills-pack-validator.unit.test.ts` — passes even with a stray `skills/.DS_Store` present (previously 17 failures).
- `pnpm exec vitest run --project=unit tests/unit/local-mcp-smoke.unit.test.ts` — passes (3× consecutive).
- `pnpm run typecheck` — clean.
- `pnpm run test:coverage` — full run on Node 22.22.3: **2295 passed**, and `coverage/coverage-summary.json` is written.

## Follow-up notes

- No production code changed; the fixes are confined to test setup.
- cspell rejects Node pre-release build strings (e.g. a `26.x-alpha`); running the suite on a pinned Node (22.22+/24, as CI uses) avoids that unrelated environmental failure.
