### PR TITLE
security(ci): add concurrency groups to quality-keeper and release-tag

### DIFF
--- a/.github/workflows/quality-keeper.yml
+++ b/.github/workflows/quality-keeper.yml
@@ -17,6 +17,10 @@ on:
   pull_request:
     types: [opened, synchronize, reopened, ready_for_review]
 
+concurrency:
+  group: quality-keeper-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 # No pull_request_target: fork, draft, and unknown-head code is never trusted.
 permissions: {}
 

--- a/.github/workflows/release-tag.yml
+++ b/.github/workflows/release-tag.yml
@@ -18,6 +18,10 @@ on:
 permissions:
   contents: read
 
+concurrency:
+  group: release-tag-${{ github.ref }}
+  cancel-in-progress: false
+
 jobs:
   request:
     runs-on: ubuntu-latest

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- Add workflow-level concurrency groups to the Quality Keeper and release-tag
+  request workflows, coalescing superseded PR analysis without interrupting
+  release signals. (#420)
+
 ## [0.2.1] - 2026-09-04
 
 ### Added

--- a/tests/contract/ci-workflow-policy.contract.test.ts
+++ b/tests/contract/ci-workflow-policy.contract.test.ts
@@ -80,6 +80,7 @@ describe("CI workflow policy", () => {
   const evals = readFileSync(join(root, ".github/workflows/evals.yml"), "utf8");
   const publish = readFileSync(join(root, ".github/workflows/publish.yml"), "utf8");
   const qualityKeeper = readFileSync(join(root, ".github/workflows/quality-keeper.yml"), "utf8");
+  const releaseTag = readFileSync(join(root, ".github/workflows/release-tag.yml"), "utf8");
 
   function workflowJob(name: string): string {
     const job = workflowJobBlock(ci, name);
@@ -95,6 +96,17 @@ describe("CI workflow policy", () => {
       "group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}",
     );
     expect(ci).toContain("cancel-in-progress: ${{ github.event_name == 'pull_request' }}");
+  });
+
+  it("sets workflow-specific concurrency controls", () => {
+    expect(yamlMappingForKey(qualityKeeper, "concurrency")).toMatchObject({
+      group: "quality-keeper-${{ github.workflow }}-${{ github.ref }}",
+      "cancel-in-progress": "true",
+    });
+    expect(yamlMappingForKey(releaseTag, "concurrency")).toMatchObject({
+      group: "release-tag-${{ github.ref }}",
+      "cancel-in-progress": "false",
+    });
   });
 
   it("keeps Quality Keeper pull_request execution unprivileged", () => {


### PR DESCRIPTION
## Summary

Add workflow-level concurrency controls to the two workflows identified by the repository's zizmor audit. Superseded Quality Keeper runs will be cancelled per pull request, while release-tag requests are serialized without interrupting an in-progress release signal.

## Changes

- Add a per-workflow/per-ref concurrency group to `quality-keeper.yml` with `cancel-in-progress: true`.
- Add a per-ref concurrency group to `release-tag.yml` with `cancel-in-progress: false`.
- Add a CI workflow-policy contract assertion for both group keys and cancellation modes.
- Record the fix under `CHANGELOG.md`'s Unreleased section.

## Linked Issues

- Closes #420

## Verification

- [x] `zizmor 1.29.0 --persona=pedantic --no-online-audits` reports both `concurrency-limits` findings on the unmodified files and zero `concurrency-limits` findings after this change.
- [x] The targeted `ci-workflow-policy.contract.test.ts` suite passes (17 tests) with Vitest 4.1.11.
- [x] `node scripts/check-runtime-policy.mjs` passes.
- [x] The repository workflow parser resolves the exact expected group and cancellation values for both files.
- [x] Biome format and lint checks pass for the changed TypeScript contract test.
- [x] `git diff --check` passes.
- [ ] `pnpm install --frozen-lockfile` — an offline frozen install verified the lockfile but could not complete because the local cache lacked `@aws-sdk/client-s3@3.1125.0`.
- [ ] `pnpm run verify` — not run locally because the frozen dependency install could not be completed; the directly relevant workflow, runtime-policy, formatting, lint, and contract checks above pass.
- [ ] `pnpm run test:contract` — the full layer was not run; the changed `ci-workflow-policy` contract file passes all 17 tests.
- [ ] `pnpm run test:protocol` — not applicable; no protocol changes.
- [ ] `pnpm run test:package` — not applicable; no package changes.
- [ ] `pnpm run audit:production` — not applicable; no production dependency changes.
- [ ] `pnpm run audit:supply-chain` — not applicable; no dependency changes.
- [x] CI required checks are expected to pass without B2 credentials.

Required CI check names for `main` protection:

- [ ] `format/lint/typecheck`
- [ ] `docs/spelling/links`
- [ ] `unit/coverage`
- [ ] `reliability/resilience`
- [ ] `MCP contract`
- [ ] `modern and legacy protocol/transport`
- [ ] `observability/logging behavior`
- [ ] `package install smoke`
- [ ] `runtime engine floor`
- [ ] `production dependency audit`
- [ ] `package budget`
- [ ] `Vercel build output scan`
- [ ] `container image`
- [ ] `supply-chain audit`
- [ ] `CodeQL/workflow security`
- [ ] `slow/lifecycle`
- [ ] `cross-platform minimum`

## Security / Credential Handling

- [ ] Modifies authentication, authorization, or token handling
- [ ] Changes how B2 credentials flow through the server
- [ ] Touches the HTTP transport or request parsing
- [ ] Updates dependencies or package/runtime budgets
- [x] Changes GitHub Actions, branch protection, publishing, or `ci-green`

## Follow-up Notes

The remaining informational `anonymous-definition` finding in `release-tag.yml` predates and is outside the scope of #420.
