### PR TITLE
fix(ci): re-anchor zizmor adhoc-packages ignore + drift guard

### DIFF
--- a/tests/unit/supply-chain-policy.unit.test.ts
+++ b/tests/unit/supply-chain-policy.unit.test.ts
@@ -1677,14 +1677,17 @@ describe("supply-chain audit policy", () => {
     expect(anchoredText).toContain("--ignore-scripts");
     expect(anchoredText).toContain("--omit=dev");
 
-    // Alert #95 reopened because the PROSE `(test.yml:<line>)` references drifted
-    // out of sync with the real install line. The `- test.yml:<line>` entry is
-    // not the only place the number lives: the two human-readable comment
-    // references ("The packed-install smoke test (test.yml:406)" and "Anchored to
-    // the `npm install "$tarball_path"` line (test.yml:406)") mislead the next
-    // maintainer if they go stale independently. Require EVERY `test.yml:<line>`
-    // occurrence in the block — the guarded entry and both comment references —
-    // to point at the same anchored line, so a partial re-anchor fails CI.
+    // Alert #95 reopened because the FUNCTIONAL `- test.yml:397` suppression
+    // entry drifted out of sync with the real install line — zizmor ignores the
+    // comments entirely, so only that entry (asserted above) controls whether the
+    // finding is suppressed. The prose is a separate, documentation-only hazard:
+    // the same number is restated in two human-readable comment references ("The
+    // packed-install smoke test (test.yml:406)" and "Anchored to the `npm install
+    // "$tarball_path"` line (test.yml:406)"), and if those drift independently of
+    // the entry they mislead the next maintainer into re-reviewing the wrong line.
+    // Require EVERY `test.yml:<line>` occurrence in the block — the guarded entry
+    // and both comment references — to point at the same anchored line, so a
+    // partial re-anchor that leaves stale documentation fails CI.
     const allTestYmlRefs = [...adhocBlock!.matchAll(/test\.yml:(\d+)/g)].map((match) =>
       Number(match[1]),
     );

--- a/tests/unit/supply-chain-policy.unit.test.ts
+++ b/tests/unit/supply-chain-policy.unit.test.ts
@@ -1676,6 +1676,20 @@ describe("supply-chain audit policy", () => {
     expect(adhocBlock).toContain(`- test.yml:${anchoredLine}`);
     expect(anchoredText).toContain("--ignore-scripts");
     expect(anchoredText).toContain("--omit=dev");
+
+    // Alert #95 reopened because the PROSE `(test.yml:<line>)` references drifted
+    // out of sync with the real install line. The `- test.yml:<line>` entry is
+    // not the only place the number lives: the two human-readable comment
+    // references ("The packed-install smoke test (test.yml:406)" and "Anchored to
+    // the `npm install "$tarball_path"` line (test.yml:406)") mislead the next
+    // maintainer if they go stale independently. Require EVERY `test.yml:<line>`
+    // occurrence in the block — the guarded entry and both comment references —
+    // to point at the same anchored line, so a partial re-anchor fails CI.
+    const allTestYmlRefs = [...adhocBlock!.matchAll(/test\.yml:(\d+)/g)].map((match) =>
+      Number(match[1]),
+    );
+    expect(allTestYmlRefs.length).toBeGreaterThanOrEqual(3);
+    expect(new Set(allTestYmlRefs)).toEqual(new Set([anchoredLine]));
   });
 
   it("refuses environment-injected audit fixtures outside tests", () => {

--- a/tests/unit/supply-chain-policy.unit.test.ts
+++ b/tests/unit/supply-chain-policy.unit.test.ts
@@ -1626,6 +1626,58 @@ describe("supply-chain audit policy", () => {
     );
   });
 
+  it("anchors the zizmor adhoc-packages ignore to the packed-install smoke", () => {
+    // The adhoc-packages suppression accepts the pack-smoke `npm install
+    // "$tarball_path"` of the locally-built tarball ON PURPOSE (installing the
+    // artifact under test outside a lockfile is the whole point of the smoke
+    // test), and it is pinned by raw line number (test.yml:<line>). zizmor
+    // matches ignores by file:line, not by job/step identity, so a future edit
+    // that shifts a DIFFERENT line onto that number silently un-suppresses the
+    // finding — exactly the drift that reopened alert #95. This required test
+    // compensates: it fails if the pinned line no longer resolves to the
+    // packed-install `npm install "$tarball_path"` step, forcing a re-anchor
+    // instead of a silent regression.
+    const zizmorConfig = readFileSync(join(root, "zizmor.yml"), "utf8");
+    const adhocBlock = yamlBlockForKey(zizmorConfig, "adhoc-packages");
+    expect(adhocBlock).not.toBeNull();
+    const anchors = [...(adhocBlock ?? "").matchAll(/-\s*test\.yml:(\d+)/g)];
+    // Exactly one anchored install may carry this accepted-risk suppression.
+    expect(anchors).toHaveLength(1);
+    const anchoredLine = Number(anchors[0]?.[1]);
+    expect(Number.isInteger(anchoredLine)).toBe(true);
+
+    // Normalize to LF so the character-offset math below is newline-convention
+    // agnostic (see the artipacked guard for the same rationale).
+    const workflowLf = workflow.replace(/\r\n/g, "\n");
+    const workflowLines = workflowLf.split("\n");
+    // Anchor is 1-indexed and must be the pack-smoke install line itself — the
+    // hardened `npm install ... "$tarball_path"` of the locally-built tarball,
+    // start-anchored so a commented reference cannot satisfy it.
+    const anchoredText = workflowLines[anchoredLine - 1] ?? "";
+    expect(anchoredText).toMatch(
+      /^\s*npm install --ignore-scripts --omit=dev --no-audit --no-fund "\$tarball_path"$/,
+    );
+
+    // That line must fall inside the packaged-install smoke job so an unrelated
+    // ad-hoc install elsewhere cannot inherit the ignore on the same line number.
+    const smokeJob = jobBlock("runtime-engine-floor").replace(/\r\n/g, "\n");
+    expect(smokeJob).not.toBe("");
+    const jobStartOffset = workflowLf.indexOf(smokeJob);
+    expect(jobStartOffset).toBeGreaterThanOrEqual(0);
+    const anchoredOffset = workflowLines
+      .slice(0, anchoredLine - 1)
+      .reduce((sum, line) => sum + line.length + 1, 0);
+    expect(anchoredOffset).toBeGreaterThanOrEqual(jobStartOffset);
+    expect(anchoredOffset).toBeLessThan(jobStartOffset + smokeJob.length);
+
+    // The pack-smoke install is a false positive only because it is hardened and
+    // installs the locally-built tarball — pin both the comment rationale and the
+    // hardening flags so weakening either forces a re-review of the suppression.
+    expect(adhocBlock).toContain(`- test.yml:${anchoredLine}`);
+    expect(anchoredText).toContain("--ignore-scripts");
+    expect(anchoredText).toContain("--omit=dev");
+  });
+
   it("refuses environment-injected audit fixtures outside tests", () => {
     const result = spawnSync(process.execPath, ["scripts/audit-supply-chain.mjs"], {
       cwd: root,

--- a/zizmor.yml
+++ b/zizmor.yml
@@ -51,7 +51,7 @@ rules:
       - publish.yml:9
   adhoc-packages:
     ignore:
-      # The packed-install smoke test (test.yml:397) is the pack-smoke install
+      # The packed-install smoke test (test.yml:406) is the pack-smoke install
       # of the locally-built tarball, not an unpinned third-party dependency.
       # It builds the package tarball, then `npm install`s THAT tarball into an
       # isolated temp dir to prove the published artifact installs cleanly —
@@ -61,10 +61,10 @@ rules:
       # installs only the locally-built `$tarball_path`. The adhoc-packages
       # risk this audit flags does not apply, so the finding is accepted.
       #
-      # Anchored to the `npm install "$tarball_path"` line (test.yml:397).
+      # Anchored to the `npm install "$tarball_path"` line (test.yml:406).
       # Re-review whenever the pack-smoke install step moves or changes what it
       # installs.
-      - test.yml:397
+      - test.yml:406
   artipacked:
     ignore:
       # The ci-green marker job (test.yml:1021) checks out with


### PR DESCRIPTION
## Summary

Code-scanning alert #95 (`zizmor/adhoc-packages`) reopened on `main` because the suppression anchor **drifted**. Upstream merges (#431, #426, #432) added lines earlier in `test.yml` and pushed the pack-smoke install down 9 lines (397 → 406). Since zizmor matches ignores by exact `file:line`, the stale `test.yml:397` anchor no longer covered the install line, so the accepted false-positive re-fired.

This is a **bookkeeping fix, not a real regression**: the pack-smoke step deliberately installs the locally-built tarball outside a lockfile (the whole point of the packaged-install smoke test), already hardened with `--ignore-scripts --omit=dev`.

### Changes

1. **Re-anchor** `zizmor.yml`'s `adhoc-packages` ignore `test.yml:397` → `test.yml:406` (the functional entry plus its two prose comment references).
2. **Add a drift guard** in `tests/unit/supply-chain-policy.unit.test.ts` mirroring the existing `artipacked` guard: it asserts the `adhoc-packages` anchor resolves to the hardened `npm install "$tarball_path"` line inside the packaged-install smoke job (`runtime-engine-floor`). The `artipacked` anchor already had such a guard; `adhoc-packages` did not, which is why this drift shipped silently. Now a future line shift fails CI instead of silently un-suppressing the alert.
3. **Extend the guard to the prose references** (review follow-up): require *every* `test.yml:<line>` occurrence in the block — the functional `- test.yml:<line>` entry **and** both human-readable comment references — to point at the same anchored line, so a partial re-anchor that leaves stale documentation also fails CI. The accompanying rationale comment attributes alert #95 to the functional entry drifting (zizmor ignores comments) and frames the prose consistency check as a separate documentation-only hazard.

## Commits

- `fix(ci): re-anchor zizmor adhoc-packages ignore + drift guard` — re-anchor 397 → 406 and add the base drift guard.
- `test: guard adhoc-packages prose line refs against drift` — assert the two prose `(test.yml:<line>)` references also match the anchored line.
- `docs: clarify functional entry vs prose in adhoc guard` — reword the guard rationale so alert #95's cause (functional entry, not comments) is stated accurately.

## Linked issue

Closes #434

## Tests run

- `pnpm exec vitest run --config vitest.config.mts --project=unit tests/unit/supply-chain-policy.unit.test.ts` → 65 passed (incl. the new guard).
- Verified the guard fails when the functional entry is reverted to the stale `397`, and also when a single prose reference drifts to `397` independently; restored to `406`.
- `pnpm run typecheck` → clean.

## Follow-up notes

- The `adhoc-packages` and `artipacked` guards now both fail-closed on anchor drift; any future line shift in `test.yml` that moves either anchored step will fail CI rather than silently masking a finding.
- The two guards intentionally keep self-contained, snapshot-style assertions per suppression (matching the established local pattern) rather than sharing a helper.
