### PR TITLE
test: cover error branches in buckets, server, resources, oauth (#400)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -132,7 +132,7 @@ jobs:
         run: |
           echo "## Coverage summary" >> "$GITHUB_STEP_SUMMARY"
           echo "Node.js ${{ matrix.node-version }}" >> "$GITHUB_STEP_SUMMARY"
-          echo "Required: statements 94.3%, branches 88%, functions 97.2%, lines 96.6%." >> "$GITHUB_STEP_SUMMARY"
+          echo "Required: statements 94.5%, branches 89%, functions 97.5%, lines 96.7%." >> "$GITHUB_STEP_SUMMARY"
           echo '```' >> "$GITHUB_STEP_SUMMARY"
           if [ -f coverage/coverage-summary.json ]; then
             node -e "

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@
 [![Node.js](https://img.shields.io/badge/Node.js-22.22%2B%20%7C%2024%20%7C%2026-339933?logo=nodedotjs&logoColor=white)](https://nodejs.org/)
 [![MCP](https://img.shields.io/badge/MCP-2026--07--28-5b5fc7)](https://modelcontextprotocol.io/specification/2026-07-28)
 [![API docs](https://img.shields.io/badge/API%20docs-TypeDoc-3178c6?logo=readthedocs&logoColor=white)](https://backblaze-labs.github.io/b2-mcp/)
-[![Coverage floors](https://img.shields.io/badge/coverage-S%2094.3%20%7C%20B%2088%20%7C%20F%2097.2%20%7C%20L%2096.6-brightgreen)](docs/TESTING.md)
+[![Coverage floors](https://img.shields.io/badge/coverage-S%2094.5%20%7C%20B%2089%20%7C%20F%2097.5%20%7C%20L%2096.7-brightgreen)](docs/TESTING.md)
 [![Runtime dependencies](https://img.shields.io/badge/runtime_dependencies-9-blue)](package-budget.json)
 
 <!-- Directory badges point at deterministic per-server URLs derived from the locked

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -182,8 +182,8 @@ The stable required PR check names are:
 - `slow/lifecycle`
 - `cross-platform minimum`
 
-Global V8 coverage must remain at or above 94.3% statements, 88% branches,
-97.2% functions, and 96.6% lines. Raise these floors as coverage improves;
+Global V8 coverage must remain at or above 94.5% statements, 89% branches,
+97.5% functions, and 96.7% lines. Raise these floors as coverage improves;
 lowering them requires explicit review and justification. Coverage collection is source
 only: `src/**/*.ts`, excluding `dist/`, declarations, generated files, and test
 files. The current Phase 1 floor is a ratchet: when `coverage/coverage-summary.json`

--- a/tests/contract/test-layering.contract.test.ts
+++ b/tests/contract/test-layering.contract.test.ts
@@ -371,20 +371,20 @@ describe("test layer naming", () => {
     const ciWorkflow = readFileSync(join(root, ".github/workflows/test.yml"), "utf8");
 
     expect(vitestConfig).toMatch(
-      /thresholds:\s*{\s*statements:\s*94\.3,\s*branches:\s*88,\s*functions:\s*97\.2,\s*lines:\s*96\.6,?\s*}/,
+      /thresholds:\s*{\s*statements:\s*94\.5,\s*branches:\s*89,\s*functions:\s*97\.5,\s*lines:\s*96\.7,?\s*}/,
     );
     expect(vitestConfig).toContain('include: ["src/**/*.ts"]');
     expect(vitestConfig).toContain('"html"');
     expect(vitestConfig).toContain('"lcov"');
     expect(vitestConfig).toContain('"cobertura"');
     expect(readme).toContain(
-      "coverage-S%2094.3%20%7C%20B%2088%20%7C%20F%2097.2%20%7C%20L%2096.6-brightgreen",
+      "coverage-S%2094.5%20%7C%20B%2089%20%7C%20F%2097.5%20%7C%20L%2096.7-brightgreen",
     );
     expect(testingGuide).toMatch(
-      /Global V8 coverage must remain at or above 94\.3% statements,\s*88% branches,\s*97\.2% functions, and 96\.6% lines\./,
+      /Global V8 coverage must remain at or above 94\.5% statements,\s*89% branches,\s*97\.5% functions, and 96\.7% lines\./,
     );
     expect(ciWorkflow).toContain(
-      "Required: statements 94.3%, branches 88%, functions 97.2%, lines 96.6%.",
+      "Required: statements 94.5%, branches 89%, functions 97.5%, lines 96.7%.",
     );
   });
 

--- a/tests/runtime-security/oauth-token-validation.runtime-security.test.ts
+++ b/tests/runtime-security/oauth-token-validation.runtime-security.test.ts
@@ -107,11 +107,10 @@ describe("oauth malformed bearer token rejection", () => {
   });
 
   it("rejects a request with no Authorization header", async () => {
-    const result = await authenticateOAuthRequest(
-      new Request(oauthConfig.publicUrl),
-      oauthConfig,
-      { fetch: rejectingFetch, nowSeconds: () => 1_000 },
-    );
+    const result = await authenticateOAuthRequest(new Request(oauthConfig.publicUrl), oauthConfig, {
+      fetch: rejectingFetch,
+      nowSeconds: () => 1_000,
+    });
     expect(result).toBeInstanceOf(Response);
     expect((result as Response).status).toBe(401);
   });
@@ -140,7 +139,9 @@ describe("oauth aborted in-flight verification", () => {
 
 describe("oauth pre-verified auth info validation", () => {
   it("accepts auth info that satisfies every deployment rule", () => {
-    expect(() => validatePreverifiedOAuthAuthInfo(baseAuthInfo(), oauthConfig, () => 1_000)).not.toThrow();
+    expect(() =>
+      validatePreverifiedOAuthAuthInfo(baseAuthInfo(), oauthConfig, () => 1_000),
+    ).not.toThrow();
   });
 
   it("rejects an untrusted issuer", () => {
@@ -176,7 +177,9 @@ describe("oauth pre-verified auth info validation", () => {
     const info = baseAuthInfo();
     (info.extra as Record<string, unknown>).alg = "HS256";
     const permissiveConfig = { ...oauthConfig, allowedAlgorithms: [] } as OAuthJwtVerifierConfig;
-    expect(() => validatePreverifiedOAuthAuthInfo(info, permissiveConfig, () => 1_000)).not.toThrow();
+    expect(() =>
+      validatePreverifiedOAuthAuthInfo(info, permissiveConfig, () => 1_000),
+    ).not.toThrow();
   });
 
   it("loads a hardened default config with a non-empty algorithm allow-list", () => {

--- a/tests/runtime-security/oauth-token-validation.runtime-security.test.ts
+++ b/tests/runtime-security/oauth-token-validation.runtime-security.test.ts
@@ -1,0 +1,171 @@
+/**
+ * Runtime-security coverage for src/oauth-resource-server.ts (issue #400).
+ *
+ * Injects malformed bearer tokens, an aborted in-flight request, and invalid
+ * pre-verified auth info to exercise the OAuth verifier's rejection branches
+ * (JWT structure parsing, client-disconnect abort, issuer/resource/audience
+ * mismatch, and algorithm policy) without a live authorization server.
+ */
+import {
+  authenticateOAuthRequest,
+  resetOAuthVerifierCacheForTests,
+  validatePreverifiedOAuthAuthInfo,
+} from "../../src/oauth-resource-server";
+import type { OAuthJwtVerifierConfig } from "../../src/oauth-resource-server";
+import { jwksResponse, signedJwt } from "../support/oauth-jwks";
+
+const oauthConfig = {
+  issuer: "http://localhost:9000/",
+  resource: "http://localhost:3000/mcp",
+  audience: "http://localhost:3000/mcp",
+  publicUrl: "http://localhost:3000/mcp",
+  authorizationEndpoint: "http://localhost:9000/oauth2/authorize",
+  tokenEndpoint: "http://localhost:9000/oauth2/token",
+  jwksUri: "http://localhost:9000/oauth2/jwks",
+  requiredScopes: [],
+  allowedSubjects: [],
+  allowedTokenTypes: ["bearer"],
+  allowedAlgorithms: ["RS256"],
+  allowedJwtAlgorithms: ["RS256"],
+  allowedJwtTypes: ["at+jwt", "application/at+jwt"],
+  dangerouslyAllowInsecureIssuerUrl: true,
+  dangerouslyAllowUnauthenticatedIntrospection: false,
+  tokenCacheMaxEntries: 100,
+  tokenCacheTtlSeconds: 300,
+  tokenCacheSkewSeconds: 0,
+  jwksCacheTtlSeconds: 300,
+  jwksCacheMinTtlSeconds: 30,
+  jwksTimeoutMs: 50,
+  jwksMaxRetries: 1,
+  jwksRetryDelayMs: 0,
+  jwksCircuitFailures: 1,
+  jwksCircuitOpenMs: 2_000,
+  jwksRefreshCooldownMs: 30_000,
+  jwtClockSkewSeconds: 60,
+} satisfies OAuthJwtVerifierConfig;
+
+function bearerRequest(token: string, init: RequestInit = {}): Request {
+  return new Request(oauthConfig.publicUrl, {
+    headers: { Authorization: `Bearer ${token}` },
+    ...init,
+  });
+}
+
+function validJwt(): string {
+  return signedJwt({
+    iss: oauthConfig.issuer,
+    aud: oauthConfig.audience,
+    resource: oauthConfig.resource,
+    exp: 2_000_000_000,
+    nbf: 900,
+    token_type: "bearer",
+    scope: "b2:read",
+    client_id: "runtime-client",
+    sub: "user-123",
+  });
+}
+
+function baseAuthInfo(): Parameters<typeof validatePreverifiedOAuthAuthInfo>[0] {
+  return {
+    token: "preverified",
+    clientId: "runtime-client",
+    scopes: ["b2:read"],
+    expiresAt: 2_000_000_000,
+    resource: new URL(oauthConfig.resource),
+    extra: {
+      iss: oauthConfig.issuer,
+      aud: oauthConfig.audience,
+      resource: oauthConfig.resource,
+      nbf: 900,
+      token_type: "bearer",
+      alg: "RS256",
+    },
+  } as Parameters<typeof validatePreverifiedOAuthAuthInfo>[0];
+}
+
+afterEach(() => {
+  resetOAuthVerifierCacheForTests();
+});
+
+describe("oauth malformed bearer token rejection", () => {
+  const rejectingFetch = (async () => {
+    throw new Error("network must not be reached for a malformed token");
+  }) as unknown as typeof fetch;
+
+  it.each([
+    { name: "two-segment token", token: "header.claims" },
+    { name: "empty middle segment", token: "header..signature" },
+    { name: "non-base64 JSON segments", token: "!!!.@@@.###" },
+  ])("rejects a $name as an unauthorized request", async ({ token }) => {
+    const result = await authenticateOAuthRequest(bearerRequest(token), oauthConfig, {
+      fetch: rejectingFetch,
+      nowSeconds: () => 1_000,
+    });
+    expect(result).toBeInstanceOf(Response);
+    expect((result as Response).status).toBe(401);
+  });
+
+  it("rejects a request with no Authorization header", async () => {
+    const result = await authenticateOAuthRequest(
+      new Request(oauthConfig.publicUrl),
+      oauthConfig,
+      { fetch: rejectingFetch, nowSeconds: () => 1_000 },
+    );
+    expect(result).toBeInstanceOf(Response);
+    expect((result as Response).status).toBe(401);
+  });
+});
+
+describe("oauth aborted in-flight verification", () => {
+  it("fails closed when the caller aborts before JWKS resolves", async () => {
+    resetOAuthVerifierCacheForTests();
+    const controller = new AbortController();
+    controller.abort();
+    const fetchMock = (async () => jwksResponse()) as unknown as typeof fetch;
+
+    const result = await authenticateOAuthRequest(
+      bearerRequest(validJwt(), { signal: controller.signal }),
+      oauthConfig,
+      { fetch: fetchMock, nowSeconds: () => 1_000 },
+    );
+
+    expect(result).toBeInstanceOf(Response);
+  });
+});
+
+describe("oauth pre-verified auth info validation", () => {
+  it("accepts auth info that satisfies every deployment rule", () => {
+    expect(() => validatePreverifiedOAuthAuthInfo(baseAuthInfo(), oauthConfig, () => 1_000)).not.toThrow();
+  });
+
+  it("rejects an untrusted issuer", () => {
+    const info = baseAuthInfo();
+    (info.extra as Record<string, unknown>).iss = "http://evil.example/";
+    expect(() => validatePreverifiedOAuthAuthInfo(info, oauthConfig, () => 1_000)).toThrow(
+      /issuer is not trusted/,
+    );
+  });
+
+  it("rejects a mismatched resource", () => {
+    const info = baseAuthInfo();
+    info.resource = new URL("http://localhost:3000/other");
+    expect(() => validatePreverifiedOAuthAuthInfo(info, oauthConfig, () => 1_000)).toThrow(
+      /resource is not accepted/,
+    );
+  });
+
+  it("rejects a token whose algorithm is outside the allow-list", () => {
+    const info = baseAuthInfo();
+    (info.extra as Record<string, unknown>).alg = "HS256";
+    expect(() => validatePreverifiedOAuthAuthInfo(info, oauthConfig, () => 1_000)).toThrow(
+      /algorithm is not accepted/,
+    );
+  });
+
+  it("skips algorithm enforcement when no algorithms are configured", () => {
+    const info = baseAuthInfo();
+    (info.extra as Record<string, unknown>).alg = "HS256";
+    const permissiveConfig = { ...oauthConfig, allowedAlgorithms: [] } as OAuthJwtVerifierConfig;
+    expect(() => validatePreverifiedOAuthAuthInfo(info, permissiveConfig, () => 1_000)).not.toThrow();
+  });
+});

--- a/tests/runtime-security/oauth-token-validation.runtime-security.test.ts
+++ b/tests/runtime-security/oauth-token-validation.runtime-security.test.ts
@@ -8,6 +8,7 @@
  */
 import {
   authenticateOAuthRequest,
+  loadOAuthResourceServerConfig,
   resetOAuthVerifierCacheForTests,
   validatePreverifiedOAuthAuthInfo,
 } from "../../src/oauth-resource-server";
@@ -129,7 +130,11 @@ describe("oauth aborted in-flight verification", () => {
       { fetch: fetchMock, nowSeconds: () => 1_000 },
     );
 
+    // Must fail closed: an aborted in-flight verification maps to a
+    // 503 (request_aborted dependency error), never a success/leaky response.
     expect(result).toBeInstanceOf(Response);
+    expect((result as Response).status).toBe(503);
+    expect((result as Response).status).not.toBe(200);
   });
 });
 
@@ -162,10 +167,48 @@ describe("oauth pre-verified auth info validation", () => {
     );
   });
 
+  // An empty allowedAlgorithms disables algorithm-policy enforcement (a
+  // fail-open path that would re-enable JWT alg-confusion). This test only
+  // documents that branch's behavior; the companion test below proves the
+  // default/loaded config never reaches it, so the fail-open state is
+  // unreachable in a real deployment.
   it("skips algorithm enforcement when no algorithms are configured", () => {
     const info = baseAuthInfo();
     (info.extra as Record<string, unknown>).alg = "HS256";
     const permissiveConfig = { ...oauthConfig, allowedAlgorithms: [] } as OAuthJwtVerifierConfig;
     expect(() => validatePreverifiedOAuthAuthInfo(info, permissiveConfig, () => 1_000)).not.toThrow();
+  });
+
+  it("loads a hardened default config with a non-empty algorithm allow-list", () => {
+    const loaded = loadOAuthResourceServerConfig({
+      B2_MCP_PUBLIC_URL: oauthConfig.publicUrl,
+      B2_OAUTH_JWKS_URI: oauthConfig.jwksUri,
+      B2_OAUTH_ISSUER: oauthConfig.issuer,
+      B2_OAUTH_AUDIENCE: oauthConfig.audience,
+      B2_OAUTH_AUTHORIZATION_ENDPOINT: oauthConfig.authorizationEndpoint,
+      B2_OAUTH_TOKEN_ENDPOINT: oauthConfig.tokenEndpoint,
+      B2_OAUTH_DANGEROUSLY_ALLOW_INSECURE_ISSUER_URL: "true",
+    } as NodeJS.ProcessEnv);
+
+    // The fail-open branch above is unreachable by default: the loaded config
+    // always populates allowedAlgorithms with asymmetric algorithms only.
+    expect(loaded.allowedAlgorithms.length).toBeGreaterThan(0);
+    expect(loaded.allowedAlgorithms).not.toContain("HS256");
+
+    // With the loaded (non-empty) allow-list an HS256 token is rejected, so the
+    // alg-confusion downgrade the permissive test allows cannot happen by default.
+    const info = baseAuthInfo();
+    (info.extra as Record<string, unknown>).iss = loaded.issuer;
+    (info.extra as Record<string, unknown>).aud = loaded.audience;
+    (info.extra as Record<string, unknown>).resource = loaded.resource;
+    (info.extra as Record<string, unknown>).alg = "HS256";
+    info.resource = new URL(loaded.resource);
+    expect(() =>
+      validatePreverifiedOAuthAuthInfo(
+        info,
+        loaded as unknown as OAuthJwtVerifierConfig,
+        () => 1_000,
+      ),
+    ).toThrow(/algorithm is not accepted/);
   });
 });

--- a/tests/unit/coverage-buckets-400.unit.test.ts
+++ b/tests/unit/coverage-buckets-400.unit.test.ts
@@ -33,9 +33,7 @@ function bucketFixture() {
  * Build a bucket-tool harness over an in-memory B2 client double whose
  * notification-rule response can be customized per test.
  */
-function makeHarness(
-  notificationRules?: unknown,
-): { tools: ToolHarness; calls: Recorded[] } {
+function makeHarness(notificationRules?: unknown): { tools: ToolHarness; calls: Recorded[] } {
   const calls: Recorded[] = [];
   const b2 = {
     async createBucket(input: unknown) {
@@ -93,7 +91,11 @@ describe("buckets webhook URL guard (SSRF defense-in-depth)", () => {
   });
 
   it.each([
-    { name: "IPv6 zone identifier", url: "https://[fe80::1%25en0]/hook", reason: "zone identifier" },
+    {
+      name: "IPv6 zone identifier",
+      url: "https://[fe80::1%25en0]/hook",
+      reason: "zone identifier",
+    },
     { name: "non-canonical numeric host", url: "https://127.1/hook", reason: "numeric IP address" },
     { name: "unparseable URL", url: "ht!tp://x", reason: "is not a valid URL" },
     { name: "non-https scheme", url: "http://example.com/hook", reason: "must use https" },
@@ -103,10 +105,18 @@ describe("buckets webhook URL guard (SSRF defense-in-depth)", () => {
       reason: "must not include credentials",
     },
     { name: "localhost", url: "https://localhost/hook", reason: "must not target localhost" },
-    { name: "dotted localhost", url: "https://api.localhost/hook", reason: "must not target localhost" },
+    {
+      name: "dotted localhost",
+      url: "https://api.localhost/hook",
+      reason: "must not target localhost",
+    },
     { name: "hex numeric host", url: "https://0x7f000001/hook", reason: "IP address" },
     { name: "private IPv4 literal", url: "https://10.0.0.1/hook", reason: "non-public IP address" },
-    { name: "link-local metadata IPv4", url: "https://169.254.169.254/latest", reason: "non-public IP address" },
+    {
+      name: "link-local metadata IPv4",
+      url: "https://169.254.169.254/latest",
+      reason: "non-public IP address",
+    },
     { name: "ULA IPv6 literal", url: "https://[fec0::1]/hook", reason: "non-public IP address" },
     {
       name: "IPv4-mapped IPv6 literal",
@@ -184,7 +194,10 @@ describe("buckets handler option normalization", () => {
       defaultServerSideEncryption: { mode: "none" },
     });
     const creates = calls.filter((c) => c.operation === "createBucket").map((c) => c.input as any);
-    expect(creates[0].defaultServerSideEncryption).toEqual({ mode: "SSE-B2", algorithm: undefined });
+    expect(creates[0].defaultServerSideEncryption).toEqual({
+      mode: "SSE-B2",
+      algorithm: undefined,
+    });
     expect(creates[1].defaultServerSideEncryption).toEqual({ mode: "none" });
   });
 
@@ -194,7 +207,10 @@ describe("buckets handler option normalization", () => {
       bucketName: "minimal-bucket",
       bucketType: "allPrivate",
     });
-    const input = calls.find((c) => c.operation === "createBucket")?.input as Record<string, unknown>;
+    const input = calls.find((c) => c.operation === "createBucket")?.input as Record<
+      string,
+      unknown
+    >;
     expect(input).toEqual({ bucketName: "minimal-bucket", bucketType: "allPrivate" });
   });
 
@@ -209,7 +225,10 @@ describe("buckets handler option normalization", () => {
       defaultServerSideEncryption: { mode: "SSE-B2", algorithm: "AES256" },
       fileLockEnabled: true,
     });
-    const input = calls.find((c) => c.operation === "createBucket")?.input as Record<string, unknown>;
+    const input = calls.find((c) => c.operation === "createBucket")?.input as Record<
+      string,
+      unknown
+    >;
     expect(input).toMatchObject({
       bucketInfo: { team: "ops" },
       lifecycleRules: [{ fileNamePrefix: "tmp/", daysFromHidingToDeleting: 1 }],
@@ -222,7 +241,10 @@ describe("buckets handler option normalization", () => {
   it("updates with only a bucketId, omitting every optional field", async () => {
     const { tools, calls } = makeHarness();
     await tools.call("b2_update_bucket", { bucketId: "bucket-1" });
-    const input = calls.find((c) => c.operation === "updateBucket")?.input as Record<string, unknown>;
+    const input = calls.find((c) => c.operation === "updateBucket")?.input as Record<
+      string,
+      unknown
+    >;
     expect(input).toEqual({ bucketId: "bucket-1" });
   });
 
@@ -240,7 +262,10 @@ describe("buckets handler option normalization", () => {
       ifRevisionIs: 7,
       confirm: true,
     });
-    const input = calls.find((c) => c.operation === "updateBucket")?.input as Record<string, unknown>;
+    const input = calls.find((c) => c.operation === "updateBucket")?.input as Record<
+      string,
+      unknown
+    >;
     expect(input).toMatchObject({
       bucketId: "bucket-1",
       bucketType: "allPublic",

--- a/tests/unit/coverage-buckets-400.unit.test.ts
+++ b/tests/unit/coverage-buckets-400.unit.test.ts
@@ -1,0 +1,318 @@
+// Branch-coverage expansion for src/b2/buckets.ts (issue #400, phase 1).
+//
+// Targets the webhook SSRF/URL guard, the DNS-resolution fallbacks, the
+// server-side-encryption normalizer, the bucketInfo key-quoting helper, the
+// notification-secret redaction spreads, and the optional-argument spreads in
+// b2_create_bucket / b2_update_bucket. These are pure-function permutations
+// reached through the registered tool handlers.
+import { registerBucketTools, setWebhookDnsLookupForTests } from "../../src/b2/buckets";
+import type { B2Client } from "../../src/b2/client";
+import { circuitBreaker } from "../../src/utils/circuit-breaker";
+import { ToolHarness, parseResult, testConfig } from "../support/deterministic-fakes";
+
+interface Recorded {
+  operation: string;
+  input: unknown;
+}
+
+function bucketFixture() {
+  return {
+    accountId: "test-account-123",
+    bucketId: "bucket-1",
+    bucketName: "bucket-1",
+    bucketType: "allPrivate",
+    bucketInfo: {},
+    corsRules: [],
+    lifecycleRules: [],
+    revision: 1,
+    options: [],
+  };
+}
+
+/**
+ * Build a bucket-tool harness over an in-memory B2 client double whose
+ * notification-rule response can be customized per test.
+ */
+function makeHarness(
+  notificationRules?: unknown,
+): { tools: ToolHarness; calls: Recorded[] } {
+  const calls: Recorded[] = [];
+  const b2 = {
+    async createBucket(input: unknown) {
+      calls.push({ operation: "createBucket", input });
+      return { ...bucketFixture(), ...(input as object) };
+    },
+    async updateBucket(input: unknown) {
+      calls.push({ operation: "updateBucket", input });
+      return { ...bucketFixture(), ...(input as object) };
+    },
+    async getBucketNotificationRules(bucketId: string) {
+      calls.push({ operation: "getBucketNotificationRules", input: bucketId });
+      return (
+        notificationRules ?? {
+          bucketId,
+          eventNotificationRules: [],
+        }
+      );
+    },
+    async setBucketNotificationRules(bucketId: string, eventNotificationRules: unknown[]) {
+      calls.push({ operation: "setBucketNotificationRules", input: { bucketId } });
+      return { bucketId, eventNotificationRules };
+    },
+  };
+  const tools = new ToolHarness();
+  registerBucketTools(tools, b2 as unknown as B2Client, testConfig);
+  return { tools, calls };
+}
+
+const validRule = {
+  name: "r",
+  eventTypes: ["b2:ObjectCreated:*"],
+  isEnabled: true,
+  targetConfiguration: { targetType: "webhook", url: "https://placeholder.example/x" },
+};
+
+/** Invoke b2_set_bucket_notification_rules with a single webhook URL. */
+async function setWebhook(tools: ToolHarness, url: string) {
+  return tools.call("b2_set_bucket_notification_rules", {
+    bucketId: "bucket-1",
+    confirm: true,
+    eventNotificationRules: [{ ...validRule, targetConfiguration: { targetType: "webhook", url } }],
+  });
+}
+
+afterEach(() => {
+  setWebhookDnsLookupForTests(null);
+  circuitBreaker.close();
+  vi.useRealTimers();
+});
+
+describe("buckets webhook URL guard (SSRF defense-in-depth)", () => {
+  beforeEach(() => {
+    setWebhookDnsLookupForTests(async () => [{ address: "93.184.216.34" }]);
+  });
+
+  it.each([
+    { name: "IPv6 zone identifier", url: "https://[fe80::1%25en0]/hook", reason: "zone identifier" },
+    { name: "non-canonical numeric host", url: "https://127.1/hook", reason: "numeric IP address" },
+    { name: "unparseable URL", url: "ht!tp://x", reason: "is not a valid URL" },
+    { name: "non-https scheme", url: "http://example.com/hook", reason: "must use https" },
+    {
+      name: "embedded credentials",
+      url: "https://user:pw@hooks.example.test/x",
+      reason: "must not include credentials",
+    },
+    { name: "localhost", url: "https://localhost/hook", reason: "must not target localhost" },
+    { name: "dotted localhost", url: "https://api.localhost/hook", reason: "must not target localhost" },
+    { name: "hex numeric host", url: "https://0x7f000001/hook", reason: "IP address" },
+    { name: "private IPv4 literal", url: "https://10.0.0.1/hook", reason: "non-public IP address" },
+    { name: "link-local metadata IPv4", url: "https://169.254.169.254/latest", reason: "non-public IP address" },
+    { name: "ULA IPv6 literal", url: "https://[fec0::1]/hook", reason: "non-public IP address" },
+    {
+      name: "IPv4-mapped IPv6 literal",
+      url: "https://[::ffff:127.0.0.1]/hook",
+      reason: "non-public IP address",
+    },
+  ])("rejects $name webhook targets", async ({ url, reason }) => {
+    const { tools } = makeHarness();
+    const result = await setWebhook(tools, url);
+    expect(result).toMatchObject({ isError: true });
+    expect(String(parseResult(result))).toContain(reason);
+  });
+
+  it("accepts a raw public dotted-quad host without a DNS lookup", async () => {
+    const { tools, calls } = makeHarness();
+    setWebhookDnsLookupForTests(async () => {
+      throw new Error("DNS lookup must not run for a raw public IP literal");
+    });
+    const result = await setWebhook(tools, "https://93.184.216.34/hook");
+    expect(result).not.toMatchObject({ isError: true });
+    expect(calls.some((c) => c.operation === "setBucketNotificationRules")).toBe(true);
+  });
+});
+
+describe("buckets webhook DNS resolution fallbacks", () => {
+  it("rejects hostnames that resolve to a non-public address", async () => {
+    setWebhookDnsLookupForTests(async () => [{ address: "10.0.0.7" }]);
+    const { tools } = makeHarness();
+    const result = await setWebhook(tools, "https://hooks.example.test/path");
+    expect(String(parseResult(result))).toContain("must not resolve to a non-public IP address");
+  });
+
+  it("rejects hostnames with no DNS answers", async () => {
+    setWebhookDnsLookupForTests(async () => []);
+    const { tools } = makeHarness();
+    const result = await setWebhook(tools, "https://hooks.example.test/path");
+    expect(String(parseResult(result))).toContain("must resolve to a public IP address");
+  });
+
+  it("rejects hostnames whose DNS lookup throws", async () => {
+    setWebhookDnsLookupForTests(async () => {
+      throw new Error("resolver down");
+    });
+    const { tools } = makeHarness();
+    const result = await setWebhook(tools, "https://hooks.example.test/path");
+    expect(String(parseResult(result))).toContain("must resolve to a public IP address");
+  });
+
+  it("times out a hung DNS lookup and rejects the target", async () => {
+    vi.useFakeTimers();
+    setWebhookDnsLookupForTests(() => new Promise<never>(() => undefined));
+    const { tools } = makeHarness();
+    const pending = setWebhook(tools, "https://hooks.example.test/path");
+    await vi.advanceTimersByTimeAsync(2_000);
+    const result = await pending;
+    expect(String(parseResult(result))).toContain("must resolve to a public IP address");
+  });
+});
+
+describe("buckets handler option normalization", () => {
+  beforeEach(() => {
+    setWebhookDnsLookupForTests(async () => [{ address: "93.184.216.34" }]);
+  });
+
+  it("normalizes SSE-B2 with an unexpected algorithm and the none mode", async () => {
+    const { tools, calls } = makeHarness();
+    await tools.call("b2_create_bucket", {
+      bucketName: "sse-b2-bucket",
+      bucketType: "allPrivate",
+      defaultServerSideEncryption: { mode: "SSE-B2", algorithm: "unexpected" },
+    });
+    await tools.call("b2_create_bucket", {
+      bucketName: "sse-none-bucket",
+      bucketType: "allPrivate",
+      defaultServerSideEncryption: { mode: "none" },
+    });
+    const creates = calls.filter((c) => c.operation === "createBucket").map((c) => c.input as any);
+    expect(creates[0].defaultServerSideEncryption).toEqual({ mode: "SSE-B2", algorithm: undefined });
+    expect(creates[1].defaultServerSideEncryption).toEqual({ mode: "none" });
+  });
+
+  it("omits optional create fields when they are not supplied", async () => {
+    const { tools, calls } = makeHarness();
+    await tools.call("b2_create_bucket", {
+      bucketName: "minimal-bucket",
+      bucketType: "allPrivate",
+    });
+    const input = calls.find((c) => c.operation === "createBucket")?.input as Record<string, unknown>;
+    expect(input).toEqual({ bucketName: "minimal-bucket", bucketType: "allPrivate" });
+  });
+
+  it("spreads every optional create field when supplied", async () => {
+    const { tools, calls } = makeHarness();
+    await tools.call("b2_create_bucket", {
+      bucketName: "full-bucket",
+      bucketType: "allPrivate",
+      bucketInfo: { team: "ops" },
+      corsRules: [],
+      lifecycleRules: [{ fileNamePrefix: "tmp/", daysFromHidingToDeleting: 1 }],
+      defaultServerSideEncryption: { mode: "SSE-B2", algorithm: "AES256" },
+      fileLockEnabled: true,
+    });
+    const input = calls.find((c) => c.operation === "createBucket")?.input as Record<string, unknown>;
+    expect(input).toMatchObject({
+      bucketInfo: { team: "ops" },
+      lifecycleRules: [{ fileNamePrefix: "tmp/", daysFromHidingToDeleting: 1 }],
+      defaultServerSideEncryption: { mode: "SSE-B2", algorithm: "AES256" },
+      fileLockEnabled: true,
+    });
+    expect(input.corsRules).toBeDefined();
+  });
+
+  it("updates with only a bucketId, omitting every optional field", async () => {
+    const { tools, calls } = makeHarness();
+    await tools.call("b2_update_bucket", { bucketId: "bucket-1" });
+    const input = calls.find((c) => c.operation === "updateBucket")?.input as Record<string, unknown>;
+    expect(input).toEqual({ bucketId: "bucket-1" });
+  });
+
+  it("spreads every optional update field when supplied", async () => {
+    const { tools, calls } = makeHarness();
+    await tools.call("b2_update_bucket", {
+      bucketId: "bucket-1",
+      bucketType: "allPublic",
+      bucketInfo: { team: "ops" },
+      corsRules: [],
+      lifecycleRules: [{ fileNamePrefix: "tmp/", daysFromHidingToDeleting: 2 }],
+      defaultServerSideEncryption: { mode: "none" },
+      fileLockEnabled: false,
+      defaultRetention: { mode: null, period: null },
+      ifRevisionIs: 7,
+      confirm: true,
+    });
+    const input = calls.find((c) => c.operation === "updateBucket")?.input as Record<string, unknown>;
+    expect(input).toMatchObject({
+      bucketId: "bucket-1",
+      bucketType: "allPublic",
+      bucketInfo: { team: "ops" },
+      fileLockEnabled: false,
+      defaultRetention: { mode: null, period: null },
+      ifRevisionIs: 7,
+    });
+  });
+
+  it("truncates an over-long bucketInfo key in the validation error", async () => {
+    const { tools } = makeHarness();
+    const longKey = "k".repeat(120);
+    const result = await tools.call("b2_create_bucket", {
+      bucketName: "bad-info-bucket",
+      bucketType: "allPrivate",
+      bucketInfo: { [longKey]: "v" },
+    });
+    expect(result).toMatchObject({ isError: true });
+    const text = String(parseResult(result));
+    expect(text).toContain("...");
+    expect(text).not.toContain(longKey);
+  });
+});
+
+describe("buckets notification-secret redaction spreads", () => {
+  it("omits bucketId and untouched target fields when absent from the response", async () => {
+    const { tools } = makeHarness({
+      // No bucketId key; rule target carries only an HMAC secret (no url, no headers).
+      eventNotificationRules: [
+        {
+          name: "hmac-only",
+          eventTypes: ["b2:ObjectCreated:*"],
+          isEnabled: true,
+          targetConfiguration: {
+            targetType: "webhook",
+            hmacSha256SigningSecret: "topsecret",
+          },
+        },
+      ],
+    });
+    const result = parseResult(
+      await tools.call("b2_get_bucket_notification_rules", { bucketId: "bucket-1" }),
+    );
+    expect(result).not.toHaveProperty("bucketId");
+    const tc = result.eventNotificationRules[0].targetConfiguration;
+    expect(tc).not.toHaveProperty("url");
+    expect(tc).not.toHaveProperty("customHeaders");
+    expect(tc.hmacSha256SigningSecret).toBe("[redacted]");
+  });
+
+  it("redacts an unparseable webhook URL to a bare placeholder", async () => {
+    const { tools } = makeHarness({
+      bucketId: "bucket-1",
+      eventNotificationRules: [
+        {
+          name: "bad-url",
+          eventTypes: ["b2:ObjectCreated:*"],
+          isEnabled: true,
+          targetConfiguration: {
+            targetType: "webhook",
+            url: "not a url",
+            customHeaders: { "X-Token": "secret" },
+          },
+        },
+      ],
+    });
+    const result = parseResult(
+      await tools.call("b2_get_bucket_notification_rules", { bucketId: "bucket-1" }),
+    );
+    const tc = result.eventNotificationRules[0].targetConfiguration;
+    expect(tc.url).toBe("[redacted]");
+    expect(tc.customHeaders).toEqual({ "X-Token": "[redacted]" });
+  });
+});

--- a/tests/unit/coverage-resources-400.unit.test.ts
+++ b/tests/unit/coverage-resources-400.unit.test.ts
@@ -202,18 +202,27 @@ describe("resources list guards", () => {
 });
 
 describe("resources sanitizer key-id handling", () => {
-  it("reads server-config when every credential id is too short to redact", async () => {
+  it("does not leak credential ids that are too short to redact", async () => {
+    // Distinctive <8-char ids drive the branch that skips adding them to the
+    // redaction set; server-config must still never echo a credential id.
     const shortIdConfig = {
       ...testConfig,
-      applicationKeyId: "k",
-      appKeyId: "k",
-      masterKeyId: "k",
+      applicationKeyId: "shortA1",
+      appKeyId: "shortB2",
+      masterKeyId: "shortC3",
     } as B2Config;
     const { client, close } = await connect({ config: shortIdConfig });
     try {
-      const payload = parseJson<ServerConfigResourcePayload>(
-        await client.readResource({ uri: SERVER_CONFIG_RESOURCE_URI }, { cacheMode: "refresh" }),
+      const result = await client.readResource(
+        { uri: SERVER_CONFIG_RESOURCE_URI },
+        { cacheMode: "refresh" },
       );
+      const serialized = String("text" in result.contents[0] ? result.contents[0].text : "");
+      expect(serialized).not.toContain("shortA1");
+      expect(serialized).not.toContain("shortB2");
+      expect(serialized).not.toContain("shortC3");
+
+      const payload = JSON.parse(serialized) as ServerConfigResourcePayload;
       expect(payload.uri).toBe(SERVER_CONFIG_RESOURCE_URI);
     } finally {
       await close();

--- a/tests/unit/coverage-resources-400.unit.test.ts
+++ b/tests/unit/coverage-resources-400.unit.test.ts
@@ -1,0 +1,222 @@
+// Branch-coverage expansion for src/resources.ts (issue #400, phase 1).
+//
+// Exercises the HTTP credential-mode env parsing fallbacks, the bucket
+// visibility mapping across every bucketType, the bucketPayload `?? []`/`?? null`
+// fallbacks (including the two-step defaultRetention derivation), the
+// resources/list buckets-not-array guard, and the sanitizer's empty-keyId path.
+import { Client, InMemoryTransport } from "@modelcontextprotocol/client";
+import { type ReadResourceResult } from "@modelcontextprotocol/server";
+import {
+  SERVER_CONFIG_RESOURCE_URI,
+  type BucketResourcePayload,
+  type ServerConfigResourcePayload,
+} from "../../src/resources";
+import { createServer, invalidateAuthManagerCache } from "../../src/server";
+import type { B2Config } from "../../src/utils/types";
+import { DeterministicB2NativeFake, testConfig } from "../support/deterministic-fakes";
+import { installSdkTransport, StaticHttpResponse } from "../support/sdk-test-helpers";
+
+function minimalBucket(bucketType: string, overrides: Record<string, unknown> = {}) {
+  return {
+    accountId: "account-123",
+    bucketId: "bucket-id-1",
+    bucketName: "resource-bucket",
+    bucketType,
+    bucketInfo: {},
+    options: [],
+    revision: 1,
+    ...overrides,
+  };
+}
+
+async function connect(
+  options: {
+    capabilities?: string[] | null;
+    config?: B2Config;
+    fake?: DeterministicB2NativeFake;
+  } = {},
+) {
+  const fake =
+    options.fake ?? new DeterministicB2NativeFake({ capabilities: options.capabilities ?? undefined });
+  installSdkTransport(fake);
+  const server = createServer(options.config ?? testConfig, options.capabilities);
+  const client = new Client({ name: "b2-mcp-resource-cov", version: "1.0.0" }, { defaultCacheTtlMs: 0 });
+  const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
+  await server.connect(serverTransport);
+  await client.connect(clientTransport);
+  return {
+    client,
+    async close() {
+      await client.close().catch(() => undefined);
+      await server.close().catch(() => undefined);
+    },
+  };
+}
+
+function parseJson<T extends object>(result: ReadResourceResult): T {
+  const [content] = result.contents;
+  return JSON.parse(String("text" in content ? content.text : "")) as T;
+}
+
+const previousEnv = process.env.B2_HTTP_CREDENTIAL_MODE;
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  invalidateAuthManagerCache();
+  if (previousEnv === undefined) delete process.env.B2_HTTP_CREDENTIAL_MODE;
+  else process.env.B2_HTTP_CREDENTIAL_MODE = previousEnv;
+});
+
+describe("resources HTTP credential mode parsing", () => {
+  const httpConfig = { ...testConfig, transport: "http" } as B2Config;
+
+  it("defaults an unset B2_HTTP_CREDENTIAL_MODE to headers", async () => {
+    delete process.env.B2_HTTP_CREDENTIAL_MODE;
+    const { client, close } = await connect({ config: httpConfig });
+    try {
+      const payload = parseJson<ServerConfigResourcePayload>(
+        await client.readResource({ uri: SERVER_CONFIG_RESOURCE_URI }, { cacheMode: "refresh" }),
+      );
+      expect(payload.credentialMode).toBe("headers");
+    } finally {
+      await close();
+    }
+  });
+
+  it("falls back to headers for an unrecognized B2_HTTP_CREDENTIAL_MODE", async () => {
+    process.env.B2_HTTP_CREDENTIAL_MODE = "bogus-mode";
+    const { client, close } = await connect({ config: httpConfig });
+    try {
+      const payload = parseJson<ServerConfigResourcePayload>(
+        await client.readResource({ uri: SERVER_CONFIG_RESOURCE_URI }, { cacheMode: "refresh" }),
+      );
+      expect(payload.credentialMode).toBe("headers");
+    } finally {
+      await close();
+    }
+  });
+
+  it("reports stdio credential mode for the stdio transport", async () => {
+    const { client, close } = await connect();
+    try {
+      const payload = parseJson<ServerConfigResourcePayload>(
+        await client.readResource({ uri: SERVER_CONFIG_RESOURCE_URI }, { cacheMode: "refresh" }),
+      );
+      expect(payload.credentialMode).toBe("stdio");
+    } finally {
+      await close();
+    }
+  });
+});
+
+describe("resources bucket visibility mapping", () => {
+  it.each([
+    { bucketType: "allPublic", visibility: "public" },
+    { bucketType: "restricted", visibility: "restricted" },
+    { bucketType: "snapshot", visibility: "snapshot" },
+    { bucketType: "somethingElse", visibility: "unknown" },
+  ])("maps bucketType $bucketType to $visibility", async ({ bucketType, visibility }) => {
+    const fake = new DeterministicB2NativeFake({ capabilities: ["listBuckets"] }).respond(
+      "b2_list_buckets",
+      new StaticHttpResponse(200, { buckets: [minimalBucket(bucketType)] }),
+    );
+    const { client, close } = await connect({ capabilities: ["listBuckets"], fake });
+    try {
+      const payload = parseJson<BucketResourcePayload>(
+        await client.readResource({ uri: "b2://bucket/resource-bucket" }, { cacheMode: "refresh" }),
+      );
+      expect(payload.visibility).toBe(visibility);
+    } finally {
+      await close();
+    }
+  });
+});
+
+describe("resources bucketPayload fallbacks", () => {
+  it("defaults absent optional bucket config to empty arrays and null", async () => {
+    const fake = new DeterministicB2NativeFake({ capabilities: ["listBuckets"] }).respond(
+      "b2_list_buckets",
+      new StaticHttpResponse(200, { buckets: [minimalBucket("allPrivate")] }),
+    );
+    const { client, close } = await connect({ capabilities: ["listBuckets"], fake });
+    try {
+      const payload = parseJson<BucketResourcePayload>(
+        await client.readResource({ uri: "b2://bucket/resource-bucket" }, { cacheMode: "refresh" }),
+      );
+      expect(payload.corsRules).toEqual([]);
+      expect(payload.lifecycleRules).toEqual([]);
+      expect(payload.defaultServerSideEncryption).toBeNull();
+      expect(payload.objectLock).toBeNull();
+      expect(payload.defaultRetention).toBeNull();
+      expect(payload.replicationConfiguration).toBeNull();
+    } finally {
+      await close();
+    }
+  });
+
+  it("derives defaultRetention from the Object Lock configuration when not set directly", async () => {
+    const bucket = minimalBucket("allPrivate", {
+      fileLockConfiguration: {
+        isClientAuthorizedToRead: true,
+        value: {
+          isFileLockEnabled: true,
+          defaultRetention: { mode: "compliance", period: { duration: 14, unit: "days" } },
+        },
+      },
+    });
+    const fake = new DeterministicB2NativeFake({ capabilities: ["listBuckets"] }).respond(
+      "b2_list_buckets",
+      new StaticHttpResponse(200, { buckets: [bucket] }),
+    );
+    const { client, close } = await connect({ capabilities: ["listBuckets"], fake });
+    try {
+      const payload = parseJson<BucketResourcePayload>(
+        await client.readResource({ uri: "b2://bucket/resource-bucket" }, { cacheMode: "refresh" }),
+      );
+      expect(payload.defaultRetention).toMatchObject({
+        mode: "compliance",
+        period: { duration: 14, unit: "days" },
+      });
+    } finally {
+      await close();
+    }
+  });
+});
+
+describe("resources list guards", () => {
+  it("treats a non-array bucket listing as empty in resources/list", async () => {
+    const fake = new DeterministicB2NativeFake({ capabilities: ["listBuckets"] }).respond(
+      "b2_list_buckets",
+      new StaticHttpResponse(200, { buckets: null }),
+    );
+    const { client, close } = await connect({ capabilities: ["listBuckets"], fake });
+    try {
+      const listed = await client.listResources(undefined, { cacheMode: "refresh" });
+      const uris = listed.resources.map((resource) => resource.uri);
+      expect(uris).toContain(SERVER_CONFIG_RESOURCE_URI);
+      expect(uris.some((uri) => uri.startsWith("b2://bucket/"))).toBe(false);
+    } finally {
+      await close();
+    }
+  });
+});
+
+describe("resources sanitizer key-id handling", () => {
+  it("reads server-config when every credential id is too short to redact", async () => {
+    const shortIdConfig = {
+      ...testConfig,
+      applicationKeyId: "k",
+      appKeyId: "k",
+      masterKeyId: "k",
+    } as B2Config;
+    const { client, close } = await connect({ config: shortIdConfig });
+    try {
+      const payload = parseJson<ServerConfigResourcePayload>(
+        await client.readResource({ uri: SERVER_CONFIG_RESOURCE_URI }, { cacheMode: "refresh" }),
+      );
+      expect(payload.uri).toBe(SERVER_CONFIG_RESOURCE_URI);
+    } finally {
+      await close();
+    }
+  });
+});

--- a/tests/unit/coverage-resources-400.unit.test.ts
+++ b/tests/unit/coverage-resources-400.unit.test.ts
@@ -37,10 +37,14 @@ async function connect(
   } = {},
 ) {
   const fake =
-    options.fake ?? new DeterministicB2NativeFake({ capabilities: options.capabilities ?? undefined });
+    options.fake ??
+    new DeterministicB2NativeFake({ capabilities: options.capabilities ?? undefined });
   installSdkTransport(fake);
   const server = createServer(options.config ?? testConfig, options.capabilities);
-  const client = new Client({ name: "b2-mcp-resource-cov", version: "1.0.0" }, { defaultCacheTtlMs: 0 });
+  const client = new Client(
+    { name: "b2-mcp-resource-cov", version: "1.0.0" },
+    { defaultCacheTtlMs: 0 },
+  );
   const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
   await server.connect(serverTransport);
   await client.connect(clientTransport);

--- a/tests/unit/coverage-server-400.unit.test.ts
+++ b/tests/unit/coverage-server-400.unit.test.ts
@@ -1,0 +1,195 @@
+// Branch-coverage expansion for src/server.ts (issue #400, phase 1).
+//
+// Drives the capability-failure error mapper through fetchCapabilities across
+// the retryable/non-retryable and network-code permutations that existing
+// tests leave uncovered, plus the discovery-mode argument-summary helper via
+// createMissingCredentialsToolCallback and the low-level tools/call interceptor.
+import { Client, InMemoryTransport } from "@modelcontextprotocol/client";
+import {
+  createMissingCredentialsToolCallback,
+  createServer,
+  fetchCapabilities,
+  invalidateCapabilityCache,
+} from "../../src/server";
+import { logger } from "../../src/utils/logger";
+import type { B2Config } from "../../src/utils/types";
+import { testConfig } from "../support/deterministic-fakes";
+import { setB2SdkClientFactoryForTests } from "../support/sdk-factory-hook";
+import {
+  installSdkTransport,
+  RecordingTransport,
+  StaticHttpResponse,
+} from "../support/sdk-test-helpers";
+
+const baseConfig = {
+  applicationKeyId: "k",
+  applicationKey: "s",
+  appKeyId: "k",
+  appKey: "s",
+  masterKeyId: "k",
+  masterKey: "s",
+  region: "us-west-004",
+  allowLocalFiles: true,
+  fileRoot: null,
+} as unknown as B2Config;
+
+function installAuthorizeFailure(
+  status: number,
+  code: string,
+  message: string,
+  headers: Record<string, string> = {},
+): RecordingTransport {
+  const transport = new RecordingTransport(
+    () => new StaticHttpResponse(status, { status, code, message }, headers),
+  );
+  installSdkTransport(transport);
+  return transport;
+}
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  setB2SdkClientFactoryForTests(null);
+  invalidateCapabilityCache();
+});
+
+describe("capability failure error mapper", () => {
+  it("maps a 403 upstream status to a fail-closed auth error", async () => {
+    installAuthorizeFailure(403, "forbidden", "no access");
+    await expect(fetchCapabilities(baseConfig)).rejects.toMatchObject({
+      status: 403,
+      code: "capability_auth_failed",
+    });
+  });
+
+  it.each(["ECONNABORTED", "ETIMEDOUT", "ECONNRESET", "ENOTFOUND"])(
+    "treats a client-status failure carrying %s as retryable",
+    async (networkCode) => {
+      const warnSpy = vi.spyOn(logger, "warn").mockImplementation(() => undefined as never);
+      installAuthorizeFailure(400, networkCode, `network ${networkCode}`);
+      await expect(
+        fetchCapabilities(baseConfig, `credential:${networkCode}`, `log:${networkCode}`),
+      ).rejects.toMatchObject({
+        status: 503,
+        code: "capability_upstream_unavailable",
+      });
+      expect(warnSpy).toHaveBeenCalledWith(
+        expect.objectContaining({ retryable: true }),
+        "capability.fetch.failed",
+      );
+    },
+  );
+
+  it("maps a non-retryable client failure to capability_upstream_failed (502)", async () => {
+    const warnSpy = vi.spyOn(logger, "warn").mockImplementation(() => undefined as never);
+    installAuthorizeFailure(400, "bad_request", "malformed capability request");
+    await expect(
+      fetchCapabilities(baseConfig, "credential:client-fail", "log:client-fail"),
+    ).rejects.toMatchObject({
+      status: 502,
+      code: "capability_upstream_failed",
+    });
+    expect(warnSpy).toHaveBeenCalledWith(
+      expect.objectContaining({ retryable: false }),
+      "capability.fetch.failed",
+    );
+  });
+
+  it("treats a statusless transport error as retryable with no upstream code", async () => {
+    const warnSpy = vi.spyOn(logger, "warn").mockImplementation(() => undefined as never);
+    installSdkTransport(
+      new RecordingTransport(() => {
+        throw new Error("socket exploded before any response");
+      }),
+    );
+    await expect(
+      fetchCapabilities(baseConfig, "credential:statusless", "log:statusless"),
+    ).rejects.toMatchObject({
+      status: 503,
+      code: "capability_upstream_unavailable",
+    });
+    expect(warnSpy).toHaveBeenCalledWith(
+      expect.objectContaining({ upstreamStatus: undefined, upstreamCode: undefined }),
+      "capability.fetch.failed",
+    );
+  });
+});
+
+describe("discovery-mode argument summary helper", () => {
+  it.each([
+    { label: "array", args: ["a", "b"], expected: { argKeyCount: 0 } },
+    { label: "primitive", args: 42, expected: { argKeyCount: 0 } },
+    { label: "null", args: null, expected: { argKeyCount: 0 } },
+    { label: "object", args: { one: 1, two: 2 }, expected: { argKeyCount: 2 } },
+  ])("summarizes $label arguments as $expected.argKeyCount keys", async ({ args, expected }) => {
+    const infoSpy = vi.spyOn(logger, "info").mockImplementation(() => undefined as never);
+    const callback = createMissingCredentialsToolCallback("b2_list_buckets", testConfig);
+
+    const result = await callback(args as never, {} as never);
+
+    expect(result.isError).toBe(true);
+    expect(infoSpy).toHaveBeenCalledWith(
+      expect.objectContaining({ tool: "b2_list_buckets", ...expected }),
+      "tool.call",
+    );
+  });
+
+  it("truncates an oversized argument-key count and flags it", async () => {
+    const infoSpy = vi.spyOn(logger, "info").mockImplementation(() => undefined as never);
+    const callback = createMissingCredentialsToolCallback("b2_list_buckets", testConfig);
+    const manyKeys: Record<string, number> = {};
+    for (let i = 0; i < 150; i++) manyKeys[`k${i}`] = i;
+
+    await callback(manyKeys as never, {} as never);
+
+    expect(infoSpy).toHaveBeenCalledWith(
+      expect.objectContaining({ argKeyCount: 100, argKeysTruncated: true }),
+      "tool.call",
+    );
+  });
+});
+
+describe("discovery-mode tools/call interceptor", () => {
+  async function connectDiscoveryClient() {
+    const server = createServer(testConfig, null, { credentialsUnavailable: true });
+    const client = new Client({ name: "discovery-test", version: "1.0.0" });
+    const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
+    await server.connect(serverTransport);
+    await client.connect(clientTransport);
+    return {
+      client,
+      async close() {
+        await client.close().catch(() => undefined);
+        await server.close().catch(() => undefined);
+      },
+    };
+  }
+
+  it("records the resolved tool name for a registered tool call", async () => {
+    const infoSpy = vi.spyOn(logger, "info").mockImplementation(() => undefined as never);
+    const { client, close } = await connectDiscoveryClient();
+    try {
+      const result = await client.callTool({ name: "b2_list_buckets", arguments: {} });
+      expect((result as { isError?: boolean }).isError).toBe(true);
+      expect(infoSpy).toHaveBeenCalledWith(
+        expect.objectContaining({ tool: "b2_list_buckets", code: "missing_credentials" }),
+        "tool.call",
+      );
+    } finally {
+      await close();
+    }
+  });
+
+  it("classifies an unregistered tool name as unknown_tool", async () => {
+    const infoSpy = vi.spyOn(logger, "info").mockImplementation(() => undefined as never);
+    const { client, close } = await connectDiscoveryClient();
+    try {
+      await client.callTool({ name: "totally_made_up_tool", arguments: { a: 1 } });
+      expect(infoSpy).toHaveBeenCalledWith(
+        expect.objectContaining({ tool: "unknown_tool", argKeyCount: 1 }),
+        "tool.call",
+      );
+    } finally {
+      await close();
+    }
+  });
+});

--- a/vitest.config.mts
+++ b/vitest.config.mts
@@ -34,10 +34,10 @@ export default defineConfig({
       include: ["src/**/*.ts"],
       exclude: ["dist/**", "tests/**", "**/*.d.ts", "**/*.test.ts", "**/generated/**"],
       thresholds: {
-        statements: 94.3,
-        branches: 88,
-        functions: 97.2,
-        lines: 96.6,
+        statements: 94.8,
+        branches: 89.1,
+        functions: 97.6,
+        lines: 96.9,
       },
     },
     projects: layerProjectNamesForConfig().map((name) =>

--- a/vitest.config.mts
+++ b/vitest.config.mts
@@ -33,11 +33,17 @@ export default defineConfig({
       reporter: ["text-summary", "html", "json-summary", "lcov", "cobertura"],
       include: ["src/**/*.ts"],
       exclude: ["dist/**", "tests/**", "**/*.d.ts", "**/*.test.ts", "**/generated/**"],
+      // Floors sit a deliberate buffer below the achieved merged coverage
+      // (statements 94.81 / branches 89.15 / functions 97.61 / lines 96.91 as of
+      // this change) so normal per-layer execution and v8 measurement variance,
+      // or an unrelated PR that drops a branch or two, does not wedge the global
+      // merge/deploy gate. Each floor stays at or above the previous value so the
+      // ratchet never weakens; raise them only when a durable gain is measured.
       thresholds: {
-        statements: 94.8,
-        branches: 89.1,
-        functions: 97.6,
-        lines: 96.9,
+        statements: 94.5,
+        branches: 89,
+        functions: 97.5,
+        lines: 96.7,
       },
     },
     projects: layerProjectNamesForConfig().map((name) =>


### PR DESCRIPTION
## Summary

Phase 1 (focused subset) of the branch-coverage expansion from #400. Adds
scenario-based tests for the error/edge branches of four of the top modules,
expands the `runtime-security` thin layer, and ratchets the coverage floors up
with a deliberate buffer below the achieved numbers (keeping the single source
of truth in sync).

Merged branch coverage rises **88.17% → 89.15%** (+49 covered branches);
statements 94.56% → 94.81%, functions 97.54% → 97.61%, lines 96.78% → 96.91%.

## Commits

- `test:` cover error branches in buckets, server, resources, oauth
- `test:` add buffer below achieved coverage floors
- `test:` strengthen oauth and credential-redaction assertions (review round 1)
- `test:` sync coverage-floor guard to new thresholds (CI single-source-of-truth)
- `style:` apply biome formatting to new tests
- `ci:` two empty re-trigger commits after a transient GitHub artifact-upload 403
  (`FinalizeArtifact (403) Forbidden`) hit unrelated jobs; all tests passed, the
  re-triggered run is green.

## New tests

- `tests/unit/coverage-buckets-400.unit.test.ts` — webhook SSRF/URL guard
  (zone-id, non-canonical/hex numeric hosts, non-https, credentials, localhost,
  private IPv4/IPv6 and IPv4-mapped literals), DNS-resolution fallbacks
  (non-public, empty, throwing, and timed-out lookups), SSE normalization, the
  bucketInfo key-quoting truncation, notification-secret redaction spreads, and
  the optional-argument spreads in `b2_create_bucket` / `b2_update_bucket`.
- `tests/unit/coverage-server-400.unit.test.ts` — the capability-failure error
  mapper across the retryable (`ECONNABORTED`/`ETIMEDOUT`/`ECONNRESET`/
  `ENOTFOUND`) → 503, non-retryable client → 502, 403 auth-fail, and statusless
  transport-error branches, plus the discovery-mode argument-summary helper
  (array/primitive/null/object/oversized) and the `tools/call` interceptor's
  registered-vs-unknown tool classification.
- `tests/unit/coverage-resources-400.unit.test.ts` — `B2_HTTP_CREDENTIAL_MODE`
  parsing fallbacks (unset → headers, invalid → headers, stdio), bucket
  visibility mapping across every `bucketType`, the `bucketPayload` `?? []`/
  `?? null` fallbacks including the two-step `defaultRetention` derivation, the
  `resources/list` non-array-buckets guard, and the sanitizer's short-key-id
  non-leakage path.
- `tests/runtime-security/oauth-token-validation.runtime-security.test.ts` —
  malformed bearer tokens (structure, empty segment, non-base64 JSON), a
  missing Authorization header, an aborted in-flight verification (asserts the
  fail-closed 503), and pre-verified auth-info rejection (issuer/resource/
  algorithm) plus a guard that the loaded default config never leaves
  `allowedAlgorithms` empty (no alg-confusion fail-open by default).

## Coverage floors (single source of truth)

Raised from the previous floors, kept a deliberate buffer **below** achieved
merged coverage so normal per-layer execution / v8 measurement variance (or an
unrelated PR dropping a branch) does not wedge the global merge gate. Because
the floors are pinned in one contract test, the values were updated in lockstep
across `vitest.config.mts`, the `README.md` badge, `docs/TESTING.md`, and
`.github/workflows/test.yml` (enforced by
`tests/contract/test-layering.contract.test.ts`).

| Metric | Previous | Achieved | New floor |
|---|---:|---:|---:|
| Statements | 94.3 | 94.81 | 94.5 |
| Branches | 88 | 89.15 | 89 |
| Functions | 97.2 | 97.61 | 97.5 |
| Lines | 96.6 | 96.91 | 96.7 |

Each new floor stays at or above the previous value, so the ratchet never
weakens; the buffer addresses the earlier review on razor-thin margins.

## Linked issue

Part of #400 (Phase 1, partial — buckets, server, resources, oauth). The
remaining top-8 modules (`insights.ts`, `http-fetch-handler.ts`,
`secret-sink.ts`, `b2/client.ts`) and Phase 2 are follow-ups.

## Tests run

- `pnpm run typecheck` — clean (src + all tests)
- `pnpm exec vitest run` on each new file — 61 new tests pass (50 unit + 11
  runtime-security)
- `tests/contract/test-layering.contract.test.ts` — 28 tests pass (floor guard)
- `pnpm run test:coverage` — full merged coverage passes with the buffered floors
  (branches 89.15% ≥ 89)
- CI on the head commit — green (the only red steps were a transient GitHub
  artifact-service 403, cleared on re-run)

## Follow-up notes

- Remaining Phase 1 modules and the Phase 2 tier are not yet covered here.
- No `/* v8 ignore */` hints were added; all new coverage is real assertions.
- Complements mutation testing (#397) as the assertion-strength gate.
