### PR TITLE
security(ci): env-bind workflow expansions to resolve 30 zizmor template-injection findings

### DIFF
--- a/.github/workflows/contract.yml
+++ b/.github/workflows/contract.yml
@@ -272,7 +272,7 @@ jobs:
         run: |
           set -euo pipefail
           node scripts/live-b2-evidence.mjs preflight \
-            --out "reports/live-b2/validation-node-${{ matrix.node-version }}.json"
+            --out "reports/live-b2/validation-node-${MATRIX_NODE_VERSION}.json"
       - name: Run live B2 contract and integration suites
         id: live_tests
         if: steps.matrix_validation.outcome == 'success'
@@ -312,7 +312,7 @@ jobs:
           fi
           node scripts/live-b2-janitor.mjs \
             --prefix "${B2_MCP_LIVE_RUN_PREFIX}" \
-            --summary-json "reports/live-b2/cleanup-node-${{ matrix.node-version }}.json"
+            --summary-json "reports/live-b2/cleanup-node-${MATRIX_NODE_VERSION}.json"
       - name: Publish live B2 isolation and cleanup evidence
         if: always()
         env:
@@ -327,32 +327,39 @@ jobs:
           B2_MCP_LIVE_RUN_PREFIX: ${{ env.B2_MCP_LIVE_RUN_PREFIX }}
           B2_MCP_LIVE_RESOURCE_LEDGER: ${{ env.B2_MCP_LIVE_RESOURCE_LEDGER }}
           MATRIX_NODE_VERSION: ${{ matrix.node-version }}
+          MATRIX_VALIDATION_OUTCOME: ${{ steps.matrix_validation.outcome }}
+          LIVE_TESTS_OUTCOME: ${{ steps.live_tests.outcome }}
+          CLEANUP_OUTCOME: ${{ steps.cleanup.outcome }}
         run: |
           set -euo pipefail
           mkdir -p reports/live-b2
           node scripts/live-b2-evidence.mjs finalize \
-            --out "reports/live-b2/isolation-cleanup-node-${{ matrix.node-version }}.json" \
+            --out "reports/live-b2/isolation-cleanup-node-${MATRIX_NODE_VERSION}.json" \
             --resource-ledger "${B2_MCP_LIVE_RESOURCE_LEDGER}" \
-            --cleanup-summary "reports/live-b2/cleanup-node-${{ matrix.node-version }}.json" \
-            --validation-summary "reports/live-b2/validation-node-${{ matrix.node-version }}.json" \
-            --preflight-outcome "${{ steps.matrix_validation.outcome }}" \
-            --test-outcome "${{ steps.live_tests.outcome }}" \
-            --cleanup-outcome "${{ steps.cleanup.outcome }}"
+            --cleanup-summary "reports/live-b2/cleanup-node-${MATRIX_NODE_VERSION}.json" \
+            --validation-summary "reports/live-b2/validation-node-${MATRIX_NODE_VERSION}.json" \
+            --preflight-outcome "${MATRIX_VALIDATION_OUTCOME}" \
+            --test-outcome "${LIVE_TESTS_OUTCOME}" \
+            --cleanup-outcome "${CLEANUP_OUTCOME}"
       - name: Ensure live B2 final evidence exists
         if: always()
+        env:
+          MATRIX_VALIDATION_OUTCOME: ${{ steps.matrix_validation.outcome }}
+          LIVE_TESTS_OUTCOME: ${{ steps.live_tests.outcome }}
+          CLEANUP_OUTCOME: ${{ steps.cleanup.outcome }}
         run: |
           set -euo pipefail
-          final_json="reports/live-b2/isolation-cleanup-node-${{ matrix.node-version }}.json"
+          final_json="reports/live-b2/isolation-cleanup-node-${MATRIX_NODE_VERSION}.json"
           mkdir -p reports/live-b2
           if [[ -s "${final_json}" ]]; then
             exit 0
           fi
           status="configuration blocked"
           reason="live B2 final evidence fallback created before matrix validation completed"
-          if [[ "${{ steps.cleanup.outcome }}" != "success" && "${{ steps.cleanup.outcome }}" != "skipped" ]]; then
+          if [[ "${CLEANUP_OUTCOME}" != "success" && "${CLEANUP_OUTCOME}" != "skipped" ]]; then
             status="cleanup failure"
             reason="live B2 final evidence fallback created after cleanup did not complete successfully"
-          elif [[ "${{ steps.live_tests.outcome }}" != "success" && "${{ steps.live_tests.outcome }}" != "skipped" ]]; then
+          elif [[ "${LIVE_TESTS_OUTCOME}" != "success" && "${LIVE_TESTS_OUTCOME}" != "skipped" ]]; then
             status="product failure"
             reason="live B2 final evidence fallback created after tests did not complete successfully"
           fi
