### PR TITLE
docs: suppress zizmor adhoc-packages on pack-smoke install

### DIFF
--- a/zizmor.yml
+++ b/zizmor.yml
@@ -49,3 +49,19 @@ rules:
       # silently suppressed by this entry. Re-review whenever publish.yml's
       # triggers change.
       - publish.yml:9
+  adhoc-packages:
+    ignore:
+      # The packed-install smoke test (test.yml:397) is the pack-smoke install
+      # of the locally-built tarball, not an unpinned third-party dependency.
+      # It builds the package tarball, then `npm install`s THAT tarball into an
+      # isolated temp dir to prove the published artifact installs cleanly —
+      # validating the real `npm install` experience a consumer gets. Installing
+      # the artifact under test outside a lockfile is the entire point of the
+      # check, and it is already hardened (`--ignore-scripts`, `--omit=dev`) and
+      # installs only the locally-built `$tarball_path`. The adhoc-packages
+      # risk this audit flags does not apply, so the finding is accepted.
+      #
+      # Anchored to the `npm install "$tarball_path"` line (test.yml:397).
+      # Re-review whenever the pack-smoke install step moves or changes what it
+      # installs.
+      - test.yml:397


### PR DESCRIPTION
## Summary

Adds a rationale-bearing `adhoc-packages` suppression to `zizmor.yml`, scoped to
the packed-install smoke test (`test.yml:397`).

That line is the pack-smoke install: it builds the package tarball and then
`npm install`s *that locally-built tarball* into an isolated temp dir to prove
the published artifact installs cleanly — validating the real `npm install`
experience a consumer gets. Installing the artifact under test outside a
lockfile is the entire point of the check, and it is already hardened
(`--ignore-scripts`, `--omit=dev`, `--no-audit`, `--no-fund`) and installs only
`$tarball_path`. This is not an unpinned third-party dependency, so the finding
is accepted rather than fixed.

The entry follows the existing suppression convention in `zizmor.yml` (why +
anchored line + re-review note). The pack-smoke test itself is unchanged.

## Linked issue

Closes #422

## Tests run

- `uvx zizmor@1.29.0 --persona=pedantic --no-online-audits .github/workflows/test.yml`
  — `adhoc-packages` finding is suppressed via auto-discovered `zizmor.yml` (0 findings).
- CI-equivalent run (`--persona=regular --min-severity=medium --min-confidence=medium`)
  over `.github/workflows/` exits 0.

## Follow-up notes

- zizmor auto-discovers the repo-root `zizmor.yml`; the CI step passes no `--config`, so no workflow change is needed.
- Re-review the anchor line if the pack-smoke install step moves or changes what it installs.
