### PR TITLE
docs: suppress zizmor artipacked on ci-green marker checkout

### DIFF
--- a/.cspell/project-words.txt
+++ b/.cspell/project-words.txt
@@ -62,6 +62,7 @@ Lopopolo
 sophiecarreras
 
 # Cloud, network, storage, and security terms
+artipacked
 buildx
 creds
 EOCD

--- a/tests/unit/supply-chain-policy.unit.test.ts
+++ b/tests/unit/supply-chain-policy.unit.test.ts
@@ -1503,7 +1503,7 @@ describe("supply-chain audit policy", () => {
     // new `uses:`, or ANY new executable/download/upload line in the run script
     // fails this test and forces re-review of the persisted write token.
     const parsedWorkflow = parseWorkflowYaml(workflow) as {
-      jobs?: Record<string, { steps?: Array<Record<string, unknown>> }>;
+      jobs?: Record<string, { if?: string; steps?: Array<Record<string, unknown>> }>;
     };
     const markGreenSteps = parsedWorkflow.jobs?.["mark-green"]?.steps ?? [];
     expect(markGreenSteps).toHaveLength(2);
@@ -1547,6 +1547,13 @@ describe("supply-chain audit policy", () => {
       'echo "::notice::Advanced owned ci-green marker to ${GITHUB_SHA}"',
     ].join("\n");
     expect(normalizeScript(String(markerStep?.run ?? ""))).toBe(reviewedMarkerRun);
+
+    // The persisted-credential job must stay main-only (a push to refs/heads/main),
+    // so the accepted risk never runs on a PR or fork head ref. Bind that job-level
+    // guard here too, keeping the full documented invariant fail-closed in one place.
+    const markGreenIf = String(parsedWorkflow.jobs?.["mark-green"]?.if ?? "");
+    expect(markGreenIf).toContain("github.ref == 'refs/heads/main'");
+    expect(markGreenIf).toContain("github.event_name == 'push'");
   });
 
   it("refuses environment-injected audit fixtures outside tests", () => {

--- a/tests/unit/supply-chain-policy.unit.test.ts
+++ b/tests/unit/supply-chain-policy.unit.test.ts
@@ -1499,9 +1499,12 @@ describe("supply-chain audit policy", () => {
     // everything else must be inline `run:` steps. Any added `uses:` (a
     // third-party action or artifact upload) trips this and forces re-review of
     // the accepted artipacked risk.
-    // Require real `- uses:` step mappings (dash mandatory, start-anchored) so a
-    // commented `# uses:` line is never counted.
-    const markGreenUses = markGreenJob.match(/^\s*-\s*uses:\s*\S+/gm) ?? [];
+    // Count every `uses:` step property in the job — both the uses-first
+    // (`- uses:`) and the name-first (`- name:` then an indented `uses:`, as at
+    // test.yml:618) forms — with the dash optional but start-anchored so a
+    // commented `# uses:` line is never counted. A third-party action added in
+    // either form (e.g. an artifact upload) pushes the count past one.
+    const markGreenUses = markGreenJob.match(/^\s*-?\s*uses:\s*\S+/gm) ?? [];
     expect(markGreenUses).toHaveLength(1);
     expect(markGreenUses[0]).toMatch(/actions\/checkout@[0-9a-f]{40}\b/);
   });

--- a/tests/unit/supply-chain-policy.unit.test.ts
+++ b/tests/unit/supply-chain-policy.unit.test.ts
@@ -15,6 +15,7 @@ import { tmpdir } from "os";
 import { join, resolve } from "path";
 import { spawnSync } from "child_process";
 import { createRequire } from "module";
+import { parse as parseWorkflowYaml } from "yaml";
 
 const root = join(__dirname, "../..");
 const nodeRequire = createRequire(__filename);
@@ -1495,18 +1496,21 @@ describe("supply-chain audit policy", () => {
 
     // Fail-closed on the suppression's core safety invariant: the mark-green job
     // must run NO third-party action while the checkout credential is persisted.
-    // It may use exactly one `uses:` — the SHA-pinned actions/checkout — and
-    // everything else must be inline `run:` steps. Any added `uses:` (a
-    // third-party action or artifact upload) trips this and forces re-review of
-    // the accepted artipacked risk.
-    // Count every `uses:` step property in the job — both the uses-first
-    // (`- uses:`) and the name-first (`- name:` then an indented `uses:`, as at
-    // test.yml:618) forms — with the dash optional but start-anchored so a
-    // commented `# uses:` line is never counted. A third-party action added in
-    // either form (e.g. an artifact upload) pushes the count past one.
-    const markGreenUses = markGreenJob.match(/^\s*-?\s*uses:\s*\S+/gm) ?? [];
-    expect(markGreenUses).toHaveLength(1);
-    expect(markGreenUses[0]).toMatch(/actions\/checkout@[0-9a-f]{40}\b/);
+    // Parse the workflow as YAML (not a line regex) so every step-form counts —
+    // block (`- uses:`), name-first (`- name:` then `uses:`), and flow/aliased
+    // (`- { uses: x }`) alike — and a second action cannot slip past a
+    // line-based scan. The job may declare exactly ONE step with a `uses` key:
+    // the SHA-pinned actions/checkout. Any added action or artifact upload, in
+    // any YAML form, pushes the count past one and forces re-review.
+    const parsedWorkflow = parseWorkflowYaml(workflow) as {
+      jobs?: Record<string, { steps?: Array<Record<string, unknown>> }>;
+    };
+    const markGreenSteps = parsedWorkflow.jobs?.["mark-green"]?.steps ?? [];
+    const markGreenUsesSteps = markGreenSteps.filter(
+      (step) => step != null && typeof step === "object" && "uses" in step,
+    );
+    expect(markGreenUsesSteps).toHaveLength(1);
+    expect(String(markGreenUsesSteps[0]?.uses)).toMatch(/actions\/checkout@[0-9a-f]{40}\b/);
   });
 
   it("refuses environment-injected audit fixtures outside tests", () => {

--- a/tests/unit/supply-chain-policy.unit.test.ts
+++ b/tests/unit/supply-chain-policy.unit.test.ts
@@ -1497,8 +1497,23 @@ describe("supply-chain audit policy", () => {
     // new `uses:`, or ANY new executable/download/upload line in the run script
     // fails this test and forces re-review of the persisted write token.
     const parsedWorkflow = parseWorkflowYaml(workflow) as {
+      defaults?: unknown;
+      env?: Record<string, unknown>;
       jobs?: Record<string, { if?: string; steps?: Array<Record<string, unknown>> }>;
     };
+
+    // Fail closed on WORKFLOW-level execution surfaces inherited by every job,
+    // including this credential-bearing one. The job-key allowlist below stops a
+    // job-level `defaults`/`env`, but a top-level `defaults.run.shell` wrapper or
+    // a global `env.BASH_ENV` would run extra code with the persisted write token
+    // while the job/step keys and snapshotted `run` text stay unchanged (the repo
+    // already treats workflow-level custom shells as an execution surface in
+    // scripts/check-runtime-policy.mjs). Require NO top-level `defaults` at all,
+    // and pin the top-level `env` to its single reviewed data key so any inherited
+    // execution setting forces re-review. A legitimate future addition must update
+    // this allowlist, which re-anchors the review to the persisted-credential job.
+    expect(parsedWorkflow.defaults).toBeUndefined();
+    expect(Object.keys(parsedWorkflow.env ?? {})).toEqual(["ZIZMOR_IMAGE"]);
 
     // actions/checkout defaults `persist-credentials` to true, so "only
     // mark-green persists the token" is NOT proven by counting literal

--- a/tests/unit/supply-chain-policy.unit.test.ts
+++ b/tests/unit/supply-chain-policy.unit.test.ts
@@ -1528,7 +1528,11 @@ describe("supply-chain audit policy", () => {
       (checkoutStep?.with as Record<string, unknown> | undefined)?.["persist-credentials"],
     ).toBe(true);
 
-    expect("uses" in (markerStep ?? {})).toBe(false);
+    // Bind the marker step's exact key set (as for the checkout step) so an
+    // execution-affecting field — `uses`, a custom `shell:` (e.g. running a
+    // checked-in script), `env:` (e.g. BASH_ENV), `working-directory`, `if`, … —
+    // added alongside the snapshotted `run` still forces re-review.
+    expect(Object.keys(markerStep ?? {}).sort()).toEqual(["name", "run"]);
     expect(typeof markerStep?.run).toBe("string");
 
     // Snapshot the inline step's script, whitespace-normalized (per-line trim,
@@ -1564,9 +1568,14 @@ describe("supply-chain audit policy", () => {
     // The persisted-credential job must stay main-only (a push to refs/heads/main),
     // so the accepted risk never runs on a PR or fork head ref. Bind that job-level
     // guard here too, keeping the full documented invariant fail-closed in one place.
+    // Pin the ENTIRE reviewed condition, not substrings: a broadening clause
+    // (e.g. `|| github.event_name == 'pull_request'`) preserves both substrings
+    // yet would let the credentialed marker push run off `main` — comparing the
+    // normalized condition to the exact reviewed expression forces re-review.
     const markGreenIf = String(parsedWorkflow.jobs?.["mark-green"]?.if ?? "");
-    expect(markGreenIf).toContain("github.ref == 'refs/heads/main'");
-    expect(markGreenIf).toContain("github.event_name == 'push'");
+    expect(markGreenIf.trim()).toBe(
+      "github.ref == 'refs/heads/main' && github.event_name == 'push'",
+    );
   });
 
   it("refuses environment-injected audit fixtures outside tests", () => {

--- a/tests/unit/supply-chain-policy.unit.test.ts
+++ b/tests/unit/supply-chain-policy.unit.test.ts
@@ -1427,6 +1427,48 @@ describe("supply-chain audit policy", () => {
     expect(markGreenJob).toContain("Advanced owned ci-green marker to");
   });
 
+  it("anchors the zizmor artipacked ignore to the ci-green marker checkout", () => {
+    // The artipacked suppression persists the checkout credential ON PURPOSE so
+    // the ci-green marker push works, and it is pinned by raw line number
+    // (test.yml:<line>). zizmor matches ignores by file:line, not by job/step
+    // identity, so a future edit that shifts a DIFFERENT actions/checkout onto
+    // that line would silently inherit the suppression. This required test
+    // compensates for that brittleness: it fails if the pinned line no longer
+    // resolves to the persist-credentials:true checkout inside the mark-green
+    // (ci-green marker) job, forcing a re-review instead of a silent mask.
+    const zizmorConfig = readFileSync(join(root, "zizmor.yml"), "utf8");
+    const artipackedBlock = yamlBlockForKey(zizmorConfig, "artipacked");
+    expect(artipackedBlock).not.toBeNull();
+    const anchors = [...(artipackedBlock ?? "").matchAll(/-\s*test\.yml:(\d+)/g)];
+    // Exactly one anchored checkout may carry this accepted-risk suppression.
+    expect(anchors).toHaveLength(1);
+    const anchoredLine = Number(anchors[0]?.[1]);
+    expect(Number.isInteger(anchoredLine)).toBe(true);
+
+    const workflowLines = workflow.split(/\r?\n/);
+    // Anchor is 1-indexed and must be the checkout `uses:` line itself.
+    const anchoredText = workflowLines[anchoredLine - 1] ?? "";
+    expect(anchoredText).toMatch(/uses:\s*actions\/checkout@/);
+
+    // That line must fall inside the mark-green job block, and that job must be
+    // the one persisting credentials — so an unrelated checkout cannot inherit
+    // the ignore even if it lands on the same line number.
+    const markGreenJob = jobBlock("mark-green");
+    const jobStartOffset = workflow.indexOf(markGreenJob);
+    expect(jobStartOffset).toBeGreaterThanOrEqual(0);
+    const anchoredOffset = workflowLines
+      .slice(0, anchoredLine - 1)
+      .reduce((sum, line) => sum + line.length + 1, 0);
+    expect(anchoredOffset).toBeGreaterThanOrEqual(jobStartOffset);
+    expect(anchoredOffset).toBeLessThan(jobStartOffset + markGreenJob.length);
+    expect(markGreenJob).toContain("persist-credentials: true");
+
+    // The persisted-credential checkout is unique to this job: no other job in
+    // the workflow uses persist-credentials:true, so the accepted risk stays
+    // scoped to the reviewed ci-green marker push.
+    expect(workflow.match(/persist-credentials:\s*true/g) ?? []).toHaveLength(1);
+  });
+
   it("refuses environment-injected audit fixtures outside tests", () => {
     const result = spawnSync(process.execPath, ["scripts/audit-supply-chain.mjs"], {
       cwd: root,

--- a/tests/unit/supply-chain-policy.unit.test.ts
+++ b/tests/unit/supply-chain-policy.unit.test.ts
@@ -1518,6 +1518,21 @@ describe("supply-chain audit policy", () => {
     }
     expect(persistingCheckoutJobs).toEqual(["mark-green"]);
 
+    // Fail closed on the job's OWN top-level surface too: a step allowlist does
+    // not stop `container:`, `services:`, or a job-level `defaults.run.shell:`
+    // from running or altering code in this credential-bearing job while every
+    // step assertion still passes. Pin the exact set of reviewed job keys so any
+    // new job-level execution surface forces re-review of the persisted token.
+    expect(Object.keys(parsedWorkflow.jobs?.["mark-green"] ?? {}).sort()).toEqual([
+      "concurrency",
+      "if",
+      "name",
+      "needs",
+      "permissions",
+      "runs-on",
+      "steps",
+    ]);
+
     const markGreenSteps = parsedWorkflow.jobs?.["mark-green"]?.steps ?? [];
     expect(markGreenSteps).toHaveLength(2);
 

--- a/tests/unit/supply-chain-policy.unit.test.ts
+++ b/tests/unit/supply-chain-policy.unit.test.ts
@@ -1450,9 +1450,11 @@ describe("supply-chain audit policy", () => {
     // per preceding line (`\r\n` split away but only `\n` re-added).
     const workflowLf = workflow.replace(/\r\n/g, "\n");
     const workflowLines = workflowLf.split("\n");
-    // Anchor is 1-indexed and must be the checkout `uses:` line itself.
+    // Anchor is 1-indexed and must be the checkout `uses:` line itself — a real
+    // SHA-pinned `- uses:` mapping, start-anchored so a commented
+    // `# uses: actions/checkout@…` line cannot satisfy it.
     const anchoredText = workflowLines[anchoredLine - 1] ?? "";
-    expect(anchoredText).toMatch(/uses:\s*actions\/checkout@/);
+    expect(anchoredText).toMatch(/^\s*-\s*uses:\s*actions\/checkout@[0-9a-f]{40}\b/);
 
     // That line must fall inside the mark-green job block, and that job must be
     // the one persisting credentials — so an unrelated checkout cannot inherit
@@ -1497,9 +1499,11 @@ describe("supply-chain audit policy", () => {
     // everything else must be inline `run:` steps. Any added `uses:` (a
     // third-party action or artifact upload) trips this and forces re-review of
     // the accepted artipacked risk.
-    const markGreenUses = markGreenJob.match(/^\s*-?\s*uses:\s*\S+/gm) ?? [];
+    // Require real `- uses:` step mappings (dash mandatory, start-anchored) so a
+    // commented `# uses:` line is never counted.
+    const markGreenUses = markGreenJob.match(/^\s*-\s*uses:\s*\S+/gm) ?? [];
     expect(markGreenUses).toHaveLength(1);
-    expect(markGreenUses[0]).toMatch(/actions\/checkout@/);
+    expect(markGreenUses[0]).toMatch(/actions\/checkout@[0-9a-f]{40}\b/);
   });
 
   it("refuses environment-injected audit fixtures outside tests", () => {

--- a/tests/unit/supply-chain-policy.unit.test.ts
+++ b/tests/unit/supply-chain-policy.unit.test.ts
@@ -1494,23 +1494,59 @@ describe("supply-chain audit policy", () => {
     // commented occurrences.
     expect(workflowLf.match(/^\s*persist-credentials:\s*true\b/gm) ?? []).toHaveLength(1);
 
-    // Fail-closed on the suppression's core safety invariant: the mark-green job
-    // must run NO third-party action while the checkout credential is persisted.
-    // Parse the workflow as YAML (not a line regex) so every step-form counts —
-    // block (`- uses:`), name-first (`- name:` then `uses:`), and flow/aliased
-    // (`- { uses: x }`) alike — and a second action cannot slip past a
-    // line-based scan. The job may declare exactly ONE step with a `uses` key:
-    // the SHA-pinned actions/checkout. Any added action or artifact upload, in
-    // any YAML form, pushes the count past one and forces re-review.
+    // Fail-closed on the FULL accepted-risk invariant, not just an action count.
+    // Parse the workflow as YAML (not a line regex) so every step form is seen —
+    // block (`- uses:`), name-first (`- name:`/`uses:`), and flow/aliased
+    // (`- { uses: x }`) alike. mark-green must be EXACTLY its two reviewed steps:
+    // the SHA-pinned actions/checkout (which persists the credential) and one
+    // inline git `run:` step whose script is snapshotted below. Adding a step, a
+    // new `uses:`, or ANY new executable/download/upload line in the run script
+    // fails this test and forces re-review of the persisted write token.
     const parsedWorkflow = parseWorkflowYaml(workflow) as {
       jobs?: Record<string, { steps?: Array<Record<string, unknown>> }>;
     };
     const markGreenSteps = parsedWorkflow.jobs?.["mark-green"]?.steps ?? [];
-    const markGreenUsesSteps = markGreenSteps.filter(
-      (step) => step != null && typeof step === "object" && "uses" in step,
-    );
-    expect(markGreenUsesSteps).toHaveLength(1);
-    expect(String(markGreenUsesSteps[0]?.uses)).toMatch(/actions\/checkout@[0-9a-f]{40}\b/);
+    expect(markGreenSteps).toHaveLength(2);
+
+    const [checkoutStep, markerStep] = markGreenSteps;
+    expect(Object.keys(checkoutStep ?? {}).sort()).toEqual(["uses", "with"]);
+    expect(String(checkoutStep?.uses)).toMatch(/^actions\/checkout@[0-9a-f]{40}$/);
+    expect(
+      (checkoutStep?.with as Record<string, unknown> | undefined)?.["persist-credentials"],
+    ).toBe(true);
+
+    expect("uses" in (markerStep ?? {})).toBe(false);
+    expect(typeof markerStep?.run).toBe("string");
+
+    // Snapshot the inline step's script, whitespace-normalized (per-line trim,
+    // blank lines dropped), so formatting stays flexible but the executable
+    // content is pinned to these reviewed git/echo/shell-control commands.
+    const normalizeScript = (script: string) =>
+      script
+        .split("\n")
+        .map((line) => line.trim())
+        .filter((line) => line !== "")
+        .join("\n");
+    const reviewedMarkerRun = [
+      "set -euo pipefail",
+      'tested_sha="$(git rev-parse HEAD)"',
+      "current_main_sha=\"$(git ls-remote origin refs/heads/main | awk '{print $1}')\"",
+      'if [[ "$tested_sha" != "$GITHUB_SHA" ]]; then',
+      'echo "::error::Checked-out HEAD ${tested_sha} does not match GITHUB_SHA ${GITHUB_SHA}"',
+      "exit 1",
+      "fi",
+      'if [[ -z "$current_main_sha" ]]; then',
+      'echo "::error::Could not resolve remote refs/heads/main"',
+      "exit 1",
+      "fi",
+      'if [[ "$current_main_sha" != "$GITHUB_SHA" ]]; then',
+      'echo "::notice::Skipping ci-green update for stale run ${GITHUB_SHA}; current main is ${current_main_sha}"',
+      "exit 0",
+      "fi",
+      'git push origin "${GITHUB_SHA}:refs/heads/ci-green" --force',
+      'echo "::notice::Advanced owned ci-green marker to ${GITHUB_SHA}"',
+    ].join("\n");
+    expect(normalizeScript(String(markerStep?.run ?? ""))).toBe(reviewedMarkerRun);
   });
 
   it("refuses environment-injected audit fixtures outside tests", () => {

--- a/tests/unit/supply-chain-policy.unit.test.ts
+++ b/tests/unit/supply-chain-policy.unit.test.ts
@@ -1481,12 +1481,25 @@ describe("supply-chain audit policy", () => {
       }
       stepBlock.push(next);
     }
-    expect(stepBlock.join("\n")).toMatch(/persist-credentials:\s*true/);
+    // Anchored to a real YAML mapping line (start-of-line after indent) so a
+    // commented `# persist-credentials: true` cannot satisfy the assertion.
+    expect(stepBlock.join("\n")).toMatch(/^\s*persist-credentials:\s*true\b/m);
 
     // The persisted-credential checkout is unique to this job: no other job in
-    // the workflow uses persist-credentials:true, so the accepted risk stays
-    // scoped to the reviewed ci-green marker push.
-    expect(workflowLf.match(/persist-credentials:\s*true/g) ?? []).toHaveLength(1);
+    // the workflow persists credentials, so the accepted risk stays scoped to
+    // the reviewed ci-green marker push. Same start-of-line anchor excludes
+    // commented occurrences.
+    expect(workflowLf.match(/^\s*persist-credentials:\s*true\b/gm) ?? []).toHaveLength(1);
+
+    // Fail-closed on the suppression's core safety invariant: the mark-green job
+    // must run NO third-party action while the checkout credential is persisted.
+    // It may use exactly one `uses:` — the SHA-pinned actions/checkout — and
+    // everything else must be inline `run:` steps. Any added `uses:` (a
+    // third-party action or artifact upload) trips this and forces re-review of
+    // the accepted artipacked risk.
+    const markGreenUses = markGreenJob.match(/^\s*-?\s*uses:\s*\S+/gm) ?? [];
+    expect(markGreenUses).toHaveLength(1);
+    expect(markGreenUses[0]).toMatch(/actions\/checkout@/);
   });
 
   it("refuses environment-injected audit fixtures outside tests", () => {

--- a/tests/unit/supply-chain-policy.unit.test.ts
+++ b/tests/unit/supply-chain-policy.unit.test.ts
@@ -1445,7 +1445,11 @@ describe("supply-chain audit policy", () => {
     const anchoredLine = Number(anchors[0]?.[1]);
     expect(Number.isInteger(anchoredLine)).toBe(true);
 
-    const workflowLines = workflow.split(/\r?\n/);
+    // Normalize to LF so the character-offset math below is newline-convention
+    // agnostic: a CRLF checkout would otherwise skew every offset by one byte
+    // per preceding line (`\r\n` split away but only `\n` re-added).
+    const workflowLf = workflow.replace(/\r\n/g, "\n");
+    const workflowLines = workflowLf.split("\n");
     // Anchor is 1-indexed and must be the checkout `uses:` line itself.
     const anchoredText = workflowLines[anchoredLine - 1] ?? "";
     expect(anchoredText).toMatch(/uses:\s*actions\/checkout@/);
@@ -1453,8 +1457,8 @@ describe("supply-chain audit policy", () => {
     // That line must fall inside the mark-green job block, and that job must be
     // the one persisting credentials — so an unrelated checkout cannot inherit
     // the ignore even if it lands on the same line number.
-    const markGreenJob = jobBlock("mark-green");
-    const jobStartOffset = workflow.indexOf(markGreenJob);
+    const markGreenJob = jobBlock("mark-green").replace(/\r\n/g, "\n");
+    const jobStartOffset = workflowLf.indexOf(markGreenJob);
     expect(jobStartOffset).toBeGreaterThanOrEqual(0);
     const anchoredOffset = workflowLines
       .slice(0, anchoredLine - 1)
@@ -1482,7 +1486,7 @@ describe("supply-chain audit policy", () => {
     // The persisted-credential checkout is unique to this job: no other job in
     // the workflow uses persist-credentials:true, so the accepted risk stays
     // scoped to the reviewed ci-green marker push.
-    expect(workflow.match(/persist-credentials:\s*true/g) ?? []).toHaveLength(1);
+    expect(workflowLf.match(/persist-credentials:\s*true/g) ?? []).toHaveLength(1);
   });
 
   it("refuses environment-injected audit fixtures outside tests", () => {

--- a/tests/unit/supply-chain-policy.unit.test.ts
+++ b/tests/unit/supply-chain-policy.unit.test.ts
@@ -1539,9 +1539,14 @@ describe("supply-chain audit policy", () => {
     const [checkoutStep, markerStep] = markGreenSteps;
     expect(Object.keys(checkoutStep ?? {}).sort()).toEqual(["uses", "with"]);
     expect(String(checkoutStep?.uses)).toMatch(/^actions\/checkout@[0-9a-f]{40}$/);
-    expect(
-      (checkoutStep?.with as Record<string, unknown> | undefined)?.["persist-credentials"],
-    ).toBe(true);
+    // Bind the checkout's `with` map to ONLY `persist-credentials` too: an extra
+    // input such as `token: ${{ secrets.PAT }}` or `github-server-url: https://…`
+    // changes which credential/host is persisted — invalidating the suppression's
+    // GITHUB_TOKEN/no-exfiltration rationale — without altering the step keys, so
+    // a bare value check would still pass. Any new input now forces re-review.
+    const checkoutWith = (checkoutStep?.with as Record<string, unknown> | undefined) ?? {};
+    expect(Object.keys(checkoutWith)).toEqual(["persist-credentials"]);
+    expect(checkoutWith["persist-credentials"]).toBe(true);
 
     // Bind the marker step's exact key set (as for the checkout step) so an
     // execution-affecting field — `uses`, a custom `shell:` (e.g. running a

--- a/tests/unit/supply-chain-policy.unit.test.ts
+++ b/tests/unit/supply-chain-policy.unit.test.ts
@@ -1488,12 +1488,6 @@ describe("supply-chain audit policy", () => {
     // commented `# persist-credentials: true` cannot satisfy the assertion.
     expect(stepBlock.join("\n")).toMatch(/^\s*persist-credentials:\s*true\b/m);
 
-    // The persisted-credential checkout is unique to this job: no other job in
-    // the workflow persists credentials, so the accepted risk stays scoped to
-    // the reviewed ci-green marker push. Same start-of-line anchor excludes
-    // commented occurrences.
-    expect(workflowLf.match(/^\s*persist-credentials:\s*true\b/gm) ?? []).toHaveLength(1);
-
     // Fail-closed on the FULL accepted-risk invariant, not just an action count.
     // Parse the workflow as YAML (not a line regex) so every step form is seen —
     // block (`- uses:`), name-first (`- name:`/`uses:`), and flow/aliased
@@ -1505,6 +1499,25 @@ describe("supply-chain audit policy", () => {
     const parsedWorkflow = parseWorkflowYaml(workflow) as {
       jobs?: Record<string, { if?: string; steps?: Array<Record<string, unknown>> }>;
     };
+
+    // actions/checkout defaults `persist-credentials` to true, so "only
+    // mark-green persists the token" is NOT proven by counting literal
+    // `persist-credentials: true` — a checkout that omits the input persists by
+    // default. Enumerate every checkout across all jobs and require the only
+    // credential-persisting one to be mark-green's; every other checkout must opt
+    // out with `persist-credentials: false` explicitly.
+    const persistingCheckoutJobs: string[] = [];
+    for (const [jobId, job] of Object.entries(parsedWorkflow.jobs ?? {})) {
+      for (const step of job.steps ?? []) {
+        if (step == null || typeof step !== "object") continue;
+        const stepUses = typeof step.uses === "string" ? step.uses : "";
+        if (!/^actions\/checkout@/.test(stepUses)) continue;
+        const withBlock = (step.with as Record<string, unknown> | undefined) ?? {};
+        if (withBlock["persist-credentials"] !== false) persistingCheckoutJobs.push(jobId);
+      }
+    }
+    expect(persistingCheckoutJobs).toEqual(["mark-green"]);
+
     const markGreenSteps = parsedWorkflow.jobs?.["mark-green"]?.steps ?? [];
     expect(markGreenSteps).toHaveLength(2);
 

--- a/tests/unit/supply-chain-policy.unit.test.ts
+++ b/tests/unit/supply-chain-policy.unit.test.ts
@@ -1461,7 +1461,23 @@ describe("supply-chain audit policy", () => {
       .reduce((sum, line) => sum + line.length + 1, 0);
     expect(anchoredOffset).toBeGreaterThanOrEqual(jobStartOffset);
     expect(anchoredOffset).toBeLessThan(jobStartOffset + markGreenJob.length);
-    expect(markGreenJob).toContain("persist-credentials: true");
+
+    // `persist-credentials: true` must belong to THIS checkout step, not merely
+    // appear somewhere in the job: extract the step block that starts at the
+    // anchored `- uses:` line and runs until the next sibling step (a `- ` at
+    // the same indent) or the end of the job. A second checkout that persists
+    // credentials elsewhere in the job would not satisfy this.
+    const anchorIndent = anchoredText.match(/^(\s*)-/)?.[1].length ?? 0;
+    const stepBlock: string[] = [anchoredText];
+    for (let i = anchoredLine; i < workflowLines.length; i += 1) {
+      const next = workflowLines[i] ?? "";
+      if (new RegExp(`^\\s{${anchorIndent}}-\\s`).test(next)) break;
+      if (next.trim() !== "" && (next.match(/^(\s*)\S/)?.[1].length ?? 0) <= anchorIndent) {
+        break;
+      }
+      stepBlock.push(next);
+    }
+    expect(stepBlock.join("\n")).toMatch(/persist-credentials:\s*true/);
 
     // The persisted-credential checkout is unique to this job: no other job in
     // the workflow uses persist-credentials:true, so the accepted risk stays

--- a/tests/unit/supply-chain-policy.unit.test.ts
+++ b/tests/unit/supply-chain-policy.unit.test.ts
@@ -1538,7 +1538,11 @@ describe("supply-chain audit policy", () => {
     // from running or altering code in this credential-bearing job while every
     // step assertion still passes. Pin the exact set of reviewed job keys so any
     // new job-level execution surface forces re-review of the persisted token.
-    expect(Object.keys(parsedWorkflow.jobs?.["mark-green"] ?? {}).sort()).toEqual([
+    const markGreenJobParsed = (parsedWorkflow.jobs?.["mark-green"] ?? {}) as Record<
+      string,
+      unknown
+    >;
+    expect(Object.keys(markGreenJobParsed).sort()).toEqual([
       "concurrency",
       "if",
       "name",
@@ -1547,6 +1551,15 @@ describe("supply-chain audit policy", () => {
       "runs-on",
       "steps",
     ]);
+
+    // Pin the VALUES of the two security-sensitive keys, not just their presence.
+    // `runs-on: self-hosted` would let the credential-bearing job run on a runner
+    // that can execute persisted hooks; `permissions: write-all` (or any extra
+    // grant) would widen the token past the documented `contents: write` scope —
+    // both leave the key set unchanged, so bind the reviewed values to force
+    // re-review of either broadening.
+    expect(markGreenJobParsed["runs-on"]).toBe("ubuntu-latest");
+    expect(markGreenJobParsed.permissions).toEqual({ contents: "write" });
 
     const markGreenSteps = parsedWorkflow.jobs?.["mark-green"]?.steps ?? [];
     expect(markGreenSteps).toHaveLength(2);

--- a/zizmor.yml
+++ b/zizmor.yml
@@ -72,12 +72,23 @@ rules:
       # `ci-green` marker ref on `main` via `git push` in the following step,
       # and that push needs the persisted checkout credential. Setting
       # `persist-credentials: false` would break the marker push — it is a
-      # functional requirement here, not an oversight. The job is `main`-only,
-      # scoped to `contents: write`, and uploads no artifacts, so the persisted
-      # credential cannot leak into build outputs. The artipacked risk this
-      # audit flags does not apply, so the finding is accepted.
+      # functional requirement here, not an oversight.
+      #
+      # `persist-credentials: true` writes the `contents: write` GITHUB_TOKEN
+      # into `.git/config`, where every step in the job can read it for the
+      # job's full duration — not only an artifact-upload step. The true safety
+      # invariant is therefore that this job runs NO untrusted/third-party code
+      # while the credential is persisted: it runs only the SHA-pinned
+      # `actions/checkout` and inline, trusted git commands, uploads no
+      # artifacts, and is `main`-only. Under that invariant the persisted
+      # credential has no exfil surface, so the artipacked finding is accepted.
+      # Re-review whenever this job gains any third-party action/script, an
+      # artifact upload, or stops pushing the marker ref.
       #
       # Anchored to the ci-green marker `actions/checkout` (test.yml:1008).
-      # Re-review whenever that job stops pushing the marker ref or gains an
-      # artifact upload.
+      # zizmor matches ignores by file:line, not by job/step identity, so a
+      # shifted line could mask an unrelated checkout. A required test
+      # (tests/unit/supply-chain-policy.unit.test.ts) compensates: it fails if
+      # this anchor no longer resolves to the persist-credentials:true checkout
+      # inside the mark-green job, or if any other job persists credentials.
       - test.yml:1008

--- a/zizmor.yml
+++ b/zizmor.yml
@@ -67,7 +67,7 @@ rules:
       - test.yml:397
   artipacked:
     ignore:
-      # The ci-green marker job (test.yml:1016) checks out with
+      # The ci-green marker job (test.yml:1021) checks out with
       # `persist-credentials: true` on purpose: it force-advances the owned
       # `ci-green` marker ref on `main` via `git push` in the following step,
       # and that push needs the persisted checkout credential. Setting
@@ -88,10 +88,10 @@ rules:
       # Re-review whenever this job gains any third-party action/script, an
       # artifact upload, or stops pushing the marker ref.
       #
-      # Anchored to the ci-green marker `actions/checkout` (test.yml:1016).
+      # Anchored to the ci-green marker `actions/checkout` (test.yml:1021).
       # zizmor matches ignores by file:line, not by job/step identity, so a
       # shifted line could mask an unrelated checkout. A required test
       # (tests/unit/supply-chain-policy.unit.test.ts) compensates: it fails if
       # this anchor no longer resolves to the persist-credentials:true checkout
       # inside the mark-green job, or if any other job persists credentials.
-      - test.yml:1016
+      - test.yml:1021

--- a/zizmor.yml
+++ b/zizmor.yml
@@ -74,9 +74,12 @@ rules:
       # `persist-credentials: false` would break the marker push — it is a
       # functional requirement here, not an oversight.
       #
-      # `persist-credentials: true` writes the `contents: write` GITHUB_TOKEN
-      # into `.git/config`, where every step in the job can read it for the
-      # job's full duration — not only an artifact-upload step. The true safety
+      # `persist-credentials: true` leaves the `contents: write` GITHUB_TOKEN
+      # usable by Git for the job's full duration: actions/checkout v7 stores
+      # the credential in a Git config file under `$RUNNER_TEMP` and wires it
+      # into the checkout's local `.git/config` via an `http.<host>.extraheader`
+      # and an `includeIf.gitdir` include, so any Git command in the job can use
+      # it — not only an artifact-upload step. The true safety
       # invariant is therefore that this job runs NO untrusted/third-party code
       # while the credential is persisted: it runs only the SHA-pinned
       # `actions/checkout` and inline, trusted git commands, uploads no

--- a/zizmor.yml
+++ b/zizmor.yml
@@ -65,3 +65,19 @@ rules:
       # Re-review whenever the pack-smoke install step moves or changes what it
       # installs.
       - test.yml:397
+  artipacked:
+    ignore:
+      # The ci-green marker job (test.yml:1008) checks out with
+      # `persist-credentials: true` on purpose: it force-advances the owned
+      # `ci-green` marker ref on `main` via `git push` in the following step,
+      # and that push needs the persisted checkout credential. Setting
+      # `persist-credentials: false` would break the marker push — it is a
+      # functional requirement here, not an oversight. The job is `main`-only,
+      # scoped to `contents: write`, and uploads no artifacts, so the persisted
+      # credential cannot leak into build outputs. The artipacked risk this
+      # audit flags does not apply, so the finding is accepted.
+      #
+      # Anchored to the ci-green marker `actions/checkout` (test.yml:1008).
+      # Re-review whenever that job stops pushing the marker ref or gains an
+      # artifact upload.
+      - test.yml:1008

--- a/zizmor.yml
+++ b/zizmor.yml
@@ -67,7 +67,7 @@ rules:
       - test.yml:397
   artipacked:
     ignore:
-      # The ci-green marker job (test.yml:1008) checks out with
+      # The ci-green marker job (test.yml:1016) checks out with
       # `persist-credentials: true` on purpose: it force-advances the owned
       # `ci-green` marker ref on `main` via `git push` in the following step,
       # and that push needs the persisted checkout credential. Setting
@@ -85,10 +85,10 @@ rules:
       # Re-review whenever this job gains any third-party action/script, an
       # artifact upload, or stops pushing the marker ref.
       #
-      # Anchored to the ci-green marker `actions/checkout` (test.yml:1008).
+      # Anchored to the ci-green marker `actions/checkout` (test.yml:1016).
       # zizmor matches ignores by file:line, not by job/step identity, so a
       # shifted line could mask an unrelated checkout. A required test
       # (tests/unit/supply-chain-policy.unit.test.ts) compensates: it fails if
       # this anchor no longer resolves to the persist-credentials:true checkout
       # inside the mark-green job, or if any other job persists credentials.
-      - test.yml:1008
+      - test.yml:1016


### PR DESCRIPTION
## Summary

Resolves the zizmor `artipacked` finding (Alert #84) on the `ci-green` marker checkout in `test.yml`. That job checks out with `persist-credentials: true` on purpose: it force-advances the owned `ci-green` marker ref on `main` via `git push`, and that push needs the persisted checkout credential. Setting `persist-credentials: false` would break the marker push, a functional requirement, not an oversight.

The fix adds a rationale-bearing `artipacked` ignore for `test.yml:1021` to the checked-in `zizmor.yml`, matching the existing suppression convention (every entry carries a why + a re-review note). No push credential is changed, so the `ci-green` marker push still works.

This PR is intentionally scoped to the `artipacked` suppression only. It touches **three files** — `zizmor.yml`, `tests/unit/supply-chain-policy.unit.test.ts`, and `.cspell/project-words.txt` — and no dependency, lockfile, or `pnpm-workspace.yaml` changes (the sharp/js-yaml advisory patching landed separately on `main`).

## Changes

**zizmor suppression (the fix)**
- `zizmor.yml`: added an `artipacked` ignore anchored to `test.yml:1021` with a rationale stating the true safety invariant, the persisted `contents: write` token lands in `.git/config` and is readable by every step for the job's duration, so safety depends on the job running **no untrusted/third-party code** (only the SHA-pinned checkout + inline trusted git commands, no artifact upload, `main`-only). The re-review trigger fires on any added third-party action/script, artifact upload, or change to the marker push.

**Compensating test (review feedback)**
- `tests/unit/supply-chain-policy.unit.test.ts`: added a required test that binds the suppression to intent. zizmor matches ignores by `file:line`, not job/step identity, so a shifted line could mask an unrelated checkout. The test fails unless `test.yml:1021` still resolves to the `actions/checkout` inside the `mark-green` job, the anchor offset falls within that job block, `persist-credentials: true` lives in that **specific** checkout step block (not merely somewhere in the job), and no other job in the workflow persists credentials. The offset math is newline-convention agnostic (normalized to LF), so it holds on CRLF checkouts too.

**CI fix (unblock the branch)**
- `.cspell/project-words.txt`: added `artipacked` (the zizmor rule name) to the project dictionary; it was failing cspell and the `spelling-policy` contract test.

## Commits

- `docs: suppress zizmor artipacked on ci-green marker checkout`
- `test: bind artipacked ignore to ci-green checkout`
- `test: assert persist-credentials in anchored checkout step`
- `chore: add artipacked to cspell dictionary`
- `fix: re-anchor artipacked ignore to shifted ci-green checkout line`
- `test: make artipacked anchor offset math CRLF-safe`

## Linked issue

Closes #421

## Tests run

- `zizmor --no-config .github/workflows/test.yml` reports the target `artipacked` finding at `test.yml:1021`; with `zizmor.yml` it reports `No findings to report. Good job!` (ignored + suppressed).
- `pnpm exec vitest run tests/unit/supply-chain-policy.unit.test.ts` passes (64/64), including the anchor test.
- `pnpm run spell`, `pnpm run lint`, `pnpm run format:check`, and `pnpm run typecheck` all pass.

## Follow-up notes

- Re-review the suppression if the marker-advance job stops pushing the `ci-green` ref, gains an artifact upload, or adds any third-party action/script while credentials are persisted.
- The alternative restructure (mint a scoped push token so the checkout can use `persist-credentials: false`) was intentionally not taken, the documented suppression is the lowest-risk option per the issue.

