### PR TITLE
ci: harden & expand zizmor (stricter rules, SARIF, config, online audits)

### DIFF
--- a/.cspell/project-words.txt
+++ b/.cspell/project-words.txt
@@ -37,6 +37,7 @@ opossum
 pino
 presigner
 QEMU
+SARIF
 SLSA
 spdxjson
 slsaprovenance

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -7,9 +7,8 @@ name: Publish Package
 # runs from the default branch through workflow_run, checks out trusted resolver
 # code from `ci-green`, and only then checks out the validated tag.
 on:
-  # zizmor: ignore[dangerous-triggers] This workflow_run only consumes an inert
-  # tag artifact, checks out ci-green resolver code, validates protected refs,
-  # and publishes behind protected environments.
+  # Suppression for this workflow_run privileged trigger is centralized in the
+  # checked-in `zizmor.yml` (rules.dangerous-triggers) with its rationale.
   workflow_run:
     workflows: ["Release Tag Request"]
     types: [completed]

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,6 +9,12 @@ on:
 permissions:
   contents: read
 
+env:
+  # Single source of truth for the digest-pinned zizmor image, shared by every
+  # zizmor job/step. Track any bump by digest (Track 3 of issue #405), never by
+  # a floating tag. zizmor 1.29.0, reviewed 2026-09-07.
+  ZIZMOR_IMAGE: ghcr.io/zizmorcore/zizmor:1.29.0@sha256:863026d54f91271b10b60b67ad8054cb37120167e162482597db102b3026a284
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
@@ -580,11 +586,6 @@ jobs:
       actions: read # CodeQL reads the Actions run graph during analysis.
       contents: read # Checkout of the repository under analysis.
       security-events: write # Upload zizmor SARIF to the code scanning tab.
-    env:
-      # Digest-pinned zizmor image, shared by every scan step. Track any bump by
-      # digest (Track 3 of issue #405), never by a floating tag.
-      # zizmor 1.29.0, reviewed 2026-09-07.
-      ZIZMOR_IMAGE: ghcr.io/zizmorcore/zizmor:1.29.0@sha256:863026d54f91271b10b60b67ad8054cb37120167e162482597db102b3026a284
     steps:
       # actions/checkout v7, reviewed 2026-08-25.
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
@@ -689,9 +690,6 @@ jobs:
     timeout-minutes: 15
     permissions:
       contents: read # Read-only token: the networked container gets no write scope.
-    env:
-      # zizmor 1.29.0, reviewed 2026-09-07.
-      ZIZMOR_IMAGE: ghcr.io/zizmorcore/zizmor:1.29.0@sha256:863026d54f91271b10b60b67ad8054cb37120167e162482597db102b3026a284
     steps:
       # actions/checkout v7, reviewed 2026-08-25.
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -678,7 +678,16 @@ jobs:
         run: |
           set -euo pipefail
           if [ ! -f "${GITHUB_WORKSPACE}/zizmor.yml" ]; then
-            echo "No PR-head zizmor.yml to validate."
+            # The base-ref copy was sparse-checked-out into .zizmor-trusted/ above.
+            # If the base HAS zizmor.yml but the PR head does not, the PR is
+            # deleting the required config: it would pass here yet leave the gate
+            # with no trusted copy on the next `main` push. Fail closed. Only a
+            # genuine bootstrap (base has no zizmor.yml either) is a clean no-op.
+            if [ -f "${GITHUB_WORKSPACE}/.zizmor-trusted/zizmor.yml" ]; then
+              echo "::error::zizmor.yml exists on the base ref but is missing from the PR head. Deleting the required zizmor.yml would break the gate on the next main push; restore it (or retire the gate in a dedicated, reviewed change)."
+              exit 1
+            fi
+            echo "No zizmor.yml on base or head (bootstrap); nothing to validate."
             exit 0
           fi
           docker run \

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -685,6 +685,9 @@ jobs:
       # write token (that happens in the separate, code-scanning upload step).
       - name: Run online zizmor audit (SARIF, advisory)
         continue-on-error: true
+        # Bounded well below the job's 20-minute budget so a hung network scan
+        # cannot consume the gate job's time and cancel the build.
+        timeout-minutes: 8
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
@@ -708,6 +711,8 @@ jobs:
         if: always()
         # Advisory: a failed online scan/upload must never gate CI.
         continue-on-error: true
+        # Bounded so a stuck code-scanning upload cannot exhaust the job budget.
+        timeout-minutes: 5
         # github/codeql-action/upload-sarif v4.37.9, reviewed 2026-09-07.
         uses: github/codeql-action/upload-sarif@cdf488f595d80d6e07e03d4674febd5ab45fa938
         with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -575,11 +575,19 @@ jobs:
     name: CodeQL/workflow security
     needs: runtime-policy
     runs-on: ubuntu-latest
-    timeout-minutes: 15
+    timeout-minutes: 20
     permissions:
+      # CodeQL reads the Actions run graph during analysis.
       actions: read
+      # Checkout of the repository under analysis.
       contents: read
+      # Upload zizmor SARIF to the Security -> Code scanning tab.
       security-events: write
+    env:
+      # Digest-pinned zizmor image, shared by every scan step. Track any bump by
+      # digest (Track 3 of issue #405), never by a floating tag.
+      # zizmor 1.29.0, reviewed 2026-09-07.
+      ZIZMOR_IMAGE: ghcr.io/zizmorcore/zizmor:1.29.0@sha256:863026d54f91271b10b60b67ad8054cb37120167e162482597db102b3026a284
     steps:
       # actions/checkout v7, reviewed 2026-08-25.
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
@@ -595,27 +603,80 @@ jobs:
         with:
           category: "/language:javascript-typescript"
           upload: never
