### PR TITLE
fix(ci): gate eval ANTHROPIC_API_KEY behind dedicated environment

### DIFF
--- a/.github/workflows/evals.yml
+++ b/.github/workflows/evals.yml
@@ -6,6 +6,22 @@ name: LLM Evals
 # OpenAI is temporarily disabled (the account has no API credits), so scheduled
 # runs cover Anthropic only. Re-enable OpenAI by restoring OPENAI_API_KEY to the
 # guard's required secrets and to the eval step env below.
+#
+# OPERATOR RUNBOOK — the `guard` and `evals` jobs bind to the `llm-evals`
+# GitHub environment (below) to scope ANTHROPIC_API_KEY. Referencing an
+# environment that does not exist auto-creates it with NO protection rules and
+# a repo-level ANTHROPIC_API_KEY still resolves, so the gate delivers no real
+# protection until an operator, out-of-band, has:
+#   1. Created the `llm-evals` environment.
+#   2. Added ANTHROPIC_API_KEY as an environment secret (and removed the
+#      repo-level copy if it should no longer be repo-scoped).
+#   3. Restricted deployment branches to `main` only.
+# REQUIRED CONSTRAINT: this workflow runs unattended (weekly `schedule` cron +
+# `workflow_dispatch`), so the environment MUST NOT carry required-reviewer or
+# wait-timer protection rules — either would pause the job in `Waiting` with no
+# human to approve, silently halting the eval evidence. Use branch restrictions
+# and secret scoping only. Verify by running the workflow via workflow_dispatch
+# after configuring the environment.
 
 on:
   workflow_dispatch:
@@ -23,9 +39,11 @@ jobs:
   guard:
     if: github.repository == 'backblaze-labs/b2-mcp'
     runs-on: ubuntu-latest
-    # Gate ANTHROPIC_API_KEY behind a dedicated environment so environment
-    # protection rules (required reviewers, branch restrictions, secret
-    # scoping) govern the provider secret (zizmor secrets-outside-env).
+    # Gate ANTHROPIC_API_KEY behind a dedicated environment so branch and
+    # secret-scoping protection rules govern the provider secret (zizmor
+    # secrets-outside-env). See the OPERATOR RUNBOOK at the top of this file:
+    # the environment must be configured out-of-band and must NOT use
+    # required-reviewer/wait-timer rules (they would stall the cron run).
     environment: llm-evals
     timeout-minutes: 5
     outputs:

--- a/.github/workflows/evals.yml
+++ b/.github/workflows/evals.yml
@@ -13,15 +13,18 @@ name: LLM Evals
 # a repo-level ANTHROPIC_API_KEY still resolves, so the gate delivers no real
 # protection until an operator, out-of-band, has:
 #   1. Created the `llm-evals` environment.
-#   2. Added ANTHROPIC_API_KEY as an environment secret (and removed the
-#      repo-level copy if it should no longer be repo-scoped).
+#   2. Added ANTHROPIC_API_KEY as an environment secret AND removed any
+#      repository-level ANTHROPIC_API_KEY copy, which otherwise stays resolvable
+#      to jobs outside llm-evals and keeps the key broadly scoped.
 #   3. Restricted deployment branches to `main` only.
 # REQUIRED CONSTRAINT: this workflow runs unattended (weekly `schedule` cron +
-# `workflow_dispatch`), so the environment MUST NOT carry required-reviewer or
-# wait-timer protection rules — either would pause the job in `Waiting` with no
-# human to approve, silently halting the eval evidence. Use branch restrictions
-# and secret scoping only. Verify by running the workflow via workflow_dispatch
-# after configuring the environment.
+# `workflow_dispatch`), so the environment MUST NOT carry a required-reviewer
+# rule — with no human to approve, it pauses the job in `Waiting` forever and
+# silently halts the eval evidence. A wait-timer rule only delays the run by its
+# configured interval (it auto-releases), so it does not stall the workflow but
+# still needlessly postpones the evidence; prefer branch restrictions and secret
+# scoping only. Verify by running the workflow via workflow_dispatch after
+# configuring the environment.
 
 on:
   workflow_dispatch:
@@ -42,8 +45,9 @@ jobs:
     # Gate ANTHROPIC_API_KEY behind a dedicated environment so branch and
     # secret-scoping protection rules govern the provider secret (zizmor
     # secrets-outside-env). See the OPERATOR RUNBOOK at the top of this file:
-    # the environment must be configured out-of-band and must NOT use
-    # required-reviewer/wait-timer rules (they would stall the cron run).
+    # the environment must be configured out-of-band (including removing any
+    # repo-level ANTHROPIC_API_KEY copy) and must NOT use a required-reviewer
+    # rule, which would stall the unattended cron run in `Waiting` forever.
     environment: llm-evals
     timeout-minutes: 5
     outputs:

