### PR TITLE
docs(ci): document 7 workflow permissions blocks

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -27,10 +27,11 @@ jobs:
     if: ${{ github.event.pull_request.user.login != 'dependabot[bot]' }}
     runs-on: ubuntu-latest
     timeout-minutes: 30
+    # Least privilege for CodeQL: read the run graph + code, write findings.
     permissions:
-      actions: read
-      contents: read
-      security-events: write
+      actions: read # CodeQL reads the Actions run graph during analysis.
+      contents: read # Checkout of the repository under analysis.
+      security-events: write # Upload CodeQL SARIF to the code scanning tab.
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -56,9 +56,10 @@ jobs:
     if: github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
     timeout-minutes: 10
+    # Pages deployment only: no repo write, just publish + OIDC attestation.
     permissions:
-      pages: write
-      id-token: write
+      pages: write # Deploy the built API docs to GitHub Pages.
+      id-token: write # OIDC token required by the Pages deployment.
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -375,10 +375,9 @@ jobs:
     if: github.repository == 'backblaze-labs/b2-mcp'
     runs-on: ubuntu-latest
     timeout-minutes: 20
-    # Preflight only reads: pull prepare-job artifacts and check out the tree.
+    # Preflight only consumes prepare-job artifacts; no repo checkout needed.
     permissions:
       actions: read # Download build artifacts from the prepare job's run.
-      contents: read # Checkout for the registry preflight validation.
     steps:
       # actions/download-artifact v8, reviewed 2026-08-25.
       - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c
@@ -480,10 +479,9 @@ jobs:
     if: github.repository == 'backblaze-labs/b2-mcp'
     runs-on: ubuntu-latest
     timeout-minutes: 30
-    # Publish needs OIDC for provenance; repo/artifacts stay read-only.
+    # Publish consumes downloaded artifacts with OIDC provenance; no checkout.
     permissions:
       actions: read # Download build artifacts from the prepare job's run.
-      contents: read # Checkout trusted resolver code and the validated tag.
       id-token: write # OIDC token for npm/registry publish provenance.
     steps:
       # actions/download-artifact v8, reviewed 2026-08-25.

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -375,9 +375,9 @@ jobs:
     if: github.repository == 'backblaze-labs/b2-mcp'
     runs-on: ubuntu-latest
     timeout-minutes: 20
-    # Preflight only consumes prepare-job artifacts; no repo checkout needed.
-    permissions:
-      actions: read # Download build artifacts from the prepare job's run.
+    # Preflight only consumes same-run artifacts (runner artifact token, not
+    # GITHUB_TOKEN) and external curl downloads, so it needs no token scopes.
+    permissions: {}
     steps:
       # actions/download-artifact v8, reviewed 2026-08-25.
       - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c
@@ -479,9 +479,9 @@ jobs:
     if: github.repository == 'backblaze-labs/b2-mcp'
     runs-on: ubuntu-latest
     timeout-minutes: 30
-    # Publish consumes downloaded artifacts with OIDC provenance; no checkout.
+    # Publish consumes same-run artifacts (runner artifact token) and needs
+    # only OIDC; no GITHUB_TOKEN actions/contents scopes are used.
     permissions:
-      actions: read # Download build artifacts from the prepare job's run.
       id-token: write # OIDC token for npm/registry publish provenance.
     steps:
       # actions/download-artifact v8, reviewed 2026-08-25.
@@ -736,9 +736,9 @@ jobs:
     if: github.repository == 'backblaze-labs/b2-mcp'
     runs-on: ubuntu-latest
     timeout-minutes: 5
-    # Release job needs contents:write to create the GitHub release + assets.
+    # Release job downloads same-run artifacts (runner artifact token) and
+    # needs only contents:write to create the GitHub release + assets.
     permissions:
-      actions: read # Download release artifacts from prior jobs.
       contents: write # Create the GitHub release and upload assets.
     steps:
       # actions/download-artifact v8, reviewed 2026-08-25.

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -13,9 +13,11 @@ on:
     workflows: ["Release Tag Request"]
     types: [completed]
 
+# Workflow-wide default floor: read-only. Each job re-declares the exact
+# scopes it needs so no job silently inherits more than read access.
 permissions:
-  actions: read
-  contents: read
+  actions: read # Read the triggering workflow_run graph/artifacts.
+  contents: read # Checkout trusted resolver code and the validated tag.
 
 concurrency:
   group: npm-publish-${{ github.repository }}
@@ -372,9 +374,10 @@ jobs:
     if: github.repository == 'backblaze-labs/b2-mcp'
     runs-on: ubuntu-latest
     timeout-minutes: 20
+    # Preflight only reads: pull prepare-job artifacts and check out the tree.
     permissions:
-      actions: read
-      contents: read
+      actions: read # Download build artifacts from the prepare job's run.
+      contents: read # Checkout for the registry preflight validation.
     steps:
       # actions/download-artifact v8, reviewed 2026-08-25.
       - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c
@@ -476,10 +479,11 @@ jobs:
     if: github.repository == 'backblaze-labs/b2-mcp'
     runs-on: ubuntu-latest
     timeout-minutes: 30
+    # Publish needs OIDC for provenance; repo/artifacts stay read-only.
     permissions:
-      actions: read
-      contents: read
-      id-token: write
+      actions: read # Download build artifacts from the prepare job's run.
+      contents: read # Checkout trusted resolver code and the validated tag.
+      id-token: write # OIDC token for npm/registry publish provenance.
     steps:
       # actions/download-artifact v8, reviewed 2026-08-25.
       - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c