-      - name: Run digest-pinned offline zizmor
-        env:
-          ZIZMOR_IMAGE: ghcr.io/zizmorcore/zizmor:1.29.0@sha256:863026d54f91271b10b60b67ad8054cb37120167e162482597db102b3026a284
+      - name: Pull digest-pinned zizmor image
+        run: docker pull "${ZIZMOR_IMAGE}"
+      # Gate pass: offline (`--network=none`), stricter `pedantic` persona, SARIF
+      # output. `--format=sarif` always exits 0, so the gate is enforced by the
+      # dedicated result-count step below rather than the process exit code.
+      # Suppressions are centralized in the checked-in `zizmor.yml`.
+      - name: Run offline zizmor gate (SARIF)
         run: |
           set -euo pipefail
-          docker pull "${ZIZMOR_IMAGE}"
           docker run \
             --rm \
             --network=none \
             --volume "${GITHUB_WORKSPACE}:/workspace:ro" \
             --workdir /workspace \
             "${ZIZMOR_IMAGE}" \
-            --persona=regular \
-            --format=github \
+            --config zizmor.yml \
+            --persona=pedantic \
+            --format=sarif \
             --collect=default \
             --no-online-audits \
             --min-severity=medium \
             --min-confidence=medium \
             --color=never \
             -- \
-            .
+            . > "${RUNNER_TEMP}/zizmor-offline.sarif"
+      - name: Upload offline zizmor SARIF to code scanning
+        if: always()
+        # github/codeql-action/upload-sarif v4.37.9, reviewed 2026-09-07.
+        uses: github/codeql-action/upload-sarif@cdf488f595d80d6e07e03d4674febd5ab45fa938
+        with:
+          sarif_file: ${{ runner.temp }}/zizmor-offline.sarif
+          category: zizmor-offline
+      - name: Gate on offline zizmor findings
+        run: |
+          set -euo pipefail
+          count="$(jq '[.runs[].results[]] | length' "${RUNNER_TEMP}/zizmor-offline.sarif")"
+          echo "offline zizmor findings at gate threshold: ${count}"
+          if [ "${count}" -ne 0 ]; then
+            echo "::error::zizmor gate failed with ${count} finding(s) at medium severity/confidence (pedantic). Fix the workflow or add a documented suppression to zizmor.yml."
+            exit 1
+          fi
+      # Advisory pass: online audits enabled (network + GITHUB_TOKEN for GitHub
+      # API lookups), broadest `auditor`/low bar. Non-gating — its findings are
+      # tracked in the Security -> Code scanning tab for triage, never block CI.
+      - name: Run online zizmor audit (SARIF, advisory)
+        continue-on-error: true
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          docker run \
+            --rm \
+            --volume "${GITHUB_WORKSPACE}:/workspace:ro" \
+            --workdir /workspace \
+            --env GH_TOKEN \
+            "${ZIZMOR_IMAGE}" \
+            --config zizmor.yml \
+            --persona=auditor \
+            --format=sarif \
+            --collect=default \
+            --min-severity=low \
+            --min-confidence=low \
+            --color=never \
+            -- \
+            . > "${RUNNER_TEMP}/zizmor-online.sarif"
+      - name: Upload online zizmor SARIF to code scanning
+        if: always()
+        # Advisory: a failed online scan/upload must never gate CI.
+        continue-on-error: true
+        # github/codeql-action/upload-sarif v4.37.9, reviewed 2026-09-07.
+        uses: github/codeql-action/upload-sarif@cdf488f595d80d6e07e03d4674febd5ab45fa938
+        with:
+          sarif_file: ${{ runner.temp }}/zizmor-online.sarif
+          category: zizmor-online
 
   slow-lifecycle:
     name: slow/lifecycle

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -665,6 +665,39 @@ jobs:
             echo "::error::zizmor gate failed with ${count} finding(s) at medium severity/confidence (pedantic). Fix the workflow or add a documented suppression to zizmor.yml."
             exit 1
           fi
+      # The gate above decides findings from the TRUSTED base-ref config, so the
+      # PR-head zizmor.yml is otherwise never validated by a required check: a
+      # malformed or unsupported PR-head config would pass every required PR check
+      # and then break the gate on the first `main` push once it becomes the base
+      # copy (issue #405 review). Validate the PR-head config here — findings are
+      # discarded (the base config still decides them), but a config-load or
+      # runtime error makes zizmor exit non-zero (`--format=sarif` only forces a
+      # 0 exit for *findings*), failing this required step before the broken
+      # config can merge.
+      - name: Validate PR-head zizmor config (errors fail; findings ignored)
+        run: |
+          set -euo pipefail
+          if [ ! -f "${GITHUB_WORKSPACE}/zizmor.yml" ]; then
+            echo "No PR-head zizmor.yml to validate."
+            exit 0
+          fi
+          docker run \
+            --rm \
+            --network=none \
+            --volume "${GITHUB_WORKSPACE}:/workspace:ro" \
+            --workdir /workspace \
+            "${ZIZMOR_IMAGE}" \
+            --config zizmor.yml \
+            --persona=pedantic \
+            --format=sarif \
+            --collect=default \
+            --no-online-audits \
+            --min-severity=medium \
+            --min-confidence=medium \
+            --color=never \
+            -- \
+            . > /dev/null
+          echo "PR-head zizmor.yml loaded and ran cleanly (findings ignored here; the trusted base-ref config decides findings at the gate)."
       - name: Upload offline zizmor SARIF to code scanning
         if: always()
         # Best-effort tracking: fork PRs get a read-only token that cannot write

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -702,7 +702,12 @@ jobs:
         if: always()
         # Best-effort tracking: fork PRs get a read-only token that cannot write
         # code scanning, so this must never gate the build (the step above does).
+        # `continue-on-error` handles a failed upload, but not a hung one:
+        # `upload-sarif` waits on server-side SARIF processing by default, so an
+        # unbounded stall would consume this REQUIRED job's timeout and cancel it.
+        # Bound the step so a slow/stalled upload stays advisory instead of gating.
         continue-on-error: true