--- a/.github/workflows/evals.yml
+++ b/.github/workflows/evals.yml
@@ -23,6 +23,10 @@ jobs:
   guard:
     if: github.repository == 'backblaze-labs/b2-mcp'
     runs-on: ubuntu-latest
+    # Gate ANTHROPIC_API_KEY behind a dedicated environment so environment
+    # protection rules (required reviewers, branch restrictions, secret
+    # scoping) govern the provider secret (zizmor secrets-outside-env).
+    environment: llm-evals
     timeout-minutes: 5
     outputs:
       checkout-sha: ${{ steps.ref.outputs.checkout_sha }}
@@ -64,6 +68,9 @@ jobs:
     name: Claude pass rates
     needs: guard
     runs-on: ubuntu-latest
+    # Same dedicated environment as the guard job so the provider secret stays
+    # scoped to environment protection rules (zizmor secrets-outside-env).
+    environment: llm-evals
     timeout-minutes: 20
     steps:
       # actions/checkout v7, reviewed 2026-08-25.

--- a/.github/workflows/evals.yml
+++ b/.github/workflows/evals.yml
@@ -76,7 +76,7 @@ jobs:
           done
 
           if [[ -z "${ANTHROPIC_API_KEY:-}" ]]; then
-            echo "::error::ANTHROPIC_API_KEY is required for canonical scheduled/dispatch LLM evals; configure it with gh secret set ANTHROPIC_API_KEY"
+            echo "::error::ANTHROPIC_API_KEY is required for canonical scheduled/dispatch LLM evals; configure it as an llm-evals environment secret with gh secret set ANTHROPIC_API_KEY --env llm-evals"
             exit 1
           fi
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -44,7 +44,12 @@ jobs:
     name: format/lint/typecheck
     needs: runtime-policy
     runs-on: ubuntu-latest
-    timeout-minutes: 30
+    # `pnpm run verify` ends with leak diagnostics, whose worst case is
+    # 3 layers x 2 attempts x B2_MCP_LEAK_DIAGNOSTIC_TIMEOUT_MS (5m) = 30m of
+    # child timeouts. This ceiling leaves headroom for that plus install,
+    # typecheck, build, lint, spell, runtime-security, and smoke so a hung
+    # layer still reports its verdict instead of the job being cancelled.
+    timeout-minutes: 45
     steps:
       # actions/checkout v7, reviewed 2026-08-25.
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1

--- a/docs/EVALS.md
+++ b/docs/EVALS.md
@@ -165,7 +165,9 @@ must not run against unreviewed code. It runs only on:
 The `guard` and `evals` jobs both bind to the `llm-evals` GitHub environment,
 so `ANTHROPIC_API_KEY` must be configured as an **environment secret** scoped to
 `llm-evals` (`gh secret set ANTHROPIC_API_KEY --env llm-evals`), not a
-repository secret. The guard job checks that the repository is
+repository secret. Any repository-level `ANTHROPIC_API_KEY` copy must be
+removed: it stays resolvable to jobs outside `llm-evals` and keeps the key
+broadly scoped, defeating the gate. The guard job checks that the repository is
 `backblaze-labs/b2-mcp`, the ref is `refs/heads/main`, and the
 `ANTHROPIC_API_KEY` environment secret is present. Because scheduled and manual
 CI evals are canonical-main only, a missing `ANTHROPIC_API_KEY` is treated as
@@ -174,9 +176,11 @@ the workflow. `OPENAI_API_KEY` is not required by CI while OpenAI evals are
 disabled.
 
 > The `llm-evals` environment must be restricted to the `main` branch with
-> secret scoping only. Do **not** add required-reviewer or wait-timer rules:
-> the workflow runs unattended (weekly cron + `workflow_dispatch`), and either
-> rule would pause it in `Waiting` with no human to approve.
+> secret scoping only. Do **not** add a required-reviewer rule: the workflow
+> runs unattended (weekly cron + `workflow_dispatch`), so with no human to
+> approve it would pause in `Waiting` forever. A wait-timer rule does not stall
+> the run (it auto-releases after its configured delay) but still needlessly
+> postpones the evidence, so avoid it too.
 
 The eval job installs with the pinned package manager, builds once, then runs:
 

--- a/docs/EVALS.md
+++ b/docs/EVALS.md
@@ -162,12 +162,21 @@ must not run against unreviewed code. It runs only on:
 > [`../.github/workflows/evals.yml`](../.github/workflows/evals.yml); no code
 > change is needed.
 