@@ -370,9 +377,9 @@ jobs:
             "status": "${status}",
             "statusReason": "${reason}",
             "outcomes": {
-              "preflight": "${{ steps.matrix_validation.outcome }}",
-              "tests": "${{ steps.live_tests.outcome }}",
-              "cleanup": "${{ steps.cleanup.outcome }}"
+              "preflight": "${MATRIX_VALIDATION_OUTCOME}",
+              "tests": "${LIVE_TESTS_OUTCOME}",
+              "cleanup": "${CLEANUP_OUTCOME}"
             },
             "sensitivity": {
               "secretSafe": true,
@@ -398,22 +405,26 @@ jobs:
           retention-days: 14
       - name: Require live B2 run success
         if: always()
+        env:
+          MATRIX_VALIDATION_OUTCOME: ${{ steps.matrix_validation.outcome }}
+          LIVE_TESTS_OUTCOME: ${{ steps.live_tests.outcome }}
+          CLEANUP_OUTCOME: ${{ steps.cleanup.outcome }}
         run: |
           set -euo pipefail
           failed=0
-          if [[ "${{ steps.matrix_validation.outcome }}" != "success" ]]; then
-            echo "::error::live B2 matrix validation outcome was ${{ steps.matrix_validation.outcome }}"
+          if [[ "${MATRIX_VALIDATION_OUTCOME}" != "success" ]]; then
+            echo "::error::live B2 matrix validation outcome was ${MATRIX_VALIDATION_OUTCOME}"
             failed=1
           fi
-          if [[ "${{ steps.live_tests.outcome }}" != "success" ]]; then
-            echo "::error::live B2 tests outcome was ${{ steps.live_tests.outcome }}"
+          if [[ "${LIVE_TESTS_OUTCOME}" != "success" ]]; then
+            echo "::error::live B2 tests outcome was ${LIVE_TESTS_OUTCOME}"
             failed=1
           fi
-          if [[ "${{ steps.cleanup.outcome }}" != "success" ]]; then
-            echo "::error::live B2 cleanup outcome was ${{ steps.cleanup.outcome }}"
+          if [[ "${CLEANUP_OUTCOME}" != "success" ]]; then
+            echo "::error::live B2 cleanup outcome was ${CLEANUP_OUTCOME}"
             failed=1
           fi
-          evidence_json="reports/live-b2/isolation-cleanup-node-${{ matrix.node-version }}.json"
+          evidence_json="reports/live-b2/isolation-cleanup-node-${MATRIX_NODE_VERSION}.json"
           evidence_status="$(
             node -e '
               const fs = require("node:fs");

--- a/.github/workflows/contract.yml
+++ b/.github/workflows/contract.yml
@@ -326,7 +326,6 @@ jobs:
           B2_MCP_EXPECTED_TOOL_PROFILE: ${{ vars.B2_MCP_EXPECTED_TOOL_PROFILE }}
           B2_MCP_LIVE_RUN_PREFIX: ${{ env.B2_MCP_LIVE_RUN_PREFIX }}
           B2_MCP_LIVE_RESOURCE_LEDGER: ${{ env.B2_MCP_LIVE_RESOURCE_LEDGER }}
-          MATRIX_NODE_VERSION: ${{ matrix.node-version }}
           MATRIX_VALIDATION_OUTCOME: ${{ steps.matrix_validation.outcome }}
           LIVE_TESTS_OUTCOME: ${{ steps.live_tests.outcome }}
           CLEANUP_OUTCOME: ${{ steps.cleanup.outcome }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -129,9 +129,11 @@ jobs:
       - run: pnpm run test:coverage
       - name: Publish coverage summary
         if: always()
+        env:
+          MATRIX_NODE_VERSION: ${{ matrix.node-version }}
         run: |
           echo "## Coverage summary" >> "$GITHUB_STEP_SUMMARY"
-          echo "Node.js ${{ matrix.node-version }}" >> "$GITHUB_STEP_SUMMARY"
+          echo "Node.js ${MATRIX_NODE_VERSION}" >> "$GITHUB_STEP_SUMMARY"
           echo "Required: statements 96%, branches 92%, functions 97.7%, lines 97.4%." >> "$GITHUB_STEP_SUMMARY"
           echo '```' >> "$GITHUB_STEP_SUMMARY"
           if [ -f coverage/coverage-summary.json ]; then
@@ -168,9 +170,11 @@ jobs:
     timeout-minutes: 5
     steps:
       - name: Require complete coverage matrix
+        env:
+          MATRIX_RESULT: ${{ needs.unit-coverage-matrix.result }}
         run: |
-          if [[ "${{ needs.unit-coverage-matrix.result }}" != "success" ]]; then
-            echo "::error::unit coverage matrix result was ${{ needs.unit-coverage-matrix.result }}"
+          if [[ "${MATRIX_RESULT}" != "success" ]]; then
+            echo "::error::unit coverage matrix result was ${MATRIX_RESULT}"
             exit 1
           fi
 
@@ -444,9 +448,11 @@ jobs:
     timeout-minutes: 5
     steps:
       - name: Require complete production dependency audit matrix
+        env:
+          MATRIX_RESULT: ${{ needs.production-dependency-audit-matrix.result }}
         run: |
-          if [[ "${{ needs.production-dependency-audit-matrix.result }}" != "success" ]]; then
-            echo "::error::production dependency audit matrix result was ${{ needs.production-dependency-audit-matrix.result }}"
+          if [[ "${MATRIX_RESULT}" != "success" ]]; then
+            echo "::error::production dependency audit matrix result was ${MATRIX_RESULT}"
             exit 1
           fi
 
@@ -898,9 +904,11 @@ jobs:
     timeout-minutes: 5
     steps:
       - name: Require complete cross-platform minimum matrix
+        env:
+          MATRIX_RESULT: ${{ needs.cross-platform-minimum-matrix.result }}
         run: |
-          if [[ "${{ needs.cross-platform-minimum-matrix.result }}" != "success" ]]; then
-            echo "::error::cross-platform minimum matrix result was ${{ needs.cross-platform-minimum-matrix.result }}"
+          if [[ "${MATRIX_RESULT}" != "success" ]]; then
+            echo "::error::cross-platform minimum matrix result was ${MATRIX_RESULT}"
             exit 1
           fi
       # actions/download-artifact v6, reviewed 2026-08-25.

--- a/tests/contract/live-workflows-policy.contract.test.ts
+++ b/tests/contract/live-workflows-policy.contract.test.ts
@@ -400,7 +400,7 @@ describe("live secret workflow policy", () => {
     expect(matrixValidation).toContain("B2_LIVE_NOTIFICATION_BUCKET");
     expect(matrixValidation).toContain("node scripts/live-b2-evidence.mjs preflight");
     expect(matrixValidation).toContain(
-      "reports/live-b2/validation-node-${{ matrix.node-version }}.json",
+      "reports/live-b2/validation-node-${MATRIX_NODE_VERSION}.json",
     );
     expect(liveTests).toContain("if: steps.matrix_validation.outcome == 'success'");
     expect(liveTests).toContain(
@@ -415,8 +415,8 @@ describe("live secret workflow policy", () => {
     expect(finalizer).toContain(
       "B2_LIVE_NOTIFICATION_BUCKET: ${{ vars.B2_LIVE_NOTIFICATION_BUCKET }}",
     );
-    expect(finalizer).toContain("reports/live-b2/validation-node-${{ matrix.node-version }}.json");
-    expect(finalizer).toContain('--preflight-outcome "${{ steps.matrix_validation.outcome }}"');
+    expect(finalizer).toContain("reports/live-b2/validation-node-${MATRIX_NODE_VERSION}.json");
+    expect(finalizer).toContain('--preflight-outcome "${MATRIX_VALIDATION_OUTCOME}"');
     expect(finalFallback).toContain("live B2 final evidence fallback");
     expect(finalFallback).toContain("configuration blocked");
     expect(finalFallback).toContain("cleanup failure");


### PR DESCRIPTION
## Summary

Resolves all 30 zizmor `template-injection` findings by binding every
`${{ … }}` expansion that was inlined into a `run:` shell block to a
step-level (or existing job-level) `env:` variable, then referencing the shell
variable inside the script. All flagged expansions are workflow-controlled
(matrix values, `needs.*.result`, `steps.*.outcome`) and not
attacker-controllable, so this is a hardening change with no behavioral
difference — the shell scripts evaluate the same values.

- `.github/workflows/contract.yml` — 23 findings fixed. `matrix.node-version`
  now flows through the existing job-level `MATRIX_NODE_VERSION`; step outcomes
  are bound to `MATRIX_VALIDATION_OUTCOME` / `LIVE_TESTS_OUTCOME` /
  `CLEANUP_OUTCOME` on each consuming step.
- `.github/workflows/test.yml` — 7 findings fixed. `matrix.node-version` bound
  to `MATRIX_NODE_VERSION`; each `needs.<matrix>.result` gate bound to
  `MATRIX_RESULT`.

## Commits

- `ci: env-bind workflow expansions to fix zizmor injection` — the core fix
  across both workflow files (30 → 0 template-injection findings).
- `ci: drop redundant step-level MATRIX_NODE_VERSION` — review follow-up:
  removed a step-level `MATRIX_NODE_VERSION` redeclaration in the "Publish live
  B2 isolation and cleanup evidence" step so all `contract`-job steps uniformly
  consume the job-level binding (contract.yml:226).
- `test: update live-workflow assertions for env binding` — CI follow-up:
  `tests/contract/live-workflows-policy.contract.test.ts` asserts the literal
  workflow content, so its expected strings were updated to the env-bound form
  (`${MATRIX_NODE_VERSION}`, `${MATRIX_VALIDATION_OUTCOME}`).

## Linked issue

Closes #417

## Tests run

- `zizmor --persona=auditor --no-online-audits` on both files:
  template-injection findings **30 → 0**; the only remaining findings
  (`anonymous-definition`, `artipacked`, `adhoc-packages`) are pre-existing and
  out of scope.
- `pnpm run build && pnpm run test:contract` locally: **338/338** passing.
- Full CI on the branch is green (MCP contract, unit coverage on Node
  22.23.1 / 24 / 26, and all other required checks pass).

## Follow-up notes

The remaining non-template-injection zizmor findings are unrelated to this
issue and can be addressed separately if desired.