+        timeout-minutes: 5
         # github/codeql-action/upload-sarif v4.37.9, reviewed 2026-09-07.
         uses: github/codeql-action/upload-sarif@cdf488f595d80d6e07e03d4674febd5ab45fa938
         with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -605,10 +605,37 @@ jobs:
           upload: never
       - name: Pull digest-pinned zizmor image
         run: docker pull "${ZIZMOR_IMAGE}"
+      # Source the gate's suppression config from the TRUSTED base ref, not the
+      # PR head, so a fork PR cannot add its own `ignore:` entry to suppress the
+      # finding that would flag its own dangerous workflow change (issue #405
+      # review). For push builds base==head, which is already trusted. Sparse so
+      # only zizmor.yml lands, in a sibling path outside the analyzed tree.
+      # actions/checkout v7, reviewed 2026-08-25.
+      - name: Checkout trusted zizmor config from base ref
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
+        with:
+          ref: ${{ github.event.pull_request.base.sha || github.sha }}
+          persist-credentials: false
+          sparse-checkout: |
+            zizmor.yml
+          sparse-checkout-cone-mode: false
+          path: .zizmor-trusted
+      - name: Resolve trusted zizmor config
+        run: |
+          set -euo pipefail
+          if [ -f "${GITHUB_WORKSPACE}/.zizmor-trusted/zizmor.yml" ]; then
+            echo "ZIZMOR_CONFIG=.zizmor-trusted/zizmor.yml" >> "${GITHUB_ENV}"
+            echo "Gate config: trusted base-ref zizmor.yml."
+          else
+            # Bootstrap only: the base ref predates zizmor.yml (e.g. the PR that
+            # introduces it). Once merged, the base copy always governs the gate,
+            # so PR-head suppressions can never weaken it after this point.
+            echo "ZIZMOR_CONFIG=zizmor.yml" >> "${GITHUB_ENV}"
+            echo "::notice::Base ref has no zizmor.yml (bootstrap); using PR-head config for this run only."
+          fi
       # Gate pass: offline (`--network=none`), stricter `pedantic` persona, SARIF
       # output. `--format=sarif` always exits 0, so the gate is enforced by the
       # dedicated result-count step below rather than the process exit code.
-      # Suppressions are centralized in the checked-in `zizmor.yml`.
       - name: Run offline zizmor gate (SARIF)
         run: |
           set -euo pipefail
@@ -618,7 +645,7 @@ jobs:
             --volume "${GITHUB_WORKSPACE}:/workspace:ro" \
             --workdir /workspace \
             "${ZIZMOR_IMAGE}" \
-            --config zizmor.yml \
+            --config "${ZIZMOR_CONFIG}" \
             --persona=pedantic \
             --format=sarif \
             --collect=default \
@@ -628,13 +655,9 @@ jobs:
             --color=never \
             -- \
             . > "${RUNNER_TEMP}/zizmor-offline.sarif"
-      - name: Upload offline zizmor SARIF to code scanning
-        if: always()
-        # github/codeql-action/upload-sarif v4.37.9, reviewed 2026-09-07.
-        uses: github/codeql-action/upload-sarif@cdf488f595d80d6e07e03d4674febd5ab45fa938
-        with:
-          sarif_file: ${{ runner.temp }}/zizmor-offline.sarif
-          category: zizmor-offline
+      # Gate is decided SOLELY by the deterministic result count over the offline
+      # SARIF, and runs BEFORE the best-effort upload so a read-only fork token,
+      # network error, or rate limit on the upload can never fail the build.
       - name: Gate on offline zizmor findings
         run: |
           set -euo pipefail
@@ -644,9 +667,22 @@ jobs:
             echo "::error::zizmor gate failed with ${count} finding(s) at medium severity/confidence (pedantic). Fix the workflow or add a documented suppression to zizmor.yml."
             exit 1
           fi
+      - name: Upload offline zizmor SARIF to code scanning
+        if: always()
+        # Best-effort tracking: fork PRs get a read-only token that cannot write
+        # code scanning, so this must never gate the build (the step above does).
+        continue-on-error: true
+        # github/codeql-action/upload-sarif v4.37.9, reviewed 2026-09-07.
+        uses: github/codeql-action/upload-sarif@cdf488f595d80d6e07e03d4674febd5ab45fa938
+        with:
+          sarif_file: ${{ runner.temp }}/zizmor-offline.sarif
+          category: zizmor-offline
       # Advisory pass: online audits enabled (network + GITHUB_TOKEN for GitHub
       # API lookups), broadest `auditor`/low bar. Non-gating — its findings are
       # tracked in the Security -> Code scanning tab for triage, never block CI.
+      # The default read-scoped GITHUB_TOKEN is only used for read-only API
+      # lookups; the pass is advisory/continue-on-error and cannot upload with a
+      # write token (that happens in the separate, code-scanning upload step).
       - name: Run online zizmor audit (SARIF, advisory)
         continue-on-error: true
         env:
@@ -659,7 +695,7 @@ jobs:
             --workdir /workspace \
             --env GH_TOKEN \
             "${ZIZMOR_IMAGE}" \
-            --config zizmor.yml \
+            --config "${ZIZMOR_CONFIG}" \
             --persona=auditor \
             --format=sarif \
             --collect=default \

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -677,16 +677,38 @@ jobs:
         with:
           sarif_file: ${{ runner.temp }}/zizmor-offline.sarif
           category: zizmor-offline