-The guard job checks that the repository is `backblaze-labs/b2-mcp`, the ref is
-`refs/heads/main`, and the `ANTHROPIC_API_KEY` repository secret is present.
-Because scheduled and manual CI evals are canonical-main only, a missing
-`ANTHROPIC_API_KEY` is treated as repository misconfiguration: the guard emits a
-GitHub Actions error and fails the workflow. `OPENAI_API_KEY` is not required by
-CI while OpenAI evals are disabled.
+The `guard` and `evals` jobs both bind to the `llm-evals` GitHub environment,
+so `ANTHROPIC_API_KEY` must be configured as an **environment secret** scoped to
+`llm-evals` (`gh secret set ANTHROPIC_API_KEY --env llm-evals`), not a
+repository secret. The guard job checks that the repository is
+`backblaze-labs/b2-mcp`, the ref is `refs/heads/main`, and the
+`ANTHROPIC_API_KEY` environment secret is present. Because scheduled and manual
+CI evals are canonical-main only, a missing `ANTHROPIC_API_KEY` is treated as
+repository misconfiguration: the guard emits a GitHub Actions error and fails
+the workflow. `OPENAI_API_KEY` is not required by CI while OpenAI evals are
+disabled.
+
+> The `llm-evals` environment must be restricted to the `main` branch with
+> secret scoping only. Do **not** add required-reviewer or wait-timer rules:
+> the workflow runs unattended (weekly cron + `workflow_dispatch`), and either
+> rule would pause it in `Waiting` with no human to approve.
 
 The eval job installs with the pinned package manager, builds once, then runs:
 

