### PR TITLE
security(ci): add concurrency groups to quality-keeper and release-tag

### DIFF
--- a/.github/workflows/quality-keeper.yml
+++ b/.github/workflows/quality-keeper.yml
@@ -20,6 +20,11 @@ on:
 # No pull_request_target: fork, draft, and unknown-head code is never trusted.
 permissions: {}
 
+# Advisory PR analysis: cancel superseded runs on the same PR.
+concurrency:
+  group: quality-keeper-${{ github.repository }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   quality-keeper:
     if: >-

--- a/.github/workflows/release-tag.yml
+++ b/.github/workflows/release-tag.yml
@@ -18,6 +18,11 @@ on:
 permissions:
   contents: read
 
+# Release signal per tag: never interrupt a tag's run.
+concurrency:
+  group: release-tag-${{ github.repository }}-${{ github.ref }}
+  cancel-in-progress: false
+
 jobs:
   request:
     runs-on: ubuntu-latest

--- a/.github/workflows/release-tag.yml
+++ b/.github/workflows/release-tag.yml
@@ -18,9 +18,12 @@ on:
 permissions:
   contents: read
 
-# Release signal per tag: never interrupt a tag's run.
+# Release signal per tag: never interrupt a tag's run. Key on the resolved tag
+# (same value as the job's REQUEST_TAG) so a push-tag run and a workflow_dispatch
+# run for the same tag share one group, and distinct tags never collapse — on
+# workflow_dispatch github.ref is the branch ref, so it cannot isolate per tag.
 concurrency:
-  group: release-tag-${{ github.repository }}-${{ github.ref }}
+  group: release-tag-${{ github.repository }}-${{ github.event_name == 'workflow_dispatch' && inputs.tag || github.ref_name }}
   cancel-in-progress: false
 
 jobs:


### PR DESCRIPTION
## Summary

Adds a top-level `concurrency:` block to the two workflows that previously lacked one, resolving the zizmor `concurrency-limits` findings (#82, #83):

- **`quality-keeper.yml`** (advisory PR analysis) — group keyed on the PR number (falling back to `github.ref`) with `cancel-in-progress: true`, so superseded runs on the same PR are cancelled.
- **`release-tag.yml`** (release signal per tag) — group keyed on the **resolved release tag** with `cancel-in-progress: false`, so a tag's run is never interrupted.

Group keys follow the repo's existing style (`${{ github.repository }}` prefix, matching `mutation.yml`, `test.yml`, etc.). The values are used only as concurrency group keys — not in `run:` commands — so there is no injection surface.

### Review fix (release-tag per-tag isolation)

Initial version keyed `release-tag.yml` on `github.ref`. On `workflow_dispatch`, `github.ref` is the branch ref (e.g. `refs/heads/main`) for every invocation, so all manual dispatches — regardless of the `tag` input — collapsed into one branch-keyed group, and a push-tag run vs. a dispatch run for the *same* tag landed in different groups. The group now uses the same expression the job computes for `REQUEST_TAG`:

```yaml
group: release-tag-${{ github.repository }}-${{ github.event_name == 'workflow_dispatch' && inputs.tag || github.ref_name }}
```

This guarantees (1) distinct tags never collapse or cancel each other and (2) a push-tag run and a `workflow_dispatch` run for the same tag share one group.

## Linked issue

Closes #420

## Commits

- `security(ci): add concurrency groups to quality-keeper and release-tag`
- `fix(ci): key release-tag concurrency on resolved tag`

## Tests run

- `python -c "yaml.safe_load(...)"` on both files — YAML OK
- `zizmor --offline` on both files — **No findings to report** (concurrency-limits open count is 0)

## Follow-up notes

None.