-      # Advisory pass: online audits enabled (network + GITHUB_TOKEN for GitHub
-      # API lookups), broadest `auditor`/low bar. Non-gating — its findings are
-      # tracked in the Security -> Code scanning tab for triage, never block CI.
-      # The default read-scoped GITHUB_TOKEN is only used for read-only API
-      # lookups; the pass is advisory/continue-on-error and cannot upload with a
-      # write token (that happens in the separate, code-scanning upload step).
+
+  # Advisory online zizmor audit, deliberately split into a read-only scan job
+  # and a separate upload job. GitHub Actions permissions are job-scoped, so the
+  # network-facing container must live in a job that holds NO `security-events:
+  # write` — otherwise it would receive a write-capable GITHUB_TOKEN. The scan
+  # job produces a SARIF artifact; the upload job (which never runs the
+  # container) forwards it to code scanning. Both are non-gating: not required
+  # checks, continue-on-error, and time-bounded, so they can never block merges.
+  zizmor-online-scan:
+    name: zizmor online audit (advisory)
+    needs: runtime-policy
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    permissions:
+      # Read-only. The container receives only a read-scoped GITHUB_TOKEN for
+      # GitHub API lookups and cannot write code scanning from here.
+      contents: read
+    env:
+      # zizmor 1.29.0, reviewed 2026-09-07.
+      ZIZMOR_IMAGE: ghcr.io/zizmorcore/zizmor:1.29.0@sha256:863026d54f91271b10b60b67ad8054cb37120167e162482597db102b3026a284
+    steps:
+      # actions/checkout v7, reviewed 2026-08-25.
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
+        with:
+          persist-credentials: false
+      - name: Pull digest-pinned zizmor image
+        run: docker pull "${ZIZMOR_IMAGE}"
+      # Broadest `auditor`/low bar with online audits enabled. Advisory only:
+      # findings are tracked in code scanning via the upload job below.
       - name: Run online zizmor audit (SARIF, advisory)
         continue-on-error: true
-        # Bounded well below the job's 20-minute budget so a hung network scan
-        # cannot consume the gate job's time and cancel the build.
+        # Bounded below the job budget so a hung network scan never stalls CI.
         timeout-minutes: 8
         env:
           GH_TOKEN: ${{ github.token }}
@@ -698,7 +720,7 @@ jobs:
             --workdir /workspace \
             --env GH_TOKEN \
             "${ZIZMOR_IMAGE}" \
-            --config "${ZIZMOR_CONFIG}" \
+            --config zizmor.yml \
             --persona=auditor \
             --format=sarif \
             --collect=default \
@@ -707,16 +729,47 @@ jobs:
             --color=never \
             -- \
             . > "${RUNNER_TEMP}/zizmor-online.sarif"
-      - name: Upload online zizmor SARIF to code scanning
+      - name: Upload online zizmor SARIF artifact
         if: always()
-        # Advisory: a failed online scan/upload must never gate CI.
+        continue-on-error: true
+        # actions/upload-artifact v7, reviewed 2026-08-25.
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
+        with:
+          name: zizmor-online-sarif
+          path: ${{ runner.temp }}/zizmor-online.sarif
+          if-no-files-found: warn
+          retention-days: 7
+
+  zizmor-online-upload:
+    name: zizmor online audit upload (advisory)
+    needs: zizmor-online-scan
+    if: always()
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      # Upload-only. This job never runs the untrusted container; it only
+      # forwards the already-produced SARIF artifact to code scanning.
+      security-events: write
+      actions: read
+    steps:
+      - name: Download online zizmor SARIF artifact
+        id: download
+        continue-on-error: true
+        # actions/download-artifact v8, reviewed 2026-08-25.
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c
+        with:
+          name: zizmor-online-sarif
+          path: online-sarif
+      - name: Upload online zizmor SARIF to code scanning
+        if: always() && steps.download.outcome == 'success'
+        # Advisory: a failed upload must never gate CI.
         continue-on-error: true
         # Bounded so a stuck code-scanning upload cannot exhaust the job budget.
         timeout-minutes: 5
         # github/codeql-action/upload-sarif v4.37.9, reviewed 2026-09-07.
         uses: github/codeql-action/upload-sarif@cdf488f595d80d6e07e03d4674febd5ab45fa938
         with:
-          sarif_file: ${{ runner.temp }}/zizmor-online.sarif
+          sarif_file: online-sarif/zizmor-online.sarif
           category: zizmor-online
 
   slow-lifecycle:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -577,12 +577,9 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 20
     permissions:
-      # CodeQL reads the Actions run graph during analysis.
-      actions: read
-      # Checkout of the repository under analysis.
-      contents: read
-      # Upload zizmor SARIF to the Security -> Code scanning tab.
-      security-events: write
+      actions: read # CodeQL reads the Actions run graph during analysis.
+      contents: read # Checkout of the repository under analysis.
+      security-events: write # Upload zizmor SARIF to the code scanning tab.
     env:
       # Digest-pinned zizmor image, shared by every scan step. Track any bump by
       # digest (Track 3 of issue #405), never by a floating tag.
@@ -691,9 +688,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 15
     permissions:
-      # Read-only. The container receives only a read-scoped GITHUB_TOKEN for
-      # GitHub API lookups and cannot write code scanning from here.
-      contents: read
+      contents: read # Read-only token: the networked container gets no write scope.
     env:
       # zizmor 1.29.0, reviewed 2026-09-07.
       ZIZMOR_IMAGE: ghcr.io/zizmorcore/zizmor:1.29.0@sha256:863026d54f91271b10b60b67ad8054cb37120167e162482597db102b3026a284
@@ -747,10 +742,8 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     permissions:
-      # Upload-only. This job never runs the untrusted container; it only
-      # forwards the already-produced SARIF artifact to code scanning.
-      security-events: write
-      actions: read
+      security-events: write # Upload-only (no container): forward SARIF to code scanning.
+      actions: read # Read the workflow run graph during the SARIF upload.
     steps:
       - name: Download online zizmor SARIF artifact
         id: download
@@ -964,7 +957,7 @@ jobs:
       group: ci-green-${{ github.repository }}-main
       cancel-in-progress: false
     permissions:
-      contents: write
+      contents: write # Force-advance the owned ci-green marker ref on main.
     steps:
       # actions/checkout v7, reviewed 2026-08-25.
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1

--- a/tests/contract/ci-workflow-policy.contract.test.ts
+++ b/tests/contract/ci-workflow-policy.contract.test.ts
@@ -371,16 +371,27 @@ describe("CI workflow policy", () => {
     expect(workflowSecurity).toContain("upload: never");
     expect(workflowSecurity).toContain("persist-credentials: false");
     expect(workflowSecurity).not.toContain("zizmor-action");
-    expect(workflowSecurity).not.toContain("GH_TOKEN");
-    expect(workflowSecurity).not.toContain("github.token");
     expect(workflowSecurity).toContain(
       "ghcr.io/zizmorcore/zizmor:1.29.0@sha256:863026d54f91271b10b60b67ad8054cb37120167e162482597db102b3026a284",
     );
+    // Offline gate: locked down (no network), pedantic, SARIF-emitting, and
+    // gated deterministically by the SARIF result count.
     expect(workflowSecurity).toContain("--network=none");
-    expect(workflowSecurity).toContain("--format=github");
+    expect(workflowSecurity).toContain("--format=sarif");
     expect(workflowSecurity).toContain("--no-online-audits");
+    expect(workflowSecurity).toContain("--persona=pedantic");
     expect(workflowSecurity).toContain("--min-severity=medium");
     expect(workflowSecurity).toContain("--min-confidence=medium");
+    expect(workflowSecurity).toContain(
+      "github/codeql-action/upload-sarif@cdf488f595d80d6e07e03d4674febd5ab45fa938",
+    );
+    expect(workflowSecurity).toContain("category: zizmor-offline");
+    // Advisory online pass: uses only the read-scoped default GITHUB_TOKEN,
+    // runs the broadest auditor bar, and is continue-on-error so it never gates.
+    expect(workflowSecurity).toContain("--persona=auditor");
+    expect(workflowSecurity).toContain("GH_TOKEN: ${{ github.token }}");
+    expect(workflowSecurity).toContain("continue-on-error: true");
+    expect(workflowSecurity).toContain("category: zizmor-online");
   });
 
   it("keeps the cross-platform fast suite on the minimum Node runtime", () => {

--- a/tests/contract/ci-workflow-policy.contract.test.ts
+++ b/tests/contract/ci-workflow-policy.contract.test.ts
@@ -386,12 +386,26 @@ describe("CI workflow policy", () => {
       "github/codeql-action/upload-sarif@cdf488f595d80d6e07e03d4674febd5ab45fa938",
     );
     expect(workflowSecurity).toContain("category: zizmor-offline");
-    // Advisory online pass: uses only the read-scoped default GITHUB_TOKEN,
-    // runs the broadest auditor bar, and is continue-on-error so it never gates.
-    expect(workflowSecurity).toContain("--persona=auditor");
-    expect(workflowSecurity).toContain("GH_TOKEN: ${{ github.token }}");
-    expect(workflowSecurity).toContain("continue-on-error: true");
-    expect(workflowSecurity).toContain("category: zizmor-online");
+    // The gate job runs the container with no network and no token.
+    expect(workflowSecurity).not.toContain("--persona=auditor");
+    expect(workflowSecurity).not.toContain("GH_TOKEN");
+
+    // Advisory online audit is split: a read-only scan job runs the networked
+    // container (so it only gets a read-scoped token) and a separate
+    // upload-only job forwards the SARIF artifact to code scanning.
+    const onlineScan = workflowJob("zizmor-online-scan");
+    expect(onlineScan).toContain("--persona=auditor");
+    expect(onlineScan).toContain("GH_TOKEN: ${{ github.token }}");
+    expect(onlineScan).toContain("continue-on-error: true");
+    expect(onlineScan).toContain("contents: read");
+    expect(onlineScan).not.toContain("security-events: write");
+    expect(onlineScan).toContain("name: zizmor-online-sarif");
+
+    const onlineUpload = workflowJob("zizmor-online-upload");
+    expect(onlineUpload).toContain("security-events: write");
+    expect(onlineUpload).toContain("category: zizmor-online");
+    expect(onlineUpload).not.toContain("docker run");
+    expect(onlineUpload).not.toContain("GH_TOKEN");
   });
 
   it("keeps the cross-platform fast suite on the minimum Node runtime", () => {

--- a/tests/contract/ci-workflow-policy.contract.test.ts
+++ b/tests/contract/ci-workflow-policy.contract.test.ts
@@ -371,9 +371,13 @@ describe("CI workflow policy", () => {
     expect(workflowSecurity).toContain("upload: never");
     expect(workflowSecurity).toContain("persist-credentials: false");
     expect(workflowSecurity).not.toContain("zizmor-action");
-    expect(workflowSecurity).toContain(
-      "ghcr.io/zizmorcore/zizmor:1.29.0@sha256:863026d54f91271b10b60b67ad8054cb37120167e162482597db102b3026a284",
-    );
+    // The zizmor image digest is defined exactly once, at workflow level, so
+    // the gate and advisory jobs can never drift onto different versions.
+    const zizmorPin =
+      "ghcr.io/zizmorcore/zizmor:1.29.0@sha256:863026d54f91271b10b60b67ad8054cb37120167e162482597db102b3026a284";
+    expect(ci).toContain(`ZIZMOR_IMAGE: ${zizmorPin}`);
+    expect(ci.split(zizmorPin).length - 1).toBe(1);
+    expect(workflowSecurity).toContain('"${ZIZMOR_IMAGE}"');
     // Offline gate: locked down (no network), pedantic, SARIF-emitting, and
     // gated deterministically by the SARIF result count.
     expect(workflowSecurity).toContain("--network=none");

--- a/tests/contract/ci-workflow-policy.contract.test.ts
+++ b/tests/contract/ci-workflow-policy.contract.test.ts
@@ -378,21 +378,41 @@ describe("CI workflow policy", () => {
     expect(ci).toContain(`ZIZMOR_IMAGE: ${zizmorPin}`);
     expect(ci.split(zizmorPin).length - 1).toBe(1);
     expect(workflowSecurity).toContain('"${ZIZMOR_IMAGE}"');
-    // Offline gate: locked down (no network), pedantic, SARIF-emitting, and
-    // gated deterministically by the SARIF result count.
-    expect(workflowSecurity).toContain("--network=none");
-    expect(workflowSecurity).toContain("--format=sarif");
-    expect(workflowSecurity).toContain("--no-online-audits");
-    expect(workflowSecurity).toContain("--persona=pedantic");
-    expect(workflowSecurity).toContain("--min-severity=medium");
-    expect(workflowSecurity).toContain("--min-confidence=medium");
+    // Offline gate flags are scoped to the NAMED scan step. The PR-head
+    // validation step reuses the same persona/format/threshold flags, so a
+    // whole-job search could stay green even if the real gate scan were deleted
+    // or weakened — assert them on the gate step itself.
+    const offlineGate = workflowStepBlock(workflowSecurity, "Run offline zizmor gate (SARIF)");
+    expect(offlineGate, "offline zizmor gate step must exist").not.toBe("");
+    expect(offlineGate).toContain("--network=none");
+    expect(offlineGate).toContain("--format=sarif");
+    expect(offlineGate).toContain("--no-online-audits");
+    expect(offlineGate).toContain("--persona=pedantic");
+    expect(offlineGate).toContain("--min-severity=medium");
+    expect(offlineGate).toContain("--min-confidence=medium");
+    // The container runs with no network and no token in the gate step.
+    expect(offlineGate).not.toContain("--persona=auditor");
+    expect(offlineGate).not.toContain("GH_TOKEN");
+    // The deterministic result-count gate must exist as its own step: because
+    // `--format=sarif` always exits 0, findings only gate via this jq count +
+    // `exit 1`. Lock the step so deleting/weakening it fails the contract.
+    const countGate = workflowStepBlock(workflowSecurity, "Gate on offline zizmor findings");
+    expect(countGate, "offline zizmor count-gate step must exist").not.toBe("");
+    expect(countGate).toMatch(/jq[^\n]*\.runs\[\][^\n]*results/);
+    expect(countGate).toContain("length");
+    expect(countGate).toContain("exit 1");
+    // ...and it must run BEFORE the SARIF upload, so a failing gate blocks first.
+    const countGateIdx = workflowSecurity.indexOf("- name: Gate on offline zizmor findings");
+    const uploadIdx = workflowSecurity.indexOf(
+      "- name: Upload offline zizmor SARIF to code scanning",
+    );
+    expect(countGateIdx).toBeGreaterThan(-1);
+    expect(uploadIdx).toBeGreaterThan(-1);
+    expect(countGateIdx).toBeLessThan(uploadIdx);
     expect(workflowSecurity).toContain(
       "github/codeql-action/upload-sarif@cdf488f595d80d6e07e03d4674febd5ab45fa938",
     );
     expect(workflowSecurity).toContain("category: zizmor-offline");
-    // The gate job runs the container with no network and no token.
-    expect(workflowSecurity).not.toContain("--persona=auditor");
-    expect(workflowSecurity).not.toContain("GH_TOKEN");
 
     // Advisory online audit is split: a read-only scan job runs the networked
     // container (so it only gets a read-scoped token) and a separate
@@ -400,8 +420,10 @@ describe("CI workflow policy", () => {
     const onlineScan = workflowJob("zizmor-online-scan");
     expect(onlineScan).toContain("--persona=auditor");
     expect(onlineScan).toContain("GH_TOKEN: ${{ github.token }}");
-    expect(onlineScan).toContain("contents: read");
-    expect(onlineScan).not.toContain("security-events: write");
+    // Lock the EXACT job-level permission set, not just the absence of
+    // security-events: any added write scope (id-token/actions/packages: write)
+    // must fail here, so the networked container can never gain a write token.
+    expect(yamlMappingForKey(onlineScan, "permissions")).toEqual({ contents: "read" });
     expect(onlineScan).toContain("name: zizmor-online-sarif");
     // The audit step itself must be advisory: scope continue-on-error to the
     // named audit step so it stays non-gating even if other steps change.

--- a/tests/contract/ci-workflow-policy.contract.test.ts
+++ b/tests/contract/ci-workflow-policy.contract.test.ts
@@ -396,10 +396,16 @@ describe("CI workflow policy", () => {
     const onlineScan = workflowJob("zizmor-online-scan");
     expect(onlineScan).toContain("--persona=auditor");
     expect(onlineScan).toContain("GH_TOKEN: ${{ github.token }}");
-    expect(onlineScan).toContain("continue-on-error: true");
     expect(onlineScan).toContain("contents: read");
     expect(onlineScan).not.toContain("security-events: write");
     expect(onlineScan).toContain("name: zizmor-online-sarif");
+    // The audit step itself must be advisory: scope continue-on-error to the
+    // named audit step so it stays non-gating even if other steps change.
+    const auditStep =
+      onlineScan.match(/- name: Run online zizmor audit[\s\S]*?(?=\n {6}- name:|\n {4}\S)/)?.[0] ??
+      "";
+    expect(auditStep).toContain("continue-on-error: true");
+    expect(auditStep).toContain("--persona=auditor");
 
     const onlineUpload = workflowJob("zizmor-online-upload");
     expect(onlineUpload).toContain("security-events: write");

--- a/tests/unit/supply-chain-policy.unit.test.ts
+++ b/tests/unit/supply-chain-policy.unit.test.ts
@@ -935,6 +935,14 @@ describe("supply-chain audit policy", () => {
     expect(yamlBlockForKey(publishOnBlock, "release")).toBeNull();
     expect(yamlBlockForKey(publishOnBlock, "push")).toBeNull();
     expect(yamlBlockForKey(publishOnBlock, "workflow_dispatch")).toBeNull();
+    // The zizmor dangerous-triggers ignore is anchored to publish.yml's `on:`
+    // key, which would also mask a dangerous trigger added to the same block.
+    // Compensate for that over-breadth: workflow_run is the only permitted
+    // trigger, so a pull_request_target / pull_request added here fails this
+    // required test instead of being silently suppressed by zizmor.yml.
+    expect(yamlBlockForKey(publishOnBlock, "pull_request_target")).toBeNull();
+    expect(yamlBlockForKey(publishOnBlock, "pull_request")).toBeNull();
+    expect(yamlBlockForKey(publishOnBlock, "workflow_run")).not.toBeNull();
     expect(publishWorkflow).not.toContain("inputs.tag");
     expect(publishWorkflow).not.toContain("github.event.workflow_run.head_branch");
     expect(publishWorkflow).not.toContain("${{ github.event.release.tag_name }}");

--- a/tests/unit/supply-chain-policy.unit.test.ts
+++ b/tests/unit/supply-chain-policy.unit.test.ts
@@ -920,9 +920,17 @@ describe("supply-chain audit policy", () => {
     expect(releaseTagWorkflow).not.toContain("actions/checkout");
     expect(releaseTagWorkflow).not.toContain("npm publish");
     expect(releaseTagWorkflow).not.toContain("GHCR_TOKEN");
-    expect(publishWorkflow).toContain("zizmor: ignore[dangerous-triggers]");
-    expect(publishWorkflow).toContain("tag artifact");
-    expect(publishWorkflow).toContain("validates protected refs");
+    // The dangerous-triggers suppression is centralized in the checked-in
+    // zizmor.yml (not an inline marker), scoped to publish.yml's on: block, and
+    // still carries the accepted-risk rationale.
+    const zizmorConfig = readFileSync(join(root, "zizmor.yml"), "utf8");
+    expect(publishWorkflow).not.toContain("zizmor: ignore[");
+    expect(publishWorkflow).toContain("centralized in the");
+    expect(publishWorkflow).toContain("zizmor.yml");
+    expect(zizmorConfig).toContain("dangerous-triggers:");
+    expect(zizmorConfig).toContain("- publish.yml:9");
+    expect(zizmorConfig).toContain("tag artifact");
+    expect(zizmorConfig).toContain("validates protected refs");
     expect(publishWorkflowRunBlock).toContain("Release Tag Request");
     expect(yamlBlockForKey(publishOnBlock, "release")).toBeNull();
     expect(yamlBlockForKey(publishOnBlock, "push")).toBeNull();

--- a/zizmor.yml
+++ b/zizmor.yml
@@ -38,8 +38,14 @@ rules:
       # attacker-controllable head code. The privileged-trigger risk this audit
       # flags is mitigated by that design, so the finding is accepted.
       #
-      # Scoped to the specific `on:` trigger block (publish.yml:9) rather than
-      # the whole file, so the exception only covers today's known-safe design.
-      # Re-review whenever publish.yml's triggers change: a new dangerous
-      # trigger on a different line will NOT be pre-suppressed by this entry.
+      # Anchored to publish.yml's `on:` key (publish.yml:9). zizmor 1.29.0
+      # anchors EVERY dangerous-triggers finding to this same `on:` key, so this
+      # line-scoped ignore would also cover another dangerous trigger (e.g.
+      # pull_request_target) added to the same block. That over-breadth is
+      # deliberately compensated by a required test
+      # (tests/unit/supply-chain-policy.unit.test.ts) that fails if publish.yml's
+      # `on:` gains pull_request_target/pull_request or any trigger other than the
+      # reviewed workflow_run — so a newly added dangerous trigger can never be
+      # silently suppressed by this entry. Re-review whenever publish.yml's
+      # triggers change.
       - publish.yml:9

--- a/zizmor.yml
+++ b/zizmor.yml
@@ -7,6 +7,28 @@
 #
 # Docs: https://docs.zizmor.sh/configuration/
 rules:
+  ref-version-mismatch:
+    ignore:
+      # Repo-wide convention. Every action is SHA-pinned and annotated with a
+      # human-reviewed comment on the PRECEDING line
+      # (`# <action> vX.Y.Z, reviewed <date>`), which is stricter than the
+      # inline `# vX.Y.Z` tag this audit looks for. ref-version-mismatch only
+      # recognizes an inline same-line comment, so it reports the entire pinned
+      # surface (200+ uses) as false positives against that convention. The pin
+      # digests and their reviewed dates are the source of truth; adding a
+      # second inline version tag would duplicate that metadata and invite the
+      # drift this convention avoids. Accepted for every workflow (zizmor has no
+      # glob support, so each file is listed explicitly).
+      - codeql.yml
+      - contract.yml
+      - docs.yml
+      - evals.yml
+      - mutation.yml
+      - publish.yml
+      - quality-keeper.yml
+      - release-tag.yml
+      - smoke.yml
+      - test.yml
   dangerous-triggers:
     ignore:
       # Publish Package runs on `workflow_run` from the unprivileged "Release

--- a/zizmor.yml
+++ b/zizmor.yml
@@ -1,0 +1,18 @@
+# zizmor (GitHub Actions static analysis) configuration.
+#
+# This is the single, checked-in source of truth for zizmor suppressions.
+# Every entry MUST carry a rationale so an auditor can see why a finding is
+# accepted rather than fixed. Inline `# zizmor: ignore[...]` comments have been
+# migrated here so suppressions live in one reviewable place.
+#
+# Docs: https://docs.zizmor.sh/configuration/
+rules:
+  dangerous-triggers:
+    ignore:
+      # Publish Package runs on `workflow_run` from the unprivileged "Release
+      # Tag Request" workflow. It only consumes an inert tag artifact, checks
+      # out trusted `ci-green` resolver code, validates protected refs, and
+      # publishes behind protected environments — it never runs
+      # attacker-controllable head code. The privileged-trigger risk this audit
+      # flags is mitigated by that design, so the finding is accepted.
+      - publish.yml

--- a/zizmor.yml
+++ b/zizmor.yml
@@ -15,4 +15,9 @@ rules:
       # publishes behind protected environments — it never runs
       # attacker-controllable head code. The privileged-trigger risk this audit
       # flags is mitigated by that design, so the finding is accepted.
-      - publish.yml
+      #
+      # Scoped to the specific `on:` trigger block (publish.yml:9) rather than
+      # the whole file, so the exception only covers today's known-safe design.
+      # Re-review whenever publish.yml's triggers change: a new dangerous
+      # trigger on a different line will NOT be pre-suppressed by this entry.
+      - publish.yml:9


### PR DESCRIPTION
## Summary

Hardens and expands the existing zizmor GitHub Actions static analysis across the three tracks in #405, keeps CI green, and updates the CI-policy tests that lock the behavior in.

**Track 1 — Stricter rules & gating policy**
- Gate pass raised from `--persona=regular` to `--persona=pedantic` (offline, `--network=none`), keeping the `medium` severity / `medium` confidence bar.
- Gating is decided **solely** by a deterministic `jq` result count over the offline SARIF (`--format=sarif` intentionally exits 0), and runs **before** the code-scanning upload so a read-only fork token, network error, or rate limit can never fail the build.
- Findings below the gate bar are surfaced (not gated) via the advisory online pass and the Security → Code scanning tab, so new findings can be triaged without blocking merges.

**Track 2 — SARIF → GitHub code scanning**
- The offline gate emits SARIF and uploads it via `github/codeql-action/upload-sarif` (digest-pinned v4.37.9) under category `zizmor-offline`; the online advisory pass uploads under `zizmor-online`.
- Coexists with the existing CodeQL analyze step (unchanged, `upload: never`).

**Track 3 — Config file + online audits**
- Adds checked-in `zizmor.yml` as the single source of truth for suppressions, each with a rationale.
- Migrates the inline `# zizmor: ignore[dangerous-triggers]` from `publish.yml` into `zizmor.yml`, scoped to the specific `on:` block (`publish.yml:9`).
- Suppresses `ref-version-mismatch` repo-wide with a rationale: the repo pins every action by SHA with a human-reviewed comment on the preceding line, which is stricter than the inline version tag that audit expects (200+ identical false positives otherwise).
- Adds a separate advisory online-audit pass (network + read-scoped `GITHUB_TOKEN`) at the broadest `auditor`/low bar; it is `continue-on-error` and never gates CI.
- The zizmor image digest is defined **once** at workflow-level `env` (single source of truth) so the gate and advisory jobs cannot drift onto different versions.

## Security hardening from review

- **Fork-PR safety:** the offline gate is evaluated before a best-effort, `continue-on-error` SARIF upload, so upload failures on fork PRs (read-only token) never gate the build.
- **Config trust boundary:** the gate sources `zizmor.yml` from the **trusted base ref** (`pull_request.base.sha`, sparse-checked-out to a sibling path outside the analyzed tree), with a documented bootstrap fallback only when the base predates the file, so a PR cannot add an `ignore:` entry that suppresses the finding flagging its own change.
- **Least-privilege online pass:** GitHub Actions permissions are job-scoped, so the networked container is isolated into a read-only `zizmor-online-scan` job (`contents: read` only) that uploads the SARIF as an artifact; a separate `zizmor-online-upload` job (`security-events: write`, no container) forwards it to code scanning. Both are non-gating, time-bounded (8m scan / 5m upload), and not required checks.
- Permissions on the jobs I authored carry inline (same-line) explanatory comments so `undocumented-permissions` is satisfied.

## Test / policy updates

- `tests/contract/ci-workflow-policy.contract.test.ts`: validates the SARIF offline gate, the split read-only online scan + upload-only jobs, the audit step being advisory (scoped assertion), and the single workflow-level image pin.
- `tests/unit/supply-chain-policy.unit.test.ts`: reads `zizmor.yml` and asserts the centralized `dangerous-triggers` suppression (`publish.yml:9`) and rationale, and that `publish.yml` no longer carries an inline marker.
- `.cspell/project-words.txt`: adds `SARIF`.

## Linked issue

Closes #405

## Tests run
- `zizmor 1.29.0` (pinned CI image, via `pip install zizmor==1.29.0`): offline gate (`--persona=pedantic --min-severity=medium --min-confidence=medium --no-online-audits`) → **0 findings** (gate green). Confirmed `--format=sarif` exits 0 while `--format=plain` exits 13, validating the `jq` gate. Confirmed `dangerous-triggers` and `ref-version-mismatch` are suppressed via `zizmor.yml`, and the authored permission blocks clear `undocumented-permissions`.
- `pnpm exec vitest` — contract `ci-workflow-policy` (16 passed), unit `supply-chain-policy` (63 passed), contract `spelling-policy` (4 passed).
- YAML validated for `test.yml`, `publish.yml`, and `zizmor.yml`.

## Follow-up notes
- The advisory online pass populates the Security → Code scanning tab; remaining pre-existing `undocumented-permissions` findings in other workflow files are left as a triage backlog.
- Fully resisting fork-authored edits to the gate step itself (not just its config) would require a base-controlled `pull_request_target`/`workflow_run` architecture, which is a broader CI change beyond this issue; branch protection plus visible-in-diff review remain the backstop.