--- a/scripts/run-leak-diagnostics.mjs
+++ b/scripts/run-leak-diagnostics.mjs
@@ -10,9 +10,12 @@ const layers = (process.env.B2_MCP_LEAK_DIAGNOSTIC_LAYERS ?? "unit,protocol-mode
   .filter(Boolean);
 const runner = process.env.B2_MCP_LEAK_DIAGNOSTIC_RUNNER ?? "scripts/run-vitest-layer.mjs";
 const maxBuffer = parsePositiveIntegerEnv("B2_MCP_LEAK_DIAGNOSTIC_MAX_BUFFER", 64 * 1024 * 1024);
-const timeout = parsePositiveIntegerEnv("B2_MCP_LEAK_DIAGNOSTIC_TIMEOUT_MS", 2 * 60 * 1000);
-// A single-threaded layer run can exceed the timeout on a loaded CI runner — a
-// transient flake, not a real leak. Re-run the layer on a timeout before failing.
+// The unit layer runs single-threaded here (--fileParallelism=false), so as the
+// suite grows it comfortably outlasts a parallel run. The default carries ample
+// headroom over the observed single-threaded duration on a loaded CI runner; a
+// timeout is still a transient flake, not a real leak.
+const timeout = parsePositiveIntegerEnv("B2_MCP_LEAK_DIAGNOSTIC_TIMEOUT_MS", 5 * 60 * 1000);
+// Re-run the layer on a timeout before failing to absorb the occasional stall.
 const attempts = parsePositiveIntegerEnv("B2_MCP_LEAK_DIAGNOSTIC_ATTEMPTS", 2);
 const warningPatterns = [
   /MaxListenersExceededWarning/,

--- a/tests/contract/ci-workflow-policy.contract.test.ts
+++ b/tests/contract/ci-workflow-policy.contract.test.ts
@@ -474,11 +474,14 @@ describe("CI workflow policy", () => {
     expect(guard).toContain("::add-mask::");
     expect(guard).toContain('[[ -z "${ANTHROPIC_API_KEY:-}" ]]');
     expect(guard).toContain("::error::ANTHROPIC_API_KEY is required");
-    expect(guard).toContain("gh secret set ANTHROPIC_API_KEY");
+    expect(guard).toContain("gh secret set ANTHROPIC_API_KEY --env llm-evals");
     expect(guard).toContain("exit 1");
     expect(guard).not.toContain("should_run=false");
     expect(guard).not.toContain("missing provider secret(s)");
-    expect(guard).not.toContain("environment:");
+    // Both secret-consuming jobs must gate ANTHROPIC_API_KEY behind the
+    // dedicated llm-evals environment (zizmor secrets-outside-env, #419).
+    expect(guard).toContain("environment: llm-evals");
+    expect(evalJob).toContain("environment: llm-evals");
 
     expect(workflowJobBlock(evals, "skipped")).toBeNull();
     expect(evals).not.toContain("LLM evals skipped");

--- a/tests/contract/ci-workflow-policy.contract.test.ts
+++ b/tests/contract/ci-workflow-policy.contract.test.ts
@@ -480,8 +480,10 @@ describe("CI workflow policy", () => {
     expect(guard).not.toContain("missing provider secret(s)");
     // Both secret-consuming jobs must gate ANTHROPIC_API_KEY behind the
     // dedicated llm-evals environment (zizmor secrets-outside-env, #419).
-    expect(guard).toContain("environment: llm-evals");
-    expect(evalJob).toContain("environment: llm-evals");
+    // Parse the active mapping (yamlValuesForKey ignores comments) so the gate
+    // being commented out fails the contract instead of silently passing.
+    expect(yamlValuesForKey(guard, "environment")).toContain("llm-evals");
+    expect(yamlValuesForKey(evalJob, "environment")).toContain("llm-evals");
 
     expect(workflowJobBlock(evals, "skipped")).toBeNull();
     expect(evals).not.toContain("LLM evals skipped");


### PR DESCRIPTION
## Summary

The `LLM Evals` workflow referenced `secrets.ANTHROPIC_API_KEY` from step-level `env:` in jobs that declared no dedicated GitHub `environment:`, tripping zizmor's `secrets-outside-env` rule (alerts #74/#75/#76). This gates the provider secret behind a dedicated `llm-evals` environment on both jobs that consume it (`guard` and `evals`), so branch and secret-scoping protection rules govern access to the key. This matches the existing pattern used by `contract.yml` (`live-b2-contract`) and `smoke.yml` (`live-b2-smoke`).

## Changes

- `.github/workflows/evals.yml`: add `environment: llm-evals` to the `guard` and `evals` jobs (the two jobs referencing `ANTHROPIC_API_KEY`).
- Add an in-file **OPERATOR RUNBOOK** documenting the out-of-band prerequisite and the required constraint (see below).
- Point the guard's recovery message at an environment-scoped secret: `gh secret set ANTHROPIC_API_KEY --env llm-evals`.
- `docs/EVALS.md`: describe `ANTHROPIC_API_KEY` as an `llm-evals` **environment** secret (not a repository secret), require removing any repository-level copy, and document the no-required-reviewer constraint.
- `tests/contract/ci-workflow-policy.contract.test.ts`: require `environment: llm-evals` on both secret-consuming jobs, asserted via parsed YAML (`yamlValuesForKey`, comment-aware) so the contract fails closed if the gate is commented out.
- `scripts/run-leak-diagnostics.mjs`: raise the single-threaded leak-diagnostics timeout default (120s -> 300s) to fix a CI flake unrelated to this change (see follow-up notes).
- `.github/workflows/test.yml`: raise the `format-lint-typecheck` job `timeout-minutes` (30 -> 45) so the leak-diagnostics worst-case retry budget plus the other verify steps fit with headroom.

## Operator runbook (required, out-of-band)

Referencing a not-yet-created environment auto-creates it with **no** protection rules, and a repo-level `ANTHROPIC_API_KEY` still resolves - so the gate delivers no real protection until an operator has:

1. Created the `llm-evals` GitHub environment.
2. Added `ANTHROPIC_API_KEY` as an **environment** secret (`gh secret set ANTHROPIC_API_KEY --env llm-evals`) and removed any repository-level copy, which otherwise stays resolvable to jobs outside `llm-evals` and keeps the key broadly scoped.
3. Restricted deployment branches to `main` only.

**Required constraint (do not skip):** this workflow runs unattended (weekly `schedule` cron + `workflow_dispatch`). The `llm-evals` environment **MUST NOT** carry a required-reviewer rule - with no human to approve, it pauses the job in `Waiting` forever and silently halts the weekly eval evidence. A wait-timer rule only delays the run (it auto-releases after its interval) but still needlessly postpones the evidence, so avoid it too. Use **branch restrictions and secret scoping only**.

**Verification:** after configuring the environment, trigger the workflow via `workflow_dispatch` and confirm the run resolves the key and completes without pausing.

## Linked issue

Closes #419

## Tests run

- Digest-pinned offline zizmor (`ghcr.io/zizmorcore/zizmor:1.29.0`, `--persona=auditor --no-online-audits`): pre-fix (origin/main) reported 3 `secrets-outside-env` warnings on `evals.yml`; post-fix reports 0.
- `ci-workflow-policy` contract test (16/16), plus `supply-chain-policy`, `runtime-policy`, and `workflow-yaml` unit tests (119/119 combined). Verified the environment-gate assertion fails closed when the gate is commented out.
- Full `pnpm run verify` passes locally (typecheck, build, lint, docs, spell, runtime-security, leak diagnostics).
- All 8 PR commits pass the CI suite (no failing checks).

## Follow-up notes

- No suppression added to `zizmor.yml`; the preferred environment-gate remediation was applied instead.
- OpenAI remains disabled in this workflow (no account credits), unchanged by this PR.
- The `format/lint/typecheck` CI job was failing (on `main` too) because the single-threaded leak-diagnostics unit run reliably exceeded the 120s spawn timeout on loaded runners after the suite grew (~1990 tests). Raising the per-layer default to 300s (still overridable via `B2_MCP_LEAK_DIAGNOSTIC_TIMEOUT_MS`) restores green CI, and the job `timeout-minutes` was raised to 45 so the worst-case retry budget still reports its verdict instead of being cancelled. The intermediate empty `chore(ci)` commit only re-triggered CI.
