### PR TITLE
test: cover error branches in insights, http, secret-sink, client (#400)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -132,7 +132,7 @@ jobs:
         run: |
           echo "## Coverage summary" >> "$GITHUB_STEP_SUMMARY"
           echo "Node.js ${{ matrix.node-version }}" >> "$GITHUB_STEP_SUMMARY"
-          echo "Required: statements 94.5%, branches 89%, functions 97.5%, lines 96.7%." >> "$GITHUB_STEP_SUMMARY"
+          echo "Required: statements 96%, branches 92%, functions 97.7%, lines 97.4%." >> "$GITHUB_STEP_SUMMARY"
           echo '```' >> "$GITHUB_STEP_SUMMARY"
           if [ -f coverage/coverage-summary.json ]; then
             node -e "

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@
 [![Node.js](https://img.shields.io/badge/Node.js-22.22%2B%20%7C%2024%20%7C%2026-339933?logo=nodedotjs&logoColor=white)](https://nodejs.org/)
 [![MCP](https://img.shields.io/badge/MCP-2026--07--28-5b5fc7)](https://modelcontextprotocol.io/specification/2026-07-28)
 [![API docs](https://img.shields.io/badge/API%20docs-TypeDoc-3178c6?logo=readthedocs&logoColor=white)](https://backblaze-labs.github.io/b2-mcp/)
-[![Coverage floors](https://img.shields.io/badge/coverage-S%2094.5%20%7C%20B%2089%20%7C%20F%2097.5%20%7C%20L%2096.7-brightgreen)](docs/TESTING.md)
+[![Coverage floors](https://img.shields.io/badge/coverage-S%2096%20%7C%20B%2092%20%7C%20F%2097.7%20%7C%20L%2097.4-brightgreen)](docs/TESTING.md)
 [![Runtime dependencies](https://img.shields.io/badge/runtime_dependencies-9-blue)](package-budget.json)
 
 <!-- Directory badges point at deterministic per-server URLs derived from the locked

--- a/deploy/customer-hosted/pnpm-lock.yaml
+++ b/deploy/customer-hosted/pnpm-lock.yaml
@@ -18,7 +18,7 @@ overrides:
   '@vercel/hono>path-to-regexp': 8.4.0
   '@vercel/node>path-to-regexp': 6.3.0
   '@vercel/node>undici': 6.28.0
-  '@vercel/python-analysis>js-yaml': 4.3.1
+  '@vercel/python-analysis>js-yaml': 4.3.2
   '@vercel/python-analysis>minimatch': 10.2.3
   '@vercel/python-analysis>smol-toml': 1.6.1
   '@vercel/remix-builder>path-to-regexp': 6.3.0
@@ -32,6 +32,7 @@ overrides:
   nanoid: 3.3.18
   fast-uri: '>=3.1.6 <4'
   qs: '>=6.16.0'
+  miniflare>sharp: '>=0.35.4'
 
 importers:
 
@@ -121,7 +122,7 @@ importers:
         version: 4.9.0
       miniflare:
         specifier: 5.20260903.0-alpha
-        version: 5.20260903.0-alpha
+        version: 5.20260903.0-alpha(@types/node@22.20.1)
       semver:
         specifier: 7.8.5
         version: 7.8.5
@@ -145,7 +146,7 @@ importers:
         version: 4.1.11(@edge-runtime/vm@3.2.0)(@types/node@22.20.1)(@vitest/coverage-v8@4.1.11)(vite@8.2.0(@types/node@22.20.1)(esbuild@0.28.1)(tsx@4.23.13)(yaml@2.9.0))
       wrangler:
         specifier: 4.129.0
-        version: 4.129.0
+        version: 4.129.0(@types/node@22.20.1)
       yaml:
         specifier: ^2.9.0
         version: 2.9.0
@@ -863,160 +864,160 @@ packages:
     resolution: {integrity: sha512-Td76q7j57o/tLVdgS746cYARfSyxk8iEfRxewL9h4OMzYhbW4TAcppl0mT4eyqXddh6L/jwoM75mo7ixa/pCeQ==}
     engines: {node: '>=18'}
 
-  '@img/sharp-darwin-arm64@0.35.2':
-    resolution: {integrity: sha512-eEieHsMksAW4IiO5NzauESRl2D2qz3J/kwUxUrSfV06A93eEaRfMpHXyUb1mAqrR7i8U9A0GRqE9pjn6u1Jjpg==}
+  '@img/sharp-darwin-arm64@0.35.4':
+    resolution: {integrity: sha512-Uhfl4V4lhP2nbUVF9+hyH1+luj86f1gUFeo8ALYxFoULoU+G87D43BfeMP8XHsk9boxAnCY/bf2EHwhA7MuGsA==}
     engines: {node: '>=20.9.0'}
     cpu: [arm64]
     os: [darwin]
 
-  '@img/sharp-darwin-x64@0.35.2':
-    resolution: {integrity: sha512-BaktuGPCeHJMARpodR8jK4uKiZrPAy9WrfQW0sdI37clracq8Bp01AYS3SZgi5FS/y5twa9t4+LIuuxQjqRrWw==}
+  '@img/sharp-darwin-x64@0.35.4':
+    resolution: {integrity: sha512-hWniXY3bG5qKpkKrAwPe4y+VTPmf086YQAnkxWh7uA1YrlRouWGa0M0Mxj3ZjnXFkv7/TD1bTy9lGUK26vRvWw==}
     engines: {node: '>=20.9.0'}
     cpu: [x64]
     os: [darwin]
 
-  '@img/sharp-freebsd-wasm32@0.35.2':
-    resolution: {integrity: sha512-YoAxdnd8hPUkvLHd3bWY+YA8nw3xM/RyRopYucNsWHVSan8NLVM3X2volsfoRDcXdUJPg6tXahSd7HXPK7lRnw==}
+  '@img/sharp-freebsd-wasm32@0.35.4':
+    resolution: {integrity: sha512-lIsKw/BU+kjB4eZjxrYrZmwOJYi3Ajrv66iAlBmUPyKc3HpnloevB1g3wxGD9P/5BbQ1brBGl65VRRrCvQDEqA==}
     engines: {node: '>=20.9.0'}
     os: [freebsd]
 
-  '@img/sharp-libvips-darwin-arm64@1.3.1':
-    resolution: {integrity: sha512-4V/M3roRMTYjiwZY9IOVQOE8OyeCxFAkYmyZDrZl51uOKjibm3oeEJ4WAmLxutAfzFbC9jqUiPs2gbnGflH+7g==}
+  '@img/sharp-libvips-darwin-arm64@1.3.3':
+    resolution: {integrity: sha512-suTBPTDGrI9WodccaDdwZItTSaBYASlBk1NSfElSHrUfzu3szG6lvIF58+WiFvnfzuK8ZBFS5zE00PxqxnRiPg==}
     cpu: [arm64]
     os: [darwin]
 
-  '@img/sharp-libvips-darwin-x64@1.3.1':
-    resolution: {integrity: sha512-c0/DxItpJv2+dGhgycJBBgotdqruGYDvA79drdh0MD1dFpy7JzJ/PlXwi1H4rFf0eTy8tgbI91aHDnZIceY3jQ==}
+  '@img/sharp-libvips-darwin-x64@1.3.3':
+    resolution: {integrity: sha512-FVJZ5mITMobmXIz/hPDTw0EintTW5H3WfrxwLqEqjiIihlu+hVRyGrFQ60xl0Lxn7Bt3zdpevPaQi0HEzqz9fw==}
     cpu: [x64]
     os: [darwin]
 
-  '@img/sharp-libvips-linux-arm64@1.3.1':
-    resolution: {integrity: sha512-JznefmcK9j1JKPz8AkQDh89kjojubyfOasWBPKfzMIhPwsgDy9evpE/naJTXXXmghS1iFwR8u/kTwh/I2/+GCw==}
+  '@img/sharp-libvips-linux-arm64@1.3.3':
+    resolution: {integrity: sha512-0DaL0A6Xu6sQSQFwe4iVCrKWU2cCTItnRsYsCdxAMm9NF6twAA9BKnoqy4hqz4+azQ0JHuA26qiUKsf1XJ/v5A==}
     cpu: [arm64]
     os: [linux]
     libc: [glibc]
 
-  '@img/sharp-libvips-linux-arm@1.3.1':
-    resolution: {integrity: sha512-aGGy9aWzXgHBG7HNyQPWorZthlp7+x6fDRoPAQbGO3ThcttuTyKIx3NuSHb6zb4gBNq6/yNn9f1cy9nFKS/Vmg==}
+  '@img/sharp-libvips-linux-arm@1.3.3':
+    resolution: {integrity: sha512-3rbU4vqXXc3hY/OiXdl52xZvT0F1yEngWfvqudtPJg/KkyiaQw2DRsFrNzpmLvfavbwOq3qXn36GP8obHRULQA==}
     cpu: [arm]
     os: [linux]
     libc: [glibc]
 
-  '@img/sharp-libvips-linux-ppc64@1.3.1':
-    resolution: {integrity: sha512-1EkwGNCZk6iWNCMWqrvdJ+r1j0PT1zIz60CNPhYnJlK/zyeWqlsPZIe+ocBVqPF8k/Ssee/NCk+tE9Ryrko6ng==}
+  '@img/sharp-libvips-linux-ppc64@1.3.3':
+    resolution: {integrity: sha512-cdn1OvUBwsXhbC0zSzJnNzf5MZ/mTrobawDvNXBTxe8VtqKAm0sRuEY2Evzovb/w9JMk4TvRxqt1mekSuJz64w==}
     cpu: [ppc64]
     os: [linux]
     libc: [glibc]
 
-  '@img/sharp-libvips-linux-riscv64@1.3.1':
-    resolution: {integrity: sha512-Ilays+w2bXdnxzxtQdmXR62u8o8GYa3eL4+Gr+1KiE4xperMZUslRaVPJwwPkzlHEjGfXAfRVAa/7CYCtSqsBw==}
+  '@img/sharp-libvips-linux-riscv64@1.3.3':
+    resolution: {integrity: sha512-HjPVx7yKz+0lqdhDlTw1tt90wamBoxhiXpvl1XZpJLiHH4RCJ5yDTqH+VlYPv2fwFs89JFw4c1IexYOcQUi4IQ==}
     cpu: [riscv64]
     os: [linux]
     libc: [glibc]
 
-  '@img/sharp-libvips-linux-s390x@1.3.1':
-    resolution: {integrity: sha512-VfBwVHQTbRoj4XlpA/KLZ7ltgMpz+4WSejFzQ+GnoImjo1PtEJ59QB2qR1xQEeRPYIkNrPIm2L4cICMvz4C2ew==}
+  '@img/sharp-libvips-linux-s390x@1.3.3':
+    resolution: {integrity: sha512-neWLh+3yCNThxnfy3c4BbVBeGgt9aftno+XbT56iK28RgeDs3UOFWviLWlUu0bArYVYJaFDK+RRohbicUNCm8Q==}
     cpu: [s390x]
     os: [linux]
     libc: [glibc]
 
-  '@img/sharp-libvips-linux-x64@1.3.1':
-    resolution: {integrity: sha512-+c8ukgwU62DS54nCAjw7keOfHUkmr0B5QHEdcOqRnodF/MNXJbVI8Eopoj4B/0H8Asr65I+A4Amrn7a85/md6A==}
+  '@img/sharp-libvips-linux-x64@1.3.3':
+    resolution: {integrity: sha512-4vKmvAst9nrowcqquKFAyZJUDolUaIp8uRiN0mWFguJ1IplC9/pitXtlnnlU4aa/eJw3J7i67V+pwUL+wZGdsA==}
     cpu: [x64]
     os: [linux]
     libc: [glibc]
 
-  '@img/sharp-libvips-linuxmusl-arm64@1.3.1':
-    resolution: {integrity: sha512-qlKb/pwbkAi1WMsJrYHk7CuDrd12s27U2QnRhFYUoJNrRCmkosMTttuRFat/DDB3IlDm5qE1TJgZ4JDnHX8Ldw==}
+  '@img/sharp-libvips-linuxmusl-arm64@1.3.3':
+    resolution: {integrity: sha512-Y9kQaLMuNoB0bPYOOdcZMaseNrFpPodIWWMrx+CZyydf2xn68j9WYc6sWWRrDwNkzCQjKYfc68L7jKjGlHMibw==}
     cpu: [arm64]
     os: [linux]
     libc: [musl]
 
-  '@img/sharp-libvips-linuxmusl-x64@1.3.1':
-    resolution: {integrity: sha512-yO21HwoUVLN8Qa+/SBjQLMYwBWAVJjeGPNe+hc0OUeMeifEtJqu5a1c4HayE1nNpDih9y3/KkoltfkDodmKAlg==}
+  '@img/sharp-libvips-linuxmusl-x64@1.3.3':
+    resolution: {integrity: sha512-fj8Mv0HHfD1Rr+4I68+3agJynxDWtBFgicTbSOb9Bke6pIwzGcJ+RX/yHjmiEGFMCavY/dxvem7MyNaJF+wDiw==}
     cpu: [x64]
     os: [linux]
     libc: [musl]
 
-  '@img/sharp-linux-arm64@0.35.2':
-    resolution: {integrity: sha512-af12Pnd0ZGu2HfP8NayB0kk6eC/lrfbQE6HlR4jD+34wdJ1Vw9TF6TMn6ZvffT+WgqVsl0hRbmNvz2u/23VmwA==}
+  '@img/sharp-linux-arm64@0.35.4':
+    resolution: {integrity: sha512-De4jpEnAU8Hd5oT0j1G3uL4ZvTuipVMn7YC6vPaJhy6/7EwEae0SVAoBrUMYQbkLGDm85taVWwuPc1a44LTzCQ==}
     engines: {node: '>=20.9.0'}
     cpu: [arm64]
     os: [linux]
     libc: [glibc]
 
-  '@img/sharp-linux-arm@0.35.2':
-    resolution: {integrity: sha512-SE4kzF2mepn6z+6E7L6lsV8FzuLL6IPQdyX8ZiwROAG/G8td+hP/m7FsFPwidtrF19gvajuC9l6TxAVcsA4S7A==}
+  '@img/sharp-linux-arm@0.35.4':
+    resolution: {integrity: sha512-7OAS8gI0EReKGVN2HssHlM6umJgxF5VI3xN0p9FA91p/YO+ou5hiNghLdZ5BEHztwaaK5+bLKRf8x/o2L2nk9A==}
     engines: {node: '>=20.9.0'}
     cpu: [arm]
     os: [linux]
     libc: [glibc]
 
-  '@img/sharp-linux-ppc64@0.35.2':
-    resolution: {integrity: sha512-hYSBm7zcNtDCozCxQHYZJiu63b/bXsgRZuOxCIBZsStMM9Vap47iFHdbX4kCvQsblPB/k+clhELpdQJHQLSHvg==}
+  '@img/sharp-linux-ppc64@0.35.4':
+    resolution: {integrity: sha512-2oYZJeIl4kCcMGk4ouZVjnkCtFrpQFlNEtJ6GbxzhHQchwH0NH/qEb9ykmOl29dqwMq+JhFdZn+1ak2FKhI9fQ==}
     engines: {node: '>=20.9.0'}
     cpu: [ppc64]
     os: [linux]
     libc: [glibc]
 
-  '@img/sharp-linux-riscv64@0.35.2':
-    resolution: {integrity: sha512-qQt0Kc13+Hoan/Awq/qMSQw3L+RI1NCRPgD5cUJ/1WSSmIoysLOc72jlRM3E0OHN9Yr313jgeQ2T+zW+F03QFA==}
+  '@img/sharp-linux-riscv64@0.35.4':
+    resolution: {integrity: sha512-cPbNChoRURAWdebDIHSenxRpgEdy7JkPydSnUxRm9VvKD7m0/xVaR/8Fzlu81pk5nHEvHH87UZUA7cTtwnbJSA==}
     engines: {node: '>=20.9.0'}
     cpu: [riscv64]
     os: [linux]
     libc: [glibc]
 
-  '@img/sharp-linux-s390x@0.35.2':
-    resolution: {integrity: sha512-E4fLLfRPzDLlEeDaTzI98OFLcv++WL5ChLLMwPoVd0CIoZQqupBSNbOisPL5am9XsbQ9T84+iiMpUvbFtkunbA==}
+  '@img/sharp-linux-s390x@0.35.4':
+    resolution: {integrity: sha512-RY0JFY8Fd6RonCBtHz+DvadaPkXDSI1AUn6yWL9TipqkZ1vY8w8evqdgyDFnkm4/K1ve1TvZiaePP5oSd4+WVQ==}
     engines: {node: '>=20.9.0'}
     cpu: [s390x]
     os: [linux]
     libc: [glibc]
 
-  '@img/sharp-linux-x64@0.35.2':
-    resolution: {integrity: sha512-gi0zFJJRLswfCZmHtJdikXPOc5u7qamSOS3NHedLqLd4W8Q0NqjdBr6TTRIgsfFjqfTsHFgdfvJ9LwqSgcHiAA==}
+  '@img/sharp-linux-x64@0.35.4':
+    resolution: {integrity: sha512-9qvvEAuk8k89TfWUoX2htWjbAMX8p+NxCppjpcg5k6xMsjhBQPTsoIh36h9Qde4WRuGpJeYnOjdosDn/cnv+OA==}
     engines: {node: '>=20.9.0'}
     cpu: [x64]
     os: [linux]
     libc: [glibc]
 
-  '@img/sharp-linuxmusl-arm64@0.35.2':
-    resolution: {integrity: sha512-siWbOW1u6HFnFLrp0waKyW7VEf7jYvcDWdrXEFa8AkdAQgEvuu5Fz8/Y70w9EeqAdwDtfU012BhEHHaDqvQNzg==}
+  '@img/sharp-linuxmusl-arm64@0.35.4':
+    resolution: {integrity: sha512-KB5jxpfWQTr0nc3xdHtWChdbifHrBGsd2SM62Eyxrl8afikm+f5qGBU75SJIZBT/S1MC8XyacdlXBMSWq6OURA==}
     engines: {node: '>=20.9.0'}
     cpu: [arm64]
     os: [linux]
     libc: [musl]
 
-  '@img/sharp-linuxmusl-x64@0.35.2':
-    resolution: {integrity: sha512-YBqMMcjDi4QGYiSn4vNOYBhmlC4z5AXqkOUUqI2e0AFA4urNv4ESgOgwNl3K+4etQhha0twXlzeF20bbULm9Yg==}
+  '@img/sharp-linuxmusl-x64@0.35.4':
+    resolution: {integrity: sha512-f+eZJZIQNEEd26RPSW+76chwOf1XtA2Y/O+5ocVyLliHkeih3e+jhLVBdNTd2rS3IbNXK8+ug93Vf5ZXtF5Lxg==}
     engines: {node: '>=20.9.0'}
     cpu: [x64]
     os: [linux]
     libc: [musl]
 
-  '@img/sharp-wasm32@0.35.2':
-    resolution: {integrity: sha512-Mrv4JQNYVQ94xH+jzZ9r+gowleN8mv2FTgKT+PI6bx5C0G8TdNYndu161pg2i7uoBwxy2ImPMHrJOM2LZef7Bw==}
+  '@img/sharp-wasm32@0.35.4':
+    resolution: {integrity: sha512-zQnl4Kwp7Q6NHsENtU2T/00Zi+w3AQNwz3+UaTyVBy2FpXrzXzGjndpK61onhZjRtRpQXxCTeqw19bVyXOh7jA==}
     engines: {node: '>=20.9.0'}
 
-  '@img/sharp-webcontainers-wasm32@0.35.2':
-    resolution: {integrity: sha512-QNV27pxs9wpApEiCfvHM1RDoP1w1+2KrUWWDPEhEwg+latvOrfuhWrHWZKwdSFwU6jh3myjw/yOCRsUIuOft3g==}
+  '@img/sharp-webcontainers-wasm32@0.35.4':
+    resolution: {integrity: sha512-ESfNkywmCfPNyaZjxooddJQiQ+l/nTpGEOGthxiLnIHXC/CmcBixnfwUleX9mCz9ovrUUvKMap/pm8RYbzfwaA==}
     engines: {node: '>=20.9.0'}
     cpu: [wasm32]
 
-  '@img/sharp-win32-arm64@0.35.2':
-    resolution: {integrity: sha512-BiVRYc/t6/Vl3e1hBx0hugG4oN9Pydf4fgMSpxTQJmwGUg/YoXTWHiFeRymHfCZzifxu4F4rpk/I67D0LQ20wQ==}
+  '@img/sharp-win32-arm64@0.35.4':
+    resolution: {integrity: sha512-iNdlBX9gLVvqe2I3uIJSIKTq6wckP/DYxZtcqxm09x5Gi24DnFBmPAWZmr60ZyYMG0xlzo6goG3670ar+RXvRw==}
     engines: {node: '>=20.9.0'}
     cpu: [arm64]
     os: [win32]
 
-  '@img/sharp-win32-ia32@0.35.2':
-    resolution: {integrity: sha512-YYEhx9PImCC7T0tI8JDMi4DB9LwLCXCU5OWNYEXAxh5Q1ShKkyC6byxzoBJ3gEFDnH2lQckWuDe70G7mB2XJog==}
+  '@img/sharp-win32-ia32@0.35.4':
+    resolution: {integrity: sha512-kqRsbaa5CS6KHlpxnN7WhE6vAAugXyZButpRdvDWetlv6Qv4N9WTcrWzF7tXfB9T7MsoadqdI8hmwLq6UlLvtw==}
     engines: {node: ^20.9.0}
     cpu: [ia32]
     os: [win32]
 
-  '@img/sharp-win32-x64@0.35.2':
-    resolution: {integrity: sha512-imoOyBcoM/iiUr4J6VPpCNjPnjvP/Gks95898yB8YqoGGYmHYbOyCuNv9FMhFgtaiHFGbHW8bxKqRV6VjtXThQ==}
+  '@img/sharp-win32-x64@0.35.4':
+    resolution: {integrity: sha512-XtmnYhBcrORsJ4XJngyzr/EWP0hRZLAZRFaApdKuviyqF78+ylxh2y06ZmtULAMOnObJ3ucpN0AcwSWnMowTRg==}
     engines: {node: '>=20.9.0'}
     cpu: [x64]
     os: [win32]
@@ -3274,8 +3275,8 @@ packages:
   js-tokens@10.0.0:
     resolution: {integrity: sha512-lM/UBzQmfJRo9ABXbPWemivdCW8V2G8FHaHdypQaIy523snUjog0W71ayWXTjiR+ixeMyVHN2XcpnTd/liPg/Q==}
 
-  js-yaml@4.3.1:
-    resolution: {integrity: sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==}
+  js-yaml@4.3.2:
+    resolution: {integrity: sha512-SFNOvSJ+Dgf/9An904Yx+CgSlIPCkIpao4qo51lpee25TIRejdH3rhR4EZMGoNx3/TP3O+wzWuiTFl4sqbltzA==}
     hasBin: true
 
   jsdoc-type-pratt-parser@9.1.2:
@@ -3934,9 +3935,14 @@ packages:
   setprototypeof@1.2.0:
     resolution: {integrity: sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==}
 
-  sharp@0.35.2:
-    resolution: {integrity: sha512-FVtFjtBCMiJS6yb5CX7Sop45WFMpeGw6oRKuJnXYgf/f1ms/D7LE/ZUSNxnW7rZ/dbslQWYkoqFHGPaDBtaK4w==}
+  sharp@0.35.4:
+    resolution: {integrity: sha512-n++8XWcj+jCOr2IOl7h8LbKnGBDY4aPbmprMONBNFdn0ImXqpGVv5zliDs0V9HbmbCQLpbuo2ej9rAoOQTvMDA==}
     engines: {node: '>=20.9.0'}
+    peerDependencies:
+      '@types/node': '*'
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
 
   shebang-command@2.0.0:
     resolution: {integrity: sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==}
@@ -5207,108 +5213,108 @@ snapshots:
 
   '@img/colour@1.1.0': {}
 
-  '@img/sharp-darwin-arm64@0.35.2':
+  '@img/sharp-darwin-arm64@0.35.4':
     optionalDependencies:
-      '@img/sharp-libvips-darwin-arm64': 1.3.1
+      '@img/sharp-libvips-darwin-arm64': 1.3.3
     optional: true
 
-  '@img/sharp-darwin-x64@0.35.2':
+  '@img/sharp-darwin-x64@0.35.4':
     optionalDependencies:
-      '@img/sharp-libvips-darwin-x64': 1.3.1
+      '@img/sharp-libvips-darwin-x64': 1.3.3
     optional: true
 
-  '@img/sharp-freebsd-wasm32@0.35.2':
+  '@img/sharp-freebsd-wasm32@0.35.4':
     dependencies:
-      '@img/sharp-wasm32': 0.35.2
+      '@img/sharp-wasm32': 0.35.4
     optional: true
 
-  '@img/sharp-libvips-darwin-arm64@1.3.1':
+  '@img/sharp-libvips-darwin-arm64@1.3.3':
     optional: true
 
-  '@img/sharp-libvips-darwin-x64@1.3.1':
+  '@img/sharp-libvips-darwin-x64@1.3.3':
     optional: true
 
-  '@img/sharp-libvips-linux-arm64@1.3.1':
+  '@img/sharp-libvips-linux-arm64@1.3.3':
     optional: true
 
-  '@img/sharp-libvips-linux-arm@1.3.1':
+  '@img/sharp-libvips-linux-arm@1.3.3':
     optional: true
 
-  '@img/sharp-libvips-linux-ppc64@1.3.1':
+  '@img/sharp-libvips-linux-ppc64@1.3.3':
     optional: true
 
-  '@img/sharp-libvips-linux-riscv64@1.3.1':
+  '@img/sharp-libvips-linux-riscv64@1.3.3':
     optional: true
 
-  '@img/sharp-libvips-linux-s390x@1.3.1':
+  '@img/sharp-libvips-linux-s390x@1.3.3':
     optional: true
 
-  '@img/sharp-libvips-linux-x64@1.3.1':
+  '@img/sharp-libvips-linux-x64@1.3.3':
     optional: true
 
-  '@img/sharp-libvips-linuxmusl-arm64@1.3.1':
+  '@img/sharp-libvips-linuxmusl-arm64@1.3.3':
     optional: true
 
-  '@img/sharp-libvips-linuxmusl-x64@1.3.1':
+  '@img/sharp-libvips-linuxmusl-x64@1.3.3':
     optional: true
 
-  '@img/sharp-linux-arm64@0.35.2':
+  '@img/sharp-linux-arm64@0.35.4':
     optionalDependencies:
-      '@img/sharp-libvips-linux-arm64': 1.3.1
+      '@img/sharp-libvips-linux-arm64': 1.3.3
     optional: true
 
-  '@img/sharp-linux-arm@0.35.2':
+  '@img/sharp-linux-arm@0.35.4':
     optionalDependencies:
-      '@img/sharp-libvips-linux-arm': 1.3.1
+      '@img/sharp-libvips-linux-arm': 1.3.3
     optional: true
 
-  '@img/sharp-linux-ppc64@0.35.2':
+  '@img/sharp-linux-ppc64@0.35.4':
     optionalDependencies:
-      '@img/sharp-libvips-linux-ppc64': 1.3.1
+      '@img/sharp-libvips-linux-ppc64': 1.3.3
     optional: true
 
-  '@img/sharp-linux-riscv64@0.35.2':
+  '@img/sharp-linux-riscv64@0.35.4':
     optionalDependencies:
-      '@img/sharp-libvips-linux-riscv64': 1.3.1
+      '@img/sharp-libvips-linux-riscv64': 1.3.3
     optional: true
 
-  '@img/sharp-linux-s390x@0.35.2':
+  '@img/sharp-linux-s390x@0.35.4':
     optionalDependencies:
-      '@img/sharp-libvips-linux-s390x': 1.3.1
+      '@img/sharp-libvips-linux-s390x': 1.3.3
     optional: true
 
-  '@img/sharp-linux-x64@0.35.2':
+  '@img/sharp-linux-x64@0.35.4':
     optionalDependencies:
-      '@img/sharp-libvips-linux-x64': 1.3.1
+      '@img/sharp-libvips-linux-x64': 1.3.3
     optional: true
 
-  '@img/sharp-linuxmusl-arm64@0.35.2':
+  '@img/sharp-linuxmusl-arm64@0.35.4':
     optionalDependencies:
-      '@img/sharp-libvips-linuxmusl-arm64': 1.3.1
+      '@img/sharp-libvips-linuxmusl-arm64': 1.3.3
     optional: true
 
-  '@img/sharp-linuxmusl-x64@0.35.2':
+  '@img/sharp-linuxmusl-x64@0.35.4':
     optionalDependencies:
-      '@img/sharp-libvips-linuxmusl-x64': 1.3.1
+      '@img/sharp-libvips-linuxmusl-x64': 1.3.3
     optional: true
 
-  '@img/sharp-wasm32@0.35.2':
+  '@img/sharp-wasm32@0.35.4':
     dependencies:
       '@emnapi/runtime': 1.11.3
     optional: true
 
-  '@img/sharp-webcontainers-wasm32@0.35.2':
+  '@img/sharp-webcontainers-wasm32@0.35.4':
     dependencies:
-      '@img/sharp-wasm32': 0.35.2
+      '@img/sharp-wasm32': 0.35.4
     optional: true
 
-  '@img/sharp-win32-arm64@0.35.2':
+  '@img/sharp-win32-arm64@0.35.4':
     optional: true
 
-  '@img/sharp-win32-ia32@0.35.2':
+  '@img/sharp-win32-ia32@0.35.4':
     optional: true
 
-  '@img/sharp-win32-x64@0.35.2':
+  '@img/sharp-win32-x64@0.35.4':
     optional: true
 
   '@inquirer/checkbox@3.0.1':
@@ -6572,7 +6578,7 @@ snapshots:
       '@bytecodealliance/preview2-shim': 0.17.6
       '@renovatebot/pep440': 4.2.1
       fs-extra: 11.1.1
-      js-yaml: 4.3.1
+      js-yaml: 4.3.2
       minimatch: 10.2.3
       smol-toml: 1.6.1
       zod: 3.22.4
@@ -7753,7 +7759,7 @@ snapshots:
 
   js-tokens@10.0.0: {}
 
-  js-yaml@4.3.1:
+  js-yaml@4.3.2:
     dependencies:
       argparse: 2.0.1
 
@@ -7928,15 +7934,16 @@ snapshots:
 
   mimic-fn@2.1.0: {}
 
-  miniflare@5.20260903.0-alpha:
+  miniflare@5.20260903.0-alpha(@types/node@22.20.1):
     dependencies:
       '@cspotcode/source-map-support': 0.8.1
-      sharp: 0.35.2
+      sharp: 0.35.4(@types/node@22.20.1)
       undici: 7.29.0
       workerd: 1.20260903.1
       ws: 8.21.0
       youch: 4.1.0-beta.10
     transitivePeerDependencies:
+      - '@types/node'
       - bufferutil
       - utf-8-validate
 
@@ -8420,37 +8427,38 @@ snapshots:
 
   setprototypeof@1.2.0: {}
 
-  sharp@0.35.2:
+  sharp@0.35.4(@types/node@22.20.1):
     dependencies:
       '@img/colour': 1.1.0
       detect-libc: 2.1.2
       semver: 7.8.5
     optionalDependencies:
-      '@img/sharp-darwin-arm64': 0.35.2
-      '@img/sharp-darwin-x64': 0.35.2
-      '@img/sharp-freebsd-wasm32': 0.35.2
-      '@img/sharp-libvips-darwin-arm64': 1.3.1
-      '@img/sharp-libvips-darwin-x64': 1.3.1
-      '@img/sharp-libvips-linux-arm': 1.3.1
-      '@img/sharp-libvips-linux-arm64': 1.3.1
-      '@img/sharp-libvips-linux-ppc64': 1.3.1
-      '@img/sharp-libvips-linux-riscv64': 1.3.1
-      '@img/sharp-libvips-linux-s390x': 1.3.1
-      '@img/sharp-libvips-linux-x64': 1.3.1
-      '@img/sharp-libvips-linuxmusl-arm64': 1.3.1
-      '@img/sharp-libvips-linuxmusl-x64': 1.3.1
-      '@img/sharp-linux-arm': 0.35.2
-      '@img/sharp-linux-arm64': 0.35.2
-      '@img/sharp-linux-ppc64': 0.35.2
-      '@img/sharp-linux-riscv64': 0.35.2
-      '@img/sharp-linux-s390x': 0.35.2
-      '@img/sharp-linux-x64': 0.35.2
-      '@img/sharp-linuxmusl-arm64': 0.35.2
-      '@img/sharp-linuxmusl-x64': 0.35.2
-      '@img/sharp-webcontainers-wasm32': 0.35.2
-      '@img/sharp-win32-arm64': 0.35.2
-      '@img/sharp-win32-ia32': 0.35.2
-      '@img/sharp-win32-x64': 0.35.2
+      '@img/sharp-darwin-arm64': 0.35.4
+      '@img/sharp-darwin-x64': 0.35.4
+      '@img/sharp-freebsd-wasm32': 0.35.4
+      '@img/sharp-libvips-darwin-arm64': 1.3.3
+      '@img/sharp-libvips-darwin-x64': 1.3.3
+      '@img/sharp-libvips-linux-arm': 1.3.3
+      '@img/sharp-libvips-linux-arm64': 1.3.3
+      '@img/sharp-libvips-linux-ppc64': 1.3.3
+      '@img/sharp-libvips-linux-riscv64': 1.3.3
+      '@img/sharp-libvips-linux-s390x': 1.3.3
+      '@img/sharp-libvips-linux-x64': 1.3.3
+      '@img/sharp-libvips-linuxmusl-arm64': 1.3.3
+      '@img/sharp-libvips-linuxmusl-x64': 1.3.3
+      '@img/sharp-linux-arm': 0.35.4
+      '@img/sharp-linux-arm64': 0.35.4
+      '@img/sharp-linux-ppc64': 0.35.4
+      '@img/sharp-linux-riscv64': 0.35.4
+      '@img/sharp-linux-s390x': 0.35.4
+      '@img/sharp-linux-x64': 0.35.4
+      '@img/sharp-linuxmusl-arm64': 0.35.4
+      '@img/sharp-linuxmusl-x64': 0.35.4
+      '@img/sharp-webcontainers-wasm32': 0.35.4
+      '@img/sharp-win32-arm64': 0.35.4
+      '@img/sharp-win32-ia32': 0.35.4
+      '@img/sharp-win32-x64': 0.35.4
+      '@types/node': 22.20.1
 
   shebang-command@2.0.0:
     dependencies:
@@ -8907,19 +8915,20 @@ snapshots:
       '@cloudflare/workerd-linux-arm64': 1.20260903.1
       '@cloudflare/workerd-windows-64': 1.20260903.1
 
-  wrangler@4.129.0:
+  wrangler@4.129.0(@types/node@22.20.1):
     dependencies:
       '@cloudflare/kv-asset-handler': 0.5.0
       '@cloudflare/unenv-preset': 2.16.1(unenv@2.0.0-rc.24)(workerd@1.20260903.1)
       blake3-wasm: 2.1.5
       esbuild: 0.28.1
-      miniflare: 5.20260903.0-alpha
+      miniflare: 5.20260903.0-alpha(@types/node@22.20.1)
       path-to-regexp: 6.3.0
       unenv: 2.0.0-rc.24
       workerd: 1.20260903.1
     optionalDependencies:
       fsevents: 2.3.3
     transitivePeerDependencies:
+      - '@types/node'
       - bufferutil
       - utf-8-validate
 

--- a/deploy/customer-hosted/pnpm-workspace.yaml
+++ b/deploy/customer-hosted/pnpm-workspace.yaml
@@ -45,7 +45,7 @@ overrides:
   '@vercel/hono>path-to-regexp': 8.4.0
   '@vercel/node>path-to-regexp': 6.3.0
   '@vercel/node>undici': 6.28.0
-  '@vercel/python-analysis>js-yaml': 4.3.1
+  '@vercel/python-analysis>js-yaml': 4.3.2
   '@vercel/python-analysis>minimatch': 10.2.3
   '@vercel/python-analysis>smol-toml': 1.6.1
   '@vercel/remix-builder>path-to-regexp': 6.3.0
@@ -61,3 +61,7 @@ overrides:
   # fast-uri host-confusion/SSRF advisories and the qs array-limit/DoS advisories.
   fast-uri: '>=3.1.6 <4'
   qs: '>=6.16.0'
+  # Dev-only transitive dep via miniflare/wrangler; force the patched build off
+  # the libheif advisories bundled in sharp <0.35.4 (GHSA-g89c-p67h-r497,
+  # GHSA-2jg2-4ch7-h545). The Worker smoke never invokes sharp's image codecs.
+  'miniflare>sharp': '>=0.35.4'

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -182,8 +182,8 @@ The stable required PR check names are:
 - `slow/lifecycle`
 - `cross-platform minimum`
 
-Global V8 coverage must remain at or above 94.5% statements, 89% branches,
-97.5% functions, and 96.7% lines. Raise these floors as coverage improves;
+Global V8 coverage must remain at or above 96% statements, 92% branches,
+97.7% functions, and 97.4% lines. Raise these floors as coverage improves;
 lowering them requires explicit review and justification. Coverage collection is source
 only: `src/**/*.ts`, excluding `dist/`, declarations, generated files, and test
 files. The current Phase 1 floor is a ratchet: when `coverage/coverage-summary.json`

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -18,7 +18,7 @@ overrides:
   '@vercel/hono>path-to-regexp': 8.4.0
   '@vercel/node>path-to-regexp': 6.3.0
   '@vercel/node>undici': 6.28.0
-  '@vercel/python-analysis>js-yaml': 4.3.1
+  '@vercel/python-analysis>js-yaml': 4.3.2
   '@vercel/python-analysis>minimatch': 10.2.3
   '@vercel/python-analysis>smol-toml': 1.6.1
   '@vercel/remix-builder>path-to-regexp': 6.3.0
@@ -32,6 +32,7 @@ overrides:
   nanoid: 3.3.18
   fast-uri: '>=3.1.6 <4'
   qs: '>=6.16.0'
+  miniflare>sharp: '>=0.35.4'
 
 importers:
 
@@ -121,7 +122,7 @@ importers:
         version: 4.9.0
       miniflare:
         specifier: 5.20260903.0-alpha
-        version: 5.20260903.0-alpha
+        version: 5.20260903.0-alpha(@types/node@22.20.1)
       semver:
         specifier: 7.8.5
         version: 7.8.5
@@ -145,7 +146,7 @@ importers:
         version: 4.1.11(@edge-runtime/vm@3.2.0)(@types/node@22.20.1)(@vitest/coverage-v8@4.1.11)(vite@8.2.0(@types/node@22.20.1)(esbuild@0.28.1)(tsx@4.23.13)(yaml@2.9.0))
       wrangler:
         specifier: 4.129.0
-        version: 4.129.0
+        version: 4.129.0(@types/node@22.20.1)
       yaml:
         specifier: ^2.9.0
         version: 2.9.0
@@ -863,160 +864,160 @@ packages:
     resolution: {integrity: sha512-Td76q7j57o/tLVdgS746cYARfSyxk8iEfRxewL9h4OMzYhbW4TAcppl0mT4eyqXddh6L/jwoM75mo7ixa/pCeQ==}
     engines: {node: '>=18'}
 
-  '@img/sharp-darwin-arm64@0.35.2':
-    resolution: {integrity: sha512-eEieHsMksAW4IiO5NzauESRl2D2qz3J/kwUxUrSfV06A93eEaRfMpHXyUb1mAqrR7i8U9A0GRqE9pjn6u1Jjpg==}
+  '@img/sharp-darwin-arm64@0.35.4':
+    resolution: {integrity: sha512-Uhfl4V4lhP2nbUVF9+hyH1+luj86f1gUFeo8ALYxFoULoU+G87D43BfeMP8XHsk9boxAnCY/bf2EHwhA7MuGsA==}
     engines: {node: '>=20.9.0'}
     cpu: [arm64]
     os: [darwin]
 
-  '@img/sharp-darwin-x64@0.35.2':
-    resolution: {integrity: sha512-BaktuGPCeHJMARpodR8jK4uKiZrPAy9WrfQW0sdI37clracq8Bp01AYS3SZgi5FS/y5twa9t4+LIuuxQjqRrWw==}
+  '@img/sharp-darwin-x64@0.35.4':
+    resolution: {integrity: sha512-hWniXY3bG5qKpkKrAwPe4y+VTPmf086YQAnkxWh7uA1YrlRouWGa0M0Mxj3ZjnXFkv7/TD1bTy9lGUK26vRvWw==}
     engines: {node: '>=20.9.0'}
     cpu: [x64]
     os: [darwin]
 
-  '@img/sharp-freebsd-wasm32@0.35.2':
-    resolution: {integrity: sha512-YoAxdnd8hPUkvLHd3bWY+YA8nw3xM/RyRopYucNsWHVSan8NLVM3X2volsfoRDcXdUJPg6tXahSd7HXPK7lRnw==}
+  '@img/sharp-freebsd-wasm32@0.35.4':
+    resolution: {integrity: sha512-lIsKw/BU+kjB4eZjxrYrZmwOJYi3Ajrv66iAlBmUPyKc3HpnloevB1g3wxGD9P/5BbQ1brBGl65VRRrCvQDEqA==}
     engines: {node: '>=20.9.0'}
     os: [freebsd]
 
-  '@img/sharp-libvips-darwin-arm64@1.3.1':
-    resolution: {integrity: sha512-4V/M3roRMTYjiwZY9IOVQOE8OyeCxFAkYmyZDrZl51uOKjibm3oeEJ4WAmLxutAfzFbC9jqUiPs2gbnGflH+7g==}
+  '@img/sharp-libvips-darwin-arm64@1.3.3':
+    resolution: {integrity: sha512-suTBPTDGrI9WodccaDdwZItTSaBYASlBk1NSfElSHrUfzu3szG6lvIF58+WiFvnfzuK8ZBFS5zE00PxqxnRiPg==}
     cpu: [arm64]
     os: [darwin]
 
-  '@img/sharp-libvips-darwin-x64@1.3.1':
-    resolution: {integrity: sha512-c0/DxItpJv2+dGhgycJBBgotdqruGYDvA79drdh0MD1dFpy7JzJ/PlXwi1H4rFf0eTy8tgbI91aHDnZIceY3jQ==}
+  '@img/sharp-libvips-darwin-x64@1.3.3':
+    resolution: {integrity: sha512-FVJZ5mITMobmXIz/hPDTw0EintTW5H3WfrxwLqEqjiIihlu+hVRyGrFQ60xl0Lxn7Bt3zdpevPaQi0HEzqz9fw==}
     cpu: [x64]
     os: [darwin]
 
-  '@img/sharp-libvips-linux-arm64@1.3.1':
-    resolution: {integrity: sha512-JznefmcK9j1JKPz8AkQDh89kjojubyfOasWBPKfzMIhPwsgDy9evpE/naJTXXXmghS1iFwR8u/kTwh/I2/+GCw==}
+  '@img/sharp-libvips-linux-arm64@1.3.3':
+    resolution: {integrity: sha512-0DaL0A6Xu6sQSQFwe4iVCrKWU2cCTItnRsYsCdxAMm9NF6twAA9BKnoqy4hqz4+azQ0JHuA26qiUKsf1XJ/v5A==}
     cpu: [arm64]
     os: [linux]
     libc: [glibc]
 
-  '@img/sharp-libvips-linux-arm@1.3.1':
-    resolution: {integrity: sha512-aGGy9aWzXgHBG7HNyQPWorZthlp7+x6fDRoPAQbGO3ThcttuTyKIx3NuSHb6zb4gBNq6/yNn9f1cy9nFKS/Vmg==}
+  '@img/sharp-libvips-linux-arm@1.3.3':
+    resolution: {integrity: sha512-3rbU4vqXXc3hY/OiXdl52xZvT0F1yEngWfvqudtPJg/KkyiaQw2DRsFrNzpmLvfavbwOq3qXn36GP8obHRULQA==}
     cpu: [arm]
     os: [linux]
     libc: [glibc]
 
-  '@img/sharp-libvips-linux-ppc64@1.3.1':
-    resolution: {integrity: sha512-1EkwGNCZk6iWNCMWqrvdJ+r1j0PT1zIz60CNPhYnJlK/zyeWqlsPZIe+ocBVqPF8k/Ssee/NCk+tE9Ryrko6ng==}
+  '@img/sharp-libvips-linux-ppc64@1.3.3':
+    resolution: {integrity: sha512-cdn1OvUBwsXhbC0zSzJnNzf5MZ/mTrobawDvNXBTxe8VtqKAm0sRuEY2Evzovb/w9JMk4TvRxqt1mekSuJz64w==}
     cpu: [ppc64]
     os: [linux]
     libc: [glibc]
 
-  '@img/sharp-libvips-linux-riscv64@1.3.1':
-    resolution: {integrity: sha512-Ilays+w2bXdnxzxtQdmXR62u8o8GYa3eL4+Gr+1KiE4xperMZUslRaVPJwwPkzlHEjGfXAfRVAa/7CYCtSqsBw==}
+  '@img/sharp-libvips-linux-riscv64@1.3.3':
+    resolution: {integrity: sha512-HjPVx7yKz+0lqdhDlTw1tt90wamBoxhiXpvl1XZpJLiHH4RCJ5yDTqH+VlYPv2fwFs89JFw4c1IexYOcQUi4IQ==}
     cpu: [riscv64]
     os: [linux]
     libc: [glibc]
 
-  '@img/sharp-libvips-linux-s390x@1.3.1':
-    resolution: {integrity: sha512-VfBwVHQTbRoj4XlpA/KLZ7ltgMpz+4WSejFzQ+GnoImjo1PtEJ59QB2qR1xQEeRPYIkNrPIm2L4cICMvz4C2ew==}
+  '@img/sharp-libvips-linux-s390x@1.3.3':
+    resolution: {integrity: sha512-neWLh+3yCNThxnfy3c4BbVBeGgt9aftno+XbT56iK28RgeDs3UOFWviLWlUu0bArYVYJaFDK+RRohbicUNCm8Q==}
     cpu: [s390x]
     os: [linux]
     libc: [glibc]
 
-  '@img/sharp-libvips-linux-x64@1.3.1':
-    resolution: {integrity: sha512-+c8ukgwU62DS54nCAjw7keOfHUkmr0B5QHEdcOqRnodF/MNXJbVI8Eopoj4B/0H8Asr65I+A4Amrn7a85/md6A==}
+  '@img/sharp-libvips-linux-x64@1.3.3':
+    resolution: {integrity: sha512-4vKmvAst9nrowcqquKFAyZJUDolUaIp8uRiN0mWFguJ1IplC9/pitXtlnnlU4aa/eJw3J7i67V+pwUL+wZGdsA==}
     cpu: [x64]
     os: [linux]
     libc: [glibc]
 
-  '@img/sharp-libvips-linuxmusl-arm64@1.3.1':
-    resolution: {integrity: sha512-qlKb/pwbkAi1WMsJrYHk7CuDrd12s27U2QnRhFYUoJNrRCmkosMTttuRFat/DDB3IlDm5qE1TJgZ4JDnHX8Ldw==}
+  '@img/sharp-libvips-linuxmusl-arm64@1.3.3':
+    resolution: {integrity: sha512-Y9kQaLMuNoB0bPYOOdcZMaseNrFpPodIWWMrx+CZyydf2xn68j9WYc6sWWRrDwNkzCQjKYfc68L7jKjGlHMibw==}
     cpu: [arm64]
     os: [linux]
     libc: [musl]
 
-  '@img/sharp-libvips-linuxmusl-x64@1.3.1':
-    resolution: {integrity: sha512-yO21HwoUVLN8Qa+/SBjQLMYwBWAVJjeGPNe+hc0OUeMeifEtJqu5a1c4HayE1nNpDih9y3/KkoltfkDodmKAlg==}
+  '@img/sharp-libvips-linuxmusl-x64@1.3.3':
+    resolution: {integrity: sha512-fj8Mv0HHfD1Rr+4I68+3agJynxDWtBFgicTbSOb9Bke6pIwzGcJ+RX/yHjmiEGFMCavY/dxvem7MyNaJF+wDiw==}
     cpu: [x64]
     os: [linux]
     libc: [musl]
 
-  '@img/sharp-linux-arm64@0.35.2':
-    resolution: {integrity: sha512-af12Pnd0ZGu2HfP8NayB0kk6eC/lrfbQE6HlR4jD+34wdJ1Vw9TF6TMn6ZvffT+WgqVsl0hRbmNvz2u/23VmwA==}
+  '@img/sharp-linux-arm64@0.35.4':
+    resolution: {integrity: sha512-De4jpEnAU8Hd5oT0j1G3uL4ZvTuipVMn7YC6vPaJhy6/7EwEae0SVAoBrUMYQbkLGDm85taVWwuPc1a44LTzCQ==}
     engines: {node: '>=20.9.0'}
     cpu: [arm64]
     os: [linux]
     libc: [glibc]
 
-  '@img/sharp-linux-arm@0.35.2':
-    resolution: {integrity: sha512-SE4kzF2mepn6z+6E7L6lsV8FzuLL6IPQdyX8ZiwROAG/G8td+hP/m7FsFPwidtrF19gvajuC9l6TxAVcsA4S7A==}
+  '@img/sharp-linux-arm@0.35.4':
+    resolution: {integrity: sha512-7OAS8gI0EReKGVN2HssHlM6umJgxF5VI3xN0p9FA91p/YO+ou5hiNghLdZ5BEHztwaaK5+bLKRf8x/o2L2nk9A==}
     engines: {node: '>=20.9.0'}
     cpu: [arm]
     os: [linux]
     libc: [glibc]
 
-  '@img/sharp-linux-ppc64@0.35.2':
-    resolution: {integrity: sha512-hYSBm7zcNtDCozCxQHYZJiu63b/bXsgRZuOxCIBZsStMM9Vap47iFHdbX4kCvQsblPB/k+clhELpdQJHQLSHvg==}
+  '@img/sharp-linux-ppc64@0.35.4':
+    resolution: {integrity: sha512-2oYZJeIl4kCcMGk4ouZVjnkCtFrpQFlNEtJ6GbxzhHQchwH0NH/qEb9ykmOl29dqwMq+JhFdZn+1ak2FKhI9fQ==}
     engines: {node: '>=20.9.0'}
     cpu: [ppc64]
     os: [linux]
     libc: [glibc]
 
-  '@img/sharp-linux-riscv64@0.35.2':
-    resolution: {integrity: sha512-qQt0Kc13+Hoan/Awq/qMSQw3L+RI1NCRPgD5cUJ/1WSSmIoysLOc72jlRM3E0OHN9Yr313jgeQ2T+zW+F03QFA==}
+  '@img/sharp-linux-riscv64@0.35.4':
+    resolution: {integrity: sha512-cPbNChoRURAWdebDIHSenxRpgEdy7JkPydSnUxRm9VvKD7m0/xVaR/8Fzlu81pk5nHEvHH87UZUA7cTtwnbJSA==}
     engines: {node: '>=20.9.0'}
     cpu: [riscv64]
     os: [linux]
     libc: [glibc]
 
-  '@img/sharp-linux-s390x@0.35.2':
-    resolution: {integrity: sha512-E4fLLfRPzDLlEeDaTzI98OFLcv++WL5ChLLMwPoVd0CIoZQqupBSNbOisPL5am9XsbQ9T84+iiMpUvbFtkunbA==}
+  '@img/sharp-linux-s390x@0.35.4':
+    resolution: {integrity: sha512-RY0JFY8Fd6RonCBtHz+DvadaPkXDSI1AUn6yWL9TipqkZ1vY8w8evqdgyDFnkm4/K1ve1TvZiaePP5oSd4+WVQ==}
     engines: {node: '>=20.9.0'}
     cpu: [s390x]
     os: [linux]
     libc: [glibc]
 
-  '@img/sharp-linux-x64@0.35.2':
-    resolution: {integrity: sha512-gi0zFJJRLswfCZmHtJdikXPOc5u7qamSOS3NHedLqLd4W8Q0NqjdBr6TTRIgsfFjqfTsHFgdfvJ9LwqSgcHiAA==}
+  '@img/sharp-linux-x64@0.35.4':
+    resolution: {integrity: sha512-9qvvEAuk8k89TfWUoX2htWjbAMX8p+NxCppjpcg5k6xMsjhBQPTsoIh36h9Qde4WRuGpJeYnOjdosDn/cnv+OA==}
     engines: {node: '>=20.9.0'}
     cpu: [x64]
     os: [linux]
     libc: [glibc]
 
-  '@img/sharp-linuxmusl-arm64@0.35.2':
-    resolution: {integrity: sha512-siWbOW1u6HFnFLrp0waKyW7VEf7jYvcDWdrXEFa8AkdAQgEvuu5Fz8/Y70w9EeqAdwDtfU012BhEHHaDqvQNzg==}
+  '@img/sharp-linuxmusl-arm64@0.35.4':
+    resolution: {integrity: sha512-KB5jxpfWQTr0nc3xdHtWChdbifHrBGsd2SM62Eyxrl8afikm+f5qGBU75SJIZBT/S1MC8XyacdlXBMSWq6OURA==}
     engines: {node: '>=20.9.0'}
     cpu: [arm64]
     os: [linux]
     libc: [musl]
 
-  '@img/sharp-linuxmusl-x64@0.35.2':
-    resolution: {integrity: sha512-YBqMMcjDi4QGYiSn4vNOYBhmlC4z5AXqkOUUqI2e0AFA4urNv4ESgOgwNl3K+4etQhha0twXlzeF20bbULm9Yg==}
+  '@img/sharp-linuxmusl-x64@0.35.4':
+    resolution: {integrity: sha512-f+eZJZIQNEEd26RPSW+76chwOf1XtA2Y/O+5ocVyLliHkeih3e+jhLVBdNTd2rS3IbNXK8+ug93Vf5ZXtF5Lxg==}
     engines: {node: '>=20.9.0'}
     cpu: [x64]
     os: [linux]
     libc: [musl]
 
-  '@img/sharp-wasm32@0.35.2':
-    resolution: {integrity: sha512-Mrv4JQNYVQ94xH+jzZ9r+gowleN8mv2FTgKT+PI6bx5C0G8TdNYndu161pg2i7uoBwxy2ImPMHrJOM2LZef7Bw==}
+  '@img/sharp-wasm32@0.35.4':
+    resolution: {integrity: sha512-zQnl4Kwp7Q6NHsENtU2T/00Zi+w3AQNwz3+UaTyVBy2FpXrzXzGjndpK61onhZjRtRpQXxCTeqw19bVyXOh7jA==}
     engines: {node: '>=20.9.0'}
 
-  '@img/sharp-webcontainers-wasm32@0.35.2':
-    resolution: {integrity: sha512-QNV27pxs9wpApEiCfvHM1RDoP1w1+2KrUWWDPEhEwg+latvOrfuhWrHWZKwdSFwU6jh3myjw/yOCRsUIuOft3g==}
+  '@img/sharp-webcontainers-wasm32@0.35.4':
+    resolution: {integrity: sha512-ESfNkywmCfPNyaZjxooddJQiQ+l/nTpGEOGthxiLnIHXC/CmcBixnfwUleX9mCz9ovrUUvKMap/pm8RYbzfwaA==}
     engines: {node: '>=20.9.0'}
     cpu: [wasm32]
 
-  '@img/sharp-win32-arm64@0.35.2':
-    resolution: {integrity: sha512-BiVRYc/t6/Vl3e1hBx0hugG4oN9Pydf4fgMSpxTQJmwGUg/YoXTWHiFeRymHfCZzifxu4F4rpk/I67D0LQ20wQ==}
+  '@img/sharp-win32-arm64@0.35.4':
+    resolution: {integrity: sha512-iNdlBX9gLVvqe2I3uIJSIKTq6wckP/DYxZtcqxm09x5Gi24DnFBmPAWZmr60ZyYMG0xlzo6goG3670ar+RXvRw==}
     engines: {node: '>=20.9.0'}
     cpu: [arm64]
     os: [win32]
 
-  '@img/sharp-win32-ia32@0.35.2':
-    resolution: {integrity: sha512-YYEhx9PImCC7T0tI8JDMi4DB9LwLCXCU5OWNYEXAxh5Q1ShKkyC6byxzoBJ3gEFDnH2lQckWuDe70G7mB2XJog==}
+  '@img/sharp-win32-ia32@0.35.4':
+    resolution: {integrity: sha512-kqRsbaa5CS6KHlpxnN7WhE6vAAugXyZButpRdvDWetlv6Qv4N9WTcrWzF7tXfB9T7MsoadqdI8hmwLq6UlLvtw==}
     engines: {node: ^20.9.0}
     cpu: [ia32]
     os: [win32]
 
-  '@img/sharp-win32-x64@0.35.2':
-    resolution: {integrity: sha512-imoOyBcoM/iiUr4J6VPpCNjPnjvP/Gks95898yB8YqoGGYmHYbOyCuNv9FMhFgtaiHFGbHW8bxKqRV6VjtXThQ==}
+  '@img/sharp-win32-x64@0.35.4':
+    resolution: {integrity: sha512-XtmnYhBcrORsJ4XJngyzr/EWP0hRZLAZRFaApdKuviyqF78+ylxh2y06ZmtULAMOnObJ3ucpN0AcwSWnMowTRg==}
     engines: {node: '>=20.9.0'}
     cpu: [x64]
     os: [win32]
@@ -3274,8 +3275,8 @@ packages:
   js-tokens@10.0.0:
     resolution: {integrity: sha512-lM/UBzQmfJRo9ABXbPWemivdCW8V2G8FHaHdypQaIy523snUjog0W71ayWXTjiR+ixeMyVHN2XcpnTd/liPg/Q==}
 
-  js-yaml@4.3.1:
-    resolution: {integrity: sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==}
+  js-yaml@4.3.2:
+    resolution: {integrity: sha512-SFNOvSJ+Dgf/9An904Yx+CgSlIPCkIpao4qo51lpee25TIRejdH3rhR4EZMGoNx3/TP3O+wzWuiTFl4sqbltzA==}
     hasBin: true
 
   jsdoc-type-pratt-parser@9.1.2:
@@ -3934,9 +3935,14 @@ packages:
   setprototypeof@1.2.0:
     resolution: {integrity: sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==}
 
-  sharp@0.35.2:
-    resolution: {integrity: sha512-FVtFjtBCMiJS6yb5CX7Sop45WFMpeGw6oRKuJnXYgf/f1ms/D7LE/ZUSNxnW7rZ/dbslQWYkoqFHGPaDBtaK4w==}
+  sharp@0.35.4:
+    resolution: {integrity: sha512-n++8XWcj+jCOr2IOl7h8LbKnGBDY4aPbmprMONBNFdn0ImXqpGVv5zliDs0V9HbmbCQLpbuo2ej9rAoOQTvMDA==}
     engines: {node: '>=20.9.0'}
+    peerDependencies:
+      '@types/node': '*'
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
 
   shebang-command@2.0.0:
     resolution: {integrity: sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==}
@@ -5207,108 +5213,108 @@ snapshots:
 
   '@img/colour@1.1.0': {}
 
-  '@img/sharp-darwin-arm64@0.35.2':
+  '@img/sharp-darwin-arm64@0.35.4':
     optionalDependencies:
-      '@img/sharp-libvips-darwin-arm64': 1.3.1
+      '@img/sharp-libvips-darwin-arm64': 1.3.3
     optional: true
 
-  '@img/sharp-darwin-x64@0.35.2':
+  '@img/sharp-darwin-x64@0.35.4':
     optionalDependencies:
-      '@img/sharp-libvips-darwin-x64': 1.3.1
+      '@img/sharp-libvips-darwin-x64': 1.3.3
     optional: true
 
-  '@img/sharp-freebsd-wasm32@0.35.2':
+  '@img/sharp-freebsd-wasm32@0.35.4':
     dependencies:
-      '@img/sharp-wasm32': 0.35.2
+      '@img/sharp-wasm32': 0.35.4
     optional: true
 
-  '@img/sharp-libvips-darwin-arm64@1.3.1':
+  '@img/sharp-libvips-darwin-arm64@1.3.3':
     optional: true
 
-  '@img/sharp-libvips-darwin-x64@1.3.1':
+  '@img/sharp-libvips-darwin-x64@1.3.3':
     optional: true
 
-  '@img/sharp-libvips-linux-arm64@1.3.1':
+  '@img/sharp-libvips-linux-arm64@1.3.3':
     optional: true
 
-  '@img/sharp-libvips-linux-arm@1.3.1':
+  '@img/sharp-libvips-linux-arm@1.3.3':
     optional: true
 
-  '@img/sharp-libvips-linux-ppc64@1.3.1':
+  '@img/sharp-libvips-linux-ppc64@1.3.3':
     optional: true
 
-  '@img/sharp-libvips-linux-riscv64@1.3.1':
+  '@img/sharp-libvips-linux-riscv64@1.3.3':
     optional: true
 
-  '@img/sharp-libvips-linux-s390x@1.3.1':
+  '@img/sharp-libvips-linux-s390x@1.3.3':
     optional: true
 
-  '@img/sharp-libvips-linux-x64@1.3.1':
+  '@img/sharp-libvips-linux-x64@1.3.3':
     optional: true
 
-  '@img/sharp-libvips-linuxmusl-arm64@1.3.1':
+  '@img/sharp-libvips-linuxmusl-arm64@1.3.3':
     optional: true
 
-  '@img/sharp-libvips-linuxmusl-x64@1.3.1':
+  '@img/sharp-libvips-linuxmusl-x64@1.3.3':
     optional: true
 
-  '@img/sharp-linux-arm64@0.35.2':
+  '@img/sharp-linux-arm64@0.35.4':
     optionalDependencies:
-      '@img/sharp-libvips-linux-arm64': 1.3.1
+      '@img/sharp-libvips-linux-arm64': 1.3.3
     optional: true
 
-  '@img/sharp-linux-arm@0.35.2':
+  '@img/sharp-linux-arm@0.35.4':
     optionalDependencies:
-      '@img/sharp-libvips-linux-arm': 1.3.1
+      '@img/sharp-libvips-linux-arm': 1.3.3
     optional: true
 
-  '@img/sharp-linux-ppc64@0.35.2':
+  '@img/sharp-linux-ppc64@0.35.4':
     optionalDependencies:
-      '@img/sharp-libvips-linux-ppc64': 1.3.1
+      '@img/sharp-libvips-linux-ppc64': 1.3.3
     optional: true
 
-  '@img/sharp-linux-riscv64@0.35.2':
+  '@img/sharp-linux-riscv64@0.35.4':
     optionalDependencies:
-      '@img/sharp-libvips-linux-riscv64': 1.3.1
+      '@img/sharp-libvips-linux-riscv64': 1.3.3
     optional: true
 
-  '@img/sharp-linux-s390x@0.35.2':
+  '@img/sharp-linux-s390x@0.35.4':
     optionalDependencies:
-      '@img/sharp-libvips-linux-s390x': 1.3.1
+      '@img/sharp-libvips-linux-s390x': 1.3.3
     optional: true
 
-  '@img/sharp-linux-x64@0.35.2':
+  '@img/sharp-linux-x64@0.35.4':
     optionalDependencies:
-      '@img/sharp-libvips-linux-x64': 1.3.1
+      '@img/sharp-libvips-linux-x64': 1.3.3
     optional: true
 
-  '@img/sharp-linuxmusl-arm64@0.35.2':
+  '@img/sharp-linuxmusl-arm64@0.35.4':
     optionalDependencies:
-      '@img/sharp-libvips-linuxmusl-arm64': 1.3.1
+      '@img/sharp-libvips-linuxmusl-arm64': 1.3.3
     optional: true
 
-  '@img/sharp-linuxmusl-x64@0.35.2':
+  '@img/sharp-linuxmusl-x64@0.35.4':
     optionalDependencies:
-      '@img/sharp-libvips-linuxmusl-x64': 1.3.1
+      '@img/sharp-libvips-linuxmusl-x64': 1.3.3
     optional: true
 
-  '@img/sharp-wasm32@0.35.2':
+  '@img/sharp-wasm32@0.35.4':
     dependencies:
       '@emnapi/runtime': 1.11.3
     optional: true
 
-  '@img/sharp-webcontainers-wasm32@0.35.2':
+  '@img/sharp-webcontainers-wasm32@0.35.4':
     dependencies:
-      '@img/sharp-wasm32': 0.35.2
+      '@img/sharp-wasm32': 0.35.4
     optional: true
 
-  '@img/sharp-win32-arm64@0.35.2':
+  '@img/sharp-win32-arm64@0.35.4':
     optional: true
 
-  '@img/sharp-win32-ia32@0.35.2':
+  '@img/sharp-win32-ia32@0.35.4':
     optional: true
 
-  '@img/sharp-win32-x64@0.35.2':
+  '@img/sharp-win32-x64@0.35.4':
     optional: true
 
   '@inquirer/checkbox@3.0.1':
@@ -6572,7 +6578,7 @@ snapshots:
       '@bytecodealliance/preview2-shim': 0.17.6
       '@renovatebot/pep440': 4.2.1
       fs-extra: 11.1.1
-      js-yaml: 4.3.1
+      js-yaml: 4.3.2
       minimatch: 10.2.3
       smol-toml: 1.6.1
       zod: 3.22.4
@@ -7753,7 +7759,7 @@ snapshots:
 
   js-tokens@10.0.0: {}
 
-  js-yaml@4.3.1:
+  js-yaml@4.3.2:
     dependencies:
       argparse: 2.0.1
 
@@ -7928,15 +7934,16 @@ snapshots:
 
   mimic-fn@2.1.0: {}
 
-  miniflare@5.20260903.0-alpha:
+  miniflare@5.20260903.0-alpha(@types/node@22.20.1):
     dependencies:
       '@cspotcode/source-map-support': 0.8.1
-      sharp: 0.35.2
+      sharp: 0.35.4(@types/node@22.20.1)
       undici: 7.29.0
       workerd: 1.20260903.1
       ws: 8.21.0
       youch: 4.1.0-beta.10
     transitivePeerDependencies:
+      - '@types/node'
       - bufferutil
       - utf-8-validate
 
@@ -8420,37 +8427,38 @@ snapshots:
 
   setprototypeof@1.2.0: {}
 
-  sharp@0.35.2:
+  sharp@0.35.4(@types/node@22.20.1):
     dependencies:
       '@img/colour': 1.1.0
       detect-libc: 2.1.2
       semver: 7.8.5
     optionalDependencies:
-      '@img/sharp-darwin-arm64': 0.35.2
-      '@img/sharp-darwin-x64': 0.35.2
-      '@img/sharp-freebsd-wasm32': 0.35.2
-      '@img/sharp-libvips-darwin-arm64': 1.3.1
-      '@img/sharp-libvips-darwin-x64': 1.3.1
-      '@img/sharp-libvips-linux-arm': 1.3.1
-      '@img/sharp-libvips-linux-arm64': 1.3.1
-      '@img/sharp-libvips-linux-ppc64': 1.3.1
-      '@img/sharp-libvips-linux-riscv64': 1.3.1
-      '@img/sharp-libvips-linux-s390x': 1.3.1
-      '@img/sharp-libvips-linux-x64': 1.3.1
-      '@img/sharp-libvips-linuxmusl-arm64': 1.3.1
-      '@img/sharp-libvips-linuxmusl-x64': 1.3.1
-      '@img/sharp-linux-arm': 0.35.2
-      '@img/sharp-linux-arm64': 0.35.2
-      '@img/sharp-linux-ppc64': 0.35.2
-      '@img/sharp-linux-riscv64': 0.35.2
-      '@img/sharp-linux-s390x': 0.35.2
-      '@img/sharp-linux-x64': 0.35.2
-      '@img/sharp-linuxmusl-arm64': 0.35.2
-      '@img/sharp-linuxmusl-x64': 0.35.2
-      '@img/sharp-webcontainers-wasm32': 0.35.2
-      '@img/sharp-win32-arm64': 0.35.2
-      '@img/sharp-win32-ia32': 0.35.2
-      '@img/sharp-win32-x64': 0.35.2
+      '@img/sharp-darwin-arm64': 0.35.4
+      '@img/sharp-darwin-x64': 0.35.4
+      '@img/sharp-freebsd-wasm32': 0.35.4
+      '@img/sharp-libvips-darwin-arm64': 1.3.3
+      '@img/sharp-libvips-darwin-x64': 1.3.3
+      '@img/sharp-libvips-linux-arm': 1.3.3
+      '@img/sharp-libvips-linux-arm64': 1.3.3
+      '@img/sharp-libvips-linux-ppc64': 1.3.3
+      '@img/sharp-libvips-linux-riscv64': 1.3.3
+      '@img/sharp-libvips-linux-s390x': 1.3.3
+      '@img/sharp-libvips-linux-x64': 1.3.3
+      '@img/sharp-libvips-linuxmusl-arm64': 1.3.3
+      '@img/sharp-libvips-linuxmusl-x64': 1.3.3
+      '@img/sharp-linux-arm': 0.35.4
+      '@img/sharp-linux-arm64': 0.35.4
+      '@img/sharp-linux-ppc64': 0.35.4
+      '@img/sharp-linux-riscv64': 0.35.4
+      '@img/sharp-linux-s390x': 0.35.4
+      '@img/sharp-linux-x64': 0.35.4
+      '@img/sharp-linuxmusl-arm64': 0.35.4
+      '@img/sharp-linuxmusl-x64': 0.35.4
+      '@img/sharp-webcontainers-wasm32': 0.35.4
+      '@img/sharp-win32-arm64': 0.35.4
+      '@img/sharp-win32-ia32': 0.35.4
+      '@img/sharp-win32-x64': 0.35.4
+      '@types/node': 22.20.1
 
   shebang-command@2.0.0:
     dependencies:
@@ -8907,19 +8915,20 @@ snapshots:
       '@cloudflare/workerd-linux-arm64': 1.20260903.1
       '@cloudflare/workerd-windows-64': 1.20260903.1
 
-  wrangler@4.129.0:
+  wrangler@4.129.0(@types/node@22.20.1):
     dependencies:
       '@cloudflare/kv-asset-handler': 0.5.0
       '@cloudflare/unenv-preset': 2.16.1(unenv@2.0.0-rc.24)(workerd@1.20260903.1)
       blake3-wasm: 2.1.5
       esbuild: 0.28.1
-      miniflare: 5.20260903.0-alpha
+      miniflare: 5.20260903.0-alpha(@types/node@22.20.1)
       path-to-regexp: 6.3.0
       unenv: 2.0.0-rc.24
       workerd: 1.20260903.1
     optionalDependencies:
       fsevents: 2.3.3
     transitivePeerDependencies:
+      - '@types/node'
       - bufferutil
       - utf-8-validate
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -45,7 +45,7 @@ overrides:
   '@vercel/hono>path-to-regexp': 8.4.0
   '@vercel/node>path-to-regexp': 6.3.0
   '@vercel/node>undici': 6.28.0
-  '@vercel/python-analysis>js-yaml': 4.3.1
+  '@vercel/python-analysis>js-yaml': 4.3.2
   '@vercel/python-analysis>minimatch': 10.2.3
   '@vercel/python-analysis>smol-toml': 1.6.1
   '@vercel/remix-builder>path-to-regexp': 6.3.0
@@ -61,3 +61,7 @@ overrides:
   # fast-uri host-confusion/SSRF advisories and the qs array-limit/DoS advisories.
   fast-uri: '>=3.1.6 <4'
   qs: '>=6.16.0'
+  # Dev-only transitive dep via miniflare/wrangler; force the patched build off
+  # the libheif advisories bundled in sharp <0.35.4 (GHSA-g89c-p67h-r497,
+  # GHSA-2jg2-4ch7-h545). The Worker smoke never invokes sharp's image codecs.
+  'miniflare>sharp': '>=0.35.4'

--- a/src/b2/insights.ts
+++ b/src/b2/insights.ts
@@ -294,6 +294,21 @@ const REPORT_SCAN_LIMITS = {
   concurrency: 1,
 };
 
+/**
+ * Wall-clock budget for the bounded native LIST scans behind
+ * `b2_list_largest_files` and `b2_unfinished_uploads`.
+ *
+ * @remarks
+ * B2 native listing has no server-side cap, so these scans stop after this
+ * budget and return truncated / lower-bound results rather than running for
+ * minutes. Exported as the single source of truth so both scan paths — and the
+ * deadline coverage tests — share one value instead of hand-copying the
+ * literal. (The report-CSV scan tracks its own `REPORT_SCAN_LIMITS.maxElapsedMs`
+ * budget, which is a separate subsystem that merely happens to share this
+ * value.)
+ */
+export const NATIVE_SCAN_TIME_BUDGET_MS = 12_000;
+
 /** Counters captured while scanning and downloading usage reports. */
 interface ReportLoadStats {
   /** Report list pages visited. */
@@ -1344,7 +1359,7 @@ export function registerInsightTools(
         // rate-limited) LIST calls that run for minutes and time out. On a bound
         // hit we return what we have with truncated=true so the caller knows the
         // ranking covers only the objects scanned.
-        const TIME_BUDGET_MS = 12_000;
+        const TIME_BUDGET_MS = NATIVE_SCAN_TIME_BUDGET_MS;
         const startedAt = Date.now();
         const top: Array<{ name: string; size: number; uploaded?: Date }> = [];
         let smallest = -Infinity;
@@ -1470,7 +1485,7 @@ export function registerInsightTools(
         // rate-limited calls that hang and time out. Cap the uploads walked and
         // put an overall wall-clock budget over the parts summation; report
         // truncated / lower-bound results instead of failing.
-        const TIME_BUDGET_MS = 12_000;
+        const TIME_BUDGET_MS = NATIVE_SCAN_TIME_BUDGET_MS;
         const startedAt = Date.now();
         const overBudget = () => Date.now() - startedAt > TIME_BUDGET_MS;
 

--- a/tests/contract/test-layering.contract.test.ts
+++ b/tests/contract/test-layering.contract.test.ts
@@ -371,20 +371,20 @@ describe("test layer naming", () => {
     const ciWorkflow = readFileSync(join(root, ".github/workflows/test.yml"), "utf8");
 
     expect(vitestConfig).toMatch(
-      /thresholds:\s*{\s*statements:\s*94\.5,\s*branches:\s*89,\s*functions:\s*97\.5,\s*lines:\s*96\.7,?\s*}/,
+      /thresholds:\s*{\s*statements:\s*96,\s*branches:\s*92,\s*functions:\s*97\.7,\s*lines:\s*97\.4,?\s*}/,
     );
     expect(vitestConfig).toContain('include: ["src/**/*.ts"]');
     expect(vitestConfig).toContain('"html"');
     expect(vitestConfig).toContain('"lcov"');
     expect(vitestConfig).toContain('"cobertura"');
     expect(readme).toContain(
-      "coverage-S%2094.5%20%7C%20B%2089%20%7C%20F%2097.5%20%7C%20L%2096.7-brightgreen",
+      "coverage-S%2096%20%7C%20B%2092%20%7C%20F%2097.7%20%7C%20L%2097.4-brightgreen",
     );
     expect(testingGuide).toMatch(
-      /Global V8 coverage must remain at or above 94\.5% statements,\s*89% branches,\s*97\.5% functions, and 96\.7% lines\./,
+      /Global V8 coverage must remain at or above 96% statements,\s*92% branches,\s*97\.7% functions, and 97\.4% lines\./,
     );
     expect(ciWorkflow).toContain(
-      "Required: statements 94.5%, branches 89%, functions 97.5%, lines 96.7%.",
+      "Required: statements 96%, branches 92%, functions 97.7%, lines 97.4%.",
     );
   });
 

--- a/tests/observability/logger-fallback.observability.test.ts
+++ b/tests/observability/logger-fallback.observability.test.ts
@@ -22,6 +22,7 @@ const FALLBACK_PREFIX = "b2-mcp:";
 let logFileCounter = 0;
 const createdLogFiles: string[] = [];
 let envSnapshot: NodeJS.ProcessEnv;
+let sighupListeners: Set<NodeJS.SignalsListener>;
 
 interface FakeDestOptions {
   throwOnWrite?: boolean;
@@ -187,12 +188,21 @@ function emitSighup(): void {
 describe("observability logger fallback paths", () => {
   beforeEach(() => {
     envSnapshot = { ...process.env };
+    // Snapshot pre-existing SIGHUP listeners so afterEach removes only the
+    // handler this suite's fresh module installs registered, never listeners
+    // owned by other suites sharing the Vitest worker.
+    sighupListeners = new Set(process.listeners("SIGHUP"));
   });
 
   afterEach(() => {
-    // Detach the SIGHUP handler each fresh module install registered so
-    // reloaded module state cannot leak across tests.
-    process.removeAllListeners("SIGHUP");
+    // Detach only the SIGHUP handler each fresh module install registered so
+    // reloaded module state cannot leak across tests, without disturbing
+    // listeners registered outside this suite.
+    for (const listener of process.listeners("SIGHUP")) {
+      if (!sighupListeners.has(listener)) {
+        process.off("SIGHUP", listener as NodeJS.SignalsListener);
+      }
+    }
     vi.restoreAllMocks();
     vi.doUnmock("pino");
     vi.doUnmock("../../src/utils/secret-sanitizer");

--- a/tests/observability/logger-fallback.observability.test.ts
+++ b/tests/observability/logger-fallback.observability.test.ts
@@ -1,0 +1,477 @@
+import { rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+/**
+ * Scenario tests for the managed B2_LOG_FILE destination fallback paths in
+ * `src/utils/logger.ts`. These exercise the write/flush/flushSync error
+ * branches, the SIGHUP rotation reopen paths, sanitizer-failure censoring, and
+ * the level default resolution.
+ *
+ * The strategy is a *partial* pino mock: the real pino runs (so the
+ * `logMethod` sanitizer hook and JSON serialization behave exactly like
+ * production), but `pino.destination` is overridden to return a controllable
+ * fake stream whose write/flush/flushSync/error emission can be steered per
+ * test. Each test loads a fresh logger module via `vi.resetModules()` +
+ * dynamic import so the module-level logging state starts clean.
+ */
+
+const FALLBACK_PREFIX = "b2-mcp:";
+
+let logFileCounter = 0;
+const createdLogFiles: string[] = [];
+let envSnapshot: NodeJS.ProcessEnv;
+
+interface FakeDestOptions {
+  throwOnWrite?: boolean;
+  throwOnFlush?: boolean;
+  throwOnFlushSync?: boolean;
+  flushNever?: boolean;
+  doubleFlushCb?: boolean;
+  flushError?: Error;
+  hasFlush?: boolean;
+  hasOff?: boolean;
+  hasRemoveListener?: boolean;
+  /** When set, throwing operations throw this raw (non-Error) value. */
+  throwValue?: unknown;
+}
+
+interface FakeDestination {
+  lines: string[];
+  calls: { write: number; flush: number; flushSync: number; destroy: number };
+  write(line: string): boolean;
+  flush?: (cb?: (err?: Error) => void) => void;
+  flushSync(): void;
+  destroy(): void;
+  on(event: "error", listener: (err: Error) => void): FakeDestination;
+  off?: (event: "error", listener: (err: Error) => void) => FakeDestination;
+  removeListener?: (event: "error", listener: (err: Error) => void) => FakeDestination;
+  emitError(err: Error): void;
+  listenerCount(): number;
+}
+
+function makeDest(opts: FakeDestOptions = {}): FakeDestination {
+  const errorListeners = new Set<(err: Error) => void>();
+  const calls = { write: 0, flush: 0, flushSync: 0, destroy: 0 };
+  const hasThrowValue = "throwValue" in opts;
+  const dest: FakeDestination = {
+    lines: [],
+    calls,
+    write(line: string) {
+      calls.write++;
+      if (opts.throwOnWrite) {
+        throw hasThrowValue ? opts.throwValue : new Error("fake write failure");
+      }
+      dest.lines.push(line);
+      return true;
+    },
+    flushSync() {
+      calls.flushSync++;
+      if (opts.throwOnFlushSync) {
+        throw hasThrowValue ? opts.throwValue : new Error("fake flushSync failure");
+      }
+    },
+    destroy() {
+      calls.destroy++;
+    },
+    on(event, listener) {
+      if (event === "error") errorListeners.add(listener);
+      return dest;
+    },
+    emitError(err: Error) {
+      for (const listener of [...errorListeners]) listener(err);
+    },
+    listenerCount() {
+      return errorListeners.size;
+    },
+  };
+  if (opts.hasFlush !== false) {
+    dest.flush = (cb) => {
+      calls.flush++;
+      if (opts.throwOnFlush) {
+        throw hasThrowValue ? opts.throwValue : new Error("fake flush failure");
+      }
+      if (opts.flushNever) return;
+      if (opts.doubleFlushCb) {
+        cb?.();
+        cb?.();
+        return;
+      }
+      cb?.(opts.flushError);
+    };
+  }
+  if (opts.hasOff !== false) {
+    dest.off = (event, listener) => {
+      if (event === "error") errorListeners.delete(listener);
+      return dest;
+    };
+  }
+  if (opts.hasRemoveListener !== false) {
+    dest.removeListener = (event, listener) => {
+      if (event === "error") errorListeners.delete(listener);
+      return dest;
+    };
+  }
+  return dest;
+}
+
+type LoggerModule = typeof import("../../src/utils/logger");
+
+interface LoadState {
+  capturedDest: unknown;
+  index: number;
+  made: FakeDestination[];
+}
+
+interface LoadResult {
+  mod: LoggerModule;
+  state: LoadState;
+  logFile: string;
+}
+
+/**
+ * Load a fresh logger module wired to a fake, file-backed destination.
+ *
+ * @param suppliers - Ordered destination factories; each `pino.destination`
+ *   call consumes the next (the last repeats). A supplier may throw to
+ *   simulate a failed reopen.
+ */
+async function loadFileLogger(
+  suppliers: Array<() => FakeDestination>,
+  { level = "info", nodeEnv = "test" }: { level?: string; nodeEnv?: string } = {},
+): Promise<LoadResult> {
+  vi.resetModules();
+  const state: LoadState = { capturedDest: undefined, index: 0, made: [] };
+
+  vi.doMock("pino", async () => {
+    const actual = (await vi.importActual("pino")) as {
+      default: (...args: unknown[]) => unknown;
+    };
+    const realPino = actual.default;
+    const fakePino = ((options: unknown, dest: unknown) => {
+      state.capturedDest = dest;
+      return realPino(options, dest);
+    }) as unknown as { (options: unknown, dest: unknown): unknown; destination: () => unknown };
+    fakePino.destination = () => {
+      const supplier = suppliers[state.index] ?? suppliers[suppliers.length - 1];
+      state.index++;
+      const dest = supplier();
+      state.made.push(dest);
+      return dest;
+    };
+    return { ...actual, default: fakePino };
+  });
+
+  process.env.LOG_LEVEL = level;
+  process.env.NODE_ENV = nodeEnv;
+  const logFile = join(tmpdir(), `logger-fallback-${process.pid}-${logFileCounter++}.log`);
+  createdLogFiles.push(logFile);
+  process.env.B2_LOG_FILE = logFile;
+
+  const mod = (await import("../../src/utils/logger")) as LoggerModule;
+  mod.initLogging();
+  return { mod, state, logFile };
+}
+
+function fallbackMessages(spy: ReturnType<typeof vi.spyOn>): string[] {
+  return (spy.mock.calls as unknown[][])
+    .map((call: unknown[]) => String(call[0]))
+    .filter((line: string) => line.startsWith(FALLBACK_PREFIX));
+}
+
+function emitSighup(): void {
+  (process.emit as (event: string) => boolean)("SIGHUP");
+}
+
+describe("observability logger fallback paths", () => {
+  beforeEach(() => {
+    envSnapshot = { ...process.env };
+  });
+
+  afterEach(() => {
+    // Detach the SIGHUP handler each fresh module install registered so
+    // reloaded module state cannot leak across tests.
+    process.removeAllListeners("SIGHUP");
+    vi.restoreAllMocks();
+    vi.doUnmock("pino");
+    vi.doUnmock("../../src/utils/secret-sanitizer");
+    vi.useRealTimers();
+    for (const key of Object.keys(process.env)) {
+      if (!(key in envSnapshot)) delete process.env[key];
+    }
+    Object.assign(process.env, envSnapshot);
+    for (const file of createdLogFiles.splice(0)) {
+      rmSync(file, { force: true });
+    }
+  });
+
+  it("resolves the log level default from LOG_LEVEL and the test flag", async () => {
+    vi.resetModules();
+    delete process.env.LOG_LEVEL;
+    process.env.NODE_ENV = "test";
+    const silent = (await import("../../src/utils/logger")) as LoggerModule;
+    expect(silent.logger.level).toBe("silent");
+
+    vi.resetModules();
+    delete process.env.LOG_LEVEL;
+    process.env.NODE_ENV = "production";
+    const info = (await import("../../src/utils/logger")) as LoggerModule;
+    expect(info.logger.level).toBe("info");
+
+    vi.resetModules();
+    process.env.LOG_LEVEL = "debug";
+    process.env.NODE_ENV = "test";
+    const explicit = (await import("../../src/utils/logger")) as LoggerModule;
+    expect(explicit.logger.level).toBe("debug");
+  });
+
+  it("censors string and object args when the sanitizer throws", async () => {
+    vi.resetModules();
+    vi.doMock("../../src/utils/secret-sanitizer", async () => {
+      const actual = await vi.importActual("../../src/utils/secret-sanitizer");
+      return {
+        ...actual,
+        sanitizeStructuredLogValue: () => {
+          throw new Error("sanitizer exploded");
+        },
+      };
+    });
+    process.env.LOG_LEVEL = "info";
+    process.env.NODE_ENV = "production";
+    delete process.env.B2_LOG_FILE;
+
+    const stderrSpy = vi.spyOn(process.stderr, "write").mockReturnValue(true);
+    const { logger } = (await import("../../src/utils/logger")) as LoggerModule;
+
+    logger.info("a plain string message");
+    logger.info({ nested: { secret: "value" } }, "an object message");
+
+    const written = stderrSpy.mock.calls.map((call) => String(call[0]));
+    const parsed = written
+      .filter((line) => line.trim().startsWith("{"))
+      .map((line) => JSON.parse(line) as Record<string, unknown>);
+
+    // String arg -> the failure sentinel becomes the log message.
+    const stringFailure = parsed.find((entry) => entry.msg === "[log_sanitizer_failed]");
+    expect(stringFailure, "string arg should be censored to the sentinel string").toBeTruthy();
+
+    // Object arg -> the failure sentinel is wrapped as { logSanitizer }.
+    const objectFailure = parsed.find((entry) => entry.logSanitizer === "[log_sanitizer_failed]");
+    expect(objectFailure, "object arg should be censored to a logSanitizer field").toBeTruthy();
+  });
+
+  it("falls back to stderr on write failure and throttles repeat reports", async () => {
+    const stderrSpy = vi.spyOn(process.stderr, "write").mockReturnValue(true);
+    const { mod } = await loadFileLogger([() => makeDest({ throwOnWrite: true })]);
+
+    mod.logger.info("first write triggers the fallback");
+    mod.logger.info("second write stays fallen back and is throttled");
+
+    const reports = fallbackMessages(stderrSpy);
+    const writeReports = reports.filter((line) => line.includes("write failed"));
+    expect(writeReports).toHaveLength(1);
+    expect(writeReports[0]).toContain("falling back to stderr");
+  });
+
+  it("routes flush(cb) through the proxy for normal, fallback, and no-flush destinations", async () => {
+    // Normal flush: destination.flush is invoked and the callback runs.
+    const normal = await loadFileLogger([() => makeDest()]);
+    const proxyNormal = normal.state.capturedDest as {
+      flush: (cb?: () => void) => void;
+    };
+    const normalCb = vi.fn();
+    proxyNormal.flush(normalCb);
+    expect(normalCb).toHaveBeenCalledTimes(1);
+    expect(normal.state.made[0].calls.flush).toBe(1);
+
+    // No-flush destination: proxy still resolves the callback.
+    const noFlush = await loadFileLogger([() => makeDest({ hasFlush: false })]);
+    const proxyNoFlush = noFlush.state.capturedDest as { flush: (cb?: () => void) => void };
+    const noFlushCb = vi.fn();
+    proxyNoFlush.flush(noFlushCb);
+    expect(noFlushCb).toHaveBeenCalledTimes(1);
+
+    // Fallback state: flush short-circuits to the callback without touching
+    // the (failed) destination.
+    vi.spyOn(process.stderr, "write").mockReturnValue(true);
+    const fallback = await loadFileLogger([() => makeDest({ throwOnWrite: true })]);
+    fallback.mod.logger.info("force fallback");
+    const proxyFallback = fallback.state.capturedDest as { flush: (cb?: () => void) => void };
+    const fallbackCb = vi.fn();
+    const flushCallsBefore = fallback.state.made[0].calls.flush;
+    proxyFallback.flush(fallbackCb);
+    expect(fallbackCb).toHaveBeenCalledTimes(1);
+    expect(fallback.state.made[0].calls.flush).toBe(flushCallsBefore);
+  });
+
+  it("flushLogsSync skips a failed destination and reports flushSync errors", async () => {
+    // Fallback: flushSync must not touch the destination once fallen back.
+    const stderrSpy = vi.spyOn(process.stderr, "write").mockReturnValue(true);
+    const fallback = await loadFileLogger([() => makeDest({ throwOnWrite: true })]);
+    fallback.mod.logger.info("force fallback");
+    const flushSyncBefore = fallback.state.made[0].calls.flushSync;
+    fallback.mod.flushLogsSync();
+    expect(fallback.state.made[0].calls.flushSync).toBe(flushSyncBefore);
+
+    stderrSpy.mockClear();
+
+    // Throwing flushSync is caught and reported, not propagated.
+    const throwing = await loadFileLogger([() => makeDest({ throwOnFlushSync: true })]);
+    expect(() => throwing.mod.flushLogsSync()).not.toThrow();
+    const reports = fallbackMessages(stderrSpy);
+    expect(reports.some((line) => line.includes("flush failed"))).toBe(true);
+  });
+
+  it("flushLogsSync flushes a healthy destination synchronously", async () => {
+    const healthy = await loadFileLogger([() => makeDest()]);
+    const before = healthy.state.made[0].calls.flushSync;
+    healthy.mod.flushLogsSync();
+    expect(healthy.state.made[0].calls.flushSync).toBe(before + 1);
+  });
+
+  it("rotates on SIGHUP, detaching via off and reporting retired-stream errors", async () => {
+    const stderrSpy = vi.spyOn(process.stderr, "write").mockReturnValue(true);
+    const loaded = await loadFileLogger([() => makeDest(), () => makeDest()]);
+
+    emitSighup();
+
+    // A second destination was opened and the first was destroyed + detached.
+    expect(loaded.state.made).toHaveLength(2);
+    const retired = loaded.state.made[0];
+    expect(retired.calls.destroy).toBe(1);
+    expect(retired.listenerCount()).toBe(1); // only the retired-error reporter remains
+
+    // The retired stream reports its first post-retirement error exactly once.
+    retired.emitError(new Error("late retired failure"));
+    retired.emitError(new Error("second late failure"));
+    const retiredReports = fallbackMessages(stderrSpy).filter((line) =>
+      line.includes("retired B2_LOG_FILE destination error"),
+    );
+    expect(retiredReports).toHaveLength(1);
+  });
+
+  it("detaches via removeListener when off is unavailable", async () => {
+    const loaded = await loadFileLogger([
+      () => makeDest({ hasOff: false }),
+      () => makeDest({ hasOff: false }),
+    ]);
+
+    const original = loaded.state.made[0];
+    emitSighup();
+
+    // The original write-error listener was removed via removeListener; only
+    // the retired-error reporter attached during retirement remains.
+    expect(loaded.state.made).toHaveLength(2);
+    expect(original.listenerCount()).toBe(1);
+  });
+
+  it("reports a reopen failure when re-opening the file throws", async () => {
+    const stderrSpy = vi.spyOn(process.stderr, "write").mockReturnValue(true);
+    await loadFileLogger([
+      () => makeDest({ hasFlush: false }),
+      () => {
+        throw new Error("reopen exploded");
+      },
+    ]);
+
+    emitSighup();
+
+    const reports = fallbackMessages(stderrSpy).filter((line) => line.includes("reopen failed"));
+    expect(reports).toHaveLength(1);
+    expect(reports[0]).toContain("falling back to stderr");
+  });
+
+  it("reports a flush failure surfaced during a bounded-flush reopen", async () => {
+    const stderrSpy = vi.spyOn(process.stderr, "write").mockReturnValue(true);
+    const loaded = await loadFileLogger([() => makeDest({ throwOnFlush: true }), () => makeDest()]);
+
+    emitSighup();
+
+    expect(loaded.state.made).toHaveLength(2); // reopen still succeeded
+    const reports = fallbackMessages(stderrSpy).filter((line) => line.includes("flush failed"));
+    expect(reports).toHaveLength(1);
+  });
+
+  it("ignores a double flush callback during reopen", async () => {
+    const loaded = await loadFileLogger([
+      () => makeDest({ doubleFlushCb: true }),
+      () => makeDest(),
+    ]);
+
+    emitSighup();
+
+    // Despite the destination invoking the flush callback twice, exactly one
+    // reopen (one new destination) happens.
+    expect(loaded.state.made).toHaveLength(2);
+  });
+
+  it("normalizes non-Error throw values from write, flushSync, flush, and reopen", async () => {
+    const stderrSpy = vi.spyOn(process.stderr, "write").mockReturnValue(true);
+
+    const write = await loadFileLogger([
+      () => makeDest({ throwOnWrite: true, throwValue: "raw write" }),
+    ]);
+    write.mod.logger.info("trigger raw write failure");
+
+    const flushSync = await loadFileLogger([
+      () => makeDest({ throwOnFlushSync: true, throwValue: "raw flushSync" }),
+    ]);
+    expect(() => flushSync.mod.flushLogsSync()).not.toThrow();
+
+    await loadFileLogger([
+      () => makeDest({ throwOnFlush: true, throwValue: "raw flush" }),
+      () => makeDest(),
+    ]);
+    emitSighup();
+
+    await loadFileLogger([
+      () => makeDest({ hasFlush: false }),
+      () => {
+        throw "raw reopen";
+      },
+    ]);
+    emitSighup();
+
+    const reports = fallbackMessages(stderrSpy);
+    expect(reports.some((line) => line.includes("write failed"))).toBe(true);
+    expect(reports.some((line) => line.includes("flush failed"))).toBe(true);
+    expect(reports.some((line) => line.includes("reopen failed"))).toBe(true);
+  });
+
+  it("initializes at most once and skips the file destination without B2_LOG_FILE", async () => {
+    vi.resetModules();
+    process.env.LOG_LEVEL = "info";
+    process.env.NODE_ENV = "production";
+    delete process.env.B2_LOG_FILE;
+
+    const mod = (await import("../../src/utils/logger")) as LoggerModule;
+    // No B2_LOG_FILE: the file-destination branch is skipped and stderr stays
+    // the active destination. A second call is a no-op (already initialized).
+    expect(() => {
+      mod.initLogging();
+      mod.initLogging();
+    }).not.toThrow();
+    // With no managed file destination, no SIGHUP handler was registered.
+    expect(process.listenerCount("SIGHUP")).toBe(0);
+  });
+
+  it("is idempotent when SIGHUP arrives mid-reopen and honors the flush timeout", async () => {
+    vi.spyOn(process.stderr, "write").mockReturnValue(true);
+    vi.useFakeTimers();
+    const loaded = await loadFileLogger([() => makeDest({ flushNever: true }), () => makeDest()]);
+
+    // First SIGHUP starts a reopen whose flush never calls back, so the reopen
+    // stays in progress.
+    emitSighup();
+    expect(loaded.state.made).toHaveLength(1);
+
+    // A second SIGHUP while the reopen is in progress is ignored.
+    emitSighup();
+    expect(loaded.state.made).toHaveLength(1);
+
+    // The bounded-flush timeout eventually fires and completes the reopen.
+    vi.advanceTimersByTime(1000);
+    expect(loaded.state.made).toHaveLength(2);
+  });
+});

--- a/tests/reliability/secret-sink-fs-faults.reliability.test.ts
+++ b/tests/reliability/secret-sink-fs-faults.reliability.test.ts
@@ -1,0 +1,654 @@
+/**
+ * Reliability-layer fault-injection coverage for the durable secret sink.
+ *
+ * These scenarios drive the filesystem fault-recovery and edge branches of
+ * `src/utils/secret-sink.ts` that the deterministic unit suite does not reach:
+ * error-cause coercion, symlink parent guards, canonicalization failures,
+ * torn-tail recovery, EEXIST claim races, and secret-scanning cycle detection.
+ * They combine real temp-dir fixtures with targeted `node:fs` fault injection
+ * (a module mock delegating to the real implementation except for the calls a
+ * test overrides), and assert the fail-safe behavior (reject, recover, or
+ * retain a pending claim) rather than merely executing the line.
+ */
+import { mkdtempSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+type FsOverride = (...args: unknown[]) => unknown;
+
+const fsMock = vi.hoisted(() => ({
+  overrides: {} as Record<string, FsOverride | undefined>,
+  actual: {} as typeof import("node:fs"),
+}));
+
+vi.mock("node:fs", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("node:fs")>();
+  Object.assign(fsMock.actual, actual);
+  const wrap =
+    (name: keyof typeof import("node:fs")) =>
+    (...args: unknown[]) => {
+      const override = fsMock.overrides[name as string];
+      if (override) return override(...args);
+      return (actual[name] as (...a: unknown[]) => unknown)(...args);
+    };
+  const realpathSync = ((...args: unknown[]) => {
+    const override = fsMock.overrides.realpathSync;
+    if (override) return override(...args);
+    return (actual.realpathSync as (...a: unknown[]) => unknown)(...args);
+  }) as unknown as typeof actual.realpathSync;
+  (realpathSync as { native: (...a: unknown[]) => unknown }).native = (...args: unknown[]) => {
+    const override = fsMock.overrides["realpathSync.native"];
+    if (override) return override(...args);
+    return (actual.realpathSync.native as (...a: unknown[]) => unknown)(...args);
+  };
+  return {
+    ...actual,
+    openSync: wrap("openSync"),
+    lstatSync: wrap("lstatSync"),
+    statSync: wrap("statSync"),
+    realpathSync,
+  };
+});
+
+import {
+  appendSecretSinkRecord,
+  durableSecretIdempotency,
+  durableSecretPostCreateFailure,
+  executeDurableSecretOperation,
+  resolveSecretSinkConfig,
+  secretSinkFileOpsForTests,
+  setSinkWriteForTests,
+} from "../../src/utils/secret-sink";
+import { logger } from "../../src/utils/logger";
+import * as fs from "node:fs";
+
+const PENDING_CLAIM_MARKER_SUFFIX = ".pending";
+const COMMITTED_MARKER_SUFFIX = ".committed.json";
+const O_DIRECTORY = fsMock.actual.constants.O_DIRECTORY;
+const O_EXCL = fsMock.actual.constants.O_EXCL;
+
+function tempDir(): string {
+  return mkdtempSync(join(tmpdir(), "b2-mcp-sink-fault-"));
+}
+
+function currentUid(): number {
+  return typeof process.getuid === "function" ? process.getuid() : 0;
+}
+
+function errno(code: string): NodeJS.ErrnoException {
+  return Object.assign(new Error(`simulated ${code}`), { code });
+}
+
+function clearFsOverrides(): void {
+  for (const key of Object.keys(fsMock.overrides)) delete fsMock.overrides[key];
+}
+
+function testIdempotency(idempotencyKey: string, normalizedInput?: unknown) {
+  return durableSecretIdempotency({
+    toolName: "b2_create_key",
+    idempotencyKey,
+    callerFingerprint: "credential-fingerprint",
+    normalizedInput: normalizedInput ?? {
+      keyName: idempotencyKey,
+      capabilities: ["listBuckets"],
+    },
+  });
+}
+
+function durableSecretOptions(
+  file: string,
+  idempotency: ReturnType<typeof durableSecretIdempotency>,
+  overrides: Partial<{
+    create: () => Promise<Record<string, unknown>>;
+    projectRedacted: (result: Record<string, unknown>, pointer: unknown) => unknown;
+  }> = {},
+) {
+  return {
+    secretSink: { mode: "file" as const, filePath: file },
+    toolName: "b2_create_key",
+    idempotency,
+    create:
+      overrides.create ??
+      (async () => ({
+        applicationKeyId: "key-id",
+        applicationKey: "B2_MCP_CANARY_SECRET_default",
+      })),
+    projectRedacted:
+      overrides.projectRedacted ??
+      ((result: Record<string, unknown>, pointer: unknown) => ({
+        ...result,
+        applicationKey: "[redacted]",
+        secretSink: pointer,
+      })),
+    projectInline: (result: Record<string, unknown>, warning: string) => ({
+      ...result,
+      warning,
+    }),
+  };
+}
+
+function loggedCalls(spy: { mock: { calls: unknown[][] } }): string {
+  return JSON.stringify(spy.mock.calls);
+}
+
+describe("secret sink filesystem fault recovery", () => {
+  afterEach(() => {
+    clearFsOverrides();
+    vi.restoreAllMocks();
+  });
+
+  it("coerces Error, non-Error, and object post-create failure causes", () => {
+    // String (non-Error, non-object) cause: message is coerced via String(),
+    // and the empty causeRecord leaves status/code undefined.
+    const stringCauseFailure = durableSecretPostCreateFailure(
+      { applicationKey: "B2_MCP_CANARY_SECRET_string_cause" },
+      "provider normalization failed",
+    ) as Error & { status?: unknown; code?: unknown; cause?: unknown };
+    expect(stringCauseFailure.message).toBe("provider normalization failed");
+    expect(stringCauseFailure.status).toBeUndefined();
+    expect(stringCauseFailure.code).toBeUndefined();
+    expect(stringCauseFailure.cause).toBe("provider normalization failed");
+
+    // Error cause: message comes from cause.message, and status/code are read
+    // off the (object) Error instance's own enumerable-ish properties.
+    const errorCause = Object.assign(new Error("normalization threw"), {
+      status: 422,
+      code: "bad_shape",
+    });
+    const errorCauseFailure = durableSecretPostCreateFailure(
+      { applicationKey: "B2_MCP_CANARY_SECRET_error_cause" },
+      errorCause,
+    ) as Error & { status?: unknown; code?: unknown; cause?: unknown };
+    expect(errorCauseFailure.message).toBe("normalization threw");
+    expect(errorCauseFailure.status).toBe(422);
+    expect(errorCauseFailure.code).toBe("bad_shape");
+    expect(errorCauseFailure.cause).toBe(errorCause);
+
+    // Plain object (non-Error) cause: message is String(cause), but status/code
+    // are still lifted from the object.
+    const objectCauseFailure = durableSecretPostCreateFailure(
+      { applicationKey: "B2_MCP_CANARY_SECRET_object_cause" },
+      { status: 409, code: "operation_status_unknown", message: "maybe created" },
+    ) as Error & { status?: unknown; code?: unknown };
+    expect(objectCauseFailure.message).toBe("[object Object]");
+    expect(objectCauseFailure.status).toBe(409);
+    expect(objectCauseFailure.code).toBe("operation_status_unknown");
+  });
+
+  it("recovers a post-create failure raised with a non-Error string cause", async () => {
+    vi.spyOn(logger, "fatal").mockImplementation(() => undefined as never);
+    const file = join(tempDir(), "secrets.jsonl");
+    const idempotency = testIdempotency("post-create-string-cause");
+
+    await expect(
+      executeDurableSecretOperation(
+        durableSecretOptions(file, idempotency, {
+          create: async () => {
+            throw durableSecretPostCreateFailure(
+              { applicationKey: "B2_MCP_CANARY_SECRET_post_create" },
+              "torn provider response",
+            );
+          },
+        }),
+      ),
+    ).rejects.toMatchObject({ status: 500, code: "secret_sink_projection_failed" });
+  });
+
+  it("rejects a parent that lstat reports as both a directory and a symlink", () => {
+    const file = join(tempDir(), "nested", "secrets.jsonl");
+    fsMock.overrides.lstatSync = () =>
+      ({
+        isDirectory: () => true,
+        isSymbolicLink: () => true,
+        uid: currentUid(),
+        mode: 0o700,
+      }) as unknown as fs.Stats;
+
+    expect(() =>
+      appendSecretSinkRecord({ mode: "file", filePath: file }, "b2_create_key", {
+        applicationKey: "B2_MCP_CANARY_SECRET_symlink_parent",
+      }),
+    ).toThrow(/parent must not be a symlink/);
+  });
+
+  it("propagates a non-ENOENT parent canonicalization failure for the log-file guard", () => {
+    const dir = tempDir();
+    const file = join(dir, "secrets.jsonl");
+    const logFile = join(dir, "b2.log");
+    fsMock.overrides["realpathSync.native"] = (target: unknown) => {
+      if (String(target) === file) throw errno("ENOENT");
+      if (String(target) === dir) throw errno("ENOTDIR");
+      return fsMock.actual.realpathSync.native(target as fs.PathLike);
+    };
+
+    expect(() =>
+      resolveSecretSinkConfig({
+        transport: "stdio",
+        env: { B2_SECRET_SINK: "file", B2_SECRET_SINK_FILE: file, B2_LOG_FILE: logFile },
+        preflight: false,
+      }),
+    ).toThrow(/simulated ENOTDIR/);
+  });
+
+  it("skips the directory-fd close when the parent directory fsync open fails", () => {
+    const dir = tempDir();
+    const file = join(dir, "secrets.jsonl");
+    fsMock.overrides.openSync = (path: unknown, flags: unknown, mode?: unknown) => {
+      if (typeof flags === "number" && (flags & O_DIRECTORY) !== 0) {
+        throw errno("EACCES");
+      }
+      return fsMock.actual.openSync(
+        path as fs.PathLike,
+        flags as number,
+        mode as fs.Mode | undefined,
+      );
+    };
+
+    // The directory descriptor is never opened, so the finally block must not
+    // dereference an undefined fd; the original EACCES is what surfaces.
+    expect(() =>
+      appendSecretSinkRecord({ mode: "file", filePath: file }, "b2_create_key", {
+        applicationKey: "B2_MCP_CANARY_SECRET_dir_open_fail",
+      }),
+    ).toThrow(/simulated EACCES/);
+  });
+
+  it("logs a pre-commit close failure that races a write failure", () => {
+    const warnSpy = vi.spyOn(logger, "warn").mockImplementation(() => undefined as never);
+    const dir = tempDir();
+    const file = join(dir, "secrets.jsonl");
+    fs.writeFileSync(file, "", { mode: 0o600 });
+    let realWrite!: (fd: number, buffer: Uint8Array, offset: number, length: number) => number;
+    // Fail only the ledger-record write (identified by its canary secret), so
+    // the append-lock write still succeeds and the ledger fd is reached.
+    realWrite = setSinkWriteForTests((fd, buffer, offset, length) => {
+      const text = Buffer.from(buffer.buffer, buffer.byteOffset, buffer.byteLength)
+        .subarray(offset, offset + length)
+        .toString("utf8");
+      if (text.includes("B2_MCP_CANARY_SECRET_write_and_close_fail")) {
+        throw new Error("simulated write failure");
+      }
+      return realWrite(fd, buffer, offset, length);
+    });
+    const restoreWrite = realWrite;
+    vi.spyOn(secretSinkFileOpsForTests, "closeSync").mockImplementation(() => {
+      throw new Error("simulated close failure");
+    });
+
+    try {
+      expect(() =>
+        appendSecretSinkRecord({ mode: "file", filePath: file }, "b2_create_key", {
+          applicationKey: "B2_MCP_CANARY_SECRET_write_and_close_fail",
+        }),
+      ).toThrow(/simulated write failure/);
+    } finally {
+      setSinkWriteForTests(restoreWrite);
+    }
+
+    expect(loggedCalls(warnSpy)).toContain("close_failed_before_commit");
+  });
+
+  it("omits undefined-valued fields when fingerprinting idempotent input", () => {
+    const withUndefined = durableSecretIdempotency({
+      toolName: "b2_create_key",
+      idempotencyKey: "undefined-field",
+      callerFingerprint: "credential-fingerprint",
+      normalizedInput: {
+        keyName: "undefined-field",
+        note: undefined,
+        capabilities: ["listBuckets"],
+      },
+    });
+    const withoutUndefined = durableSecretIdempotency({
+      toolName: "b2_create_key",
+      idempotencyKey: "undefined-field",
+      callerFingerprint: "credential-fingerprint",
+      normalizedInput: { keyName: "undefined-field", capabilities: ["listBuckets"] },
+    });
+
+    // An explicit `undefined` property is dropped by sortedJson, so the
+    // fingerprint matches the object that never carried the field.
+    expect(withUndefined.fingerprint).toBe(withoutUndefined.fingerprint);
+  });
+
+  it("truncates a trailing whitespace-only ledger fragment before reuse", async () => {
+    const warnSpy = vi.spyOn(logger, "warn").mockImplementation(() => undefined as never);
+    const dir = tempDir();
+    const file = join(dir, "secrets.jsonl");
+    const idempotency = testIdempotency("whitespace-tail");
+    const pointer = appendSecretSinkRecord(
+      { mode: "file", filePath: file },
+      "b2_create_key",
+      { applicationKeyId: "key-id", applicationKey: "B2_MCP_CANARY_SECRET_whitespace" },
+      idempotency,
+    );
+    // A torn append that left only trailing whitespace after the last newline.
+    fs.appendFileSync(file, "   ");
+    let createCalls = 0;
+
+    const result = await executeDurableSecretOperation(
+      durableSecretOptions(file, idempotency, {
+        create: async () => {
+          createCalls++;
+          return { applicationKey: "B2_MCP_CANARY_SECRET_duplicate" };
+        },
+      }),
+    );
+
+    expect(createCalls).toBe(0);
+    expect(result.structuredContent).toMatchObject({
+      applicationKeyId: "key-id",
+      applicationKey: "[redacted]",
+      secretSink: pointer,
+    });
+    expect(fs.readFileSync(file, "utf8").endsWith("\n")).toBe(true);
+    expect(loggedCalls(warnSpy)).toContain("incomplete_tail_truncated");
+  });
+
+  it("treats a vanished ledger as an empty tail during idempotency lookup", async () => {
+    const dir = tempDir();
+    const file = join(dir, "secrets.jsonl");
+    fs.writeFileSync(file, "", { mode: 0o600 });
+    const idempotency = testIdempotency("vanished-ledger");
+    fsMock.overrides.statSync = (path: unknown, options?: unknown) => {
+      if (String(path) === file) throw errno("ENOENT");
+      return fsMock.actual.statSync(path as fs.PathLike, options as fs.StatSyncOptions);
+    };
+    let createCalls = 0;
+
+    const result = await executeDurableSecretOperation(
+      durableSecretOptions(file, idempotency, {
+        create: async () => {
+          createCalls++;
+          return {
+            applicationKeyId: "key-id",
+            applicationKey: "B2_MCP_CANARY_SECRET_vanished",
+          };
+        },
+      }),
+    );
+
+    // ENOENT while reading the tail must fail safe to "no prior record" so the
+    // provider create still runs and the secret is stored.
+    expect(createCalls).toBe(1);
+    expect(result.structuredContent).toMatchObject({
+      applicationKeyId: "key-id",
+      applicationKey: "[redacted]",
+    });
+  });
+
+  it("retains a pending claim when the exclusive claim create loses an EEXIST race", async () => {
+    const dir = tempDir();
+    const file = join(dir, "secrets.jsonl");
+    const idempotency = testIdempotency("eexist-pending-race");
+    const pendingPath = `${file}.${idempotency.claimFingerprint}${PENDING_CLAIM_MARKER_SUFFIX}`;
+    let raced = false;
+    fsMock.overrides.openSync = (path: unknown, flags: unknown, mode?: unknown) => {
+      if (
+        !raced &&
+        String(path) === pendingPath &&
+        typeof flags === "number" &&
+        (flags & O_EXCL) !== 0
+      ) {
+        raced = true;
+        // A concurrent worker created the same pending claim first.
+        fsMock.actual.writeFileSync(pendingPath, `${JSON.stringify({ idempotency })}\n`, {
+          mode: 0o600,
+        });
+        throw errno("EEXIST");
+      }
+      return fsMock.actual.openSync(
+        path as fs.PathLike,
+        flags as number,
+        mode as fs.Mode | undefined,
+      );
+    };
+    let createCalls = 0;
+
+    await expect(
+      executeDurableSecretOperation(
+        durableSecretOptions(file, idempotency, {
+          create: async () => {
+            createCalls++;
+            return { applicationKey: "B2_MCP_CANARY_SECRET_duplicate" };
+          },
+        }),
+      ),
+    ).rejects.toMatchObject({ code: "idempotency_key_pending" });
+
+    expect(createCalls).toBe(0);
+    expect(raced).toBe(true);
+  });
+
+  it("rejects a conflicting pending claim that races claim creation", async () => {
+    const dir = tempDir();
+    const file = join(dir, "secrets.jsonl");
+    const idempotency = testIdempotency("eexist-conflict-race");
+    const conflicting = testIdempotency("eexist-conflict-race", {
+      keyName: "eexist-conflict-race",
+      capabilities: ["listBuckets", "writeFiles"],
+    });
+    const pendingPath = `${file}.${idempotency.claimFingerprint}${PENDING_CLAIM_MARKER_SUFFIX}`;
+    let raced = false;
+    fsMock.overrides.openSync = (path: unknown, flags: unknown, mode?: unknown) => {
+      if (
+        !raced &&
+        String(path) === pendingPath &&
+        typeof flags === "number" &&
+        (flags & O_EXCL) !== 0
+      ) {
+        raced = true;
+        fsMock.actual.writeFileSync(
+          pendingPath,
+          `${JSON.stringify({ idempotency: conflicting })}\n`,
+          { mode: 0o600 },
+        );
+        throw errno("EEXIST");
+      }
+      return fsMock.actual.openSync(
+        path as fs.PathLike,
+        flags as number,
+        mode as fs.Mode | undefined,
+      );
+    };
+
+    await expect(
+      executeDurableSecretOperation(
+        durableSecretOptions(file, idempotency, {
+          create: async () => ({ applicationKey: "B2_MCP_CANARY_SECRET_duplicate" }),
+        }),
+      ),
+    ).rejects.toMatchObject({ code: "idempotency_key_conflict" });
+    expect(raced).toBe(true);
+  });
+
+  it("returns a committed record that races exclusive claim creation", async () => {
+    const dir = tempDir();
+    const file = join(dir, "secrets.jsonl");
+    const idempotency = testIdempotency("eexist-committed-race");
+    const pendingPath = `${file}.${idempotency.claimFingerprint}${PENDING_CLAIM_MARKER_SUFFIX}`;
+    const committedPath = `${file}.${idempotency.claimFingerprint}${COMMITTED_MARKER_SUFFIX}`;
+    const pointer = { type: "file" as const, path: file, recordId: "raced-committed-record" };
+    let raced = false;
+    fsMock.overrides.openSync = (path: unknown, flags: unknown, mode?: unknown) => {
+      if (
+        !raced &&
+        String(path) === pendingPath &&
+        typeof flags === "number" &&
+        (flags & O_EXCL) !== 0
+      ) {
+        raced = true;
+        // A concurrent worker committed the same idempotency record first.
+        fsMock.actual.writeFileSync(
+          committedPath,
+          JSON.stringify({
+            ts: "2026-08-18T12:00:00Z",
+            tool: "b2_create_key",
+            recordId: pointer.recordId,
+            idempotency,
+            result: { applicationKeyId: "key-id", applicationKey: "[redacted]" },
+            pointer,
+          }),
+          { mode: 0o600 },
+        );
+        throw errno("EEXIST");
+      }
+      return fsMock.actual.openSync(
+        path as fs.PathLike,
+        flags as number,
+        mode as fs.Mode | undefined,
+      );
+    };
+    let createCalls = 0;
+
+    const result = await executeDurableSecretOperation(
+      durableSecretOptions(file, idempotency, {
+        create: async () => {
+          createCalls++;
+          return { applicationKey: "B2_MCP_CANARY_SECRET_duplicate" };
+        },
+      }),
+    );
+
+    expect(createCalls).toBe(0);
+    expect(raced).toBe(true);
+    expect(result.structuredContent).toMatchObject({
+      applicationKeyId: "key-id",
+      applicationKey: "[redacted]",
+      secretSink: pointer,
+    });
+  });
+
+  it("retries after a non-EEXIST reclaim-lock creation failure", () => {
+    const warnSpy = vi.spyOn(logger, "warn").mockImplementation(() => undefined as never);
+    const dir = tempDir();
+    const file = join(dir, "secrets.jsonl");
+    fs.writeFileSync(file, "", { mode: 0o600 });
+    const appendLock = `${file}.append.lock`;
+    const reclaimLock = `${appendLock}.reclaim`;
+    fs.writeFileSync(appendLock, `${JSON.stringify({ status: "appending" })}\n`, { mode: 0o600 });
+    const stale = new Date(Date.now() - 10 * 60 * 1000);
+    fs.utimesSync(appendLock, stale, stale);
+
+    let reclaimOpenFailed = false;
+    fsMock.overrides.openSync = (path: unknown, flags: unknown, mode?: unknown) => {
+      if (
+        !reclaimOpenFailed &&
+        String(path) === reclaimLock &&
+        typeof flags === "number" &&
+        (flags & O_EXCL) !== 0
+      ) {
+        // First attempt to grab the reclaim lock hits a transient FS error;
+        // acquireReclaimLock must warn and return null, and the append loop
+        // must sleep and retry rather than crash.
+        reclaimOpenFailed = true;
+        throw errno("EACCES");
+      }
+      return fsMock.actual.openSync(
+        path as fs.PathLike,
+        flags as number,
+        mode as fs.Mode | undefined,
+      );
+    };
+
+    const pointer = appendSecretSinkRecord({ mode: "file", filePath: file }, "b2_create_key", {
+      applicationKey: "B2_MCP_CANARY_SECRET_reclaim_lock_failed",
+    });
+
+    expect(reclaimOpenFailed).toBe(true);
+    expect(pointer.recordId).toEqual(expect.any(String));
+    expect(fs.existsSync(appendLock)).toBe(false);
+    expect(loggedCalls(warnSpy)).toContain("reclaim_lock_failed");
+    expect(loggedCalls(warnSpy)).toContain("stale_append_lock_reclaimed");
+  });
+
+  it("retries after a non-ENOENT stat error while reading a lock identity", () => {
+    const warnSpy = vi.spyOn(logger, "warn").mockImplementation(() => undefined as never);
+    const dir = tempDir();
+    const file = join(dir, "secrets.jsonl");
+    fs.writeFileSync(file, "", { mode: 0o600 });
+    const appendLock = `${file}.append.lock`;
+    fs.writeFileSync(appendLock, `${JSON.stringify({ status: "appending" })}\n`, { mode: 0o600 });
+    const stale = new Date(Date.now() - 10 * 60 * 1000);
+    fs.utimesSync(appendLock, stale, stale);
+
+    let statThrown = false;
+    fsMock.overrides.statSync = (path: unknown, options?: unknown) => {
+      if (!statThrown && String(path) === appendLock) {
+        // A transient stat error while reading the lock identity must bubble
+        // out of readLockIdentity, be treated as "not reclaimable this pass",
+        // and be retried rather than swallowed as a missing lock.
+        statThrown = true;
+        throw errno("EACCES");
+      }
+      return fsMock.actual.statSync(path as fs.PathLike, options as fs.StatSyncOptions);
+    };
+
+    const pointer = appendSecretSinkRecord({ mode: "file", filePath: file }, "b2_create_key", {
+      applicationKey: "B2_MCP_CANARY_SECRET_lock_stat_error",
+    });
+
+    expect(statThrown).toBe(true);
+    expect(pointer.recordId).toEqual(expect.any(String));
+    expect(fs.existsSync(appendLock)).toBe(false);
+    expect(loggedCalls(warnSpy)).toContain("stale_append_lock_reclaimed");
+  });
+
+  it("treats a lock that vanishes mid-reclaim as not reclaimable this pass", () => {
+    const warnSpy = vi.spyOn(logger, "warn").mockImplementation(() => undefined as never);
+    const dir = tempDir();
+    const file = join(dir, "secrets.jsonl");
+    fs.writeFileSync(file, "", { mode: 0o600 });
+    const appendLock = `${file}.append.lock`;
+    fs.writeFileSync(appendLock, `${JSON.stringify({ status: "appending" })}\n`, { mode: 0o600 });
+    const stale = new Date(Date.now() - 10 * 60 * 1000);
+    fs.utimesSync(appendLock, stale, stale);
+
+    let statMissed = false;
+    fsMock.overrides.statSync = (path: unknown, options?: unknown) => {
+      if (!statMissed && String(path) === appendLock) {
+        // The lock file disappeared between the EEXIST check and the identity
+        // read; readLockIdentity must report null so the pass yields no reclaim
+        // and the loop simply retries.
+        statMissed = true;
+        throw errno("ENOENT");
+      }
+      return fsMock.actual.statSync(path as fs.PathLike, options as fs.StatSyncOptions);
+    };
+
+    const pointer = appendSecretSinkRecord({ mode: "file", filePath: file }, "b2_create_key", {
+      applicationKey: "B2_MCP_CANARY_SECRET_lock_vanished",
+    });
+
+    expect(statMissed).toBe(true);
+    expect(pointer.recordId).toEqual(expect.any(String));
+    expect(fs.existsSync(appendLock)).toBe(false);
+    expect(loggedCalls(warnSpy)).toContain("stale_append_lock_reclaimed");
+  });
+
+  it("scans circular and getter-only result graphs when logging a sink failure", async () => {
+    vi.spyOn(logger, "fatal").mockImplementation(() => undefined as never);
+    const dir = tempDir();
+    const file = join(dir, "secrets.jsonl");
+    const idempotency = testIdempotency("circular-getter-result");
+    const circular: Record<string, unknown> = {
+      applicationKey: "B2_MCP_CANARY_SECRET_circular",
+    };
+    circular.self = circular;
+    Object.defineProperty(circular, "lazy", {
+      enumerable: true,
+      get: () => "getter-value",
+    });
+
+    await expect(
+      executeDurableSecretOperation(
+        durableSecretOptions(file, idempotency, {
+          create: async () => circular,
+          projectRedacted: () => {
+            throw new Error("projection boom");
+          },
+        }),
+      ),
+    ).rejects.toMatchObject({ status: 500, code: "secret_sink_projection_failed" });
+  });
+});

--- a/tests/runtime-security/http-fetch-handler-faults.runtime-security.test.ts
+++ b/tests/runtime-security/http-fetch-handler-faults.runtime-security.test.ts
@@ -1,0 +1,344 @@
+/**
+ * Runtime-security fault-path coverage for the runtime-neutral HTTP fetch
+ * handler (issue #400).
+ *
+ * These cases drive `createB2McpFetchHandler` directly with crafted Web
+ * `Request` objects and a stubbed MCP handler so the security-sensitive error
+ * branches — rate-limit rejection, credential-resolution failures, non-POST
+ * preflight, Host/Origin edge cases, and the body cap — are exercised
+ * deterministically without a network listener or real B2 credentials.
+ */
+
+import type { AuthInfo } from "@modelcontextprotocol/server";
+import {
+  type CredentialProvider,
+  type CredentialResolution,
+  CredentialResolutionError,
+} from "../../src/credentials";
+import { type B2McpFetchHandler, createB2McpFetchHandler } from "../../src/http-fetch-handler";
+import { MAX_MCP_BODY_BYTES } from "../../src/utils/http-body-limit";
+import { logger } from "../../src/utils/logger";
+import { _resetRateLimiter } from "../../src/utils/rate-limiter";
+
+const ISSUE = "issue-400-http-fetch-handler-faults";
+
+const META = {
+  "io.modelcontextprotocol/protocolVersion": "2026-07-28",
+  "io.modelcontextprotocol/clientCapabilities": {},
+};
+
+function modernBody(method: string, params: Record<string, unknown> = {}, id = 1): string {
+  return JSON.stringify({ jsonrpc: "2.0", id, method, params: { ...params, _meta: META } });
+}
+
+function modernHeaders(method: string, name?: string): Record<string, string> {
+  return {
+    "content-type": "application/json",
+    accept: "application/json, text/event-stream",
+    "mcp-protocol-version": "2026-07-28",
+    "mcp-method": method,
+    ...(name && { "mcp-name": name }),
+  };
+}
+
+function okMcpHandler() {
+  return {
+    fetch: vi.fn(
+      async () =>
+        new Response(JSON.stringify({ jsonrpc: "2.0", id: 1, result: { ok: true } }), {
+          status: 200,
+          headers: { "Content-Type": "application/json" },
+        }),
+    ),
+    close: vi.fn(),
+  };
+}
+
+function resolution(cacheKey = "credential:fixed"): CredentialResolution {
+  return {
+    config: {} as CredentialResolution["config"],
+    cacheKey,
+    capabilityCacheKey: `capability:${cacheKey}`,
+  };
+}
+
+/** Provider that always resolves to a fixed credential handle. */
+function fixedProvider(cacheKey = "credential:fixed"): CredentialProvider {
+  return {
+    name: "test-fixed",
+    resolve: () => resolution(cacheKey),
+    validateConfiguration: () => undefined,
+  };
+}
+
+/** Provider whose resolve() throws the supplied error. */
+function throwingProvider(err: unknown, name = "test-throwing"): CredentialProvider {
+  return {
+    name,
+    resolve: () => {
+      throw err;
+    },
+    validateConfiguration: () => undefined,
+  };
+}
+
+function post(body: string, headers: Record<string, string> = {}): Request {
+  return new Request("http://localhost/mcp", {
+    method: "POST",
+    headers: { host: "localhost", ...headers },
+    body,
+  });
+}
+
+let handler: B2McpFetchHandler | null = null;
+const savedEnv = { ...process.env };
+
+function build(options: Parameters<typeof createB2McpFetchHandler>[0] = {}): B2McpFetchHandler {
+  handler = createB2McpFetchHandler({
+    idleSweepMode: "request",
+    mcpHandler: okMcpHandler(),
+    fetchCapabilities: async () => null,
+    ...options,
+  });
+  return handler;
+}
+
+beforeEach(() => {
+  process.env = { ...savedEnv, NODE_ENV: "test" };
+  delete process.env.B2_ALLOWED_HOSTS;
+  delete process.env.B2_ALLOWED_ORIGINS;
+  _resetRateLimiter();
+});
+
+afterEach(async () => {
+  if (handler) {
+    await handler.close();
+    handler = null;
+  }
+  _resetRateLimiter();
+  vi.restoreAllMocks();
+  process.env = { ...savedEnv };
+});
+
+describe(`HTTP fetch handler fault paths (#400)`, () => {
+  it("rejects a non-POST/GET/DELETE method with 405 and an Allow header", async () => {
+    const h = build({ credentialProvider: fixedProvider() });
+    const res = await h.fetch(
+      new Request("http://localhost/mcp", { method: "PUT", headers: { host: "localhost" } }),
+    );
+    expect(res.status, `${ISSUE}: unsupported method must be 405`).toBe(405);
+    expect(res.headers.get("allow")).toBe("GET, POST, DELETE");
+  });
+
+  it("returns 413 when the POST body exceeds the 1 MiB cap", async () => {
+    const h = build({ credentialProvider: fixedProvider() });
+    const res = await h.fetch(
+      post("x".repeat(MAX_MCP_BODY_BYTES + 1), modernHeaders("tools/list")),
+    );
+    expect(res.status, `${ISSUE}: oversized body must return 413`).toBe(413);
+    expect(res.headers.get("connection")).toBe("close");
+  });
+
+  it("accepts an empty POST body and treats it as an empty JSON-RPC parse", async () => {
+    const h = build({ credentialProvider: fixedProvider() });
+    // Exercises the empty-body branch of parsedJsonBody without throwing.
+    const res = await h.fetch(post("", modernHeaders("tools/list")));
+    expect(res.status).not.toBe(413);
+    expect(res.status).not.toBe(500);
+  });
+
+  it("returns a typed JSON-RPC error status when credential resolution fails", async () => {
+    const warn = vi.spyOn(logger, "warn").mockImplementation(() => undefined as never);
+    const err = new CredentialResolutionError("nope", 401, "capability_auth_failed");
+    const h = build({ credentialProvider: throwingProvider(err) });
+    const res = await h.fetch(post(modernBody("tools/list"), modernHeaders("tools/list")));
+    expect(res.status, `${ISSUE}: typed credential error must surface its status`).toBe(401);
+    const body = JSON.parse(await res.text());
+    expect(body.error.data).toMatchObject({ code: "capability_auth_failed", status: 401 });
+    expect(warn.mock.calls.some(([, event]) => event === "credential.resolve.failed")).toBe(true);
+  });
+
+  it("returns a generic 500 when credential resolution throws a non-typed error", async () => {
+    vi.spyOn(logger, "warn").mockImplementation(() => undefined as never);
+    const h = build({ credentialProvider: throwingProvider(new Error("boom")) });
+    const res = await h.fetch(post(modernBody("tools/list"), modernHeaders("tools/list")));
+    expect(res.status, `${ISSUE}: non-typed credential error must be 500`).toBe(500);
+    const body = JSON.parse(await res.text());
+    expect(body.error.message).toBe("Credential resolution failed");
+    expect(body.error.data).toBeUndefined();
+  });
+
+  it("labels the principal from subject/issuer and principal auth-info shapes on failure", async () => {
+    const warn = vi.spyOn(logger, "warn").mockImplementation(() => undefined as never);
+    const h = build({ credentialProvider: throwingProvider(new Error("boom")) });
+
+    await h.fetch(post(modernBody("tools/list"), modernHeaders("tools/list")), {
+      authInfo: {
+        token: "t",
+        clientId: "c",
+        scopes: [],
+        extra: { subject: "subj", issuer: "iss" },
+      } as AuthInfo,
+    });
+    await h.fetch(post(modernBody("tools/list"), modernHeaders("tools/list")), {
+      authInfo: { token: "t", clientId: "c", scopes: [], extra: { principal: "pr" } } as AuthInfo,
+    });
+
+    const failures = warn.mock.calls.filter(([, event]) => event === "credential.resolve.failed");
+    expect(failures.length, `${ISSUE}: both principal shapes should log a failure`).toBe(2);
+    for (const [fields] of failures) {
+      expect((fields as Record<string, unknown>).principal).toBeTruthy();
+    }
+  });
+
+  it("enters discovery mode on missing credentials and rate-limits repeated discovery", async () => {
+    process.env.B2_MCP_RATE_LIMIT_RPS = "1";
+    process.env.B2_MCP_RATE_LIMIT_BURST = "1";
+    _resetRateLimiter();
+    const info = vi.spyOn(logger, "info").mockImplementation(() => undefined as never);
+    const err = new CredentialResolutionError("no creds", 401, "missing_credentials");
+    const h = build({ credentialProvider: throwingProvider(err) });
+
+    const first = await h.fetch(post(modernBody("tools/list"), modernHeaders("tools/list")), {
+      remoteAddress: "203.0.113.1",
+    });
+    const second = await h.fetch(post(modernBody("tools/list"), modernHeaders("tools/list")), {
+      remoteAddress: "203.0.113.2",
+    });
+
+    expect(first.status, `${ISSUE}: first discovery request should be served`).toBe(200);
+    expect(second.status, `${ISSUE}: shared discovery key must rate-limit`).toBe(429);
+    expect(info.mock.calls.some(([, event]) => event === "credential.discovery_mode")).toBe(true);
+  });
+
+  it("rate-limits repeated requests for the same resolved credential key", async () => {
+    process.env.B2_MCP_RATE_LIMIT_RPS = "1";
+    process.env.B2_MCP_RATE_LIMIT_BURST = "1";
+    _resetRateLimiter();
+    const h = build({ credentialProvider: fixedProvider("credential:shared") });
+
+    const first = await h.fetch(post(modernBody("tools/list"), modernHeaders("tools/list")), {
+      remoteAddress: "198.51.100.1",
+    });
+    const second = await h.fetch(post(modernBody("tools/list"), modernHeaders("tools/list")), {
+      remoteAddress: "198.51.100.2",
+    });
+
+    expect(first.status, `${ISSUE}: first credential request is served`).toBe(200);
+    expect(second.status, `${ISSUE}: exhausted credential bucket must return 429`).toBe(429);
+  });
+
+  it.each([
+    {
+      name: "no host header rejected",
+      env: {},
+      headers: {} as Record<string, string>,
+      noHost: true,
+      expected: 403,
+    },
+    {
+      name: "bare IPv6 loopback host allowed in localhost mode",
+      env: {},
+      headers: { host: "::1" },
+      expected: 200,
+    },
+    {
+      name: "malformed origin rejected in localhost mode",
+      env: {},
+      headers: { host: "localhost", origin: "http://[bad" },
+      expected: 403,
+    },
+    {
+      name: "bracketed IPv6 host without matching port rejected",
+      env: { B2_ALLOWED_HOSTS: "[::1]:8080" },
+      headers: { host: "[::1]" },
+      expected: 403,
+    },
+    {
+      name: "host+port allowlist match with origin port allowed",
+      env: { B2_ALLOWED_HOSTS: "mcp.example.com:8443" },
+      headers: { host: "mcp.example.com:8443", origin: "https://mcp.example.com:8443" },
+      expected: 200,
+    },
+    {
+      name: "malformed origin under host allowlist rejected",
+      env: { B2_ALLOWED_HOSTS: "mcp.example.com" },
+      headers: { host: "mcp.example.com", origin: "::::" },
+      expected: 403,
+    },
+    {
+      name: "empty-hostname origin under host allowlist rejected",
+      env: { B2_ALLOWED_HOSTS: "mcp.example.com" },
+      headers: { host: "mcp.example.com", origin: "file:///etc/passwd" },
+      expected: 403,
+    },
+  ])("host/origin policy: $name", async ({ env, headers, expected, noHost }) => {
+    for (const [key, value] of Object.entries(env)) process.env[key] = value as string;
+    const h = build({ credentialProvider: fixedProvider() });
+    const requestHeaders = noHost ? {} : { host: "localhost", ...headers };
+    const req = new Request("http://localhost/mcp", { method: "GET", headers: requestHeaders });
+    const res = await h.fetch(req);
+    expect(res.status, `${ISSUE}: host/origin case '${expected}'`).toBe(expected);
+  });
+
+  it("permits a loopback /health probe under a strict host allowlist", async () => {
+    process.env.B2_ALLOWED_HOSTS = "mcp.example.com";
+    const h = build({ credentialProvider: fixedProvider() });
+
+    const req = new Request("http://localhost/health", {
+      method: "GET",
+      headers: { host: "localhost" },
+    });
+    const res = await h.fetch(req, {
+      allowLoopbackHealthProbe: true,
+      remoteAddress: "::1",
+    });
+    expect(res.status, `${ISSUE}: loopback health probe should pass strict host policy`).toBe(200);
+    expect(JSON.parse(await res.text()).status).toBe("ok");
+  });
+
+  it("permits a loopback /health probe with a loopback Origin header", async () => {
+    process.env.B2_ALLOWED_HOSTS = "mcp.example.com";
+    const h = build({ credentialProvider: fixedProvider() });
+
+    const req = new Request("http://localhost/health", {
+      method: "GET",
+      headers: { host: "127.0.0.1", origin: "http://localhost" },
+    });
+    const res = await h.fetch(req, {
+      allowLoopbackHealthProbe: true,
+      remoteAddress: "127.0.0.1",
+    });
+    expect(res.status).toBe(200);
+  });
+
+  it("rejects a health probe when the remote address is not loopback", async () => {
+    process.env.B2_ALLOWED_HOSTS = "mcp.example.com";
+    const h = build({ credentialProvider: fixedProvider() });
+
+    const req = new Request("http://localhost/health", {
+      method: "GET",
+      headers: { host: "localhost" },
+    });
+    const res = await h.fetch(req, {
+      allowLoopbackHealthProbe: true,
+      // no remoteAddress -> isLoopbackRemoteAddress(undefined) is false
+    });
+    expect(res.status, `${ISSUE}: non-loopback health probe must fail closed`).toBe(403);
+  });
+
+  it("returns 503 while shutting down", async () => {
+    const h = build({ credentialProvider: fixedProvider() });
+    h.drain();
+    const res = await h.fetch(post(modernBody("tools/list"), modernHeaders("tools/list")));
+    expect(res.status, `${ISSUE}: draining server must refuse new work`).toBe(503);
+  });
+
+  it("returns 404 for unknown paths", async () => {
+    const h = build({ credentialProvider: fixedProvider() });
+    const res = await h.fetch(
+      new Request("http://localhost/nope", { method: "GET", headers: { host: "localhost" } }),
+    );
+    expect(res.status).toBe(404);
+  });
+});

--- a/tests/runtime-security/http-fetch-handler-faults.runtime-security.test.ts
+++ b/tests/runtime-security/http-fetch-handler-faults.runtime-security.test.ts
@@ -139,12 +139,41 @@ describe(`HTTP fetch handler fault paths (#400)`, () => {
     expect(res.headers.get("connection")).toBe("close");
   });
 
-  it("accepts an empty POST body and treats it as an empty JSON-RPC parse", async () => {
-    const h = build({ credentialProvider: fixedProvider() });
-    // Exercises the empty-body branch of parsedJsonBody without throwing.
+  it("routes an empty POST body through to the MCP handler with the contracted 200 envelope", async () => {
+    const mcpHandler = okMcpHandler();
+    const h = build({ credentialProvider: fixedProvider(), mcpHandler });
+    // The `/mcp` POST body is an untrusted-input boundary: an empty body is a
+    // valid empty JSON-RPC parse and must reach the handler with the exact
+    // contracted 200 + JSON-RPC envelope — not a partial/unauthenticated 2xx,
+    // redirect, or error. Pinning the status and shape (rather than only
+    // "not 413/500") makes a future malformed-input regression fail here.
     const res = await h.fetch(post("", modernHeaders("tools/list")));
-    expect(res.status).not.toBe(413);
-    expect(res.status).not.toBe(500);
+    expect(res.status, `${ISSUE}: empty body must yield the contracted 200`).toBe(200);
+    const body = JSON.parse(await res.text());
+    expect(body).toMatchObject({ jsonrpc: "2.0" });
+    expect(
+      mcpHandler.fetch,
+      `${ISSUE}: empty body must reach the MCP handler`,
+    ).toHaveBeenCalledTimes(1);
+  });
+
+  it("still enforces credential resolution on a malformed JSON body (no unauthenticated bypass)", async () => {
+    vi.spyOn(logger, "warn").mockImplementation(() => undefined as never);
+    const mcpHandler = okMcpHandler();
+    const err = new CredentialResolutionError("nope", 401, "capability_auth_failed");
+    const h = build({ credentialProvider: throwingProvider(err), mcpHandler });
+    // A malformed (unparseable) body must not skip the credential trust
+    // boundary or reach the MCP handler with an unexpected 2xx. An unparseable
+    // body cannot carry a JSON-RPC id, so the failure surfaces through the plain
+    // credential-error envelope at the resolver's status — pin that exact shape.
+    const res = await h.fetch(post("{ not json", modernHeaders("tools/list")));
+    expect(res.status, `${ISSUE}: malformed body must not bypass credential resolution`).toBe(401);
+    const body = JSON.parse(await res.text());
+    expect(body).toEqual({ error: "nope" });
+    expect(
+      mcpHandler.fetch,
+      `${ISSUE}: malformed body must not reach the MCP handler`,
+    ).not.toHaveBeenCalled();
   });
 
   it("returns a typed JSON-RPC error status when credential resolution fails", async () => {

--- a/tests/unit/coverage-client-400.unit.test.ts
+++ b/tests/unit/coverage-client-400.unit.test.ts
@@ -1,0 +1,489 @@
+import { B2Client as SdkB2Client } from "@backblaze-labs/b2-sdk";
+import type { PartnerClient as SdkPartnerClient } from "@backblaze-labs/b2-sdk/partner";
+import { B2AuthManager } from "../../src/auth";
+import { B2Client, setB2PartnerClientFactoryForTests } from "../../src/b2/client";
+import { runWithMcpRequestSignal } from "../../src/request-context";
+import { circuitBreaker } from "../../src/utils/circuit-breaker";
+import { logger } from "../../src/utils/logger";
+import { _resetRetryBudget } from "../../src/utils/retry";
+import type { B2AuthResponse } from "../../src/utils/types";
+import { testConfig } from "../support/deterministic-fakes";
+import { setB2SdkClientFactoryForTests } from "../support/sdk-factory-hook";
+import {
+  b2EndpointName,
+  RecordingTransport,
+  StaticHttpResponse,
+  installSdkTransport,
+} from "../support/sdk-test-helpers";
+
+function partnerAuthorizeResponse(authorizationToken = "partner-token-xyz") {
+  return {
+    accountId: "test-account-123",
+    authorizationToken,
+    apiInfo: {
+      groupsApi: {
+        capabilities: ["all"],
+        groupsApiUrl: "http://127.0.0.1/partner",
+        infoType: "groupsApi",
+      },
+    },
+    applicationKeyExpirationTimestamp: null,
+  };
+}
+
+function bucketInfo(overrides: Record<string, unknown> = {}) {
+  return {
+    accountId: "test-account-123",
+    bucketId: "bucket-1",
+    bucketName: "edge-bucket",
+    bucketType: "allPrivate",
+    bucketInfo: {},
+    corsRules: [],
+    lifecycleRules: [],
+    revision: 1,
+    options: [],
+    ...overrides,
+  };
+}
+
+function nativeAuthResponse(
+  options: {
+    token?: string;
+    apiUrl?: string;
+    allowedBuckets?: B2AuthResponse["allowedBuckets"];
+  } = {},
+): B2AuthResponse {
+  return {
+    accountId: "test-account-123",
+    authorizationToken: options.token ?? "native-token",
+    apiUrl: options.apiUrl ?? "https://api005.backblazeb2.com",
+    downloadUrl: "https://f005.backblazeb2.com",
+    recommendedPartSize: 100 * 1024 * 1024,
+    absoluteMinimumPartSize: 5 * 1024 * 1024,
+    s3ApiUrl: "https://s3.us-west-004.backblazeb2.com",
+    capabilities: ["listBuckets", "listFiles", "readFiles", "writeFiles"],
+    allowedBuckets: options.allowedBuckets ?? null,
+  };
+}
+
+interface NativeSdkFixture {
+  createBucket?: (options: object) => Promise<object>;
+  createKey?: (options: object) => Promise<object>;
+  getBucket?: (bucketName: string) => Promise<{ id: string } | null>;
+  raw?: Record<string, (...args: never[]) => Promise<object>>;
+}
+
+function sdkClientFromFixture(fixture: NativeSdkFixture): SdkB2Client {
+  const client = new SdkB2Client({
+    applicationKeyId: testConfig.applicationKeyId,
+    applicationKey: testConfig.applicationKey,
+    transport: {
+      async send() {
+        throw new Error("Unexpected SDK transport request");
+      },
+    },
+  });
+
+  for (const method of ["createBucket", "createKey", "getBucket"] as const) {
+    const impl = fixture[method];
+    if (impl) {
+      vi.spyOn(client, method).mockImplementation(impl as never);
+    }
+  }
+  if (fixture.raw) {
+    for (const [method, impl] of Object.entries(fixture.raw)) {
+      vi.spyOn(client.raw, method as keyof SdkB2Client["raw"]).mockImplementation(impl as never);
+    }
+  }
+  return client;
+}
+
+function clientWithMockedNativeSdk(
+  sdk: NativeSdkFixture,
+  authResponses: B2AuthResponse[] = [nativeAuthResponse()],
+) {
+  let authIndex = 0;
+  const authManager = new B2AuthManager(testConfig);
+  const sdkClient = sdkClientFromFixture(sdk);
+  vi.spyOn(authManager, "getAuthorizedSdk").mockImplementation(async () => {
+    const auth = authResponses[Math.min(authIndex, authResponses.length - 1)];
+    authIndex += 1;
+    return { client: sdkClient, auth };
+  });
+  vi.spyOn(authManager, "syncCachedAuthFromSdk").mockImplementation(() => undefined);
+  vi.spyOn(authManager, "invalidate").mockImplementation(() => undefined);
+  return { authManager, client: new B2Client(authManager) };
+}
+
+function clientWithTransport(transport: RecordingTransport): B2Client {
+  installSdkTransport(transport);
+  return new B2Client(new B2AuthManager(testConfig));
+}
+
+function partnerClientWithCreateFacades(options: {
+  createGroupMember?: ReturnType<typeof vi.fn>;
+}): SdkPartnerClient {
+  const partnerAuth = partnerAuthorizeResponse();
+  return {
+    authorize: vi.fn(async () => partnerAuth),
+    partnerAccountInfo: {
+      clear: vi.fn(),
+      getAuth: vi.fn(() => null),
+    },
+    createGroupMember: options.createGroupMember ?? vi.fn(),
+    reserveTrialAccount: vi.fn(),
+    raw: {},
+  } as unknown as SdkPartnerClient;
+}
+
+describe("B2Client coverage branches", () => {
+  afterEach(() => {
+    circuitBreaker.close();
+    vi.useRealTimers();
+    vi.restoreAllMocks();
+    vi.unstubAllGlobals();
+    _resetRetryBudget();
+    setB2SdkClientFactoryForTests(null);
+    setB2PartnerClientFactoryForTests(null);
+  });
+
+  describe("test-runtime guard", () => {
+    it("rejects the Partner factory override outside the test runtime", () => {
+      const originalNodeEnv = process.env.NODE_ENV;
+      const originalWorker = process.env.VITEST_WORKER_ID;
+      try {
+        delete process.env.NODE_ENV;
+        delete process.env.VITEST_WORKER_ID;
+        expect(() => setB2PartnerClientFactoryForTests(null)).toThrow(/only available in tests/);
+      } finally {
+        if (originalNodeEnv !== undefined) process.env.NODE_ENV = originalNodeEnv;
+        if (originalWorker !== undefined) process.env.VITEST_WORKER_ID = originalWorker;
+      }
+    });
+  });
+
+  describe("Partner response validation", () => {
+    it("rejects a create-group-member response with a non-object groupMember", async () => {
+      const createGroupMember = vi.fn(async () => ({
+        applicationKeyId: "group-member-key-id",
+        applicationKey: "B2_MCP_CANARY_SECRET_group_member_bad_nested",
+        groupMember: "not-an-object",
+      }));
+      setB2PartnerClientFactoryForTests(() =>
+        partnerClientWithCreateFacades({ createGroupMember }),
+      );
+      const client = new B2Client(new B2AuthManager(testConfig));
+
+      await expect(
+        client.createGroupMember({
+          adminAccountId: "test-account-123",
+          groupId: "group-1",
+          memberEmail: "member@example.com",
+        }),
+      ).rejects.toMatchObject({ status: 502, code: "unexpected_partner_response" });
+    });
+  });
+
+  describe("notification rule custom headers", () => {
+    it("normalizes array-form and object-form custom headers and preserves the hmac secret", async () => {
+      const sdk = {
+        raw: {
+          getBucketNotificationRules: async () => ({
+            bucketId: "bucket-1",
+            eventNotificationRules: [
+              {
+                name: "array-headers",
+                eventTypes: ["b2:ObjectCreated:*"],
+                isEnabled: true,
+                isSuspended: false,
+                objectNamePrefix: "",
+                suspensionReason: "",
+                targetConfiguration: {
+                  targetType: "webhook",
+                  url: "https://hooks.example.com/a",
+                  hmacSha256SigningSecret: "top-secret",
+                  customHeaders: [{ name: "X-A", value: "1" }],
+                },
+              },
+              {
+                name: "object-headers",
+                eventTypes: ["b2:ObjectDeleted:*"],
+                isEnabled: true,
+                isSuspended: false,
+                objectNamePrefix: "",
+                suspensionReason: "",
+                targetConfiguration: {
+                  targetType: "webhook",
+                  url: "https://hooks.example.com/b",
+                  customHeaders: { "X-B": "2" },
+                },
+              },
+            ],
+          }),
+        },
+      };
+      const { client } = clientWithMockedNativeSdk(sdk);
+
+      const result = await client.getBucketNotificationRules("bucket-1");
+
+      expect(result.eventNotificationRules[0]?.targetConfiguration).toMatchObject({
+        hmacSha256SigningSecret: "top-secret",
+        customHeaders: { "X-A": "1" },
+      });
+      expect(result.eventNotificationRules[1]?.targetConfiguration.customHeaders).toEqual({
+        "X-B": "2",
+      });
+    });
+  });
+
+  describe("bucket scope resolution", () => {
+    it("rejects conflicting bucketId and bucketName filters in the authorized scope", async () => {
+      const sdk = { raw: { listBuckets: vi.fn(async () => ({ buckets: [] })) } };
+      const { client } = clientWithMockedNativeSdk(sdk, [
+        nativeAuthResponse({
+          allowedBuckets: [
+            { id: "bucket-1", name: "bucket-one" },
+            { id: "bucket-2", name: "other-bucket" },
+          ],
+        }),
+      ]);
+
+      await expect(
+        client.listBuckets({ bucketId: "bucket-1", bucketName: "other-bucket" }),
+      ).rejects.toMatchObject({ status: 403, code: "forbidden" });
+      expect(sdk.raw.listBuckets).not.toHaveBeenCalled();
+    });
+
+    it("auto-scopes an unfiltered list to the authorized bucket set and logs it", async () => {
+      const debug = vi.spyOn(logger, "debug").mockImplementation(() => undefined);
+      const listBuckets = vi.fn(
+        async (_apiUrl: string, _token: string, request: { bucketId?: string }) => ({
+          buckets: [bucketInfo({ bucketId: request.bucketId ?? "bucket-1" })],
+        }),
+      );
+      const { client } = clientWithMockedNativeSdk({ raw: { listBuckets } }, [
+        nativeAuthResponse({
+          allowedBuckets: [
+            { id: "bucket-1", name: "bucket-one" },
+            { id: "bucket-2", name: "bucket-two" },
+          ],
+        }),
+      ]);
+
+      const result = await client.listBuckets();
+
+      expect(result.buckets).toHaveLength(2);
+      expect(listBuckets).toHaveBeenCalledTimes(2);
+      expect(
+        debug.mock.calls.find(([, message]) => message === "b2.list_buckets.auto_scoped")?.[0],
+      ).toMatchObject({ bucketCount: 2, tool: "b2_list_buckets" });
+    });
+
+    it("throws the caller abort reason when the signal aborts before results resolve", async () => {
+      const controller = new AbortController();
+      const abortReason = new Error("caller aborted before list");
+      controller.abort(abortReason);
+      const listBuckets = vi.fn(async () => ({ buckets: [bucketInfo()] }));
+      const { client } = clientWithMockedNativeSdk({ raw: { listBuckets } }, [
+        nativeAuthResponse({
+          allowedBuckets: [{ id: "bucket-1", name: "bucket-one" }],
+        }),
+      ]);
+
+      await expect(
+        runWithMcpRequestSignal(controller.signal, () => client.listBuckets()),
+      ).rejects.toBe(abortReason);
+      expect(listBuckets).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("native option normalization branches", () => {
+    it("normalizes lifecycle, encryption, retention, and cleared replication on create", async () => {
+      const createBucket = vi.fn(async () => ({ info: bucketInfo({ bucketName: "created" }) }));
+      const { client } = clientWithMockedNativeSdk({ createBucket });
+
+      await client.createBucket({
+        bucketName: "created",
+        bucketType: "allPrivate",
+        defaultServerSideEncryption: { mode: "SSE-B2" },
+        defaultRetention: { mode: "governance", period: { duration: 7, unit: "days" } },
+        lifecycleRules: [{ fileNamePrefix: "logs/", daysFromHidingToDeleting: 5 }],
+        replicationConfiguration: {
+          asReplicationSource: null,
+          asReplicationDestination: null,
+        },
+      });
+
+      expect(createBucket).toHaveBeenCalledWith(
+        expect.objectContaining({
+          defaultServerSideEncryption: { mode: "SSE-B2", algorithm: "AES256" },
+          defaultRetention: { mode: "governance", period: { duration: 7, unit: "days" } },
+          lifecycleRules: [
+            {
+              fileNamePrefix: "logs/",
+              daysFromHidingToDeleting: 5,
+              daysFromUploadingToHiding: null,
+            },
+          ],
+          replicationConfiguration: {
+            asReplicationSource: null,
+            asReplicationDestination: null,
+          },
+        }),
+      );
+    });
+
+    it("omits an absent bucketType from the native update request", async () => {
+      const updateBucket = vi.fn(async (_apiUrl: string, _token: string, _request: object) =>
+        bucketInfo({ bucketName: "updated" }),
+      );
+      const { client } = clientWithMockedNativeSdk({ raw: { updateBucket } });
+
+      await client.updateBucket({ bucketId: "bucket-1", bucketInfo: { env: "prod" } });
+
+      const request = updateBucket.mock.calls[0]?.[2] as Record<string, unknown>;
+      expect(request).not.toHaveProperty("bucketType");
+      expect(request).toMatchObject({ bucketId: "bucket-1", bucketInfo: { env: "prod" } });
+    });
+  });
+
+  describe("non-object native errors", () => {
+    it("surfaces a non-object native error without treating it as unauthorized", async () => {
+      const sdk = {
+        getBucket: vi.fn(async () => ({ id: "bucket-1" })),
+        raw: {
+          getFileInfo: vi.fn(async () => {
+            throw "native-string-failure";
+          }),
+        },
+      };
+      const { client, authManager } = clientWithMockedNativeSdk(sdk);
+
+      await expect(
+        client.resolveS3FileVersion({
+          bucket: "bucket",
+          key: "file.txt",
+          versionId: "version-1",
+        }),
+      ).rejects.toBe("native-string-failure");
+      expect(authManager.invalidate).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("Partner optional request fields", () => {
+    it("passes optional list-groups filters through the Partner request", async () => {
+      const transport = new RecordingTransport((request) => {
+        const endpoint = b2EndpointName(request);
+        if (endpoint === "b2_authorize_account") {
+          return new StaticHttpResponse(200, partnerAuthorizeResponse());
+        }
+        if (endpoint === "b2_list_groups") {
+          return new StaticHttpResponse(200, {
+            accountId: "test-account-123",
+            groups: [],
+            nextGroupId: null,
+          });
+        }
+        return new StaticHttpResponse(500, { status: 500, code: "unexpected", message: endpoint });
+      });
+      const client = clientWithTransport(transport);
+
+      await expect(
+        client.listGroups({
+          adminAccountId: "test-account-123",
+          groupName: "team",
+          startGroupId: 5,
+          maxGroupCount: 10,
+        }),
+      ).resolves.toMatchObject({ groups: [] });
+
+      expect(
+        transport.requests.filter((request) => b2EndpointName(request) === "b2_list_groups"),
+      ).toHaveLength(1);
+    });
+
+    it("passes optional list-group-members filters and wraps a singleton response", async () => {
+      const transport = new RecordingTransport((request) => {
+        const endpoint = b2EndpointName(request);
+        if (endpoint === "b2_authorize_account") {
+          return new StaticHttpResponse(200, partnerAuthorizeResponse());
+        }
+        if (endpoint === "b2_list_group_members") {
+          return new StaticHttpResponse(200, {
+            accountId: "test-account-123",
+            groupMembers: [],
+            nextEmail: null,
+          });
+        }
+        return new StaticHttpResponse(500, { status: 500, code: "unexpected", message: endpoint });
+      });
+      const client = clientWithTransport(transport);
+
+      const result = await client.listGroupMembers({
+        adminAccountId: "test-account-123",
+        groupId: "123",
+        startEmail: "cursor@example.com",
+        maxMemberCount: 25,
+      });
+
+      expect(Array.isArray(result)).toBe(true);
+      expect(result).toHaveLength(1);
+      expect(
+        transport.requests.filter((request) => b2EndpointName(request) === "b2_list_group_members"),
+      ).toHaveLength(1);
+    });
+
+    it("omits an absent region from the create-group-member request", async () => {
+      const createGroupMember = vi.fn(async (_options: Record<string, unknown>) => ({
+        applicationKeyId: "group-member-key-id",
+        applicationKey: "B2_MCP_CANARY_SECRET_group_member_no_region",
+        groupMember: {
+          accountId: "member-account-id",
+          email: "member@example.com",
+          groupId: "group-1",
+          groupName: "Group 1",
+          region: "us-west",
+          s3Endpoint: "s3.us-west-001.backblazeb2.com",
+        },
+      }));
+      setB2PartnerClientFactoryForTests(() =>
+        partnerClientWithCreateFacades({ createGroupMember }),
+      );
+      const client = new B2Client(new B2AuthManager(testConfig));
+
+      await client.createGroupMember({
+        adminAccountId: "test-account-123",
+        groupId: "group-1",
+        memberEmail: "member@example.com",
+      });
+
+      const callArg = createGroupMember.mock.calls[0]?.[0] as Record<string, unknown>;
+      expect(callArg).toMatchObject({ groupId: "group-1", memberEmail: "member@example.com" });
+      expect(callArg).not.toHaveProperty("region");
+    });
+  });
+
+  describe("Partner caller-abort race", () => {
+    it("rejects a signalled Partner read when authorization fails", async () => {
+      const controller = new AbortController();
+      const transport = new RecordingTransport((request) => {
+        const endpoint = b2EndpointName(request);
+        if (endpoint === "b2_authorize_account") {
+          return new StaticHttpResponse(500, {
+            status: 500,
+            code: "server_error",
+            message: "authorize failed",
+          });
+        }
+        return new StaticHttpResponse(500, { status: 500, code: "unexpected", message: endpoint });
+      });
+      const client = clientWithTransport(transport);
+
+      await expect(
+        runWithMcpRequestSignal(controller.signal, () =>
+          client.listGroups({ adminAccountId: "test-account-123" }),
+        ),
+      ).rejects.toBeTruthy();
+    });
+  });
+});

--- a/tests/unit/coverage-destructive-elicitation-400.unit.test.ts
+++ b/tests/unit/coverage-destructive-elicitation-400.unit.test.ts
@@ -1,0 +1,303 @@
+import { PROTOCOL_VERSION_META_KEY, type ClientCapabilities } from "@modelcontextprotocol/server";
+import {
+  DESTRUCTIVE_ELICITATION_RESPONSE_KEY,
+  clientCanUseReturnBasedElicitation,
+  clientSupportsFormElicitation,
+  createDestructiveElicitationRequestStateCodec,
+  destructiveElicitationMessage,
+  maybeRequireDestructiveElicitation,
+} from "../../src/utils/destructive-elicitation";
+import type { B2Config, DestructivePolicy } from "../../src/utils/types";
+
+const CONFIGURED_SECRET = "configured-elicitation-secret-value";
+const MODERN_PROTOCOL_VERSION = "2026-07-28";
+
+const cfg = (destructivePolicy: DestructivePolicy = "confirm"): B2Config =>
+  ({
+    applicationKeyId: "test-key-id",
+    applicationKey: CONFIGURED_SECRET,
+    appKeyId: "test-key-id",
+    appKey: CONFIGURED_SECRET,
+    masterKeyId: "test-master-key-id",
+    masterKey: "test-master-key-secret",
+    region: "us-west-004",
+    allowLocalFiles: true,
+    fileRoot: null,
+    destructivePolicy,
+  }) as B2Config;
+
+const FORM_ELICITATION: ClientCapabilities = { elicitation: { form: {} } };
+
+function capableExtra(inputResponses?: Record<string, unknown>, requestState?: unknown) {
+  return {
+    mcpReq: {
+      clientCapabilities: FORM_ELICITATION,
+      envelope: { [PROTOCOL_VERSION_META_KEY]: MODERN_PROTOCOL_VERSION },
+      ...(inputResponses ? { inputResponses } : {}),
+      ...(requestState !== undefined ? { requestState } : {}),
+    },
+  };
+}
+
+const providers = {
+  getClientCapabilities: (): ClientCapabilities => FORM_ELICITATION,
+  getProtocolVersion: (): string => MODERN_PROTOCOL_VERSION,
+};
+
+interface RunResult {
+  isError?: boolean;
+  resultType?: string;
+  requestState?: string;
+  content?: Array<{ text?: string }>;
+}
+
+async function runElicitation(options: {
+  toolName?: string;
+  args: Record<string, unknown>;
+  extra: unknown;
+  config?: B2Config;
+  runOriginal?: () => unknown;
+}): Promise<RunResult> {
+  return (await maybeRequireDestructiveElicitation({
+    toolName: options.toolName ?? "s3_delete_object",
+    args: options.args,
+    extra: options.extra,
+    config: options.config ?? cfg(),
+    sanitizerOptions: {},
+    contextProviders: providers,
+    runOriginal:
+      options.runOriginal ?? (() => ({ content: [{ type: "text" as const, text: "ran" }] })),
+  })) as RunResult;
+}
+
+describe("destructive-elicitation coverage", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+    delete process.env.B2_DESTRUCTIVE_ELICITATION;
+  });
+
+  describe("prompt detail rendering", () => {
+    it("notes a requested governance bypass in the prompt", () => {
+      const message = destructiveElicitationMessage("b2_update_file_retention", "clear retention", {
+        fileId: "file-1",
+        bypassGovernance: true,
+      });
+      expect(message).toContain("Governance bypass requested.");
+    });
+
+    it("omits non-primitive and blank field values", () => {
+      const message = destructiveElicitationMessage("s3_delete_object", "delete an object", {
+        operation: { nested: true },
+        bucketId: "   ",
+      });
+      expect(message).not.toContain("Operation:");
+      expect(message).not.toContain("Bucket ID:");
+    });
+
+    it("truncates overlong field values", () => {
+      const longKey = "k".repeat(130);
+      const message = destructiveElicitationMessage("s3_delete_object", "delete an object", {
+        key: longKey,
+      });
+      expect(message).toContain(`Object key: ${"k".repeat(117)}...`);
+      expect(message).not.toContain(longKey);
+    });
+
+    it("skips notification event types that are not an array", () => {
+      const message = destructiveElicitationMessage(
+        "b2_set_bucket_notification_rules",
+        "replace notification rules",
+        {
+          eventNotificationRules: [{ name: "rule", eventTypes: "not-an-array" }],
+        },
+      );
+      expect(message).toContain("Notification rule 1 name: rule.");
+      expect(message).not.toContain("event types:");
+    });
+
+    it("skips notification event type lists with no safe entries", () => {
+      const message = destructiveElicitationMessage(
+        "b2_set_bucket_notification_rules",
+        "replace notification rules",
+        {
+          eventNotificationRules: [{ name: "rule", eventTypes: [{}, []] }],
+        },
+      );
+      expect(message).not.toContain("event types:");
+    });
+
+    it("summarizes truncated notification event type lists", () => {
+      const message = destructiveElicitationMessage(
+        "b2_set_bucket_notification_rules",
+        "replace notification rules",
+        {
+          eventNotificationRules: [
+            {
+              name: "rule",
+              eventTypes: ["e1", "e2", "e3", "e4", "e5", "e6", "e7"],
+            },
+          ],
+        },
+      );
+      expect(message).toContain("Notification rule 1 event types:");
+      expect(message).toContain("+2 more");
+    });
+
+    it("skips non-object bulk delete targets while rendering later ones", () => {
+      const message = destructiveElicitationMessage(
+        "s3_delete_objects",
+        "delete multiple objects",
+        {
+          objects: ["not-an-object", { key: "real.txt", versionId: "v-1" }],
+        },
+      );
+      expect(message).toContain("Object 2 key: real.txt.");
+      expect(message).toContain("Object 2 version ID: v-1.");
+    });
+
+    it("renders and omits lifecycle rule nested fields", () => {
+      const message = destructiveElicitationMessage("s3_put_bucket_lifecycle", "expire objects", {
+        rules: [
+          "not-an-object",
+          {
+            id: "full",
+            status: "Enabled",
+            filter: { prefix: "archive/" },
+            expiration: { days: 5, expiredObjectDeleteMarker: true },
+            noncurrentVersionExpiration: { noncurrentDays: 9 },
+            abortIncompleteMultipartUpload: { daysAfterInitiation: 3 },
+          },
+          { id: "bare" },
+        ],
+      });
+      expect(message).toContain("Rule 2 ID: full.");
+      expect(message).toContain("Rule 2 prefix: archive/.");
+      expect(message).toContain("Rule 2 expiration days: 5.");
+      expect(message).toContain("Rule 2 expired object delete marker: true.");
+      expect(message).toContain("Rule 2 noncurrent expiration days: 9.");
+      expect(message).toContain("Rule 2 abort incomplete upload days: 3.");
+      expect(message).toContain("Rule 3 ID: bare.");
+      expect(message).not.toContain("Rule 3 prefix:");
+    });
+
+    it("skips non-object notification rules while rendering later ones", () => {
+      const message = destructiveElicitationMessage(
+        "b2_set_bucket_notification_rules",
+        "replace notification rules",
+        {
+          eventNotificationRules: ["not-an-object", { name: "n1", objectNamePrefix: "in/" }],
+        },
+      );
+      expect(message).toContain("Notification rule 2 name: n1.");
+      expect(message).toContain("Notification rule 2 object prefix: in/.");
+    });
+
+    it("counts only deletion lifecycle rules and ignores non-object entries", () => {
+      const message = destructiveElicitationMessage("s3_put_bucket_lifecycle", "expire objects", {
+        rules: [
+          null,
+          { id: "expire", expiration: { days: 1 } },
+          { id: "noncurrent", noncurrentVersionExpiration: { noncurrentDays: 2 } },
+          { id: "keep" },
+        ],
+      });
+      expect(message).toContain("Deletion rule count: 2.");
+    });
+  });
+
+  describe("client capability probing", () => {
+    it("treats non-object extra as lacking form elicitation", () => {
+      expect(clientSupportsFormElicitation(null)).toBe(false);
+      expect(clientSupportsFormElicitation("not-an-object")).toBe(false);
+    });
+
+    it("rejects return-based elicitation when no protocol version is present", () => {
+      expect(clientCanUseReturnBasedElicitation({ mcpReq: { envelope: {} } })).toBe(false);
+      expect(
+        clientCanUseReturnBasedElicitation({
+          mcpReq: { envelope: { [PROTOCOL_VERSION_META_KEY]: 2026 } },
+        }),
+      ).toBe(false);
+    });
+  });
+
+  describe("request-state codec", () => {
+    it("rejects request state without the destructive-elicitation prefix", async () => {
+      const codec = createDestructiveElicitationRequestStateCodec(cfg());
+      await expect(codec.verify("unprefixed-state", {} as never)).rejects.toThrow(/malformed/);
+    });
+  });
+
+  describe("state verification refusals", () => {
+    it("refuses non-elicit input responses even with valid minted state", async () => {
+      const args = { bucket: "photos", key: "old.jpg" };
+      const original = vi.fn(() => ({ content: [{ type: "text" as const, text: "ran" }] }));
+
+      const minted = await runElicitation({ args, extra: capableExtra(), runOriginal: original });
+      expect(minted.resultType).toBe("input_required");
+      const requestState = minted.requestState as string;
+
+      const result = await runElicitation({
+        args,
+        extra: capableExtra(
+          { [DESTRUCTIVE_ELICITATION_RESPONSE_KEY]: { roots: [] } },
+          requestState,
+        ),
+        runOriginal: original,
+      });
+
+      expect(result.isError).toBe(true);
+      expect(result.content?.[0]?.text).toMatch(/response was invalid/i);
+      expect(original).not.toHaveBeenCalled();
+    });
+
+    it("refuses an accepted response whose request-state payload is invalid", async () => {
+      const original = vi.fn(() => ({ content: [{ type: "text" as const, text: "ran" }] }));
+      const result = await runElicitation({
+        args: { bucket: "photos", key: "old.jpg" },
+        extra: capableExtra(
+          {
+            [DESTRUCTIVE_ELICITATION_RESPONSE_KEY]: {
+              action: "accept",
+              content: { confirm: true },
+            },
+          },
+          { v: 2, kind: "wrong" },
+        ),
+        runOriginal: original,
+      });
+
+      expect(result.isError).toBe(true);
+      expect(result.content?.[0]?.text).toMatch(/payload was invalid/i);
+      expect(original).not.toHaveBeenCalled();
+    });
+
+    it("refuses an accepted response whose request-state has expired", async () => {
+      const original = vi.fn(() => ({ content: [{ type: "text" as const, text: "ran" }] }));
+      const result = await runElicitation({
+        args: { bucket: "photos", key: "old.jpg" },
+        extra: capableExtra(
+          {
+            [DESTRUCTIVE_ELICITATION_RESPONSE_KEY]: {
+              action: "accept",
+              content: { confirm: true },
+            },
+          },
+          {
+            v: 1,
+            kind: "destructive-elicitation",
+            toolName: "s3_delete_object",
+            effect: "permanently delete an object",
+            argsDigest: "some-digest",
+            issuedAt: 0,
+          },
+        ),
+        runOriginal: original,
+      });
+
+      expect(result.isError).toBe(true);
+      expect(result.content?.[0]?.text).toMatch(/expired/i);
+      expect(original).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/tests/unit/coverage-insights-400.unit.test.ts
+++ b/tests/unit/coverage-insights-400.unit.test.ts
@@ -1,0 +1,825 @@
+// Branch-coverage tests for src/b2/insights.ts (issue #400).
+//
+// These exercise the analytics-aggregation edge branches that the existing
+// insight suites leave uncovered: empty/null report rows, the Usage-Reports
+// not-enabled path reached through the "then" snapshot, report page/candidate
+// budget breaks, non-CSV key skips, single-subject + bucket-scoped resolution,
+// and the native-scan deadline / abort plumbing. Scenarios assert the tool JSON
+// output/shape rather than hitting lines for their own sake.
+
+import type {
+  B2Client,
+  BucketFilters,
+  BucketInfoResult,
+  FileVersionResult,
+  ListBucketsResult,
+  ListFileNamesOptions,
+  ListFileNamesResult,
+  ListPartsOptions,
+  ListPartsResult,
+  ListUnfinishedLargeFilesOptions,
+  ListUnfinishedLargeFilesResult,
+  PartInfoResult,
+  UnfinishedLargeFileResult,
+} from "../../src/b2/client";
+import {
+  registerInsightTools,
+  parseCsv,
+  normalizeDate,
+  computeAccountGrowth,
+  computeEgressLeaders,
+  latestSnapshotDate,
+  loadDayRows,
+  type ReportRow,
+} from "../../src/b2/insights";
+import type {
+  ListReportObjectKeysOptions,
+  ReportObjectClient,
+  ReportObjectPage,
+  ReportObjectText,
+} from "../../src/b2/report-client";
+import { runWithMcpRequestSignal } from "../../src/request-context";
+import { abortError } from "../../src/utils/named-error";
+import { parseResult, ToolHarness } from "../support/deterministic-fakes";
+
+const GB = 1e9;
+const DAY_MS = 86400_000;
+// Mirrors the private 12s scan budget in src/b2/insights.ts.
+const TIME_BUDGET_MS = 12_000;
+
+function daysAgo(days: number): string {
+  return new Date(Date.now() - days * DAY_MS).toISOString().slice(0, 10);
+}
+
+const CSV_HEADER =
+  "account_id,date,bucket_id,bucket_name,stored_gb,downloaded_gb,uploaded_gb,api_txn_class_c\n";
+
+function csv(rows: string[]): string {
+  return CSV_HEADER + rows.join("");
+}
+
+function noSuchBucket(): Error {
+  return Object.assign(new Error("report bucket missing"), {
+    name: "NoSuchBucket",
+    $metadata: { httpStatusCode: 404 },
+  });
+}
+
+function timeoutError(): Error {
+  return Object.assign(new Error("scan timed out"), { name: "TimeoutError" });
+}
+
+// ── Report client fake (prefix/startAfter/continuationToken/maxKeys aware) ────
+
+type ReportFake = {
+  calls: Array<{ bucketName: string; input: ListReportObjectKeysOptions }>;
+  client: ReportObjectClient;
+};
+
+function reportFake(
+  csvByKey: Record<string, string>,
+  options: {
+    pageSize?: number;
+    listError?: Error;
+    // Per-call override: return a page or throw. Receives the 1-based call index.
+    onList?: (
+      input: ListReportObjectKeysOptions,
+      callIndex: number,
+    ) => ReportObjectPage | Error | undefined;
+  } = {},
+): ReportFake {
+  const calls: ReportFake["calls"] = [];
+  const allKeys = Object.keys(csvByKey).sort();
+  return {
+    calls,
+    client: {
+      async listReportObjectKeys(
+        bucketName: string,
+        input: ListReportObjectKeysOptions = {},
+      ): Promise<ReportObjectPage> {
+        calls.push({ bucketName, input });
+        const override = options.onList?.(input, calls.length);
+        if (override instanceof Error) throw override;
+        if (override) return override;
+        if (options.listError) throw options.listError;
+        let keys = allKeys.slice();
+        const { prefix, startAfter } = input;
+        if (prefix) keys = keys.filter((key) => key.startsWith(prefix));
+        if (startAfter) keys = keys.filter((key) => key > startAfter);
+        const offset = input.continuationToken ? Number(input.continuationToken) : 0;
+        const requested = input.maxKeys ?? keys.length;
+        const pageSize = Math.min(options.pageSize ?? requested, requested);
+        const page = keys.slice(offset, offset + pageSize);
+        const nextOffset = offset + page.length;
+        const isTruncated = nextOffset < keys.length;
+        return {
+          keys: page,
+          isTruncated,
+          nextContinuationToken: isTruncated ? String(nextOffset) : undefined,
+        };
+      },
+      async downloadReportObjectText(_bucketName: string, key: string): Promise<ReportObjectText> {
+        const text = csvByKey[key] ?? "";
+        return { text, bytes: Buffer.byteLength(text, "utf8"), truncated: false };
+      },
+    },
+  };
+}
+
+// ── Native client fake ────────────────────────────────────────────────────────
+
+const defaultBucket: BucketInfoResult = {
+  bucketId: "bucket-1",
+  bucketName: "photos",
+  bucketType: "allPrivate",
+};
+
+type NativeOptions = {
+  buckets?: BucketInfoResult[];
+  listBucketsError?: Error;
+  filePages?: Array<ListFileNamesResult | Error>;
+  uploadPages?: Array<ListUnfinishedLargeFilesResult | Error>;
+  partPagesByFileId?: Record<string, Array<ListPartsResult | Error>>;
+};
+
+function createNativeClient(options: NativeOptions) {
+  const filePages = [...(options.filePages ?? [])];
+  const uploadPages = [...(options.uploadPages ?? [])];
+  const partPagesByFileId: Record<string, Array<ListPartsResult | Error>> = {};
+  for (const [fileId, pages] of Object.entries(options.partPagesByFileId ?? {})) {
+    partPagesByFileId[fileId] = [...pages];
+  }
+  return {
+    listBuckets: vi.fn(async (_input: BucketFilters = {}): Promise<ListBucketsResult> => {
+      if (options.listBucketsError) throw options.listBucketsError;
+      return { buckets: options.buckets ?? [defaultBucket] };
+    }),
+    listFileNames: vi.fn(async (_input: ListFileNamesOptions): Promise<ListFileNamesResult> => {
+      const reply = filePages.shift() ?? { files: [], nextFileName: null };
+      if (reply instanceof Error) throw reply;
+      return reply;
+    }),
+    listUnfinishedLargeFiles: vi.fn(
+      async (_input: ListUnfinishedLargeFilesOptions): Promise<ListUnfinishedLargeFilesResult> => {
+        const reply = uploadPages.shift() ?? { files: [], nextFileId: null };
+        if (reply instanceof Error) throw reply;
+        return reply;
+      },
+    ),
+    listParts: vi.fn(async (input: ListPartsOptions): Promise<ListPartsResult> => {
+      const reply = partPagesByFileId[input.fileId]?.shift() ?? {
+        parts: [],
+        nextPartNumber: null,
+      };
+      if (reply instanceof Error) throw reply;
+      return reply;
+    }),
+  };
+}
+
+function file(fileName: string, contentLength: number): FileVersionResult {
+  return { fileName, contentLength, uploadTimestamp: Date.parse("2026-01-01T00:00:00.000Z") };
+}
+
+function upload(fileName: string, fileId: string, isoDate: string): UnfinishedLargeFileResult {
+  return { fileName, fileId, uploadTimestamp: Date.parse(isoDate) };
+}
+
+function part(contentLength: number, partNumber = 1): PartInfoResult {
+  return { partNumber, contentLength };
+}
+
+function registerTools(
+  reportClient: ReportObjectClient,
+  nativeClient: ReturnType<typeof createNativeClient> = createNativeClient({}),
+  allowedBuckets?: Array<{ id: string; name: string | null }> | null,
+) {
+  const harness = new ToolHarness();
+  registerInsightTools(
+    harness,
+    nativeClient as unknown as B2Client,
+    { getAuth: async () => ({ accountId: "test-account", allowedBuckets }) } as Parameters<
+      typeof registerInsightTools
+    >[2],
+    reportClient,
+  );
+  return harness;
+}
+
+const REPORT_CLOCK = new Date("2026-06-28T12:00:00.000Z");
+
+afterEach(() => {
+  vi.useRealTimers();
+  vi.restoreAllMocks();
+});
+
+// ── Pure aggregation edge branches ────────────────────────────────────────────
+
+describe("insights #400 — pure aggregation guards", () => {
+  it("parseCsv drops blank trailing rows and back-fills short rows", () => {
+    // Trailing blank line (row[0] === "") is dropped; a final row shorter than the
+    // header back-fills missing cells with "".
+    const rows = parseCsv("a,b,c\n1,2,3\n\n4\n");
+    expect(rows).toEqual([
+      { a: "1", b: "2", c: "3" },
+      { a: "4", b: "", c: "" },
+    ]);
+  });
+
+  it("parseCsv keeps a trailing row that ends without a newline", () => {
+    const rows = parseCsv("a,b\nx,y");
+    expect(rows).toEqual([{ a: "x", b: "y" }]);
+  });
+
+  it("normalizeDate expands a four-digit M/D/YYYY value without prefixing", () => {
+    expect(normalizeDate("6/5/2026")).toBe("2026-06-05");
+  });
+
+  it("computeAccountGrowth tolerates a null row list", () => {
+    expect(computeAccountGrowth(null as unknown as ReportRow[])).toEqual([]);
+  });
+
+  it("computeAccountGrowth skips rows missing account/date and accounts with no snapshots", () => {
+    const rows: ReportRow[] = [
+      // missing accountId → skipped
+      {
+        accountId: "",
+        _date: "2026-06-01",
+        storageBytes: 5,
+        egressBytes: 1,
+        uploadBytes: 0,
+        classCTxn: 0,
+      },
+      // egress-only account: storageBytes null → no daily snapshot, so it is dropped
+      {
+        accountId: "egress-only",
+        _date: "2026-06-01",
+        storageBytes: null,
+        egressBytes: 9,
+        uploadBytes: 0,
+        classCTxn: 0,
+      },
+      // zero baseline → growthPct null
+      {
+        accountId: "zero",
+        _date: "2026-06-01",
+        storageBytes: 0,
+        egressBytes: 0,
+        uploadBytes: 0,
+        classCTxn: 0,
+      },
+      {
+        accountId: "zero",
+        _date: "2026-06-03",
+        storageBytes: 100,
+        egressBytes: 0,
+        uploadBytes: 0,
+        classCTxn: 0,
+      },
+    ];
+    const out = computeAccountGrowth(rows);
+    expect(out.map((r) => r.accountId)).toEqual(["zero"]);
+    expect(out[0].growthBytes).toBe(100);
+    expect(out[0].growthPct).toBeNull();
+  });
+
+  it("computeEgressLeaders tolerates a null row list and skips rows without a bucket key", () => {
+    expect(computeEgressLeaders(null as unknown as ReportRow[])).toEqual([]);
+    const rows: ReportRow[] = [
+      // by-bucket key is bucketId || bucketName; neither present → skipped
+      {
+        accountId: "a",
+        _date: "d1",
+        storageBytes: 0,
+        egressBytes: 50,
+        uploadBytes: 0,
+        classCTxn: 0,
+      },
+      {
+        accountId: "a",
+        _date: "d2",
+        bucketName: "bkt",
+        storageBytes: 0,
+        egressBytes: 10,
+        uploadBytes: 0,
+        classCTxn: 0,
+      },
+    ];
+    const leaders = computeEgressLeaders(rows, "bucket");
+    expect(leaders).toEqual([{ key: "bkt", accountId: "a", bucketName: "bkt", egress: 10 }]);
+  });
+});
+
+// ── latestSnapshotDate / loadDayRows direct branches ──────────────────────────
+
+describe("insights #400 — snapshot listing helpers", () => {
+  it("latestSnapshotDate picks the max date across several candidate keys", async () => {
+    const today = new Date(Date.UTC(2026, 5, 28));
+    const report = reportFake({
+      "2026-06-20/usage.account-a.csv": "",
+      "2026-06-25/usage.account-a.csv": "",
+      "2026-06-22/usage.account-a.csv": "",
+    });
+    const result = await latestSnapshotDate(report.client, "b2-reports-x", today);
+    expect(result).toEqual({ date: "2026-06-25", bucketMissing: false });
+  });
+
+  it("latestSnapshotDate stops immediately when the scan budget is already spent", async () => {
+    const report = reportFake({ "2026-06-25/usage.account-a.csv": "" });
+    // A budget whose startedAt is well in the past trips the page-budget guard on
+    // the first iteration, so nothing is listed and the result is inconclusive.
+    const spentBudget = {
+      startedAt: Date.now() - 60_000,
+      stats: {
+        pages: 0,
+        listed_keys: 0,
+        candidate_keys: 0,
+        selected_keys: 0,
+        downloaded_keys: 0,
+        downloaded_bytes: 0,
+        parsed_rows: 0,
+      },
+    };
+    const result = await latestSnapshotDate(
+      report.client,
+      "b2-reports-x",
+      new Date(Date.UTC(2026, 5, 28)),
+      spentBudget as unknown as Parameters<typeof latestSnapshotDate>[3],
+    );
+    expect(result).toEqual({ date: null, bucketMissing: false, searchedSince: undefined });
+    expect(report.calls).toHaveLength(0);
+  });
+
+  it("loadDayRows skips non-CSV keys in the day folder", async () => {
+    const day = "2026-01-09";
+    const report = reportFake({
+      [`${day}/notes.txt`]: "ignored",
+      [`${day}/usage.account-a.csv`]: csv([`acct-a,${day},bucket-a,bucket-a,2,1,0,0\n`]),
+    });
+    const rows = await loadDayRows(report.client, "b2-reports-x", day);
+    expect(rows).toHaveLength(1);
+    expect(rows[0]).toMatchObject({ accountId: "acct-a", storageBytes: 2e9 });
+    // The .txt object was never requested for download.
+    expect(report.calls.length).toBeGreaterThan(0);
+  });
+});
+
+// ── b2_report_usage_growth branches ───────────────────────────────────────────
+
+describe("insights #400 — b2_report_usage_growth", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(REPORT_CLOCK);
+  });
+
+  it("returns not-enabled when the 'then' snapshot lookup 404s after a latest snapshot exists", async () => {
+    const latest = daysAgo(1);
+    const report = reportFake(
+      { [`${latest}/usage.account-a.csv`]: csv([`a,${latest},b,b,10,0,0,0\n`]) },
+      {
+        // latestSnapshotDate lists with maxKeys 1000; nearestSnapshotDate uses
+        // maxKeys 1 — fail only that lookup so latest succeeds but "then" 404s.
+        onList: (input) => (input.maxKeys === 1 ? noSuchBucket() : undefined),
+      },
+    );
+    const tools = registerTools(report.client);
+
+    const result = parseResult(
+      await tools.call("b2_report_usage_growth", {
+        period: "month",
+        order: "most_grown",
+        limit: 10,
+      }),
+    );
+
+    expect(result.reports_enabled).toBe(false);
+    expect(result.note).toContain("No b2-reports");
+  });
+
+  it("reports insufficient history when the 'then' lookup returns an empty page", async () => {
+    const latest = daysAgo(1);
+    const report = reportFake(
+      { [`${latest}/usage.account-a.csv`]: csv([`a,${latest},b,b,10,0,0,0\n`]) },
+      { onList: (input) => (input.maxKeys === 1 ? { keys: [], isTruncated: false } : undefined) },
+    );
+    const tools = registerTools(report.client);
+
+    const result = parseResult(
+      await tools.call("b2_report_usage_growth", { days: 30, order: "most_grown", limit: 10 }),
+    );
+
+    expect(result.reports_enabled).toBe(true);
+    expect(result.latest_snapshot).toBe(latest);
+    expect(result.note).toContain("Not enough report history");
+  });
+
+  it("flags new accounts and null growth_pct for a zero-baseline account", async () => {
+    const thenDay = daysAgo(30);
+    const latest = daysAgo(1);
+    const report = reportFake({
+      [`${thenDay}/usage.account-then.csv`]: csv([
+        `base,${thenDay},bk-base,bk-base,10,0,0,0\n`,
+        // zero baseline in the earlier snapshot → growth_pct must be null
+        `zero,${thenDay},bk-zero,bk-zero,0,0,0,0\n`,
+      ]),
+      [`${latest}/usage.account-now.csv`]: csv([
+        `base,${latest},bk-base,bk-base,20,0,0,0\n`,
+        `zero,${latest},bk-zero,bk-zero,5,0,0,0\n`,
+        // present only in the later snapshot → new: true
+        `newbie,${latest},bk-new,bk-new,7,0,0,0\n`,
+        // blank stored_gb → null storage, skipped by storedByAccount
+        `blank,${latest},bk-blank,bk-blank,,0,0,0\n`,
+      ]),
+    });
+    const tools = registerTools(report.client);
+
+    const result = parseResult(
+      await tools.call("b2_report_usage_growth", { days: 30, order: "most_grown", limit: 10 }),
+    );
+
+    expect(result.comparison).toBe("last 30 days");
+    expect(result.from_date).toBe(thenDay);
+    expect(result.to_date).toBe(latest);
+    const byAccount = Object.fromEntries(
+      result.accounts.map((a: { account: string }) => [a.account, a]),
+    );
+    expect(byAccount.newbie).toMatchObject({ start_gb: 0, current_gb: 7, new: true });
+    expect(byAccount.zero.growth_pct).toBeNull();
+    expect(byAccount.base).toMatchObject({ growth_gb: 10, growth_pct: 100 });
+    expect(byAccount.base).not.toHaveProperty("new");
+    // The blank-storage account never enters the growth set.
+    expect(byAccount).not.toHaveProperty("blank");
+  });
+});
+
+// ── b2_rank_egress_leaders branches ───────────────────────────────────────────
+
+describe("insights #400 — b2_rank_egress_leaders", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(REPORT_CLOCK);
+  });
+
+  it("returns not-enabled when the fallback latest-snapshot lookup 404s on an empty window", async () => {
+    let listCalls = 0;
+    const report = reportFake(
+      {},
+      {
+        onList: () => {
+          listCalls++;
+          // First list (loadReportRows) succeeds with a non-report object so the
+          // window is empty and inconclusive-free; the fallback latestSnapshotDate
+          // lookup then 404s → the tool must surface reports-not-enabled.
+          if (listCalls === 1) return { keys: ["not-a-report.txt"], isTruncated: false };
+          return noSuchBucket();
+        },
+      },
+    );
+    const tools = registerTools(report.client);
+
+    const result = parseResult(
+      await tools.call("b2_rank_egress_leaders", { by: "account", days: 7, limit: 5 }),
+    );
+
+    expect(result.reports_enabled).toBe(false);
+    expect(listCalls).toBeGreaterThan(1);
+  });
+
+  it("breaks on the candidate-key cap and reports an inconclusive empty scan", async () => {
+    // 5001 date-prefixed audit CSVs: they are candidates (match the day/….csv
+    // shape) so the loader hits maxCandidateKeys (5000) and stops, but audit files
+    // are not usage data so nothing is selected/downloaded — a fast, inconclusive
+    // empty result.
+    const day = daysAgo(0);
+    const csvByKey: Record<string, string> = {};
+    for (let i = 0; i < 5001; i++) {
+      csvByKey[`${day}/usage.audit-account-${String(i).padStart(5, "0")}.csv`] = "x";
+    }
+    const report = reportFake(csvByKey, { pageSize: 1000 });
+    const tools = registerTools(report.client);
+
+    const result = parseResult(
+      await tools.call("b2_rank_egress_leaders", { by: "account", days: 1, limit: 5 }),
+    );
+
+    expect(result.reports_enabled).toBe(true);
+    expect(result.leaders).toEqual([]);
+    expect(result.report_scan.candidate_keys).toBe(5000);
+    expect(result.report_scan.selected_keys).toBe(0);
+    expect(result.report_scan.stop_reasons).toContain("max_candidate_keys");
+    expect(result.truncated).toBe(true);
+  });
+});
+
+// ── Bucket resolution branches ────────────────────────────────────────────────
+
+describe("insights #400 — bucket resolution", () => {
+  it("resolves a single substring match from the authorized scope", async () => {
+    const nativeClient = createNativeClient({
+      listBucketsError: Object.assign(new Error("unauthorized"), { status: 401 }),
+      filePages: [{ files: [file("raw/a.bin", 10 * GB)], nextFileName: null }],
+    });
+    const tools = registerTools(reportFake({}).client, nativeClient, [
+      { id: "bucket-42", name: "photos-main" },
+    ]);
+
+    const result = parseResult(
+      await tools.call("b2_list_largest_files", { bucket: "photos", limit: 5, max_scan: 1000 }),
+    );
+
+    expect(result).toMatchObject({ bucket: "photos-main", returned: 1, truncated: false });
+    expect(nativeClient.listBuckets).not.toHaveBeenCalled();
+    expect(nativeClient.listFileNames).toHaveBeenCalledWith(
+      expect.objectContaining({ bucketId: "bucket-42" }),
+    );
+  });
+
+  it("reports bucket_id_unavailable when a scoped match resolves a name but no id", async () => {
+    const nativeClient = createNativeClient({
+      listBucketsError: Object.assign(new Error("unauthorized"), { status: 401 }),
+    });
+    // An exact name match whose scope entry carries no id → name resolves, id does not.
+    const tools = registerTools(reportFake({}).client, nativeClient, [
+      { id: undefined as unknown as string, name: "photos" },
+    ]);
+
+    const result = parseResult(
+      await tools.call("b2_unfinished_uploads", { bucket: "photos", max_uploads: 10 }),
+    );
+
+    expect(result).toEqual({
+      error: "bucket_id_unavailable",
+      candidates: [],
+      note: "No bucket ID could be resolved for 'photos'.",
+    });
+    expect(nativeClient.listBuckets).not.toHaveBeenCalled();
+  });
+
+  it("reports no match when a live listBuckets fallback returns no bucket list", async () => {
+    // listBuckets resolving to an object without a `buckets` array exercises the
+    // `result.buckets ?? []` guard and yields a clean not-found resolution error.
+    const nativeClient = createNativeClient({});
+    nativeClient.listBuckets.mockResolvedValueOnce({} as ListBucketsResult);
+    const tools = registerTools(reportFake({}).client, nativeClient);
+
+    const result = parseResult(
+      await tools.call("b2_list_largest_files", { bucket: "ghost", limit: 5, max_scan: 1000 }),
+    );
+
+    expect(result).toEqual({
+      error: "bucket_not_uniquely_resolved",
+      candidates: [],
+      note: "No bucket matches 'ghost'.",
+    });
+  });
+
+  it("resolves a single substring match from a live listBuckets fallback", async () => {
+    const nativeClient = createNativeClient({
+      buckets: [
+        { bucketId: "logs-b", bucketName: "logs-beta", bucketType: "allPrivate" },
+        { bucketId: "pics-1", bucketName: "pics", bucketType: "allPrivate" },
+      ],
+      filePages: [{ files: [], nextFileName: null }],
+    });
+    const tools = registerTools(reportFake({}).client, nativeClient);
+
+    const result = parseResult(
+      await tools.call("b2_list_largest_files", { bucket: "beta", limit: 5, max_scan: 1000 }),
+    );
+
+    expect(result).toMatchObject({ bucket: "logs-beta", returned: 0 });
+    expect(nativeClient.listBuckets).toHaveBeenCalled();
+  });
+});
+
+// ── Native scan deadline / abort plumbing ─────────────────────────────────────
+
+describe("insights #400 — native scan deadlines", () => {
+  it("largest-files throws-then-truncates when the budget is already spent on entry", async () => {
+    // startedAt reads 0; the very first withNativeInsightDeadline sees the clock at
+    // 12001ms, so remaining <= 0 and it throws a TimeoutError before any listing.
+    let call = 0;
+    vi.spyOn(Date, "now").mockImplementation(() => (call++ === 0 ? 0 : TIME_BUDGET_MS + 1));
+    const nativeClient = createNativeClient({
+      filePages: [{ files: [file("raw/a.bin", GB)], nextFileName: null }],
+    });
+    const tools = registerTools(reportFake({}).client, nativeClient);
+
+    const result = parseResult(
+      await tools.call("b2_list_largest_files", { bucket: "photos", limit: 5, max_scan: 1000 }),
+    );
+
+    expect(result.truncated).toBe(true);
+    expect(result.scanned).toBe(0);
+    expect(result.note).toContain("time budget");
+    expect(nativeClient.listFileNames).not.toHaveBeenCalled();
+  });
+
+  it("largest-files rethrows a non-deadline listing error and tolerates a page without files", async () => {
+    // First page omits `files` (files ?? [] guard); a later page fails with a
+    // non-deadline error, which must propagate to the MCP error shape.
+    const boom = Object.assign(new Error("native listing failed"), { name: "InternalError" });
+    const nativeClient = createNativeClient({
+      filePages: [{ nextFileName: "next" } as ListFileNamesResult, boom],
+    });
+    const tools = registerTools(reportFake({}).client, nativeClient);
+
+    const result = await tools.call("b2_list_largest_files", {
+      bucket: "photos",
+      limit: 5,
+      max_scan: 1000,
+    });
+
+    expect(result.isError).toBe(true);
+    expect(result.content[0].text).toContain("native listing failed");
+  });
+
+  it("largest-files honors an already-aborted parent request signal", async () => {
+    const controller = new AbortController();
+    controller.abort(abortError());
+    const nativeClient = createNativeClient({
+      filePages: [{ files: [file("raw/a.bin", GB)], nextFileName: null }],
+    });
+    const tools = registerTools(reportFake({}).client, nativeClient);
+
+    const result = parseResult(
+      await runWithMcpRequestSignal(controller.signal, () =>
+        tools.call("b2_list_largest_files", { bucket: "photos", limit: 5, max_scan: 1000 }),
+      ),
+    );
+
+    // The abort propagates to the inner controller; the fake native client does not
+    // observe the signal, so the page still returns and the largest file is ranked.
+    expect(result).toMatchObject({ bucket: "photos", returned: 1 });
+  });
+
+  it("largest-files registers an abort listener for a live (non-aborted) parent signal", async () => {
+    const controller = new AbortController();
+    const nativeClient = createNativeClient({
+      filePages: [{ files: [file("raw/a.bin", 2 * GB)], nextFileName: null }],
+    });
+    const tools = registerTools(reportFake({}).client, nativeClient);
+
+    const result = parseResult(
+      await runWithMcpRequestSignal(controller.signal, () =>
+        tools.call("b2_list_largest_files", { bucket: "photos", limit: 5, max_scan: 1000 }),
+      ),
+    );
+
+    expect(result).toMatchObject({ bucket: "photos", returned: 1, truncated: false });
+  });
+});
+
+// ── b2_unfinished_uploads note/branch coverage ────────────────────────────────
+
+describe("insights #400 — b2_unfinished_uploads", () => {
+  it("truncates at the max_uploads cap and still sums parts", async () => {
+    const nativeClient = createNativeClient({
+      uploadPages: [
+        {
+          files: [
+            upload("a.bin", "u1", "2026-01-02T00:00:00.000Z"),
+            upload("b.bin", "u2", "2026-01-03T00:00:00.000Z"),
+          ],
+          nextFileId: "more",
+        },
+      ],
+      partPagesByFileId: { u1: [{ parts: [part(GB)], nextPartNumber: null }] },
+    });
+    const tools = registerTools(reportFake({}).client, nativeClient);
+
+    const result = parseResult(
+      await tools.call("b2_unfinished_uploads", { bucket: "photos", max_uploads: 1 }),
+    );
+
+    expect(result.truncated).toBe(true);
+    expect(result.unfinished_count).toBe(1);
+    expect(result.wasted_gb).toBe(1);
+    expect(result.note).toContain("max_uploads cap");
+  });
+
+  it("tracks the oldest upload and reports wasted_gb as a lower bound when parts time out", async () => {
+    const nativeClient = createNativeClient({
+      uploadPages: [
+        {
+          files: [
+            upload("new.bin", "u1", "2026-01-05T00:00:00.000Z"),
+            upload("old.bin", "u2", "2026-01-01T00:00:00.000Z"),
+          ],
+          nextFileId: null,
+        },
+      ],
+      partPagesByFileId: {
+        u1: [{ parts: [part(GB)], nextPartNumber: null }],
+        // The second upload's parts scan hits the deadline → lower-bound result.
+        u2: [timeoutError()],
+      },
+    });
+    const tools = registerTools(reportFake({}).client, nativeClient);
+
+    const result = parseResult(
+      await tools.call("b2_unfinished_uploads", { bucket: "photos", max_uploads: 10 }),
+    );
+
+    expect(result.truncated).toBe(false);
+    expect(result.unfinished_count).toBe(2);
+    expect(result.wasted_is_lower_bound).toBe(true);
+    expect(result.sized_uploads).toBe(1);
+    // Oldest is the earlier-initiated upload even though it appeared second.
+    expect(result.oldest_file).toBe("old.bin");
+    expect(result.note).toContain("lower bound");
+  });
+
+  it("times out mid-pagination with uploads already collected", async () => {
+    let clock = 0;
+    vi.spyOn(Date, "now").mockImplementation(() => clock);
+    const nativeClient = createNativeClient({});
+    nativeClient.listUnfinishedLargeFiles.mockImplementationOnce(async () => {
+      clock = TIME_BUDGET_MS + 1;
+      return {
+        files: [upload("a.bin", "u1", "2026-01-02T00:00:00.000Z")],
+        nextFileId: "more",
+      };
+    });
+    const tools = registerTools(reportFake({}).client, nativeClient);
+
+    const result = parseResult(
+      await tools.call("b2_unfinished_uploads", { bucket: "photos", max_uploads: 10 }),
+    );
+
+    expect(result.truncated).toBe(true);
+    expect(result.unfinished_count).toBe(1);
+    expect(result.note).toContain("time budget");
+  });
+
+  it("rethrows a non-deadline unfinished-upload listing error", async () => {
+    const boom = Object.assign(new Error("upload listing failed"), { name: "InternalError" });
+    const nativeClient = createNativeClient({ uploadPages: [boom] });
+    const tools = registerTools(reportFake({}).client, nativeClient);
+
+    const result = await tools.call("b2_unfinished_uploads", { bucket: "photos", max_uploads: 10 });
+
+    expect(result.isError).toBe(true);
+    expect(result.content[0].text).toContain("upload listing failed");
+  });
+
+  it("tolerates upload/part pages without arrays and undefined upload timestamps", async () => {
+    const undatedUpload = { fileName: "undated.bin", fileId: "u2", uploadTimestamp: undefined };
+    const nativeClient = createNativeClient({
+      uploadPages: [
+        // First page omits `files` (page.files ?? [] guard) but keeps paginating.
+        { nextFileId: "more" } as ListUnfinishedLargeFilesResult,
+        {
+          files: [upload("dated.bin", "u1", "2026-01-05T00:00:00.000Z"), undatedUpload],
+          nextFileId: null,
+        },
+      ],
+      partPagesByFileId: {
+        // A parts page without a `parts` array exercises the parts ?? [] guard.
+        u1: [{ nextPartNumber: null } as ListPartsResult],
+        u2: [{ parts: [part(GB)], nextPartNumber: null }],
+      },
+    });
+    const tools = registerTools(reportFake({}).client, nativeClient);
+
+    const result = parseResult(
+      await tools.call("b2_unfinished_uploads", { bucket: "photos", max_uploads: 10 }),
+    );
+
+    expect(result.unfinished_count).toBe(2);
+    expect(result.truncated).toBe(false);
+    expect(result.wasted_gb).toBe(1);
+    // The dated upload has a finite initiation time; the undated one folds to
+    // Infinity, so the dated upload remains the oldest.
+    expect(result.oldest_file).toBe("dated.bin");
+  });
+
+  it("rethrows a non-deadline parts-listing error", async () => {
+    const boom = Object.assign(new Error("parts listing failed"), { name: "InternalError" });
+    const nativeClient = createNativeClient({
+      uploadPages: [
+        { files: [upload("old.bin", "u1", "2026-01-01T00:00:00.000Z")], nextFileId: null },
+      ],
+      partPagesByFileId: { u1: [boom] },
+    });
+    const tools = registerTools(reportFake({}).client, nativeClient);
+
+    const result = await tools.call("b2_unfinished_uploads", { bucket: "photos", max_uploads: 10 });
+
+    expect(result.isError).toBe(true);
+    expect(result.content[0].text).toContain("parts listing failed");
+  });
+
+  it("truncates unfinished-upload pagination when the listing deadline fires", async () => {
+    const nativeClient = createNativeClient({ uploadPages: [timeoutError()] });
+    const tools = registerTools(reportFake({}).client, nativeClient);
+
+    const result = parseResult(
+      await tools.call("b2_unfinished_uploads", { bucket: "photos", max_uploads: 10 }),
+    );
+
+    expect(result.unfinished_count).toBe(0);
+    expect(result.truncated).toBe(true);
+    expect(result.note).toContain("time budget");
+  });
+});

--- a/tests/unit/coverage-insights-400.unit.test.ts
+++ b/tests/unit/coverage-insights-400.unit.test.ts
@@ -30,6 +30,7 @@ import {
   computeEgressLeaders,
   latestSnapshotDate,
   loadDayRows,
+  NATIVE_SCAN_TIME_BUDGET_MS,
   type ReportRow,
 } from "../../src/b2/insights";
 import type {
@@ -44,8 +45,9 @@ import { parseResult, ToolHarness } from "../support/deterministic-fakes";
 
 const GB = 1e9;
 const DAY_MS = 86400_000;
-// Mirrors the private 12s scan budget in src/b2/insights.ts.
-const TIME_BUDGET_MS = 12_000;
+// Single source of truth: imported from the module under test so a change to
+// the native-scan budget is reflected here automatically instead of drifting.
+const TIME_BUDGET_MS = NATIVE_SCAN_TIME_BUDGET_MS;
 
 function daysAgo(days: number): string {
   return new Date(Date.now() - days * DAY_MS).toISOString().slice(0, 10);

--- a/tests/unit/coverage-partner-400.unit.test.ts
+++ b/tests/unit/coverage-partner-400.unit.test.ts
@@ -1,0 +1,411 @@
+import { mkdtempSync, writeSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { registerPartnerTools } from "../../src/b2/partner";
+import type { B2Client } from "../../src/b2/client";
+import type { B2AuthManager } from "../../src/auth";
+import type { B2Config } from "../../src/utils/types";
+import { setSinkWriteForTests } from "../../src/utils/secret-sink";
+import { ToolHarness, parseResult, testConfig } from "../support/deterministic-fakes";
+
+function tempSecretFile(): string {
+  return join(mkdtempSync(join(tmpdir(), "b2-mcp-partner-400-")), "secrets.jsonl");
+}
+
+// Fail only the ledger record write (the line carrying the secret), letting lock
+// and index bookkeeping writes proceed so the post-create recovery path runs.
+function failSecretLedgerWriteContaining(marker: string): () => void {
+  const previous = setSinkWriteForTests((fd, buffer, offset, length) => {
+    const text = Buffer.from(buffer.buffer, buffer.byteOffset + offset, length).toString("utf8");
+    if (text.includes(marker)) throw new Error("disk full");
+    return writeSync(fd, buffer, offset, length);
+  });
+  return () => {
+    setSinkWriteForTests(previous);
+  };
+}
+
+function makeConfig(overrides: Partial<B2Config> = {}): B2Config {
+  return {
+    ...testConfig,
+    masterKeyId: "master-key-id",
+    masterKey: "master-key",
+    destructivePolicy: "allow",
+    secretSink: { mode: "inline" },
+    ...overrides,
+  } as B2Config;
+}
+
+// Loose override map: the tests stub these methods with partial response
+// shapes on purpose (to drive specific normalization/error branches), so we do
+// not constrain them to the exact B2Client signatures. makeClient re-casts the
+// assembled object to B2Client.
+type PartnerClientOverrides = Partial<
+  Record<
+    | "listGroups"
+    | "listGroupMembers"
+    | "ejectGroupMember"
+    | "createGroupMember"
+    | "reserveTrialCreateAccount",
+    (...args: never[]) => unknown
+  >
+>;
+
+function makeClient(overrides: PartnerClientOverrides = {}): B2Client {
+  return {
+    listGroups: vi.fn(async () => ({ groups: [] })),
+    listGroupMembers: vi.fn(async () => ({ groupMembers: [] })),
+    ejectGroupMember: vi.fn(async () => ({})),
+    createGroupMember: vi.fn(async () => ({})),
+    reserveTrialCreateAccount: vi.fn(async () => ({})),
+    ...overrides,
+  } as unknown as B2Client;
+}
+
+function register(
+  client: B2Client,
+  config: B2Config,
+  options: { registerDurableSecretSchemas?: boolean } = {},
+) {
+  const harness = new ToolHarness();
+  registerPartnerTools(harness, client, {} as unknown as B2AuthManager, config, options);
+  return harness;
+}
+
+const fullGroupMember = {
+  accountId: "acc-1",
+  email: "member@example.com",
+  groupId: "g1",
+  groupName: "Group One",
+  region: "us-west",
+  s3Endpoint: "https://s3.us-west.example",
+};
+
+const fullCreateEntry = {
+  applicationKeyId: "key-id-1",
+  applicationKey: "K005SecretApplicationKeyValue1234567890abc",
+  groupMember: fullGroupMember,
+};
+
+describe("registerPartnerTools coverage (issue 400)", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("passes optional groupName and startGroupId through to listGroups", async () => {
+    const listGroups = vi.fn(async () => ({ groups: [] }));
+    const harness = register(makeClient({ listGroups }), makeConfig());
+
+    await harness.call("b2_list_groups", {
+      adminAccountId: "admin-1",
+      groupName: "team",
+      startGroupId: 42,
+      maxGroupCount: 10,
+    });
+
+    expect(listGroups).toHaveBeenCalledWith({
+      adminAccountId: "admin-1",
+      maxGroupCount: 10,
+      groupName: "team",
+      startGroupId: 42,
+    });
+  });
+
+  it("omits optional groupName and startGroupId and defaults maxGroupCount", async () => {
+    const listGroups = vi.fn(async () => ({ groups: [] }));
+    const harness = register(makeClient({ listGroups }), makeConfig());
+
+    await harness.call("b2_list_groups", { adminAccountId: "admin-1" });
+
+    expect(listGroups).toHaveBeenCalledWith({ adminAccountId: "admin-1", maxGroupCount: 100 });
+  });
+
+  it("returns an error when listGroups fails", async () => {
+    const listGroups = vi.fn(async () => {
+      throw new Error("partner unavailable");
+    });
+    const harness = register(makeClient({ listGroups }), makeConfig());
+
+    const raw = await harness.call("b2_list_groups", { adminAccountId: "admin-1" });
+
+    expect(raw.isError).toBe(true);
+  });
+
+  it("creates a group member inline from an array response and forwards the region", async () => {
+    const createGroupMember = vi.fn(async () => [fullCreateEntry]);
+    const harness = register(makeClient({ createGroupMember }), makeConfig());
+
+    const result = parseResult(
+      await harness.call("b2_create_group_member", {
+        adminAccountId: "admin-1",
+        groupId: "g1",
+        memberEmail: "member@example.com",
+        region: "us-west",
+        idempotencyKey: "idem-array",
+      }),
+    );
+
+    expect(createGroupMember).toHaveBeenCalledWith(
+      expect.objectContaining({ region: "us-west", groupId: "g1" }),
+    );
+    expect(result.results[0].applicationKey).toBe(fullCreateEntry.applicationKey);
+    expect(result.results[0].groupMember.accountId).toBe("acc-1");
+  });
+
+  it("creates a group member inline from a results-wrapped response with a null region", async () => {
+    const createGroupMember = vi.fn(async () => ({ results: [fullCreateEntry] }));
+    const harness = register(makeClient({ createGroupMember }), makeConfig());
+
+    const result = parseResult(
+      await harness.call("b2_create_group_member", {
+        adminAccountId: "admin-1",
+        groupId: "g1",
+        memberEmail: "member@example.com",
+        region: null,
+        idempotencyKey: "idem-results",
+      }),
+    );
+
+    // region null => normalizedPartnerRegion returns {}
+    expect(createGroupMember).toHaveBeenCalledWith(
+      expect.not.objectContaining({ region: expect.anything() }),
+    );
+    expect(result.results[0].groupMember.email).toBe("member@example.com");
+  });
+
+  it("creates a group member inline from a bare object response", async () => {
+    const createGroupMember = vi.fn(async () => ({ ...fullCreateEntry }));
+    const harness = register(makeClient({ createGroupMember }), makeConfig());
+
+    const result = parseResult(
+      await harness.call("b2_create_group_member", {
+        adminAccountId: "admin-1",
+        groupId: "g1",
+        memberEmail: "member@example.com",
+        idempotencyKey: "idem-bare",
+      }),
+    );
+
+    expect(result.results).toHaveLength(1);
+    expect(result.results[0].applicationKeyId).toBe("key-id-1");
+  });
+
+  it("errors when the create-group-member response is missing groupMember fields", async () => {
+    const createGroupMember = vi.fn(async () => ({
+      applicationKeyId: "key-id-1",
+      applicationKey: "secret",
+      // groupMember missing => requiredStringValue throws unexpected_partner_response
+    }));
+    const harness = register(makeClient({ createGroupMember }), makeConfig());
+
+    const raw = await harness.call("b2_create_group_member", {
+      adminAccountId: "admin-1",
+      groupId: "g1",
+      memberEmail: "member@example.com",
+      idempotencyKey: "idem-bad",
+    });
+
+    expect(raw.isError).toBe(true);
+    expect(JSON.stringify(raw)).toContain("unexpected_partner_response");
+  });
+
+  it("blocks create_group_member under the block destructive policy", async () => {
+    const createGroupMember = vi.fn(async () => [fullCreateEntry]);
+    const harness = register(
+      makeClient({ createGroupMember }),
+      makeConfig({ destructivePolicy: "block" }),
+    );
+
+    const raw = await harness.call("b2_create_group_member", {
+      adminAccountId: "admin-1",
+      groupId: "g1",
+      memberEmail: "member@example.com",
+      idempotencyKey: "idem-blocked",
+    });
+
+    expect(raw.isError).toBe(true);
+    expect(createGroupMember).not.toHaveBeenCalled();
+  });
+
+  it("ejects a member and forwards an optional new email", async () => {
+    const ejectGroupMember = vi.fn(async () => ({ ejected: true }));
+    const harness = register(makeClient({ ejectGroupMember }), makeConfig());
+
+    await harness.call("b2_eject_group_member", {
+      adminAccountId: "admin-1",
+      groupId: "g1",
+      memberAccountId: "acc-1",
+      email: "renamed@example.com",
+    });
+
+    expect(ejectGroupMember).toHaveBeenCalledWith(
+      expect.objectContaining({ email: "renamed@example.com" }),
+    );
+  });
+
+  it("reserves a trial account inline with all optional projection fields", async () => {
+    const reserveTrialCreateAccount = vi.fn(async () => ({
+      applicationKeyId: "trial-key-id",
+      applicationKey: "K005TrialSecretApplicationKeyValue1234567",
+      accountId: "trial-acc",
+      s3Endpoint: "https://s3.trial.example",
+      startDate: "2026-01-01",
+      endDate: "2026-01-31",
+      email: "trial@example.com",
+      bucketName: "trial-bucket",
+      bucketId: "bucket-1",
+    }));
+    const harness = register(makeClient({ reserveTrialCreateAccount }), makeConfig());
+
+    const result = parseResult(
+      await harness.call("b2_reserve_trial_create_account", {
+        email: "trial@example.com",
+        region: "eu-central",
+        term: 7,
+        storage: 1,
+        idempotencyKey: "idem-trial",
+      }),
+    );
+
+    expect(reserveTrialCreateAccount).toHaveBeenCalledWith(
+      expect.objectContaining({ region: "eu-central" }),
+    );
+    expect(result.results[0].applicationKey).toBe("K005TrialSecretApplicationKeyValue1234567");
+    expect(result.results[0].accountId).toBe("trial-acc");
+    expect(result.results[0].bucketId).toBe("bucket-1");
+  });
+
+  it("reserves a trial account inline omitting absent optional fields", async () => {
+    const reserveTrialCreateAccount = vi.fn(async () => ({
+      applicationKeyId: "trial-key-id",
+      applicationKey: "K005TrialSecretMinimal1234567890abcdefghi",
+    }));
+    const harness = register(makeClient({ reserveTrialCreateAccount }), makeConfig());
+
+    const result = parseResult(
+      await harness.call("b2_reserve_trial_create_account", {
+        email: "trial@example.com",
+        term: 7,
+        storage: 1,
+        idempotencyKey: "idem-trial-min",
+      }),
+    );
+
+    expect(result.results[0]).not.toHaveProperty("accountId");
+    expect(result.results[0].applicationKeyId).toBe("trial-key-id");
+  });
+
+  it("blocks reserve_trial_create_account under the block destructive policy", async () => {
+    const reserveTrialCreateAccount = vi.fn(async () => ({}));
+    const harness = register(
+      makeClient({ reserveTrialCreateAccount }),
+      makeConfig({ destructivePolicy: "block" }),
+    );
+
+    const raw = await harness.call("b2_reserve_trial_create_account", {
+      email: "trial@example.com",
+      term: 7,
+      storage: 1,
+      idempotencyKey: "idem-trial-blocked",
+    });
+
+    expect(raw.isError).toBe(true);
+    expect(reserveTrialCreateAccount).not.toHaveBeenCalled();
+  });
+
+  it("redacts the reserve-trial application key when a file sink stores it", async () => {
+    const reserveTrialCreateAccount = vi.fn(async () => ({
+      applicationKeyId: "trial-key-id",
+      applicationKey: "K005TrialSecretFileSink1234567890abcdefgh",
+      accountId: "trial-acc",
+    }));
+    const harness = register(
+      makeClient({ reserveTrialCreateAccount }),
+      makeConfig({ secretSink: { mode: "file", filePath: tempSecretFile() } }),
+      { registerDurableSecretSchemas: true },
+    );
+
+    const result = parseResult(
+      await harness.call("b2_reserve_trial_create_account", {
+        email: "trial@example.com",
+        term: 7,
+        storage: 1,
+        idempotencyKey: "idem-trial-file",
+      }),
+    );
+
+    expect(result.results[0].applicationKey).toBe("[redacted]");
+    expect(result.secretSink).toMatchObject({ type: "file" });
+  });
+
+  it("recovers by ejecting confirmed members when the file sink write fails", async () => {
+    const created = [fullCreateEntry];
+    const listGroupMembers = vi.fn(async () => ({
+      results: [
+        { groupMembers: "not-an-array" },
+        {
+          groupMembers: [{ accountId: "acc-1", email: "member@example.com", groupId: "g1" }],
+        },
+      ],
+    }));
+    const ejectGroupMember = vi.fn(async () => ({ ejected: true }));
+    const harness = register(
+      makeClient({
+        createGroupMember: vi.fn(async () => created),
+        listGroupMembers,
+        ejectGroupMember,
+      }),
+      makeConfig({ secretSink: { mode: "file", filePath: tempSecretFile() } }),
+    );
+
+    const restore = failSecretLedgerWriteContaining("SecretApplicationKeyValue");
+    try {
+      const raw = await harness.call("b2_create_group_member", {
+        adminAccountId: "admin-1",
+        groupId: "g1",
+        memberEmail: "member@example.com",
+        idempotencyKey: "idem-recover",
+      });
+      expect(raw.isError).toBe(true);
+    } finally {
+      restore();
+    }
+
+    expect(ejectGroupMember).toHaveBeenCalledWith(
+      expect.objectContaining({ memberAccountId: "acc-1" }),
+    );
+  });
+
+  it("reports an eject failure message during file-sink failure recovery", async () => {
+    const created = [fullCreateEntry];
+    const listGroupMembers = vi.fn(async () => ({
+      groupMembers: [{ accountId: "acc-1", email: "member@example.com", groupId: "g1" }],
+    }));
+    const ejectGroupMember = vi.fn(async () => {
+      throw new Error("eject denied");
+    });
+    const harness = register(
+      makeClient({
+        createGroupMember: vi.fn(async () => created),
+        listGroupMembers,
+        ejectGroupMember,
+      }),
+      makeConfig({ secretSink: { mode: "file", filePath: tempSecretFile() } }),
+    );
+
+    const restore = failSecretLedgerWriteContaining("SecretApplicationKeyValue");
+    try {
+      const raw = await harness.call("b2_create_group_member", {
+        adminAccountId: "admin-1",
+        groupId: "g1",
+        memberEmail: "member@example.com",
+        idempotencyKey: "idem-recover-eject-fail",
+      });
+      expect(raw.isError).toBe(true);
+    } finally {
+      restore();
+    }
+
+    expect(ejectGroupMember).toHaveBeenCalledTimes(1);
+  });
+});

--- a/tests/unit/coverage-report-client-400.unit.test.ts
+++ b/tests/unit/coverage-report-client-400.unit.test.ts
@@ -1,0 +1,182 @@
+import { B2ReportClient } from "../../src/b2/report-client";
+import { runWithMcpRequestSignal } from "../../src/request-context";
+import { createReportS3Client } from "../../src/s3/client";
+import { DeterministicS3ClientFake, testConfig } from "../support/deterministic-fakes";
+
+vi.mock("../../src/s3/client", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("../../src/s3/client")>()),
+  createReportS3Client: vi.fn(),
+}));
+
+function reportAuth() {
+  return {
+    accountId: "test-account-123",
+    authorizationToken: "mock-token-xyz",
+    apiUrl: "https://api005.backblazeb2.com",
+    downloadUrl: "https://f005.backblazeb2.com",
+    s3ApiUrl: "https://s3.us-west-004.backblazeb2.com",
+    recommendedPartSize: 100 * 1024 * 1024,
+    absoluteMinimumPartSize: 5 * 1024 * 1024,
+    capabilities: ["readFiles"],
+  };
+}
+
+function createReportClient(s3 = new DeterministicS3ClientFake()) {
+  const getAuth = vi.fn(async () => reportAuth());
+  const getConfig = vi.fn(() => testConfig);
+  vi.mocked(createReportS3Client).mockReturnValue(
+    s3.asPeerClient() as ReturnType<typeof createReportS3Client>,
+  );
+  return {
+    client: new B2ReportClient({ getAuth, getConfig } as never),
+    getAuth,
+    s3,
+  };
+}
+
+describe("B2ReportClient coverage (issue 400)", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("reads an async-iterable body exposed on a function value", async () => {
+    // isAsyncIterable() must accept typeof value === "function" bodies.
+    const body = function reportBody() {
+      /* only used as a function-typed carrier for an asyncIterator */
+    } as unknown as {
+      [Symbol.asyncIterator](): AsyncIterator<unknown>;
+    };
+    (body as { [Symbol.asyncIterator]: unknown })[Symbol.asyncIterator] = async function* () {
+      yield Buffer.from("csv");
+    };
+    const s3 = new DeterministicS3ClientFake().respond("downloadReportObject", {
+      body,
+    });
+    const { client } = createReportClient(s3);
+
+    const result = await client.downloadReportObjectText("b2-reports-test", "fn.csv");
+
+    expect(result).toEqual({ text: "csv", bytes: 3, truncated: false });
+  });
+
+  it("stops when a later chunk arrives after the byte cap is exactly filled", async () => {
+    // First chunk fills the cap exactly; the next chunk hits `remaining <= 0`.
+    const body = {
+      async *[Symbol.asyncIterator]() {
+        yield Buffer.from("abc");
+        yield Buffer.from("def");
+      },
+    };
+    const s3 = new DeterministicS3ClientFake().respond("downloadReportObject", {
+      body,
+    });
+    const { client } = createReportClient(s3);
+
+    const result = await client.downloadReportObjectText("b2-reports-test", "cap.csv", {
+      maxBytes: 3,
+    });
+
+    expect(result).toEqual({ text: "abc", bytes: 3, truncated: true });
+  });
+
+  it("destroys an async-iterable body with a wrapped Error on a non-Error abort reason", async () => {
+    const controller = new AbortController();
+    const iterator = {
+      next: vi.fn(async () => {
+        controller.abort("boom-string");
+        return { done: false, value: Buffer.from("ignored") };
+      }),
+      return: vi.fn(async () => ({ done: true, value: undefined as never })),
+    };
+    const body = {
+      destroy: vi.fn(),
+      [Symbol.asyncIterator]: () => iterator,
+    };
+    const s3 = new DeterministicS3ClientFake().respond("downloadReportObject", {
+      body,
+    });
+    const { client } = createReportClient(s3);
+
+    await expect(
+      runWithMcpRequestSignal(controller.signal, () =>
+        client.downloadReportObjectText("b2-reports-test", "abort-string.csv"),
+      ),
+    ).rejects.toBe("boom-string");
+    // Non-Error reason gets wrapped: destroy sees an Error whose message is the string.
+    expect(body.destroy).toHaveBeenCalledWith(expect.objectContaining({ message: "boom-string" }));
+    expect(iterator.return).toHaveBeenCalledTimes(1);
+  });
+
+  it("destroys a transformToByteArray body with a wrapped Error on a non-Error abort reason", async () => {
+    const controller = new AbortController();
+    const destroy = vi.fn();
+    // Synchronously abort the parent, then never resolve: the read observes an
+    // already-aborted signal and runs the transformToByteArray cleanup path.
+    const transformToByteArray = vi.fn(
+      () =>
+        new Promise<Uint8Array>(() => {
+          controller.abort("transform-boom");
+        }),
+    );
+    const body = { destroy, transformToByteArray };
+    const s3 = new DeterministicS3ClientFake().respond("downloadReportObject", {
+      body,
+    });
+    const { client } = createReportClient(s3);
+
+    await expect(
+      runWithMcpRequestSignal(controller.signal, () =>
+        client.downloadReportObjectText("b2-reports-test", "transform-abort.csv"),
+      ),
+    ).rejects.toBe("transform-boom");
+    expect(destroy).toHaveBeenCalledWith(expect.objectContaining({ message: "transform-boom" }));
+  });
+
+  it("destroys a transformToByteArray body with the original Error abort reason", async () => {
+    const controller = new AbortController();
+    const destroy = vi.fn();
+    const reason = new Error("transform-error-reason");
+    const transformToByteArray = vi.fn(
+      () =>
+        new Promise<Uint8Array>(() => {
+          controller.abort(reason);
+        }),
+    );
+    const body = { destroy, transformToByteArray };
+    const s3 = new DeterministicS3ClientFake().respond("downloadReportObject", {
+      body,
+    });
+    const { client } = createReportClient(s3);
+
+    await expect(
+      runWithMcpRequestSignal(controller.signal, () =>
+        client.downloadReportObjectText("b2-reports-test", "transform-error.csv"),
+      ),
+    ).rejects.toBe(reason);
+    expect(destroy).toHaveBeenCalledWith(reason);
+  });
+
+  it("aborts immediately when the parent signal is already aborted with no reason", async () => {
+    // Fake parent signal: aborted with an undefined reason exercises the
+    // `parent?.reason ?? abortError()` fallback and the pre-run aborted branch.
+    const listeners: Array<() => void> = [];
+    const parent = {
+      aborted: true,
+      reason: undefined,
+      addEventListener: (_type: string, listener: () => void) => {
+        listeners.push(listener);
+      },
+      removeEventListener: () => undefined,
+    } as unknown as AbortSignal;
+    const s3 = new DeterministicS3ClientFake().respond("downloadReportObject", {
+      body: { transformToByteArray: vi.fn(async () => Uint8Array.of(97)) },
+    });
+    const { client } = createReportClient(s3);
+
+    await expect(
+      runWithMcpRequestSignal(parent, () =>
+        client.downloadReportObjectText("b2-reports-test", "pre-aborted.csv"),
+      ),
+    ).rejects.toMatchObject({ name: "AbortError" });
+  });
+});

--- a/vitest.config.mts
+++ b/vitest.config.mts
@@ -34,16 +34,17 @@ export default defineConfig({
       include: ["src/**/*.ts"],
       exclude: ["dist/**", "tests/**", "**/*.d.ts", "**/*.test.ts", "**/generated/**"],
       // Floors sit a deliberate buffer below the achieved merged coverage
-      // (statements 94.81 / branches 89.15 / functions 97.61 / lines 96.91 as of
-      // this change) so normal per-layer execution and v8 measurement variance,
-      // or an unrelated PR that drops a branch or two, does not wedge the global
-      // merge/deploy gate. Each floor stays at or above the previous value so the
-      // ratchet never weakens; raise them only when a durable gain is measured.
+      // (statements 96.42 / branches 92.42 / functions 97.86 / lines 97.84 as of
+      // issue #400 phase-1 error-branch coverage) so normal per-layer execution
+      // and v8 measurement variance, or an unrelated PR that drops a branch or
+      // two, does not wedge the global merge/deploy gate. Each floor stays at or
+      // above the previous value so the ratchet never weakens; raise them only
+      // when a durable gain is measured.
       thresholds: {
-        statements: 94.5,
-        branches: 89,
-        functions: 97.5,
-        lines: 96.7,
+        statements: 96,
+        branches: 92,
+        functions: 97.7,
+        lines: 97.4,
       },
     },
     projects: layerProjectNamesForConfig().map((name) =>


### PR DESCRIPTION
## Summary

Phase 1 (continued) of the error-branch coverage work for #400. PR #415 already
covered `buckets`, `server`, `resources`, and `oauth`; this PR targets the next
tier of the highest-gap modules with scenario-based (not line-hit) tests and
expands all three thin test layers.

New test files, by layer:

- **observability** — `tests/observability/logger-fallback.observability.test.ts`:
  file-destination fallback to stderr, failure-report throttling, bounded-flush
  timeout during SIGHUP rotation, reopen idempotency, and sanitizer-failure
  censoring for string vs object args. `src/utils/logger.ts` 64.7% → ~94% branches.
- **reliability** — `tests/reliability/secret-sink-fs-faults.reliability.test.ts`:
  FS fault injection (`ENOENT`/`EEXIST`/`ENOTDIR`/symlink-parent), cycle
  detection, and fail-safe recovery. `src/utils/secret-sink.ts` → ~96% branches.
- **runtime-security** — `tests/runtime-security/http-fetch-handler-faults.runtime-security.test.ts`:
  rate-limit 429 (discovery + credential keys), typed vs generic
  credential-resolution errors, non-POST/method preflight, Host/Origin edges,
  the 1 MiB body cap (413), the empty-body path pinned to its exact 200 + JSON-RPC
  envelope, and a malformed-body case proving no unauthenticated bypass of
  credential resolution.
- **unit** — `coverage-insights-400`, `coverage-client-400`,
  `coverage-partner-400`, `coverage-report-client-400`,
  `coverage-destructive-elicitation-400`: analytics-aggregation edge branches
  (empty/null rows, NOT_ENABLED, page-budget break, non-CSV skip, deadline
  rethrow vs partial result), B2Client abort/optional-arg permutations, Partner
  optional-arg/error paths, report-client body-read edges, and the destructive
  elicitation state codec / refusal paths.

Merged V8 coverage moved from **B 89.23% → 92.42%** (+159 branches recovered),
statements 94.87% → 96.42%, functions 97.61% → 97.86%, lines 96.94% → 97.84%.

Coverage floors in `vitest.config.mts` bumped with a small variance buffer
(statements 96, branches 92, functions 97.7, lines 97.4), and the pinned
mirrors in `README.md`, `docs/TESTING.md`, `.github/workflows/test.yml`, and the
`test-layering` contract test updated to match.

## Source and dependency changes

- `src/b2/insights.ts`: the 12s native-scan budget is now exported as
  `NATIVE_SCAN_TIME_BUDGET_MS` and the two inline `12_000` literals reference it,
  so the deadline tests consume a single source of truth instead of hand-copying
  the value (behavior unchanged).
- Dependency security (supply-chain audit): bumped the dev-only transitive
  `@vercel/python-analysis>js-yaml` override to `4.3.2` (the prior `4.3.1` pin
  was itself in the vulnerable range) and added a scoped `miniflare>sharp:
  >=0.35.4` override, clearing the `js-yaml` maxTotalMergeKeys advisory and the
  `sharp`/libheif advisories (GHSA-g89c-p67h-r497, GHSA-2jg2-4ch7-h545). Root
  `pnpm-workspace.yaml`/`pnpm-lock.yaml` and the byte-identical
  `deploy/customer-hosted/` mirrors were updated together.

No `/* v8 ignore */` comments were added; the residual uncovered branches are
genuinely-defensive/race-timing arms documented in the per-module analysis.

## Linked issue

Part of #400 (Phase 1). Related: #397 (mutation testing — the real gate).

## Tests run

- `pnpm run test:coverage` — 2499 passed; gate green at S 96.42 / B 92.42 / F 97.86 / L 97.84.
- `pnpm run typecheck`, `pnpm run lint`, `pnpm run format:check` — clean.
- `pnpm run audit:supply-chain` — no unallowed moderate/high/critical advisories.

## Follow-up notes

- Phase 2 (issue #400) remains: next-tier modules (`s3/objects`, `auth`,
  `s3/aws-sdk-adapter`, `s3/client`, `errors`, `credentials`) and pushing toward
  the ~95% branch target, paired with #397 mutation testing.
- Literal 100% is explicitly out of scope per the issue; residual defensive
  branches were left untested rather than masked.
