### PR TITLE
docs: add Backblaze Labs ecosystem section to README

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- README "Backblaze Labs ecosystem" section cross-linking Genblaze,
+  b2-sdk-typescript, and b2-action. (#427)
+
 ## [0.2.1] - 2026-09-04
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@ Destructive actions are gated, durable B2 secrets stay out of the model's contex
 - [Privacy](#privacy)
 - [Development](#development)
 - [Documentation](#documentation)
+- [Backblaze Labs ecosystem](#backblaze-labs-ecosystem)
 
 ---
 
@@ -378,7 +379,8 @@ Part of [Backblaze Labs](https://github.com/backblaze-labs):
   orchestrating generative-AI media pipelines across video, audio, and image
   providers, with built-in provenance for every output.
 - **[b2-sdk-typescript](https://github.com/backblaze-labs/b2-sdk-typescript)** —
-  Backblaze-maintained TypeScript / JavaScript SDK for B2 Cloud Storage.
+  Backblaze-maintained TypeScript / JavaScript SDK for B2 Cloud Storage
+  (published as `@backblaze-labs/b2-sdk`, the SDK this server is built on).
 - **[b2-action](https://github.com/backblaze-labs/b2-action)** —
   Backblaze-maintained GitHub Action for B2 Cloud Storage.
 

--- a/README.md
+++ b/README.md
@@ -370,6 +370,18 @@ The full script list (diagnostics, slow tests, provider-comparison evals, inspec
 - [`docs/references/discoverability.md`](docs/references/discoverability.md) — registry/directory listings runbook
 - [`RELEASE.md`](RELEASE.md) · [`CHANGELOG.md`](CHANGELOG.md) · [`SECURITY.md`](SECURITY.md)
 
+## Backblaze Labs ecosystem
+
+Part of [Backblaze Labs](https://github.com/backblaze-labs):
+
+- **[Genblaze](https://github.com/backblaze-labs/genblaze)** — Python SDK for
+  orchestrating generative-AI media pipelines across video, audio, and image
+  providers, with built-in provenance for every output.
+- **[b2-sdk-typescript](https://github.com/backblaze-labs/b2-sdk-typescript)** —
+  Backblaze-maintained TypeScript / JavaScript SDK for B2 Cloud Storage.
+- **[b2-action](https://github.com/backblaze-labs/b2-action)** —
+  Backblaze-maintained GitHub Action for B2 Cloud Storage.
+
 ## License
 
 MIT — © 2026 Backblaze, Inc.


### PR DESCRIPTION
## Summary

Adds a **Backblaze Labs ecosystem** section to `README.md` that cross-links the
sibling Backblaze Labs open-source projects, so readers can discover the related
SDKs and tooling. The section is placed just before the License heading and links:

- **Genblaze** — Python SDK for generative-AI media pipelines.
- **b2-sdk-typescript** — Backblaze-maintained TypeScript / JavaScript SDK for B2,
  published as `@backblaze-labs/b2-sdk` (the SDK this server is built on).
- **b2-action** — Backblaze-maintained GitHub Action for B2.

## Commits

- `docs: add Backblaze Labs ecosystem section to README` — initial section.
- `docs: address ecosystem section review notes` — review follow-ups (below).

## Review follow-ups addressed

- **CHANGELOG** — added an `### Added` entry under `[Unreleased]` referencing #427,
  matching the format of prior README/docs changelog entries.
- **README Contents/ToC** — added a `[Backblaze Labs ecosystem]` anchor to the
  Contents navigation list for discoverability.
- **b2-sdk-typescript mapping** — clarified the entry is published as
  `@backblaze-labs/b2-sdk`, the SDK this project depends on (`package.json` pins
  `@backblaze-labs/b2-sdk` 0.4.0).

## Linked issue

Closes #427

## Tests run

- `node scripts/check-doc-links.mjs` → `doc-links: local Markdown links are valid` (exit 0)
- `lint:docs` (`run-doc-lint.mjs`) only lints TypeScript doc comments under `src`, so it does not apply to this README/CHANGELOG-only change.

## Follow-up notes

- The added project links are external GitHub URLs; the repo's link checker validates local file links only.