@@ -651,10 +655,11 @@ jobs:
     if: github.repository == 'backblaze-labs/b2-mcp'
     runs-on: ubuntu-latest
     timeout-minutes: 45
+    # Container build/push: write only to GHCR; OIDC for keyless signing.
     permissions:
-      contents: read
-      id-token: write
-      packages: write
+      contents: read # Checkout the protected ci-green ref.
+      id-token: write # OIDC token for cosign keyless image signing.
+      packages: write # Push the container image to GHCR.
     steps:
       # Check out the protected `ci-green` ref (a trusted constant, like the
       # prepare job) rather than a dynamic sha in this write-privileged job, then
@@ -732,9 +737,10 @@ jobs:
     if: github.repository == 'backblaze-labs/b2-mcp'
     runs-on: ubuntu-latest
     timeout-minutes: 5
+    # Release job needs contents:write to create the GitHub release + assets.
     permissions:
-      actions: read
-      contents: write
+      actions: read # Download release artifacts from prior jobs.
+      contents: write # Create the GitHub release and upload assets.
     steps:
       # actions/download-artifact v8, reviewed 2026-08-25.
       - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -13,8 +13,9 @@ on:
     workflows: ["Release Tag Request"]
     types: [completed]
 
-# Workflow-wide default floor: read-only. Each job re-declares the exact
-# scopes it needs so no job silently inherits more than read access.
+# Workflow-wide default floor: read-only. Jobs that need more re-declare the
+# exact scopes they need; the rest (e.g. prepare) inherit this read-only floor,
+# so no job silently gets more than read access.
 permissions:
   actions: read # Read the triggering workflow_run graph/artifacts.
   contents: read # Checkout trusted resolver code and the validated tag.

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -375,9 +375,11 @@ jobs:
     if: github.repository == 'backblaze-labs/b2-mcp'
     runs-on: ubuntu-latest
     timeout-minutes: 20
-    # Preflight only consumes same-run artifacts (runner artifact token, not
-    # GITHUB_TOKEN) and external curl downloads, so it needs no token scopes.
-    permissions: {}
+    # Read-only preflight: no checkout, mints no tokens. actions/contents stay
+    # at read so the job can never mutate the repository or its workflow runs.
+    permissions:
+      actions: read # Read-only access to the workflow run and its artifacts.
+      contents: read # Read-only repository scope; preflight never writes.
     steps:
       # actions/download-artifact v8, reviewed 2026-08-25.
       - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c
@@ -479,9 +481,11 @@ jobs:
     if: github.repository == 'backblaze-labs/b2-mcp'
     runs-on: ubuntu-latest
     timeout-minutes: 30
-    # Publish consumes same-run artifacts (runner artifact token) and needs
-    # only OIDC; no GITHUB_TOKEN actions/contents scopes are used.
+    # Publish mints an OIDC token for npm provenance; repo + runs stay
+    # read-only (no checkout, no contents:write) as a least-privilege floor.
     permissions:
+      actions: read # Read-only access to the workflow run and its artifacts.
+      contents: read # Read-only repository scope; publish never writes.
       id-token: write # OIDC token for npm/registry publish provenance.
     steps:
       # actions/download-artifact v8, reviewed 2026-08-25.
@@ -736,9 +740,10 @@ jobs:
     if: github.repository == 'backblaze-labs/b2-mcp'
     runs-on: ubuntu-latest
     timeout-minutes: 5
-    # Release job downloads same-run artifacts (runner artifact token) and
-    # needs only contents:write to create the GitHub release + assets.
+    # Release job needs contents:write to create the GitHub release + assets;
+    # workflow-run access stays read-only.
     permissions:
+      actions: read # Read-only access to the workflow run and its artifacts.
       contents: write # Create the GitHub release and upload assets.
     steps:
       # actions/download-artifact v8, reviewed 2026-08-25.


### PR DESCRIPTION
## Summary

Documents the rationale for the GitHub Actions `permissions:` blocks flagged by
zizmor's `undocumented-permissions` rule. Comments only, no behavior change.

- Adds block-level and per-scope `# <why>` comments to the permission blocks in
  `codeql.yml`, `docs.yml`, and `publish.yml`.
- The workflow-wide floor comment describes read-only as the default for jobs
  without an override (e.g. `prepare`), rather than claiming every job
  re-declares its scopes.
- Comments are accurate about each job: jobs that perform no checkout (e.g.
  `publish`, `mcp-registry-preflight`) keep their explicit read-only
  `actions`/`contents` floor as a deliberate, test-enforced least-privilege
  posture (see `tests/unit/supply-chain-policy.unit.test.ts`) and the comments
  say so instead of claiming a nonexistent checkout.

No permission scopes were added, widened, or removed.

## Linked issue

Closes #418

## Tests run

- `zizmor --offline --persona=auditor .github/workflows/` -> `undocumented-permissions` open count is 0 (was 7).
- `pnpm exec vitest run --project=unit tests/unit/supply-chain-policy.unit.test.ts` -> 63 passed (permission contract intact).
- `pnpm run typecheck` -> pass; Biome format check -> clean.

## Follow-up notes

An earlier revision experimented with dropping `actions:`/`contents: read`
grants from the artifact-only publish jobs. Those grants are intentionally
locked in by the supply-chain contract test as an explicit least-privilege
floor, so the change was reverted to keep this PR comments-only per the issue.
